### PR TITLE
Package only the binary for GitHub releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
- build:
+ test:
    docker:
      # https://circleci.com/docs/2.0/building-docker-images/#docker-version
      - image: docker:17.11.0-ce
@@ -8,16 +8,15 @@ jobs:
      - checkout
      - setup_remote_docker: {docker_layer_caching: true}
      # just a simple build for now, but will use skaffold if it gets more complex
+     # TODO(p3): run unit tests
      - run: docker build .
- deploy:
+ build:
    docker:
      - image: circleci/golang:1.10
    working_directory: /go/src/github.com/weaveworks/eksctl
    steps:
      - checkout
      - setup_remote_docker: {docker_layer_caching: true}
-     - run: make install-bindata
-     - run: make update-bindata
      - run:
         name: Build and publish
         # TODO(p3): build an image that has the script and all dependencies installed
@@ -25,15 +24,15 @@ jobs:
           if [[ -z "${CIRCLE_PULL_REQUEST}" ]] && [[ "${CIRCLE_TAG}" ]] && [[ "${CIRCLE_PROJECT_USERNAME}" = "weaveworks" ]] ; then
             curl -sL https://git.io/goreleaser | bash
           else
-            echo "No deploy on PR"
+            echo "Not a tag release, skip publish"
           fi
 
 workflows:
   version: 2
-  build-and-deploy:
+  test-and-build:
     jobs:
-      - build
-      - deploy:
+      - test
+      - build:
           filters:
             tags:
               only: /^[0-9].*/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,7 @@
+before:
+  hooks:
+  - make install-bindata
+  - make update-bindata
 builds:
   - main: ./cmd/eksctl
     binary: eksctl
@@ -7,4 +11,7 @@ builds:
       - linux
     goarch:
       - amd64
-
+archive:
+  format: tar.gz
+  files:
+  - none*

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ cluster. You can manage multiple clusters this way.
 
 ## Usage
 
+To download the latest release, run:
+
+```console
+EKSCTL_VERSION=$(curl -s https://api.github.com/repos/weaveworks/eksctl/releases/latest | jq -r '.tag_name')
+curl -sL https://github.com/weaveworks/eksctl/releases/download/${EKSCTL_VERSION}/eksctl_${EKSCTL_VERSION}_`uname -s`_amd64.tar.gz | tar xzvf - -C /usr/local/bin
+```
+
 To create a basic cluster, run:
 
 ```console


### PR DESCRIPTION
- update bindata with gorelease hooks
- add download instructions for Linux and MacOS
- rename the CI steps