### PR TITLE
Add wait flag for delete cluster command

### DIFF
--- a/cmd/eksctl/delete.go
+++ b/cmd/eksctl/delete.go
@@ -14,6 +14,10 @@ import (
 	"github.com/weaveworks/eksctl/pkg/utils/kubeconfig"
 )
 
+var (
+	waitDelete bool
+)
+
 func deleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
@@ -50,6 +54,8 @@ func deleteClusterCmd() *cobra.Command {
 
 	fs.StringVarP(&cfg.Region, "region", "r", "", "AWS region")
 	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS credentials profile to use (overrides the AWS_PROFILE environment variable)")
+
+	fs.BoolVarP(&waitDelete, "wait", "w", false, "Wait for deletion of all resources before exiting")
 
 	fs.DurationVar(&cfg.WaitTimeout, "timeout", api.DefaultWaitTimeout, "max wait time in any polling operations")
 
@@ -93,15 +99,28 @@ func doDeleteCluster(cfg *api.ClusterConfig, name string) error {
 
 	stackManager := ctl.NewStackManager()
 
-	handleIfError(stackManager.WaitDeleteNodeGroup(), "node group")
-	if handleIfError(stackManager.DeleteCluster(), "cluster") {
+	if waitDelete {
+		handleIfError(stackManager.WaitDeleteNodeGroup(), "node group")
+	} else {
+		handleIfError(stackManager.DeleteNodeGroup(), "node group")
+	}
+
+	var clusterErr bool
+	if waitDelete {
+		clusterErr = handleIfError(stackManager.WaitDeleteCluster(), "cluster")
+	} else {
+		clusterErr = handleIfError(stackManager.DeleteCluster(), "cluster")
+	}
+
+	if clusterErr {
 		if handleIfError(ctl.DeprecatedDeleteControlPlane(), "control plane") {
-			handleIfError(stackManager.DeprecatedDeleteStackControlPlane(), "stack control plane")
+			handleIfError(stackManager.DeprecatedDeleteStackControlPlane(waitDelete), "stack control plane")
 		}
 	}
-	handleIfError(stackManager.DeprecatedDeleteStackServiceRole(), "node group")
-	handleIfError(stackManager.DeprecatedDeleteStackVPC(), "stack VPC")
-	handleIfError(stackManager.DeprecatedDeleteStackDefaultNodeGroup(), "default node group")
+
+	handleIfError(stackManager.DeprecatedDeleteStackServiceRole(waitDelete), "node group")
+	handleIfError(stackManager.DeprecatedDeleteStackVPC(waitDelete), "stack VPC")
+	handleIfError(stackManager.DeprecatedDeleteStackDefaultNodeGroup(waitDelete), "default node group")
 
 	ctl.MaybeDeletePublicSSHKey()
 

--- a/humans.txt
+++ b/humans.txt
@@ -22,6 +22,7 @@ Kirsten Schumy          @kschumy
 Karinna Iniguez         @karinnainiguez
 Michael Seiwald         @mseiwald
 Anton Gruebel           @gruebel
+Bryan Peterson          @lazyshot
 
 /* Thanks */
 

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -27,3 +27,8 @@ func (c *StackCollection) DeleteCluster() error {
 	_, err := c.DeleteStack(c.makeClusterStackName())
 	return err
 }
+
+// WaitDeleteCluster waits till the cluster is deleted
+func (c *StackCollection) WaitDeleteCluster() error {
+	return c.WaitDeleteStack(c.makeClusterStackName())
+}

--- a/pkg/cfn/manager/deprecated.go
+++ b/pkg/cfn/manager/deprecated.go
@@ -1,25 +1,57 @@
 package manager
 
 // DeprecatedDeleteStackVPC deletes the VPC stack
-func (c *StackCollection) DeprecatedDeleteStackVPC() error {
-	_, err := c.DeleteStack("EKS-" + c.spec.ClusterName + "-VPC")
+func (c *StackCollection) DeprecatedDeleteStackVPC(wait bool) error {
+	var err error
+	stackName := "EKS-" + c.spec.ClusterName + "-VPC"
+
+	if wait {
+		err = c.WaitDeleteStack(stackName)
+	} else {
+		_, err = c.DeleteStack(stackName)
+	}
+
 	return err
 }
 
 // DeprecatedDeleteStackServiceRole deletes the service role stack
-func (c *StackCollection) DeprecatedDeleteStackServiceRole() error {
-	_, err := c.DeleteStack("EKS-" + c.spec.ClusterName + "-ServiceRole")
+func (c *StackCollection) DeprecatedDeleteStackServiceRole(wait bool) error {
+	var err error
+	stackName := "EKS-" + c.spec.ClusterName + "-ServiceRole"
+
+	if wait {
+		err = c.WaitDeleteStack(stackName)
+	} else {
+		_, err = c.DeleteStack(stackName)
+	}
+
 	return err
 }
 
 // DeprecatedDeleteStackDefaultNodeGroup deletes the default node group stack
-func (c *StackCollection) DeprecatedDeleteStackDefaultNodeGroup() error {
-	_, err := c.DeleteStack("EKS-" + c.spec.ClusterName + "-DefaultNodeGroup")
+func (c *StackCollection) DeprecatedDeleteStackDefaultNodeGroup(wait bool) error {
+	var err error
+	stackName := "EKS-" + c.spec.ClusterName + "-DefaultNodeGroup"
+
+	if wait {
+		err = c.WaitDeleteStack(stackName)
+	} else {
+		_, err = c.DeleteStack(stackName)
+	}
+
 	return err
 }
 
 // DeprecatedDeleteStackControlPlane deletes the control plane stack
-func (c *StackCollection) DeprecatedDeleteStackControlPlane() error {
-	_, err := c.DeleteStack("EKS-" + c.spec.ClusterName + "-ControlPlane")
+func (c *StackCollection) DeprecatedDeleteStackControlPlane(wait bool) error {
+	var err error
+	stackName := "EKS-" + c.spec.ClusterName + "-ControlPlane"
+
+	if wait {
+		err = c.WaitDeleteStack(stackName)
+	} else {
+		_, err = c.DeleteStack(stackName)
+	}
+
 	return err
 }


### PR DESCRIPTION
Issue #213

### Description
Adding ability for a user to have the delete cluster command
wait until all resources are removed before exiting.

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the README)
- [x] Added yourself to the `humans.txt` file
