### PR TITLE
Support merging of config files and KUBECONFIG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ gitTag := $(shell git describe --tags --abbrev=0 --always)
 build:
 	go build -ldflags "-X main.gitCommit=$(gitCommit) -X main.builtAt=$(builtAt)" ./cmd/eksctl
 
+.PHONY: test
+test:
+	go test $(shell go list ./... | grep -v "^github.com/weaveworks/eksctl/vendor" | sort -u)
+
+
 .PHONY: update-bindata
 update-bindata:
 	go generate ./pkg/eks

--- a/cmd/eksctl/create.go
+++ b/cmd/eksctl/create.go
@@ -80,7 +80,7 @@ func createClusterCmd() *cobra.Command {
 	fs.BoolVar(&writeKubeconfig, "write-kubeconfig", true, "toggle writing of kubeconfig")
 	fs.BoolVar(&autoKubeconfigPath, "auto-kubeconfig", true, fmt.Sprintf("save kubconfig file by cluster name, e.g. %q", utils.ConfigPath(exampleClusterName)))
 	fs.StringVar(&kubeconfigPath, "kubeconfig", DEFAULT_KUBECONFIG_PATH, "path to write kubeconfig (incompatible with --auto-kubeconfig)")
-	fs.BoolVar(&setContext, "set-context", false, "If true then current-context will be set in kubeconfig. If a context is already set then it will be overwritten.")
+	fs.BoolVar(&setContext, "set-context", true, "If true then current-context will be set in kubeconfig. If a context is already set then it will be overwritten.")
 
 	return cmd
 }
