### PR TITLE
Add integration tests and update cleanup

### DIFF
--- a/tests/integration/cleanup.go
+++ b/tests/integration/cleanup.go
@@ -17,31 +17,18 @@ func CleanupAws(clusterName string, region string) {
 		}
 	}
 
-	stackName := fmt.Sprintf("EKS-%s-DefaultNodeGroup", clusterName)
+	stackName := fmt.Sprintf("eksctl-%s-cluster", clusterName)
 	if found, _ := aws.StackExists(stackName, session); found {
 		if err := aws.DeleteStack(stackName, session); err != nil {
-			logger.Debug("DefaultNodeGroup stack couldn't be deleted: %v", err)
+			logger.Debug("Cluster stack couldn't be deleted: %v", err)
 		}
 	}
 
-	stackName = fmt.Sprintf("EKS-%s-VPC", clusterName)
+	stackName = fmt.Sprintf("eksctl-%s-nodegroup-%d", clusterName, 0)
 	if found, _ := aws.StackExists(stackName, session); found {
 		if err := aws.DeleteStack(stackName, session); err != nil {
-			logger.Debug("VPC stack couldn't be deleted: %v", err)
+			logger.Debug("NodeGroup stack couldn't be deleted: %v", err)
 		}
 	}
 
-	stackName = fmt.Sprintf("EKS-%s-ControlPlane", clusterName)
-	if found, _ := aws.StackExists(stackName, session); found {
-		if err := aws.DeleteStack(stackName, session); err != nil {
-			logger.Debug("ControlPlane stack couldn't be deleted: %v", err)
-		}
-	}
-
-	stackName = fmt.Sprintf("EKS-%s-ServiceRole", clusterName)
-	if found, _ := aws.StackExists(stackName, session); found {
-		if err := aws.DeleteStack(stackName, session); err != nil {
-			logger.Debug("ServiceRole stack couldn't be deleted: %v", err)
-		}
-	}
 }

--- a/tests/integration/create_get_delete/integration_test.go
+++ b/tests/integration/create_get_delete/integration_test.go
@@ -30,6 +30,7 @@ import (
 const (
 	createTimeout = 20
 	deleteTimeout = 10
+	getTimeout    = 1
 	region        = "us-west-2"
 )
 
@@ -184,6 +185,31 @@ var _ = Describe("Create (Integration)", func() {
 					Expect(js.(map[string]interface{})).To(HaveKeyWithValue("version", "1.0.1"))
 				}
 			})
+		})
+	})
+
+	Describe("when listing clusters", func() {
+		var (
+			err     error
+			session *gexec.Session
+		)
+
+		It("should not return an error", func() {
+			args := []string{"get", "cluster", "--region", region}
+
+			command := exec.Command(eksctlPath, args...)
+			session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
+
+			if err != nil {
+				Fail(fmt.Sprintf("error starting process: %v", err), 1)
+			}
+
+			session.Wait(getTimeout * time.Minute)
+			Expect(session.ExitCode()).Should(Equal(0))
+		})
+
+		It("should return the previously created cluster", func() {
+			Expect(string(session.Buffer().Contents())).To(ContainSubstring(clusterName))
 		})
 	})
 

--- a/tests/integration/create_get_delete/integration_test.go
+++ b/tests/integration/create_get_delete/integration_test.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	createTimeout = 20
+	deleteTimeout = 10
 	region        = "us-west-2"
 )
 
@@ -184,6 +185,45 @@ var _ = Describe("Create (Integration)", func() {
 				}
 			})
 		})
+	})
+
+	Describe("when deleting a cluster", func() {
+		var (
+			err     error
+			session *gexec.Session
+		)
+
+		if !doDelete {
+			fmt.Fprintf(GinkgoWriter, "will not delete cluster %s", clusterName)
+			return
+		}
+
+		It("should not return an error", func() {
+			args := []string{"delete", "cluster", "--name", clusterName, "--region", region}
+
+			command := exec.Command(eksctlPath, args...)
+			session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
+
+			if err != nil {
+				Fail(fmt.Sprintf("error starting process: %v", err), 1)
+			}
+
+			session.Wait(deleteTimeout * time.Minute)
+			Expect(session.ExitCode()).Should(Equal(0))
+		})
+
+		It("should have deleted the EKS cluster", func() {
+			session := aws.NewSession(region)
+			Expect(session).ToNot(HaveEksCluster(clusterName, awseks.ClusterStatusActive, "1.10"))
+		})
+
+		It("should have the required cloudformation stacks", func() {
+			session := aws.NewSession(region)
+
+			Expect(session).ToNot(HaveCfnStack(fmt.Sprintf("eksctl-%s-cluster", clusterName)))
+			Expect(session).ToNot(HaveCfnStack(fmt.Sprintf("eksctl-%s-nodegroup-%d", clusterName, 0)))
+		})
+
 	})
 })
 


### PR DESCRIPTION
### Description
The initial issue #208 covers updating the stack names in the cleanup, but @richardcase mentioned the lack of coverage in the `get cluster` and `delete cluster` commands.

These tests were added and the stack names updated.

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the README)
- [ ] Added yourself to the `humans.txt` file
