### PR TITLE
Add Cluster-Autoscaling IAM

### DIFF
--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -132,5 +132,18 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 		},
 	)
 
+	if n.spec.Addons.WithIAM.PolicyAutoScaling {
+		n.rs.attachAllowPolicy("PolicyAutoScaling", refIR, "*",
+			[]string{
+				"autoscaling:DescribeAutoScalingGroups",
+				"autoscaling:DescribeAutoScalingInstances",
+				"autoscaling:DescribeLaunchConfigurations",
+				"autoscaling:DescribeTags",
+				"autoscaling:SetDesiredCapacity",
+				"autoscaling:TerminateInstanceInAutoScalingGroup",
+			},
+		)
+	}
+
 	n.rs.newOutputFromAtt(cfnOutputNodeInstanceRoleARN, "NodeInstanceRole.Arn", true)
 }

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -79,6 +79,7 @@ func createClusterCmd() *cobra.Command {
 	fs.DurationVar(&cfg.WaitTimeout, "timeout", api.DefaultWaitTimeout, "max wait time in any polling operations")
 
 	fs.BoolVar(&cfg.Addons.WithIAM.PolicyAmazonEC2ContainerRegistryPowerUser, "full-ecr-access", false, "enable full access to ECR")
+	fs.BoolVar(&cfg.Addons.WithIAM.PolicyAutoScaling, "asg-access", false, "enable iam policy dependency for cluster-autoscaler")
 	fs.BoolVar(&cfg.Addons.Storage, "storage-class", true, "if true (default) then a default StorageClass of type gp2 provisioned by EBS will be created")
 
 	fs.StringVar(&cfg.NodeAMI, "node-ami", ami.ResolverStatic, "Advanced use cases only. If 'static' is supplied (default) then eksctl will use static AMIs; if 'auto' is supplied then eksctl will automatically set the AMI based on region/instance type; if any other value is supplied it will override the AMI to use for the nodes. Use with extreme care.")

--- a/pkg/eks/api/api.go
+++ b/pkg/eks/api/api.go
@@ -92,4 +92,5 @@ type ClusterAddons struct {
 // AddonIAM provides an addon for the AWS IAM integration
 type AddonIAM struct {
 	PolicyAmazonEC2ContainerRegistryPowerUser bool
+	PolicyAutoScaling                         bool
 }


### PR DESCRIPTION
Adds the ability and flag for requesting the necessary
policy for the cluster-autoscaler application. This will
be revisited once the add-on work is done.

Issue #170

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)