@@ -104,6 +104,7 @@ func doCreateCluster(cfg *eks.ClusterConfig) error {
 	}
 	if kubeconfigPath == DEFAULT_KUBECONFIG_PATH {
 		kubeconfigPath = kubeconf.GetRecommendedPath()
+		logger.Debug("no kubeconfig specified so using recommended client path: %s", kubeconfigPath)
 	}
 
 	if cfg.SSHPublicKeyPath == "" {
@@ -137,7 +138,7 @@ func doCreateCluster(cfg *eks.ClusterConfig) error {
 	// obtain cluster credentials, write kubeconfig
 
 	{ // post-creation action
-		clientConfigBase, err := ctl.NewClientConfig()
+		clientConfigBase, err := ctl.NewClientConfig(setContext)
 		if err != nil {
 			return err
 		}
@@ -148,7 +149,7 @@ func doCreateCluster(cfg *eks.ClusterConfig) error {
 				return errors.Wrap(err, "writing kubeconfig")
 			}
 
-			logger.Info("wrote %q", kubeconfigPath)
+			logger.Success("wrote %q", kubeconfigPath)
 		} else {
 			kubeconfigPath = ""
 		}

--- a/cmd/eksctl/utils.go
+++ b/cmd/eksctl/utils.go
@@ -13,11 +13,13 @@ import (
 	"github.com/kubicorn/kubicorn/pkg/logger"
 	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/utils"
+	"github.com/weaveworks/eksctl/pkg/utils/kubeconf"
 )
 
 var (
 	utilsKubeconfigInputPath  string
 	utilsKubeconfigOutputPath string
+	utilsSetContext           bool
 )
 
 func utilsCmd() *cobra.Command {
@@ -100,6 +102,7 @@ func writeKubeconfigCmd() *cobra.Command {
 	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS profile to use. If provided, this overrides the AWS_PROFILE environment variable")
 
 	fs.StringVar(&utilsKubeconfigOutputPath, "kubeconfig", "", "path to write kubeconfig")
+	fs.BoolVar(&utilsSetContext, "set-context", true, "If true then current-context will be set in kubeconfig. If a context is already set then it will be overwritten.")
 
 	return cmd
 }
@@ -130,16 +133,17 @@ func doWriteKubeconfigCmd(cfg *eks.ClusterConfig) error {
 		return err
 	}
 
-	clientConfigBase, err := ctl.NewClientConfig()
+	clientConfigBase, err := ctl.NewClientConfig(setContext)
 	if err != nil {
 		return err
 	}
 
-	if err := clientConfigBase.WithExecHeptioAuthenticator().WriteToFile(utilsKubeconfigOutputPath); err != nil {
+	config := clientConfigBase.WithExecHeptioAuthenticator()
+	if err := kubeconf.WriteToFile(utilsKubeconfigOutputPath, config.Client, setContext); err != nil {
 		return errors.Wrap(err, "writing kubeconfig")
 	}
 
-	logger.Info("wrote kubeconfig file %q", utilsKubeconfigOutputPath)
+	logger.Success("wrote kubeconfig file %q", utilsKubeconfigOutputPath)
 
 	return nil
 }

--- a/pkg/eks/auth.go
+++ b/pkg/eks/auth.go
@@ -82,7 +82,7 @@ type ClientConfig struct {
 
 // based on "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
 // these are small, so we can copy these, and no need to deal with k/k as dependency
-func (c *ClusterProvider) NewClientConfig() (*ClientConfig, error) {
+func (c *ClusterProvider) NewClientConfig(setContext bool) (*ClientConfig, error) {
 	clusterName := fmt.Sprintf("%s.%s.eksctl.io", c.cfg.ClusterName, c.cfg.Region)
 	contextName := fmt.Sprintf("%s@%s", c.getUsername(), clusterName)
 
@@ -104,9 +104,12 @@ func (c *ClusterProvider) NewClientConfig() (*ClientConfig, error) {
 			AuthInfos: map[string]*clientcmdapi.AuthInfo{
 				contextName: &clientcmdapi.AuthInfo{},
 			},
-			CurrentContext: contextName,
 		},
 		roleARN: c.svc.arn,
+	}
+
+	if setContext {
+		clientConfig.Client.CurrentContext = contextName
 	}
 
 	return clientConfig, nil
@@ -151,13 +154,6 @@ func (c *ClientConfig) WithEmbeddedToken() (*ClientConfig, error) {
 	x.Token = tok
 
 	return &clientConfigCopy, nil
-}
-
-func (c *ClientConfig) WriteToFile(filename string) error {
-	if err := clientcmd.WriteToFile(*c.Client, filename); err != nil {
-		return errors.Wrapf(err, "couldn't write client config file %q", filename)
-	}
-	return nil
 }
 
 func (c *ClientConfig) NewClientSet() (*clientset.Clientset, error) {

--- a/pkg/utils/kubeconf/kubeconf.go
+++ b/pkg/utils/kubeconf/kubeconf.go
@@ -4,6 +4,8 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/weaveworks/eksctl/pkg/utils"
+
 	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -28,7 +30,7 @@ func GetRecommendedPath() string {
 // If file doesn't exist it will be created. If the file exists then
 // the configuration will be merged with the existing file.
 func WriteToFile(path string, config *api.Config, setContext bool) error {
-	exists, err := fileExists(path)
+	exists, err := utils.FileExists(path)
 	if err != nil {
 		return errors.Wrapf(err, "error trying to read config file %q", path)
 	}
@@ -76,19 +78,6 @@ func writeConfToFile(path string, config *api.Config) error {
 		return errors.Wrapf(err, "couldn't write client config file %q", path)
 	}
 	return nil
-}
-
-func fileExists(path string) (bool, error) {
-	_, err := os.Stat(path)
-	if err == nil {
-		return true, nil
-	}
-
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-
-	return false, err
 }
 
 func readConfigurationFile(path string) (*api.Config, error) {

--- a/pkg/utils/kubeconf/kubeconf.go
+++ b/pkg/utils/kubeconf/kubeconf.go
@@ -1,0 +1,110 @@
+package kubeconf
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/pkg/errors"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/tools/clientcmd/api/latest"
+
+	"github.com/kubicorn/kubicorn/pkg/logger"
+)
+
+// GetRecommendedPath returns the recommended kubeconf path based on the
+// Kubernetes Go Client. If the KUBECONFIG environment variable is set it will
+// use this path otherwise it will use the default path to the config file.
+func GetRecommendedPath() string {
+	kubeVar := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
+
+	if len(kubeVar) > 0 {
+		return kubeVar
+	}
+	return clientcmd.RecommendedHomeFile
+}
+
+// WriteToFile will write Kubernetes client configuration to a file.
+// If file doesn't exist it will be created. If the file exists then
+// the configuration will be merged with the existing file.
+func WriteToFile(path string, config *api.Config, setContext bool) error {
+	exists, err := fileExists(path)
+	if err != nil {
+		return errors.Wrapf(err, "error trying to read config file %q", path)
+	}
+
+	if !exists {
+		logger.Debug("Kube configuration file doesn't exist: %s", path)
+		return writeConfToFile(path, config)
+	}
+
+	existing, err := readConfigurationFile(path)
+	if err != nil {
+		return errors.Wrapf(err, "unable to read existing kube configuration file %q", path)
+	}
+
+	logger.Debug("Merging kubeconfigurations files")
+	merged, err := mergeConfigurations(existing, config)
+	if err != nil {
+		return errors.Wrapf(err, "unable to merge configuration with existing kube configuration file %q", path)
+	}
+
+	if setContext && len(config.CurrentContext) > 0 {
+		logger.Debug("Setting current-context to %s", config.CurrentContext)
+		merged.CurrentContext = config.CurrentContext
+	}
+
+	return writeConfToFile(path, merged)
+}
+
+func mergeConfigurations(existing *api.Config, tomerge *api.Config) (*api.Config, error) {
+	for k, v := range tomerge.Clusters {
+		existing.Clusters[k] = v
+	}
+	for k, v := range tomerge.AuthInfos {
+		existing.AuthInfos[k] = v
+	}
+	for k, v := range tomerge.Contexts {
+		existing.Contexts[k] = v
+	}
+
+	return existing, nil
+}
+
+func writeConfToFile(path string, config *api.Config) error {
+	if err := clientcmd.WriteToFile(*config, path); err != nil {
+		return errors.Wrapf(err, "couldn't write client config file %q", path)
+	}
+	return nil
+}
+
+func fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	return false, err
+}
+
+func readConfigurationFile(path string) (*api.Config, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error trying to read config file %q", path)
+	}
+
+	if len(data) == 0 {
+		return api.NewConfig(), nil
+	}
+
+	config, _, err := latest.Codec.Decode(data, nil, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "couldn't decode kubeconf file %q", path)
+	}
+
+	return config.(*api.Config), nil
+}

--- a/pkg/utils/kubeconf/kubeconf_test.go
+++ b/pkg/utils/kubeconf/kubeconf_test.go
@@ -1,0 +1,258 @@
+package kubeconf_test
+
+import (
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+
+	"github.com/weaveworks/eksctl/pkg/utils/kubeconf"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+const (
+	sdkRecommendedPath   = "~/.kube/config"
+	sdkRecommendedEnvVar = "KUBECONFIG"
+)
+
+func TestRecommendedPathGetFromEnvVar(t *testing.T) {
+	expectedPath := "/sometpath"
+	err := os.Setenv(sdkRecommendedEnvVar, expectedPath)
+	if err != nil {
+		t.Fatalf("Error setting KUBECONFIG: %v", err)
+	}
+
+	actual := kubeconf.GetRecommendedPath()
+
+	if actual != expectedPath {
+		t.Fatalf("Expected %s but got %s", expectedPath, actual)
+	}
+}
+
+func TestRecommendedPathFromDefault(t *testing.T) {
+	usr, _ := user.Current()
+	fullExpectedPath := filepath.Join(usr.HomeDir, sdkRecommendedPath[2:])
+
+	os.Unsetenv(sdkRecommendedEnvVar)
+	actual := kubeconf.GetRecommendedPath()
+
+	if actual != fullExpectedPath {
+		t.Fatalf("Expected %s but got %s", fullExpectedPath, actual)
+	}
+}
+
+func TestCreateNewKubeConfig(t *testing.T) {
+	configFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(configFile.Name())
+
+	testConfig := api.Config{
+		AuthInfos: map[string]*api.AuthInfo{
+			"test-user": {Token: "test-token"}},
+		Clusters: map[string]*api.Cluster{
+			"test-cluster": {Server: "https://127.0.0.1:8443"}},
+		Contexts: map[string]*api.Context{
+			"test-context": {AuthInfo: "test-user", Cluster: "test-cluster", Namespace: "test-ns"}},
+	}
+
+	err := kubeconf.WriteToFile(configFile.Name(), &testConfig, false)
+	if err != nil {
+		t.Fatalf("Error writing configuration: %v", err)
+	}
+
+	readConfig, err := clientcmd.LoadFromFile(configFile.Name())
+	if err != nil {
+		t.Fatalf("Error reading configuration file: %v", err)
+	}
+
+	if len(readConfig.Clusters) != 1 || readConfig.Clusters["test-cluster"].Server != testConfig.Clusters["test-cluster"].Server {
+		t.Fatalf("Cluster contents not the same")
+	}
+
+	if len(readConfig.AuthInfos) != 1 || readConfig.AuthInfos["test-user"].Token != testConfig.AuthInfos["test-user"].Token {
+		t.Fatalf("AuthInfos contents not the same")
+	}
+
+	if len(readConfig.Contexts) != 1 || readConfig.Contexts["test-context"].Namespace != testConfig.Contexts["test-context"].Namespace {
+		t.Fatalf("Context contents not the same")
+	}
+}
+
+func TestNewConfigSetsContext(t *testing.T) {
+	const expectedContext = "test-context"
+
+	configFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(configFile.Name())
+
+	testConfig := api.Config{
+		AuthInfos: map[string]*api.AuthInfo{
+			"test-user": {Token: "test-token"}},
+		Clusters: map[string]*api.Cluster{
+			"test-cluster": {Server: "https://127.0.0.1:8443"}},
+		Contexts: map[string]*api.Context{
+			expectedContext: {AuthInfo: "test-user", Cluster: "test-cluster", Namespace: "test-ns"}},
+		CurrentContext: expectedContext,
+	}
+
+	err := kubeconf.WriteToFile(configFile.Name(), &testConfig, true)
+	if err != nil {
+		t.Fatalf("Error writing configuration: %v", err)
+	}
+
+	readConfig, err := clientcmd.LoadFromFile(configFile.Name())
+	if err != nil {
+		t.Fatalf("Error reading configuration file: %v", err)
+	}
+
+	if readConfig.CurrentContext != expectedContext {
+		t.Fatalf("Current context is %s but expected %s", readConfig.CurrentContext, expectedContext)
+	}
+}
+
+func TestMergeKubeConfig(t *testing.T) {
+	configFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(configFile.Name())
+
+	err := writeConfig(configFile.Name())
+	if err != nil {
+		t.Errorf("Error writing initial configuration file: %v", err)
+	}
+
+	testConfig := api.Config{
+		AuthInfos: map[string]*api.AuthInfo{
+			"test-user": {Token: "test-token"}},
+		Clusters: map[string]*api.Cluster{
+			"test-cluster": {Server: "https://127.0.0.1:8443"}},
+		Contexts: map[string]*api.Context{
+			"test-context": {AuthInfo: "test-user", Cluster: "test-cluster", Namespace: "test-ns"}},
+	}
+
+	err = kubeconf.WriteToFile(configFile.Name(), &testConfig, false)
+	if err != nil {
+		t.Fatalf("Error writing configuration: %v", err)
+	}
+
+	readConfig, err := clientcmd.LoadFromFile(configFile.Name())
+	if err != nil {
+		t.Fatalf("Error reading configuration file: %v", err)
+	}
+
+	if len(readConfig.Clusters) != 2 || readConfig.Clusters["test-cluster"].Server != testConfig.Clusters["test-cluster"].Server {
+		t.Fatalf("Cluster contents not the same")
+	}
+	if readConfig.Clusters["minikube"].Server != "https://192.168.64.19:8443" {
+		t.Fatalf("Error in merging as existing cluster configuration not the same")
+	}
+
+	if len(readConfig.AuthInfos) != 2 || readConfig.AuthInfos["test-user"].Token != testConfig.AuthInfos["test-user"].Token {
+		t.Fatalf("AuthInfos contents not the same")
+	}
+	if readConfig.AuthInfos["minikube"].ClientCertificate != "/Users/bob/.minikube/client.crt" {
+		t.Fatalf("Error in merging as existing AuthInfos configuration not the same")
+	}
+
+	if len(readConfig.Contexts) != 2 || readConfig.Contexts["test-context"].Namespace != testConfig.Contexts["test-context"].Namespace {
+		t.Fatalf("Context contents not the same")
+	}
+	if readConfig.Contexts["minikube"].Cluster != "minikube" {
+		t.Fatalf("Error in merging as existing Contexts configuration not the same")
+	}
+}
+
+func TestMergeSetsContext(t *testing.T) {
+	const expectedContext = "test-context"
+
+	configFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(configFile.Name())
+
+	err := writeConfig(configFile.Name())
+	if err != nil {
+		t.Errorf("Error writing initial configuration file: %v", err)
+	}
+
+	testConfig := api.Config{
+		AuthInfos: map[string]*api.AuthInfo{
+			"test-user": {Token: "test-token"}},
+		Clusters: map[string]*api.Cluster{
+			"test-cluster": {Server: "https://127.0.0.1:8443"}},
+		Contexts: map[string]*api.Context{
+			expectedContext: {AuthInfo: "test-user", Cluster: "test-cluster", Namespace: "test-ns"}},
+		CurrentContext: expectedContext,
+	}
+
+	err = kubeconf.WriteToFile(configFile.Name(), &testConfig, true)
+	if err != nil {
+		t.Fatalf("Error writing configuration: %v", err)
+	}
+
+	readConfig, err := clientcmd.LoadFromFile(configFile.Name())
+	if err != nil {
+		t.Fatalf("Error reading configuration file: %v", err)
+	}
+
+	if readConfig.CurrentContext != expectedContext {
+		t.Fatalf("Current context is %s but expected %s", readConfig.CurrentContext, expectedContext)
+	}
+}
+
+func TestMergeDoesNotSetContext(t *testing.T) {
+	expectedContext := "minikube"
+	configFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(configFile.Name())
+
+	err := writeConfig(configFile.Name())
+	if err != nil {
+		t.Errorf("Error writing initial configuration file: %v", err)
+	}
+
+	testConfig := api.Config{
+		AuthInfos: map[string]*api.AuthInfo{
+			"test-user": {Token: "test-token"}},
+		Clusters: map[string]*api.Cluster{
+			"test-cluster": {Server: "https://127.0.0.1:8443"}},
+		Contexts: map[string]*api.Context{
+			"test-context": {AuthInfo: "test-user", Cluster: "test-cluster", Namespace: "test-ns"}},
+		CurrentContext: "test-context",
+	}
+
+	err = kubeconf.WriteToFile(configFile.Name(), &testConfig, false)
+	if err != nil {
+		t.Fatalf("Error writing configuration: %v", err)
+	}
+
+	readConfig, err := clientcmd.LoadFromFile(configFile.Name())
+	if err != nil {
+		t.Fatalf("Error reading configuration file: %v", err)
+	}
+
+	if readConfig.CurrentContext != expectedContext {
+		t.Fatalf("Current context is %s but expected %s", readConfig.CurrentContext, expectedContext)
+	}
+}
+
+func writeConfig(filename string) error {
+	return ioutil.WriteFile(filename, []byte(`
+kind: Config
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: /Users/bob/.minikube/ca.crt
+    server: https://192.168.64.19:8443
+  name: minikube
+contexts:
+- context:
+    cluster: minikube
+    user: minikube
+  name: minikube
+current-context: minikube
+kind: Config
+preferences: {}
+users:
+- name: minikube
+  user:
+    as-user-extra: {}
+    client-certificate: /Users/bob/.minikube/client.crt
+    client-key: /Users/bob/.minikube/client.key		
+    `), os.FileMode(0755))
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -59,7 +59,33 @@ func tryDeleteConfig(p, name string) {
 
 func MaybeDeleteConfig(name string) {
 	p := ConfigPath(name)
-	tryDeleteConfig(p, name)
-	// also try to delete default file in current working directory
-	tryDeleteConfig("kubeconfig", p)
+
+	autoConfExists, err := FileExists(p)
+	if err != nil {
+		logger.Debug("error checking if auto-generated kubeconfig file exists %q: %s", p, err.Error())
+		return
+	}
+	if autoConfExists {
+		if err := os.Remove(p); err != nil {
+			logger.Debug("ignoring error while removing auto-generated config file %q: %s", p, err.Error())
+		}
+		return
+	}
+
+	// Print message to manually remove from config file
+	logger.Warning("as you are not using the auto-generated kubeconfig file you will need to remove the details of cluster %s manually", name)
+}
+
+// FileExists checks to see if a file exists.
+func FileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	return false, err
 }


### PR DESCRIPTION
When writing the kubeconfig for the new EKS cluster then the following
will happen:
- If `--kubeconfig`, `--auto-kubeconfig` or `KUBECONFING` env var are NOT set
  then the default kube config location will be used (~/.kube/conf).
- If `KUBECONFIG` is set then we use this (assuming `--kubeconfig` and
  `--auto-kubeconfig` aren't specified).
- if `KUBECONFIG` is set **BUT** `--kubeconfig` or `--auto-kubeconfig` are
  specified then `KUBECONFIG` will be ignored.
- if a kubeconfig file already exists then we merge in the new EKS
  cluster details with the existing file.
- If `set-context` is true then the `current-context` will be set to that
  of the new EKS cluster.
- If `set-context` is true (default) then if we are merging with an
  existing configuration file with a `current-context` set then this won't
  be updated.

Issue #29