### PR TITLE
trivial: Update kubectl.go

### DIFF
--- a/pkg/utils/kubectl.go
+++ b/pkg/utils/kubectl.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
-	"github.com/kballard/go-shellquote"
+	shellquote "github.com/kballard/go-shellquote"
 	"github.com/pkg/errors"
 
 	"k8s.io/client-go/tools/clientcmd"


### PR DESCRIPTION
Fix the name of 'go-shellquote' at import to reflect how it is actually being used in the code at line 22

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/eksctl/174)
<!-- Reviewable:end -->
