### PR TITLE
WIP: Allow 443 between control plane  and nodes

### DIFF
--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -103,6 +103,14 @@ func (n *nodeGroupResourceSet) addResourcesForSecurityGroups() {
 		FromPort:              nodeMinPort,
 		ToPort:                nodeMaxPort,
 	})
+	n.newResource("IngressInterClusterAPI", &gfn.AWSEC2SecurityGroupIngress{
+		GroupId:               refSG,
+		SourceSecurityGroupId: refCP,
+		Description:           gfn.NewString("Allow control plane to communicate with " + desc + " (API)"),
+		IpProtocol:            tcp,
+		FromPort:              apiPort,
+		ToPort:                apiPort,
+	})
 	n.newResource("EgressInterCluster", &gfn.AWSEC2SecurityGroupEgress{
 		GroupId:                    refCP,
 		DestinationSecurityGroupId: refSG,


### PR DESCRIPTION
### Description
To help with metrics collection from the nodes
port 443 has been opened between the control plane
and node group.

Issue #233

### Checklist
- [ ] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [ ] All tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the README)
- [ ] Added yourself to the `humans.txt` file
