### PR TITLE
WIP: AMI resolution and overriding (allowing GPU support)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -274,6 +274,7 @@
   packages = [
     ".",
     "config",
+    "extensions/table",
     "internal/codelocation",
     "internal/containernode",
     "internal/failer",
@@ -706,6 +707,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a45d0efbf394f9bac1c0b2a19721e8177306c102d0d793f81a6a195f5d11d70c"
+  inputs-digest = "b23739bcb911e4d687b4c8547467b6fc992e5901368028ccea55bc3a3ce57870"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/eksctl/create.go
+++ b/cmd/eksctl/create.go
@@ -93,6 +93,8 @@ func createClusterCmd() *cobra.Command {
 
 	fs.BoolVar(&cfg.Addons.WithIAM.PolicyAmazonEC2ContainerRegistryPowerUser, "full-ecr-access", false, "enable full access to ECR")
 
+	fs.StringVar(&cfg.NodeAMI, "node-ami", "", "if not supplied then eksctl will automatically set the AMI based on region/instance type; if supplied it will override the AMI to use for the nodes")
+
 	return cmd
 }
 

--- a/pkg/ami/ami.go
+++ b/pkg/ami/ami.go
@@ -1,0 +1,70 @@
+package ami
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ResolveAMI will resolve an AMI from the supplied region
+// and instance type. It will invoke a specific resolver
+// to do the actual detrminng of AMI.
+func ResolveAMI(region string, instanceType string) (string, error) {
+	var resolver Resolver
+
+	if strings.HasPrefix(instanceType, "p2") ||
+		strings.HasPrefix(instanceType, "p3") {
+		resolver = &GpuResolver{}
+	} else {
+		resolver = &DefaultResolver{}
+	}
+
+	return resolver.Resolve(region, instanceType)
+}
+
+// Resolver provides an interface to enable implementing multiple
+// ways to determine which AMI to use from the region/instance type.
+type Resolver interface {
+	Resolve(region string, instanceType string) (string, error)
+}
+
+// DefaultResolver resolves the AMi to the defaults for the region
+type DefaultResolver struct {
+}
+
+// Resolve will return an AMI to use based on the default AMI for each region
+// TODO: https://github.com/weaveworks/eksctl/issues/49
+// currently source of truth for these is here:
+// https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html
+func (r *DefaultResolver) Resolve(region string, instanceType string) (string, error) {
+	switch region {
+	case "us-west-2":
+		return "ami-73a6e20b", nil
+	case "us-east-1":
+		return "ami-dea4d5a1", nil
+	default:
+		return "", fmt.Errorf("Unable to resolve AMI for region %s and instance type %s", region, instanceType)
+	}
+}
+
+// GpuResolver resolves the AMI for GPU instances types.
+type GpuResolver struct {
+}
+
+// Resolve will return an AMI based on the region for GPU instance types
+func (r *GpuResolver) Resolve(region string, instanceType string) (string, error) {
+	if !strings.HasPrefix(instanceType, "p2") &&
+		!strings.HasPrefix(instanceType, "p3") {
+		return "", fmt.Errorf("Cannot resolve AMI as the instance type isn'y GPU optimized")
+	}
+
+	switch region {
+	case "us-west-2":
+		return "ami-0d20f2404b9a1c4d1", nil
+	case "us-east-1":
+		return "ami-09fe6fc9106bda972", nil
+	case "eu-west-1":
+		return "ami-09e0c6b3d3cf906f1", nil
+	default:
+		return "", fmt.Errorf("Unable to resolve AMI for region %s and instance type %s", region, instanceType)
+	}
+}

--- a/pkg/ami/ami_suite_test.go
+++ b/pkg/ami/ami_suite_test.go
@@ -1,0 +1,13 @@
+package ami_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAmi(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ami Suite")
+}

--- a/pkg/ami/ami_test.go
+++ b/pkg/ami/ami_test.go
@@ -1,0 +1,72 @@
+package ami_test
+
+import (
+	"github.com/weaveworks/eksctl/pkg/ami"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AMI Resolution", func() {
+	type ResolveCase struct {
+		Region       string
+		InstanceType string
+		ExpectedAMI  string
+		ExpectError  bool
+	}
+
+	DescribeTable("When resolving an AMI to use",
+		func(c ResolveCase) {
+			actualAmi, err := ami.ResolveAMI(c.Region, c.InstanceType)
+			Expect(actualAmi).Should(Equal(c.ExpectedAMI))
+			if c.ExpectError {
+				Expect(err).Should(HaveOccurred())
+			} else {
+				Expect(err).ShouldNot(HaveOccurred())
+			}
+		},
+		Entry("with non-gpu instance and us-west-2", ResolveCase{
+			Region:       "us-west-2",
+			InstanceType: "t2.medium",
+			ExpectedAMI:  "ami-73a6e20b",
+			ExpectError:  false,
+		}),
+		Entry("with non-gpu instance and us-east-1", ResolveCase{
+			Region:       "us-east-1",
+			InstanceType: "t2.medium",
+			ExpectedAMI:  "ami-dea4d5a1",
+			ExpectError:  false,
+		}),
+		Entry("with non-gpu instance and non-eks enabled region", ResolveCase{
+			Region:       "ap-northeast-1",
+			InstanceType: "t2.medium",
+			ExpectedAMI:  "",
+			ExpectError:  true,
+		}),
+		Entry("with gpu (p2) instance and us-west-2", ResolveCase{
+			Region:       "us-west-2",
+			InstanceType: "p2.xlarge",
+			ExpectedAMI:  "ami-0d20f2404b9a1c4d1",
+			ExpectError:  false,
+		}),
+		Entry("with gpu (p3) instance and us-east-1", ResolveCase{
+			Region:       "us-east-1",
+			InstanceType: "p3.2xlarge",
+			ExpectedAMI:  "ami-09fe6fc9106bda972",
+			ExpectError:  false,
+		}),
+		Entry("with gpu (p2) instance and eu-west-1", ResolveCase{
+			Region:       "eu-west-1",
+			InstanceType: "p2.xlarge",
+			ExpectedAMI:  "ami-09e0c6b3d3cf906f1",
+			ExpectError:  false,
+		}),
+		Entry("with gpu (p3) instance and non-eks enabled region", ResolveCase{
+			Region:       "ap-northeast-1",
+			InstanceType: "p3.2xlarge",
+			ExpectedAMI:  "",
+			ExpectError:  true,
+		}),
+	)
+})

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -3,6 +3,9 @@ package builder
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+	"github.com/weaveworks/eksctl/pkg/ami"
+
 	cfn "github.com/aws/aws-sdk-go/service/cloudformation"
 	gfn "github.com/awslabs/goformation/cloudformation"
 
