### PR TITLE
Storage Class flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ To create the same kind of basic cluster, but with a different name, run:
 eksctl create cluster --name=cluster-1 --nodes=4
 ```
 
+To prevent a default StorageClass of gp2 provisioned by EBS:
+
+```
+eksctl create cluster --storage-class=false
+```
+
 To write cluster credentials to a file other than default, run:
 
 ```

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To create the same kind of basic cluster, but with a different name, run:
 eksctl create cluster --name=cluster-1 --nodes=4
 ```
 
-To prevent a default StorageClass of gp2 provisioned by EBS:
+A default [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) (gp2 volume type provisioned by EBS) will be added automatically when creating a cluster.  If you want to prevent this, use the `--storage-class` flag.  For example:
 
 ```
 eksctl create cluster --storage-class=false

--- a/cmd/eksctl/create.go
+++ b/cmd/eksctl/create.go
@@ -91,7 +91,7 @@ func createClusterCmd() *cobra.Command {
 	fs.DurationVar(&cfg.WaitTimeout, "timeout", api.DefaultWaitTimeout, "max wait time in any polling operations")
 
 	fs.BoolVar(&cfg.Addons.WithIAM.PolicyAmazonEC2ContainerRegistryPowerUser, "full-ecr-access", false, "enable full access to ECR")
-	fs.BoolVar(&cfg.Addons.Storage, "storage-class", true, "if true then a default StorageClass of type gp2 provisioned by EBS will be created")
+	fs.BoolVar(&cfg.Addons.Storage, "storage-class", true, "if true (default) then a default StorageClass of type gp2 provisioned by EBS will be created")
 
 	fs.StringVar(&cfg.NodeAMI, "node-ami", ami.ResolverStatic, "Advanced use cases only. If 'static' is supplied (default) then eksctl will use static AMIs; if 'auto' is supplied then eksctl will automatically set the AMI based on region/instance type; if any other value is supplied it will override the AMI to use for the nodes. Use with extreme care.")
 

--- a/pkg/eks/api/api.go
+++ b/pkg/eks/api/api.go
@@ -70,6 +70,7 @@ type ClusterConfig struct {
 
 type ClusterAddons struct {
 	WithIAM AddonIAM
+	Storage bool
 }
 
 type AddonIAM struct {

--- a/pkg/eks/storageclass.go
+++ b/pkg/eks/storageclass.go
@@ -1,0 +1,39 @@
+package eks
+
+import (
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+func (c *ClusterProvider) AddDefaultStorageClass(clientSet *clientset.Clientset) error {
+
+	rp := corev1.PersistentVolumeReclaimRetain
+
+	scb := &storage.StorageClass{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "StorageClass",
+			APIVersion: "storage.k8s.io/v1",
+		},
+		Provisioner: "kubernetes.io/aws-ebs",
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gp2",
+			Annotations: map[string]string{
+				"storageclass.kubernetes.io/is-default-class": "true",
+			},
+		},
+		Parameters: map[string]string{
+			"type": "gp2",
+		},
+		ReclaimPolicy: &rp,
+		MountOptions:  []string{"debug"},
+	}
+
+	if _, err := clientSet.StorageV1().StorageClasses().Create(scb); err != nil {
+		return errors.Wrap(err, "adding default StorageClass of gp2")
+	}
+
+	return nil
+}

--- a/pkg/eks/storageclass.go
+++ b/pkg/eks/storageclass.go
@@ -1,6 +1,7 @@
 package eks
 
 import (
+	"github.com/kubicorn/kubicorn/pkg/logger"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
@@ -30,6 +31,7 @@ func (c *ClusterProvider) AddDefaultStorageClass(clientSet *clientset.Clientset)
 		ReclaimPolicy: &rp,
 		MountOptions:  []string{"debug"},
 	}
+	logger.Debug("Creating a StorageClass as default")
 
 	if _, err := clientSet.StorageV1().StorageClasses().Create(scb); err != nil {
 		return errors.Wrap(err, "adding default StorageClass of gp2")


### PR DESCRIPTION
### Description
The optional flag of `--storage-class` is set to true unless the user decides to exclude it with the flag `eksctl create cluster --storage-class=false`.  The new cluster will contain a default StorageClass of gp2 provisioned by EBS. That can be confirmed using the `kubectl get storageclass` command. 

Issue #175 
Note - Discussed making the flag a string with StorageClass type, but decided to make it a bool flag instead that creates a gp2 type and sets it as default to better capture the typical use case, without putting more burden on the user.

### Checklist
- [X] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [X] All tests passing (i.e. `make test`)
- [X] Added/modified documentation as required (such as the README)
- [X] Added yourself to the `humans.txt` file (added myself in previous PR)
