### PR TITLE
Disable zone filter, add flag to set zones manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ To use a pre-existing EC2 key pair in `us-east-1` region, you can specify key pa
 eksctl create cluster --ssh-public-key=my_kubernetes_key --region=us-east-1
 ```
 
+> NOTE: In `us-east-1` you are likely to get `UnsupportedAvailabilityZoneException`. If you do, copy the suggested zones and pass `--zones` flag, e.g. `eksctl create cluster --region=us-east-1 --zones=us-east-1a,us-east-1b,us-east-1d`. This may occur in other regions, but less likely. You shouldn't need to use `--zone` flag otherwise.
+
 To delete a cluster, run:
 
 ```

--- a/cmd/eksctl/create.go
+++ b/cmd/eksctl/create.go
@@ -42,6 +42,7 @@ var (
 	kubeconfigPath     string
 	autoKubeconfigPath bool
 	setContext         bool
+	availabilityZones  []string
 )
 
 func createClusterCmd() *cobra.Command {
@@ -73,6 +74,8 @@ func createClusterCmd() *cobra.Command {
 	// TODO: https://github.com/weaveworks/eksctl/issues/28
 	fs.IntVarP(&cfg.MinNodes, "nodes-min", "m", 0, "minimum nodes in ASG")
 	fs.IntVarP(&cfg.MaxNodes, "nodes-max", "M", 0, "maximum nodes in ASG")
+
+	fs.StringSliceVar(&availabilityZones, "zones", nil, "(auto-select if unspecified)")
 
 	fs.StringVar(&cfg.SSHPublicKeyPath, "ssh-public-key", DEFAULT_SSH_PUBLIC_KEY, "SSH public key to use for nodes (import from local path, or use existing EC2 key pair)")
 
@@ -117,7 +120,7 @@ func doCreateCluster(cfg *eks.ClusterConfig, name string) error {
 		return fmt.Errorf("--region=%s is not supported only %s and %s are supported", cfg.Region, EKS_REGION_US_WEST_2, EKS_REGION_US_EAST_1)
 	}
 
-	if err := ctl.SetAvailabilityZones(); err != nil {
+	if err := ctl.SetAvailabilityZones(availabilityZones); err != nil {
 		return err
 	}
 

--- a/pkg/az/az.go
+++ b/pkg/az/az.go
@@ -84,8 +84,8 @@ type AvailabilityZoneSelector struct {
 func NewSelectorWithDefaults(ec2api ec2iface.EC2API) *AvailabilityZoneSelector {
 	avoidZones := map[string]bool{
 		// well-known over-populated zones
-		"us-east-1a": true,
-		"us-east-1b": true,
+		// "us-east-1a": true,
+		// "us-east-1b": true,
 	}
 
 	return &AvailabilityZoneSelector{

--- a/pkg/az/az_test.go
+++ b/pkg/az/az_test.go
@@ -232,8 +232,8 @@ func createAvailabilityZone(region string, state string, zone string) *ec2.Avail
 
 func avoidedZones(initialStatus string) []*ec2.AvailabilityZone {
 	return []*ec2.AvailabilityZone{
-		createAvailabilityZone("US East (N. Virginia)", initialStatus, "us-east-1a"),
-		createAvailabilityZone("US East (N. Virginia)", initialStatus, "us-east-1b"),
+		// createAvailabilityZone("US East (N. Virginia)", initialStatus, "us-east-1a"),
+		// createAvailabilityZone("US East (N. Virginia)", initialStatus, "us-east-1b"),
 	}
 }
 

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -180,16 +180,23 @@ func (c *ClusterProvider) CheckAuth() error {
 	return nil
 }
 
-func (c *ClusterProvider) SetAvailabilityZones() error {
-	logger.Debug("determining availability zones")
-	azSelector := az.NewSelectorWithDefaults(c.Provider.EC2())
-	zones, err := azSelector.SelectZones(c.Spec.Region)
-	if err != nil {
-		return errors.Wrap(err, "getting availability zones")
-	}
+func (c *ClusterProvider) SetAvailabilityZones(given []string) error {
+	if len(given) == 0 {
+		logger.Debug("determining availability zones")
+		azSelector := az.NewSelectorWithDefaults(c.Provider.EC2())
+		zones, err := azSelector.SelectZones(c.Spec.Region)
+		if err != nil {
+			return errors.Wrap(err, "getting availability zones")
+		}
 
-	logger.Info("setting availability zones to %v", zones)
-	c.Status.availabilityZones = zones
+		logger.Info("setting availability zones to %v", zones)
+		c.Status.availabilityZones = zones
+		return nil
+	}
+	if len(given) < az.DefaultRequiredAvailabilityZones {
+		return fmt.Errorf("only %d zones specified %v, %d are required (can be non-unque)", len(given), given, az.DefaultRequiredAvailabilityZones)
+	}
+	c.Status.availabilityZones = given
 	return nil
 }
 


### PR DESCRIPTION
This the only sane way to fix UnsupportedAvailabilityZoneException,
espcially because it turns out that this is somehow different in every
AWS account (at least that what seems to be the case from the docs.

> You may receive an error that one of the Availability Zones in your
> request does not have sufficient capacity to create an Amazon EKS
> cluster. If this happens, the error output contains the Availability
> Zones that can support a new cluster. Retry creating your cluster
> with at least two subnets that are located in the supported
> Availability Zones for your account.

In the future we may try parsing the error message and retrying
automatically, but it doesn't seem feasible right now as we would
need to improve some of the internals and provide stack update
functionality.

Close #118. Finally.