@@ -74,7 +77,11 @@ func (n *nodeGroupResourceSet) AddAllResources() error {
 	// - imporve validation of parameter set overall, probably in another package
 	// - validate custom AMI (check it's present) and instance type
 	if n.spec.NodeAMI == "" {
-		n.spec.NodeAMI = regionalAMIs[n.spec.Region]
+		ami, err := ami.ResolveAMI(n.spec.Region, n.spec.NodeType)
+		if err != nil {
+			return errors.Wrap(err, "Unable to determine AMI to use")
+		}
+		n.spec.NodeAMI = ami
 	}
 
 	if n.spec.MinNodes == 0 && n.spec.MaxNodes == 0 {

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table.go
@@ -1,0 +1,98 @@
+/*
+
+Table provides a simple DSL for Ginkgo-native Table-Driven Tests
+
+The godoc documentation describes Table's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo#table-driven-tests
+
+*/
+
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo"
+)
+
+/*
+DescribeTable describes a table-driven test.
+
+For example:
+
+    DescribeTable("a simple table",
+        func(x int, y int, expected bool) {
+            Ω(x > y).Should(Equal(expected))
+        },
+        Entry("x > y", 1, 0, true),
+        Entry("x == y", 0, 0, false),
+        Entry("x < y", 0, 1, false),
+    )
+
+The first argument to `DescribeTable` is a string description.
+The second argument is a function that will be run for each table entry.  Your assertions go here - the function is equivalent to a Ginkgo It.
+The subsequent arguments must be of type `TableEntry`.  We recommend using the `Entry` convenience constructors.
+
+The `Entry` constructor takes a string description followed by an arbitrary set of parameters.  These parameters are passed into your function.
+
+Under the hood, `DescribeTable` simply generates a new Ginkgo `Describe`.  Each `Entry` is turned into an `It` within the `Describe`.
+
+It's important to understand that the `Describe`s and `It`s are generated at evaluation time (i.e. when Ginkgo constructs the tree of tests and before the tests run).
+
+Individual Entries can be focused (with FEntry) or marked pending (with PEntry or XEntry).  In addition, the entire table can be focused or marked pending with FDescribeTable and PDescribeTable/XDescribeTable.
+*/
+func DescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, false, false)
+	return true
+}
+
+/*
+You can focus a table with `FDescribeTable`.  This is equivalent to `FDescribe`.
+*/
+func FDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, false, true)
+	return true
+}
+
+/*
+You can mark a table as pending with `PDescribeTable`.  This is equivalent to `PDescribe`.
+*/
+func PDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, true, false)
+	return true
+}
+
+/*
+You can mark a table as pending with `XDescribeTable`.  This is equivalent to `XDescribe`.
+*/
+func XDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, true, false)
+	return true
+}
+
+func describeTable(description string, itBody interface{}, entries []TableEntry, pending bool, focused bool) {
+	itBodyValue := reflect.ValueOf(itBody)
+	if itBodyValue.Kind() != reflect.Func {
+		panic(fmt.Sprintf("DescribeTable expects a function, got %#v", itBody))
+	}
+
+	if pending {
+		ginkgo.PDescribe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	} else if focused {
+		ginkgo.FDescribe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	} else {
+		ginkgo.Describe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	}
+}

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
@@ -1,0 +1,81 @@
+package table
+
+import (
+	"reflect"
+
+	"github.com/onsi/ginkgo"
+)
+
+/*
+TableEntry represents an entry in a table test.  You generally use the `Entry` constructor.
+*/
+type TableEntry struct {
+	Description string
+	Parameters  []interface{}
+	Pending     bool
+	Focused     bool
+}
+
+func (t TableEntry) generateIt(itBody reflect.Value) {
+	if t.Pending {
+		ginkgo.PIt(t.Description)
+		return
+	}
+
+	values := []reflect.Value{}
+	for i, param := range t.Parameters {
+		var value reflect.Value
+
+		if param == nil {
+			inType := itBody.Type().In(i)
+			value = reflect.Zero(inType)
+		} else {
+			value = reflect.ValueOf(param)
+		}
+
+		values = append(values, value)
+	}
+
+	body := func() {
+		itBody.Call(values)
+	}
+
+	if t.Focused {
+		ginkgo.FIt(t.Description, body)
+	} else {
+		ginkgo.It(t.Description, body)
+	}
+}
+
+/*
+Entry constructs a TableEntry.
+
+The first argument is a required description (this becomes the content of the generated Ginkgo `It`).
+Subsequent parameters are saved off and sent to the callback passed in to `DescribeTable`.
+
+Each Entry ends up generating an individual Ginkgo It.
+*/
+func Entry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, false, false}
+}
+
+/*
+You can focus a particular entry with FEntry.  This is equivalent to FIt.
+*/
+func FEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, false, true}
+}
+
+/*
+You can mark a particular entry as pending with PEntry.  This is equivalent to PIt.
+*/
+func PEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, true, false}
+}
+
+/*
+You can mark a particular entry as pending with XEntry.  This is equivalent to XIt.
+*/
+func XEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, true, false}
+}


### PR DESCRIPTION
### Description
If an AMI isn't specified then it will be resolved based
on region and instance type. It uses "resolvers" to do this.
Currebntly there are 2 resolvers:
- Default which uses the default EKS AMIs for a region
- GPU which for GPU instance types (p2 or p3) will use the
specific EKS GPU optimized image for a region.

This change also allows you to specify an AMI to use instead of
using resolution.

If using the GPU isntances then the NVIDIA device plugin will
still need to be installed manually:
https://github.com/NVIDIA/k8s-device-plugin
This will be an 'addon' in the future.

Issue #183

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [ ] All tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the README)
- [ ] Added yourself to the `humans.txt` file
