### PR TITLE
Minor fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ make build
 You can run the unit tests by simply doing
 
 ```bash
-make tests
+make test
 ```
 
 There are integration tests for *eksctl* being developed and more details of how to run them will be included here. You can follow the progress [here](https://github.com/weaveworks/eksctl/issues/151).

--- a/cmd/eksctl/create.go
+++ b/cmd/eksctl/create.go
@@ -67,7 +67,7 @@ func createClusterCmd() *cobra.Command {
 	fs.StringVarP(&cfg.ClusterName, "name", "n", "", fmt.Sprintf("EKS cluster name (generated if unspecified, e.g. %q)", exampleClusterName))
 
 	fs.StringVarP(&cfg.Region, "region", "r", DEFAULT_EKS_REGION, "AWS region")
-	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS creditials profile to use (overrides the AWS_PROFILE environment variable)")
+	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS credentials profile to use (overrides the AWS_PROFILE environment variable)")
 
 	fs.StringVarP(&cfg.NodeType, "node-type", "t", DEFAULT_NODE_TYPE, "node instance type")
 	fs.IntVarP(&cfg.Nodes, "nodes", "N", DEFAULT_NODE_COUNT, "total number of nodes (for a static ASG)")
@@ -142,7 +142,7 @@ func doCreateCluster(cfg *api.ClusterConfig, name string) error {
 		errs := stackManager.CreateClusterWithInitialNodeGroup()
 		// read any errors (it only gets non-nil errors)
 		if len(errs) > 0 {
-			logger.Info("%d error(s) occurred and cluster hasn't beend created properly, you may wish to check CloudFormation console", len(errs))
+			logger.Info("%d error(s) occurred and cluster hasn't been created properly, you may wish to check CloudFormation console", len(errs))
 			logger.Info("to cleanup resources, run 'eksctl delete cluster --region=%s --name=%s'", cfg.Region, cfg.ClusterName)
 			for _, err := range errs {
 				logger.Critical("%s\n", err.Error())

--- a/cmd/eksctl/delete.go
+++ b/cmd/eksctl/delete.go
@@ -46,7 +46,7 @@ func deleteClusterCmd() *cobra.Command {
 	fs.StringVarP(&cfg.ClusterName, "name", "n", "", "EKS cluster name (required)")
 
 	fs.StringVarP(&cfg.Region, "region", "r", DEFAULT_EKS_REGION, "AWS region")
-	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS creditials profile to use (overrides the AWS_PROFILE environment variable)")
+	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS credentials profile to use (overrides the AWS_PROFILE environment variable)")
 
 	fs.DurationVar(&cfg.WaitTimeout, "timeout", api.DefaultWaitTimeout, "max wait time in any polling operations")
 

--- a/cmd/eksctl/get.go
+++ b/cmd/eksctl/get.go
@@ -55,7 +55,7 @@ func getClusterCmd() *cobra.Command {
 	fs.IntVar(&chunkSize, "chunk-size", DEFAULT_CHUNK_SIZE, "Return large lists in chunks rather than all at once. Pass 0 to disable.")
 
 	fs.StringVarP(&cfg.Region, "region", "r", DEFAULT_EKS_REGION, "AWS region")
-	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS creditials profile to use (overrides the AWS_PROFILE environment variable)")
+	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS credentials profile to use (overrides the AWS_PROFILE environment variable)")
 
 	fs.StringVarP(&output, "output", "o", "table", "Specifies the output format. Choose from table,json,yaml. Defaults to table.")
 	return cmd

--- a/cmd/eksctl/utils.go
+++ b/cmd/eksctl/utils.go
@@ -105,7 +105,7 @@ func writeKubeconfigCmd() *cobra.Command {
 	fs.StringVarP(&cfg.ClusterName, "name", "n", "", "EKS cluster name (required)")
 
 	fs.StringVarP(&cfg.Region, "region", "r", DEFAULT_EKS_REGION, "AWS region")
-	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS creditials profile to use (overrides the AWS_PROFILE environment variable)")
+	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS credentials profile to use (overrides the AWS_PROFILE environment variable)")
 
 	fs.BoolVar(&utilsAutoKubeconfigPath, "auto-kubeconfig", false, fmt.Sprintf("save kubconfig file by cluster name – %q", kubeconfig.AutoPath("<name>")))
 	fs.StringVar(&utilsKubeconfigOutputPath, "kubeconfig", kubeconfig.DefaultPath, "path to write kubeconfig")

--- a/humans.txt
+++ b/humans.txt
@@ -17,6 +17,7 @@ Archis                  @archisgore
 Stefan Prodan           @stefanprodan
 James Strachan          @jstrachan
 Nick                    @bowlesns
+Kirsten Schumy          @kschumy
 
 /* Thanks */
 

--- a/pkg/az/az.go
+++ b/pkg/az/az.go
@@ -15,7 +15,7 @@ const (
 )
 
 // SelectionStrategy provides an interface to allow changing the strategy used to
-// select availaibility zones to use from a list available.
+// select availability zones to use from a list available.
 type SelectionStrategy interface {
 	Select(availableZones []string) []string
 }
@@ -60,7 +60,7 @@ type ZonesToAvoidRule struct {
 	zonesToAvoid map[string]bool
 }
 
-// CanUseZone checks if the zupplied zone is in the list of zones to be avoided.
+// CanUseZone checks if the supplied zone is in the list of zones to be avoided.
 func (za *ZonesToAvoidRule) CanUseZone(zone *ec2.AvailabilityZone) bool {
 	_, avoidZone := za.zonesToAvoid[*zone.ZoneName]
 	return !avoidZone
@@ -80,7 +80,7 @@ type AvailabilityZoneSelector struct {
 }
 
 // NewSelectorWithDefaults create a new AvailabilityZoneSelector with the
-// defaukt selection strategy and usage rules
+// default selection strategy and usage rules
 func NewSelectorWithDefaults(ec2api ec2iface.EC2API) *AvailabilityZoneSelector {
 	avoidZones := map[string]bool{
 		// well-known over-populated zones
@@ -141,7 +141,7 @@ func (a *AvailabilityZoneSelector) getZonesForRegion(regionName string) ([]*ec2.
 
 	output, err := a.ec2api.DescribeAvailabilityZones(input)
 	if err != nil {
-		return nil, errors.Wrapf(err, "getting availibility zones for %s", regionName)
+		return nil, errors.Wrapf(err, "getting availability zones for %s", regionName)
 	}
 
 	return output.AvailabilityZones, nil

--- a/pkg/az/az_test.go
+++ b/pkg/az/az_test.go
@@ -20,14 +20,12 @@ var _ = Describe("AZ", func() {
 
 	Describe("When calling SelectZones", func() {
 		var (
-			zonesToAvoid []*ec2.AvailabilityZone
-			c            *eks.ClusterProvider
-			p            *testutils.MockProvider
-			err          error
+			p   *testutils.MockProvider
+			err error
 		)
 
 		BeforeEach(func() {
-			zonesToAvoid = avoidedZones(ec2.AvailabilityZoneStateAvailable)
+			avoidedZones(ec2.AvailabilityZoneStateAvailable)
 		})
 
 		Context("with a region that has no zones to avoid", func() {
@@ -45,7 +43,7 @@ var _ = Describe("AZ", func() {
 					region = aws.String("us-west-2")
 
 					zones = usWest2Zones(ec2.AvailabilityZoneStateAvailable)
-					c, p = createProviders()
+					_, p = createProviders()
 
 					p.MockEC2().On("DescribeAvailabilityZones",
 						mock.MatchedBy(func(input *ec2.DescribeAvailabilityZonesInput) bool {
@@ -87,7 +85,7 @@ var _ = Describe("AZ", func() {
 					expectedZoneName = westZone.ZoneName
 					zones = []*ec2.AvailabilityZone{westZone}
 
-					c, p = createProviders()
+					_, p = createProviders()
 
 					p.MockEC2().On("DescribeAvailabilityZones",
 						mock.MatchedBy(func(input *ec2.DescribeAvailabilityZonesInput) bool {
@@ -136,7 +134,7 @@ var _ = Describe("AZ", func() {
 				expectedZoneName = aws.String("us-east-1c")
 
 				zones = usEast1Zones(ec2.AvailabilityZoneStateAvailable)
-				c, p = createProviders()
+				_, p = createProviders()
 
 				p.MockEC2().On("DescribeAvailabilityZones",
 					mock.MatchedBy(func(input *ec2.DescribeAvailabilityZonesInput) bool {
@@ -179,7 +177,7 @@ var _ = Describe("AZ", func() {
 				azSelector    *AvailabilityZoneSelector
 			)
 			BeforeEach(func() {
-				c, p = createProviders()
+				_, p = createProviders()
 
 				p.MockEC2().On("DescribeAvailabilityZones",
 					mock.MatchedBy(func(input *ec2.DescribeAvailabilityZonesInput) bool {

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -71,7 +71,7 @@ func (n *nodeGroupResourceSet) AddAllResources() error {
 	n.rs.newNumberParameter(ParamNodeGroupID, "")
 
 	// TODO: https://github.com/weaveworks/eksctl/issues/28
-	// - imporve validation of parameter set overall, probably in another package
+	// - improve validation of parameter set overall, probably in another package
 	// - validate custom AMI (check it's present) and instance type
 	if n.spec.NodeAMI == "" {
 		n.spec.NodeAMI = regionalAMIs[n.spec.Region]

--- a/pkg/cfn/builder/outputs.go
+++ b/pkg/cfn/builder/outputs.go
@@ -74,7 +74,7 @@ func doSetOutput(field reflect.Value, key, value string) error {
 }
 
 // doSetOutputAsSlice sets output for fields of slice kind, it supports
-// []string (for comman-separated lists defined with newJoinedOutput)
+// []string (for comma-separated lists defined with newJoinedOutput)
 // and []byte (for BASE64-encoded values)
 func doSetOutputAsSlice(field reflect.Value, key, value string) error {
 	switch field.Type() {
@@ -98,7 +98,7 @@ func doSetOutputAsSlice(field reflect.Value, key, value string) error {
 
 // GetAllOutputs collects all outputs from an instance of an active stack,
 // the outputs are defined by the current resourceSet, and are generally
-// private to how builder choses to define them. The destination obj is
+// private to how builder chooses to define them. The destination obj is
 // where outputs will be stored, it's fields are expected to match those
 // that are known to the builder (namely, those are the cfnOutput* contants).
 func (r *resourceSet) GetAllOutputs(stack cfn.Stack, obj interface{}) error {

--- a/pkg/cfn/manager/tasks.go
+++ b/pkg/cfn/manager/tasks.go
@@ -8,10 +8,10 @@ import (
 
 type task func(chan error) error
 
-// Run a set of tests in paralle and wait for them to complete;
+// Run a set of tests in parallel and wait for them to complete;
 // passError should take any errors and do what it needs to in
 // a given context, e.g. duing serial CLI-driven execution one
-// can keep errors in a slice, while in a deamon channel maybe
+// can keep errors in a slice, while in a daemon channel maybe
 // more suitable
 func Run(passError func(error), tasks ...task) {
 	wg := &sync.WaitGroup{}
@@ -38,7 +38,7 @@ func Run(passError func(error), tasks ...task) {
 
 // CreateClusterWithInitialNodeGroup runs two tasks to create
 // the stacks for use with CLI; any errors will be returned
-// as a slice on completion of one of the two taks
+// as a slice on completion of one of the two tasks
 func (s *StackCollection) CreateClusterWithInitialNodeGroup() []error {
 	errs := []error{}
 	appendErr := func(err error) {

--- a/pkg/cfn/manager/waiters.go
+++ b/pkg/cfn/manager/waiters.go
@@ -173,7 +173,7 @@ func (c *StackCollection) doWaitUntilStackIsDeleted(name string) error {
 			// you do get stack with StackStatusDeleteComplete on ListStacks,
 			// but that returns pages and pages, so we don't actually want
 			// to worry about that, in fact it also returns ones that had
-			// the same name but were deted a long time ago
+			// the same name but were dated a long time ago
 			request.WaiterAcceptor{
 				State:    request.SuccessWaiterState,
 				Matcher:  request.ErrorWaiterMatch,


### PR DESCRIPTION
### Description
- Fixed some typos.
- Fixed `az_test.go` build fail when running tests with Go 1.11. The build would fail due to vet checking for unused variables.

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the README)
- [x] Added yourself to the `humans.txt` file
