### PR TITLE
fixed typo in utils.go from "Descirbe" to "Describe"

### DIFF
--- a/cmd/eksctl/utils.go
+++ b/cmd/eksctl/utils.go
@@ -177,7 +177,7 @@ func describeStacksCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "describe-stacks",
-		Short: "Descirbe CloudFormation stack for a given cluster",
+		Short: "Describe CloudFormation stack for a given cluster",
 		Run: func(_ *cobra.Command, args []string) {
 			if err := doDescribeStacksCmd(cfg, getNameArg(args)); err != nil {
 				logger.Critical("%s\n", err.Error())


### PR DESCRIPTION
### Description
Changed short description of describe-stacks command to have the correct spelling for "Describe"
