### PR TITLE
Fix the full-ecr-access flag to give power user instead of read only

### DIFF
--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -86,9 +86,9 @@ func (n *nodeGroupResourceSet) addResourcesForIAM() {
 		n.spec.NodePolicyARNs = iamDefaultNodePolicyARNs
 	}
 	if n.spec.Addons.WithIAM.PolicyAmazonEC2ContainerRegistryPowerUser {
-		n.spec.NodePolicyARNs = append(n.spec.NodePolicyARNs, iamPolicyAmazonEC2ContainerRegistryReadOnlyARN)
-	} else {
 		n.spec.NodePolicyARNs = append(n.spec.NodePolicyARNs, iamPolicyAmazonEC2ContainerRegistryPowerUserARN)
+	} else {
+		n.spec.NodePolicyARNs = append(n.spec.NodePolicyARNs, iamPolicyAmazonEC2ContainerRegistryReadOnlyARN)
 	}
 
 	refIR := n.newResource("NodeInstanceRole", &gfn.AWSIAMRole{


### PR DESCRIPTION
### Description
When using a command like `eksctl create cluster --full-ecr-access --name MyCluster --region us-east-1 --profile my-profile` then the IAM role for accessing ECR would have the policy `AmazonEC2ContainerRegistryReadOnly` instead of `AmazonEC2ContainerRegistryPowerUser`.

### Workarounds

* Find the user in the AWS Console and remove the `AmazonEC2ContainerRegistryReadOnly` policy and add the `AmazonEC2ContainerRegistryPowerUser` policy.
* Don't use the `--full-ecr-access` flag in `eksctl create cluster` command.

### Checklist
- [X] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [X] All tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the README)
- [ ] Added yourself to the `humans.txt` file