### PR TITLE
Wait for control plane

### DIFF
--- a/cmd/eksctl/utils.go
+++ b/cmd/eksctl/utils.go
@@ -54,7 +54,8 @@ func waitNodesCmd() *cobra.Command {
 	fs := cmd.Flags()
 
 	fs.StringVar(&utilsKubeconfigInputPath, "kubeconfig", "kubeconfig", "path to read kubeconfig")
-	fs.IntVarP(&cfg.MinNodes, "nodes-min", "m", DEFAULT_NODE_COUNT, "minimum nodes to wait for")
+	fs.IntVarP(&cfg.MinNodes, "nodes-min", "m", DEFAULT_NODE_COUNT, "minimum number of nodes to wait for")
+	fs.DurationVar(&cfg.WaitTimeout, "timeout", eks.DefaultWaitTimeout, "how long to wait")
 
 	return cmd
 }

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -29,6 +29,8 @@ const (
 	AWSDebugLevel  = 5
 )
 
+var DefaultWaitTimeout = 20 * time.Minute
+
 type ClusterProvider struct {
 	// core fields used for config and AWS APIs
 	cfg *ClusterConfig
@@ -61,7 +63,7 @@ type ClusterConfig struct {
 	SSHPublicKeyPath string
 	SSHPublicKey     []byte
 
-	AWSOperationTimeout time.Duration
+	WaitTimeout time.Duration
 
 	keyName        string
 	clusterRoleARN string

--- a/pkg/eks/cfn.go
+++ b/pkg/eks/cfn.go
@@ -64,14 +64,14 @@ func (c *ClusterProvider) CreateStack(name string, templateBody []byte, paramete
 		ticker := time.NewTicker(20 * time.Second)
 		defer ticker.Stop()
 
-		timer := time.NewTimer(c.cfg.AWSOperationTimeout)
+		timer := time.NewTimer(c.cfg.WaitTimeout)
 		defer timer.Stop()
 
 		defer close(errs)
 		for {
 			select {
 			case <-timer.C:
-				errs <- fmt.Errorf("timed out creating CloudFormation stack %q after %d", name, c.cfg.AWSOperationTimeout)
+				errs <- fmt.Errorf("timed out creating CloudFormation stack %q after %d", name, c.cfg.WaitTimeout)
 				return
 
 			case <-ticker.C:

--- a/pkg/eks/nodegroup.go
+++ b/pkg/eks/nodegroup.go
@@ -81,8 +81,7 @@ func getNodes(clientSet *clientset.Clientset) (int, error) {
 }
 
 func (c *ClusterConfig) WaitForNodes(clientSet *clientset.Clientset) error {
-	timeoutAfter := 20 * time.Minute
-	timer := time.After(timeoutAfter)
+	timer := time.After(c.WaitTimeout)
 	timeout := false
 	watcher, err := clientSet.Core().Nodes().Watch(metav1.ListOptions{})
 	if err != nil {
@@ -115,7 +114,7 @@ func (c *ClusterConfig) WaitForNodes(clientSet *clientset.Clientset) error {
 		}
 	}
 	if timeout {
-		return fmt.Errorf("timed out (after %s) waitiing for at least %d nodes to join the cluster and become ready", timeoutAfter, c.MinNodes)
+		return fmt.Errorf("timed out (after %s) waitiing for at least %d nodes to join the cluster and become ready", c.WaitTimeout, c.MinNodes)
 	}
 
 	if _, err = getNodes(clientSet); err != nil {


### PR DESCRIPTION
- add `cfg.WaitForControlPlane`
- deprecate `--aws-api-timeout`
- add generalised `--timeout`

Fixes #114.