### PR TITLE
Fixed test name

### DIFF
--- a/pkg/utils/kubeconfig/kubeconfig_suite_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestPrinters(t *testing.T) {
+func TestKubeConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "KubeConfig Suite")
 }


### PR DESCRIPTION
### Description
The test name for the kubeconfig package was incorrect and
so its been changed.

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the README)
- [ ] Added yourself to the `humans.txt` file
