### PR TITLE
Changed AWS EKS Imports

### DIFF
--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -18,7 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/aws/aws-sdk-go/service/eks"
+	awseks "github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
@@ -114,7 +114,7 @@ func New(clusterConfig *ClusterConfig) *ClusterProvider {
 
 	provider := &ProviderServices{
 		cfn: cloudformation.New(s),
-		eks: eks.New(s),
+		eks: awseks.New(s),
 		ec2: ec2.New(s),
 		sts: sts.New(s),
 	}
@@ -130,7 +130,7 @@ func New(clusterConfig *ClusterConfig) *ClusterProvider {
 	}
 	if endpoint, ok := os.LookupEnv("AWS_EKS_ENDPOINT"); ok {
 		logger.Debug("Setting EKS endpoint to %s", endpoint)
-		provider.eks = eks.New(newSession(clusterConfig, endpoint, status.sessionCreds))
+		provider.eks = awseks.New(newSession(clusterConfig, endpoint, status.sessionCreds))
 	}
 	if endpoint, ok := os.LookupEnv("AWS_EC2_ENDPOINT"); ok {
 		logger.Debug("Setting EC2 endpoint to %s", endpoint)

--- a/pkg/eks/eks_test.go
+++ b/pkg/eks/eks_test.go
@@ -3,7 +3,7 @@ package eks_test
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	cfn "github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/aws/aws-sdk-go/service/eks"
+	awseks "github.com/aws/aws-sdk-go/service/eks"
 	"github.com/kubicorn/kubicorn/pkg/logger"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -37,12 +37,12 @@ var _ = Describe("Eks", func() {
 					Provider: p,
 				}
 
-				p.MockEKS().On("DescribeCluster", mock.MatchedBy(func(input *eks.DescribeClusterInput) bool {
+				p.MockEKS().On("DescribeCluster", mock.MatchedBy(func(input *awseks.DescribeClusterInput) bool {
 					return *input.Name == clusterName
-				})).Return(&eks.DescribeClusterOutput{
-					Cluster: &eks.Cluster{
+				})).Return(&awseks.DescribeClusterOutput{
+					Cluster: &awseks.Cluster{
 						Name:   aws.String(clusterName),
-						Status: aws.String(eks.ClusterStatusActive),
+						Status: aws.String(awseks.ClusterStatusActive),
 					},
 				}, nil)
 			})


### PR DESCRIPTION
The AWS EKS import statement have been changed to use an alias
of awseks. This is to stop confusion with our `eks` package. The
only places where this change hasn't been made is within generated
code suck as mocks.