### PR TITLE
Added AWS SDK Debug Logging

### DIFF
--- a/cmd/eksctl/main.go
+++ b/cmd/eksctl/main.go
@@ -20,7 +20,7 @@ func init() {
 
 	addCommands()
 
-	rootCmd.PersistentFlags().IntVarP(&logger.Level, "verbose", "v", 3, "set log level, use 0 to silence and 4 for debugging")
+	rootCmd.PersistentFlags().IntVarP(&logger.Level, "verbose", "v", 3, "set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging")
 	rootCmd.PersistentFlags().BoolVarP(&logger.Color, "color", "C", true, "toggle colorized logs")
 }
 

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -1,6 +1,7 @@
 package eks
 
 import (
+	"fmt"
 	"os"
 	"sync"
 
@@ -19,7 +20,10 @@ import (
 	"github.com/kubicorn/kubicorn/pkg/logger"
 )
 
-const ClusterNameTag = "eksctl.cluster.k8s.io/v1alpha1/cluster-name"
+const (
+	ClusterNameTag = "eksctl.cluster.k8s.io/v1alpha1/cluster-name"
+	AWSDebugLevel  = 5
+)
 
 type ClusterProvider struct {
 	cfg *ClusterConfig
@@ -166,6 +170,12 @@ func newSession(clusterConfig *ClusterConfig, endpoint string, credentials *cred
 	config := aws.NewConfig()
 	config = config.WithRegion(clusterConfig.Region)
 	config = config.WithCredentialsChainVerboseErrors(true)
+	if logger.Level > AWSDebugLevel {
+		config = config.WithLogLevel(aws.LogDebugWithHTTPBody)
+		config = config.WithLogger(aws.LoggerFunc(func(args ...interface{}) {
+			logger.Debug(fmt.Sprintln(args...))
+		}))
+	}
 
 	// Create the options for the session
 	opts := session.Options{


### PR DESCRIPTION
Added a new verbosity level of 5. If verbosity is set to a value
above this then we enable debug logging of the aws sdk and write
the log entries to the debug out of the logger.

Issue #78