### PR TITLE
trivial: Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 .goreleaser.brew.combined.yml
 
 # Locally built binary
-eksctl
+/eksctl
 
 # Bad deps
 vendor/k8s.io/kops/docs


### PR DESCRIPTION
fix binary ignore, as it was it also caused folders named 'eksctl' to be ignored, for example, `/cmd/eksctl`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/eksctl/173)
<!-- Reviewable:end -->
