### PR TITLE
AWS Profile Changes

### DIFF
--- a/cmd/eksctl/create.go
+++ b/cmd/eksctl/create.go
@@ -64,6 +64,7 @@ func createClusterCmd() *cobra.Command {
 
 	fs.StringVarP(&cfg.ClusterName, "cluster-name", "n", "", fmt.Sprintf("EKS cluster name (generated if unspecified, e.g. %q)", exampleClusterName))
 	fs.StringVarP(&cfg.Region, "region", "r", DEFAULT_EKS_REGION, "AWS region")
+	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS Profile to use. This overrides the AWS_PROFILE environment variable if its set")
 
 	fs.StringVarP(&cfg.NodeType, "node-type", "t", DEFAULT_NODE_TYPE, "node instance type")
 	fs.IntVarP(&cfg.Nodes, "nodes", "N", DEFAULT_NODE_COUNT, "total number of nodes (for a static ASG)")

--- a/cmd/eksctl/delete.go
+++ b/cmd/eksctl/delete.go
@@ -44,6 +44,7 @@ func deleteClusterCmd() *cobra.Command {
 
 	fs.StringVarP(&cfg.ClusterName, "cluster-name", "n", "", "EKS cluster name (required)")
 	fs.StringVarP(&cfg.Region, "region", "r", DEFAULT_EKS_REGION, "AWS region")
+	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS Profile to use. This overrides the AWS_PROFILE environment variable if its set")
 
 	return cmd
 }

--- a/cmd/eksctl/get.go
+++ b/cmd/eksctl/get.go
@@ -43,6 +43,7 @@ func getClusterCmd() *cobra.Command {
 
 	fs.StringVarP(&cfg.ClusterName, "cluster-name", "n", "", "EKS cluster name")
 	fs.StringVarP(&cfg.Region, "region", "r", DEFAULT_EKS_REGION, "AWS region")
+	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS Profile to use. This overrides the AWS_PROFILE environment variable if its set")
 
 	return cmd
 }

--- a/cmd/eksctl/utils.go
+++ b/cmd/eksctl/utils.go
@@ -97,6 +97,7 @@ func writeKubeconfigCmd() *cobra.Command {
 
 	fs.StringVarP(&cfg.ClusterName, "cluster-name", "n", "", fmt.Sprintf("EKS cluster name (generated if unspecified, e.g. %q)", utils.ClusterName()))
 	fs.StringVarP(&cfg.Region, "region", "r", DEFAULT_EKS_REGION, "AWS region")
+	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS Profile to use. This overrides the AWS_PROFILE environment variable if its set")
 
 	fs.StringVar(&utilsKubeconfigOutputPath, "kubeconfig", "", "path to write kubeconfig")
 


### PR DESCRIPTION
Changes to ensure that AWS profiles are supported. This involved making
sure that the AWS config file is loaded (SharedConfigEnabled) and
also making sure we have a TokenProvider set.

Added an explicit --profile flag that can be used to explicity specify
which AWS profile you would like to use. This will override any profile
that you have specified via AWS_PROFILE.

If endpoints are being overriden then the credentials from the initial
session creation are shared with any subsequent session creation to
ensure that the tokens are shared (otherwise you may get multiple MFA
prompts).

Issue #57