### PR TITLE
 Add `--vpc-cidr` flag

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1137,7 +1137,6 @@
   version = "kubernetes-1.11.3"
 
 [[projects]]
-  branch = "master"
   name = "k8s.io/kops"
   packages = [
     ".",
@@ -1169,6 +1168,7 @@
     "pkg/resources/spotinst",
     "pkg/sshcredentials",
     "pkg/try",
+    "pkg/util/subnet",
     "pkg/values",
     "protokube/pkg/etcd",
     "upup/pkg/fi",
@@ -1180,7 +1180,8 @@
     "util/pkg/tables",
     "util/pkg/vfs"
   ]
-  revision = "c33ac16c2d87fd25774f3200d1250f9315942dc6"
+  revision = "17a2c474956b3aa8513124efe6f5f431212e5216"
+  source = "https://github.com/errordeveloper/kops"
 
 [[projects]]
   branch = "master"
@@ -1253,6 +1254,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "501e3f4f9a5740c2dad2a856704e69687621d244654b702690d3c2de98e595d9"
+  inputs-digest = "75f8d73c54982feb2bc70d55e89b303a3cbd3b8154402bad9c01d70a1bda9630"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,7 +42,8 @@ required = [
 
 [[constraint]]
   name = "k8s.io/kops"
-  branch = "master"
+  source = "https://github.com/errordeveloper/kops"
+  revision = "17a2c474956b3aa8513124efe6f5f431212e5216"
 
 # copied from https://github.com/kubernetes/kops/blob/master/Gopkg.toml
 [[override]]

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,12 @@ build: ## Build eksctl
 test: generate ## Run unit tests
 	@git diff --exit-code pkg/nodebootstrap/assets.go > /dev/null || (git --no-pager diff; exit 1)
 	@git diff --exit-code ./pkg/eks/mocks > /dev/null || (git --no-pager diff; exit 1)
-	@CGO_ENABLED=0 go test -v -covermode=count -coverprofile=coverage.out ./pkg/... ./cmd/...
+	@$(MAKE) unit-test
 	@test -z $(COVERALLS_TOKEN) || $(GOPATH)/bin/goveralls -coverprofile=coverage.out -service=circle-ci
+
+.PHONY: unit-test
+unit-test:
+	@CGO_ENABLED=0 go test -v -covermode=count -coverprofile=coverage.out ./pkg/... ./cmd/...
 
 LINTER ?= gometalinter ./...
 .PHONY: lint

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -111,7 +111,7 @@ func (n *NodeGroupResourceSet) addResourcesForNodeGroup() {
 	// and tags don't have `PropagateAtLaunch` field, so we have a custom method here until this gets resolved
 	var vpcZoneIdentifier interface{}
 	if len(n.spec.AvailabilityZones) > 0 {
-		vpcZoneIdentifier = n.clusterSpec.VPC.SubnetIDs(api.SubnetTopologyPublic)
+		vpcZoneIdentifier = n.clusterSpec.SubnetIDs(api.SubnetTopologyPublic)
 	} else {
 		vpcZoneIdentifier = map[string][]interface{}{
 			gfn.FnSplit: []interface{}{

--- a/pkg/eks/api/api.go
+++ b/pkg/eks/api/api.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"net"
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
@@ -38,7 +37,7 @@ var SupportedRegions = []string{
 var DefaultWaitTimeout = 20 * time.Minute
 
 // DefaultNodeCount defines the default number of nodes to be created
-var DefaultNodeCount = 2
+const DefaultNodeCount = 2
 
 // ClusterProvider provides an interface with the needed AWS APIs
 type ClusterProvider interface {
@@ -57,7 +56,7 @@ type ClusterConfig struct {
 
 	WaitTimeout time.Duration
 
-	VPC ClusterVPC
+	VPC *ClusterVPC
 
 	NodeGroups []*NodeGroup
 
@@ -76,29 +75,14 @@ type ClusterConfig struct {
 // it doesn't include initial nodegroup, so user must
 // call NewNodeGroup to create one
 func NewClusterConfig() *ClusterConfig {
-	return &ClusterConfig{}
-}
-
-// SetSubnets defines CIDRs for each of the subnets,
-// it must be called after SetAvailabilityZones
-func (c *ClusterConfig) SetSubnets() {
-	_, c.VPC.CIDR, _ = net.ParseCIDR("192.168.0.0/16")
-
-	c.VPC.Subnets = map[SubnetTopology]map[string]Network{
-		SubnetTopologyPublic: map[string]Network{},
+	cfg := &ClusterConfig{
+		VPC: &ClusterVPC{},
 	}
 
-	zoneCIDRs := []string{
-		"192.168.64.0/18",
-		"192.168.128.0/18",
-		"192.168.192.0/18",
-	}
-	for i, zone := range c.AvailabilityZones {
-		_, zoneCIDR, _ := net.ParseCIDR(zoneCIDRs[i])
-		c.VPC.Subnets[SubnetTopologyPublic][zone] = Network{
-			CIDR: zoneCIDR,
-		}
-	}
+	cidr := DefaultCIDR()
+	cfg.VPC.CIDR = &cidr
+
+	return cfg
 }
 
 // NewNodeGroup crears new nodegroup inside cluster config,
@@ -140,72 +124,6 @@ type NodeGroup struct {
 	SSHPublicKeyPath string
 	SSHPublicKey     []byte
 	SSHPublicKeyName string
-}
-
-type (
-	// ClusterVPC holds global subnet and all child public/private subnet
-	ClusterVPC struct {
-		Network              // global CIRD and VPC ID
-		SecurityGroup string // cluster SG
-		// subnets are either public or private for use with separate nodegroups
-		// these are keyed by AZ for conveninece
-		Subnets map[SubnetTopology]map[string]Network
-		// for additional CIRD associations, e.g. to use with separate CIDR for
-		// private subnets or any ad-hoc subnets
-		ExtraCIDRs []*net.IPNet
-	}
-	// SubnetTopology can be SubnetTopologyPrivate or SubnetTopologyPublic
-	SubnetTopology string
-	// Network holds ID and CIDR
-	Network struct {
-		ID   string
-		CIDR *net.IPNet
-	}
-)
-
-const (
-	// SubnetTopologyPrivate repesents privately-routed subnets
-	SubnetTopologyPrivate SubnetTopology = "Private"
-	// SubnetTopologyPublic repesents publicly-routed subnets
-	SubnetTopologyPublic SubnetTopology = "Public"
-)
-
-// SubnetIDs returns list of subnets
-func (c ClusterVPC) SubnetIDs(topology SubnetTopology) []string {
-	subnets := []string{}
-	for _, s := range c.Subnets[topology] {
-		subnets = append(subnets, s.ID)
-	}
-	return subnets
-}
-
-// SubnetTopologies returns list of topologies supported
-// by a given cluster config
-func (c ClusterVPC) SubnetTopologies() []SubnetTopology {
-	topologies := []SubnetTopology{}
-	for topology := range c.Subnets {
-		topologies = append(topologies, topology)
-	}
-	return topologies
-}
-
-// ImportSubnet loads a given subnet into cluster config
-func (c ClusterVPC) ImportSubnet(topology SubnetTopology, az, subnetID string) {
-	if _, ok := c.Subnets[topology]; !ok {
-		c.Subnets[topology] = map[string]Network{}
-	}
-	if network, ok := c.Subnets[topology][az]; !ok {
-		c.Subnets[topology][az] = Network{ID: subnetID}
-	} else {
-		network.ID = subnetID
-		c.Subnets[topology][az] = network
-	}
-}
-
-// HasSufficientPublicSubnets validates if there is a suffiecent
-// number of subnets available to create a cluster
-func (c ClusterVPC) HasSufficientPublicSubnets() bool {
-	return len(c.SubnetIDs(SubnetTopologyPublic)) >= 3
 }
 
 type (

--- a/pkg/eks/api/vpc.go
+++ b/pkg/eks/api/vpc.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"net"
+)
+
+type (
+	// ClusterVPC holds global subnet and all child public/private subnet
+	ClusterVPC struct {
+		Network              // global CIDR and VPC ID
+		SecurityGroup string // cluster SG
+		// subnets are either public or private for use with separate nodegroups
+		// these are keyed by AZ for convenience
+		Subnets map[SubnetTopology]map[string]Network
+		// for additional CIDR associations, e.g. to use with separate CIDR for
+		// private subnets or any ad-hoc subnets
+		ExtraCIDRs []*net.IPNet
+	}
+	// SubnetTopology can be SubnetTopologyPrivate or SubnetTopologyPublic
+	SubnetTopology string
+	// Network holds ID and CIDR
+	Network struct {
+		ID   string
+		CIDR *net.IPNet
+	}
+)
+
+const (
+	// SubnetTopologyPrivate represents privately-routed subnets
+	SubnetTopologyPrivate SubnetTopology = "Private"
+	// SubnetTopologyPublic represents publicly-routed subnets
+	SubnetTopologyPublic SubnetTopology = "Public"
+)
+
+// DefaultCIDR returns default global CIDR for VPC
+func DefaultCIDR() net.IPNet {
+	return net.IPNet{
+		IP:   []byte{192, 168, 0, 0},
+		Mask: []byte{255, 255, 0, 0},
+	}
+}
+
+// SubnetIDs returns list of subnets
+func (c *ClusterConfig) SubnetIDs(topology SubnetTopology) []string {
+	subnets := []string{}
+	for _, s := range c.VPC.Subnets[topology] {
+		subnets = append(subnets, s.ID)
+	}
+	return subnets
+}
+
+// ImportSubnet loads a given subnet into cluster config
+func (c *ClusterConfig) ImportSubnet(topology SubnetTopology, az, subnetID string) {
+	if _, ok := c.VPC.Subnets[topology]; !ok {
+		c.VPC.Subnets[topology] = map[string]Network{}
+	}
+	if network, ok := c.VPC.Subnets[topology][az]; !ok {
+		c.VPC.Subnets[topology][az] = Network{ID: subnetID}
+	} else {
+		network.ID = subnetID
+		c.VPC.Subnets[topology][az] = network
+	}
+}
+
+// HasSufficientPublicSubnets validates if there is a sufficient
+// number of public subnets available to create a cluster
+func (c *ClusterConfig) HasSufficientPublicSubnets() bool {
+	return len(c.SubnetIDs(SubnetTopologyPublic)) >= 3
+}
+
+// HasSufficientPrivateSubnets validates if there is a sufficient
+// number of private subnets available to create a cluster
+func (c *ClusterConfig) HasSufficientPrivateSubnets() bool {
+	return len(c.SubnetIDs(SubnetTopologyPrivate)) >= 3
+}

--- a/pkg/eks/vpc.go
+++ b/pkg/eks/vpc.go
@@ -1,0 +1,50 @@
+package eks
+
+import (
+	"fmt"
+
+	"github.com/kubicorn/kubicorn/pkg/logger"
+	"github.com/weaveworks/eksctl/pkg/eks/api"
+	"k8s.io/kops/pkg/util/subnet"
+)
+
+// SetSubnets defines CIDRs for each of the subnets,
+// it must be called after SetAvailabilityZones
+func (c *ClusterProvider) SetSubnets() error {
+	var err error
+
+	vpc := c.Spec.VPC
+	vpc.Subnets = map[api.SubnetTopology]map[string]api.Network{
+		api.SubnetTopologyPublic:  map[string]api.Network{},
+		api.SubnetTopologyPrivate: map[string]api.Network{},
+	}
+	prefix, _ := c.Spec.VPC.CIDR.Mask.Size()
+	if (prefix < 16) || (prefix > 24) {
+		return fmt.Errorf("VPC CIDR prefix must be betwee /16 and /24")
+	}
+	zoneCIDRs, err := subnet.SplitInto8(c.Spec.VPC.CIDR)
+	if err != nil {
+		return err
+	}
+
+	logger.Debug("VPC CIDR (%s) was divided into 8 subnets %v", vpc.CIDR.String(), zoneCIDRs)
+
+	zonesTotal := len(c.Spec.AvailabilityZones)
+	if 2*zonesTotal > len(zoneCIDRs) {
+		return fmt.Errorf("insufficient number of subnets (have %d, but need %d) for %d availability zones", len(zoneCIDRs), 2*zonesTotal, zonesTotal)
+	}
+
+	for i, zone := range c.Spec.AvailabilityZones {
+		public := zoneCIDRs[i]
+		private := zoneCIDRs[i+zonesTotal]
+		vpc.Subnets[api.SubnetTopologyPublic][zone] = api.Network{
+			CIDR: public,
+		}
+		vpc.Subnets[api.SubnetTopologyPrivate][zone] = api.Network{
+			CIDR: private,
+		}
+		logger.Info("subnets for %s - public:%s private:%s", zone, public.String(), private.String())
+	}
+
+	return nil
+}

--- a/pkg/kops/kops.go
+++ b/pkg/kops/kops.go
@@ -61,13 +61,13 @@ func (k *Wrapper) UseVPC(spec *api.ClusterConfig) error {
 		subnet := subnet.Obj.(*ec2.Subnet)
 		for _, tag := range subnet.Tags {
 			if k.isOwned(tag) && *subnet.VpcId == vpcs[0] {
-				spec.VPC.ImportSubnet(api.SubnetTopologyPublic, *subnet.AvailabilityZone, *subnet.SubnetId)
+				spec.ImportSubnet(api.SubnetTopologyPublic, *subnet.AvailabilityZone, *subnet.SubnetId)
 				spec.AvailabilityZones = append(spec.AvailabilityZones, *subnet.AvailabilityZone)
 			}
 		}
 	}
 	logger.Debug("subnets = %#v", spec.VPC.Subnets)
-	if !spec.VPC.HasSufficientPublicSubnets() {
+	if !spec.HasSufficientPublicSubnets() {
 		return fmt.Errorf("cannot use VPC from kops cluster with less then 3 subnets")
 	}
 

--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -77,10 +77,15 @@ func makeAmazonLinux2Config(spec *api.ClusterConfig, nodeGroupID int) (configFil
 		c.MaxPodsPerNode = maxPodsPerNodeType[c.InstanceType]
 	}
 	// TODO: use componentconfig or kubelet config file – https://github.com/weaveworks/eksctl/issues/156
+	clusterDNS := "10.100.0.10"
+	if spec.VPC.CIDR.IP[0] == 10 {
+		// Default service network is 10.100.0.0, but it gets set 172.20.0.0 automatically when pod network
+		// is anywhere within 10.0.0.0/8
+		clusterDNS = "172.20.0.10"
+	}
 	kubeletParams := []string{
 		fmt.Sprintf("MAX_PODS=%d", c.MaxPodsPerNode),
-		// TODO: this will need to change when we provide options for using different VPCs and CIDRs – https://github.com/weaveworks/eksctl/issues/158
-		"CLUSTER_DNS=10.100.0.10",
+		fmt.Sprintf("CLUSTER_DNS=%s", clusterDNS),
 	}
 
 	metadata := []string{

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Kubeconfig", func() {
 					InstanceRoleARN:   "",
 				},
 			},
-			VPC: eksctlapi.ClusterVPC{
+			VPC: &eksctlapi.ClusterVPC{
 				Network: eksctlapi.Network{
 					ID:   "",
 					CIDR: nil,

--- a/vendor/k8s.io/kops/pkg/apis/kops/cluster.go
+++ b/vendor/k8s.io/kops/pkg/apis/kops/cluster.go
@@ -323,7 +323,7 @@ type LoadBalancerAccessSpec struct {
 	SecurityGroupOverride *string `json:"securityGroupOverride,omitempty"`
 	// AdditionalSecurityGroups attaches additional security groups (e.g. sg-123456).
 	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
-	// UseForInternalApi indicates wether the LB should be used by the kubelet
+	// UseForInternalApi indicates whether the LB should be used by the kubelet
 	UseForInternalApi bool `json:"useForInternalApi,omitempty"`
 	// SSLCertificate allows you to specify the ACM cert to be used the LB
 	SSLCertificate string `json:"sslCertificate,omitempty"`

--- a/vendor/k8s.io/kops/pkg/apis/kops/instancegroup.go
+++ b/vendor/k8s.io/kops/pkg/apis/kops/instancegroup.go
@@ -123,7 +123,7 @@ type InstanceGroupSpec struct {
 	DetailedInstanceMonitoring *bool `json:"detailedInstanceMonitoring,omitempty"`
 	// IAMProfileSpec defines the identity of the cloud group iam profile (AWS only).
 	IAM *IAMProfileSpec `json:"iam,omitempty"`
-	// SecurityGroupOverride overrides the defaut security group created by Kops for this IG (AWS only).
+	// SecurityGroupOverride overrides the default security group created by Kops for this IG (AWS only).
 	SecurityGroupOverride *string `json:"securityGroupOverride,omitempty"`
 }
 

--- a/vendor/k8s.io/kops/pkg/apis/kops/v1alpha1/cluster.go
+++ b/vendor/k8s.io/kops/pkg/apis/kops/v1alpha1/cluster.go
@@ -322,7 +322,7 @@ type LoadBalancerAccessSpec struct {
 	SecurityGroupOverride *string `json:"securityGroupOverride,omitempty"`
 	// AdditionalSecurityGroups attaches additional security groups (e.g. sg-123456).
 	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
-	// UseForInternalApi indicates wether the LB should be used by the kubelet
+	// UseForInternalApi indicates whether the LB should be used by the kubelet
 	UseForInternalApi bool `json:"useForInternalApi,omitempty"`
 	// SSLCertificate allows you to specify the ACM cert to be used the LB
 	SSLCertificate string `json:"sslCertificate,omitempty"`

--- a/vendor/k8s.io/kops/pkg/apis/kops/v1alpha1/instancegroup.go
+++ b/vendor/k8s.io/kops/pkg/apis/kops/v1alpha1/instancegroup.go
@@ -102,7 +102,7 @@ type InstanceGroupSpec struct {
 	DetailedInstanceMonitoring *bool `json:"detailedInstanceMonitoring,omitempty"`
 	// IAMProfileSpec defines the identity of the cloud group iam profile (AWS only).
 	IAM *IAMProfileSpec `json:"iam,omitempty"`
-	// SecurityGroupOverride overrides the defaut security group created by Kops for this IG (AWS only).
+	// SecurityGroupOverride overrides the default security group created by Kops for this IG (AWS only).
 	SecurityGroupOverride *string `json:"securityGroupOverride,omitempty"`
 }
 

--- a/vendor/k8s.io/kops/pkg/apis/kops/v1alpha2/cluster.go
+++ b/vendor/k8s.io/kops/pkg/apis/kops/v1alpha2/cluster.go
@@ -323,7 +323,7 @@ type LoadBalancerAccessSpec struct {
 	SecurityGroupOverride *string `json:"securityGroupOverride,omitempty"`
 	// AdditionalSecurityGroups attaches additional security groups (e.g. sg-123456).
 	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
-	// UseForInternalApi indicates wether the LB should be used by the kubelet
+	// UseForInternalApi indicates whether the LB should be used by the kubelet
 	UseForInternalApi bool `json:"useForInternalApi,omitempty"`
 	// SSLCertificate allows you to specify the ACM cert to be used the LB
 	SSLCertificate string `json:"sslCertificate,omitempty"`

--- a/vendor/k8s.io/kops/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/vendor/k8s.io/kops/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -111,7 +111,7 @@ type InstanceGroupSpec struct {
 	DetailedInstanceMonitoring *bool `json:"detailedInstanceMonitoring,omitempty"`
 	// IAMProfileSpec defines the identity of the cloud group iam profile (AWS only).
 	IAM *IAMProfileSpec `json:"iam,omitempty"`
-	// SecurityGroupOverride overrides the defaut security group created by Kops for this IG (AWS only).
+	// SecurityGroupOverride overrides the default security group created by Kops for this IG (AWS only).
 	SecurityGroupOverride *string `json:"securityGroupOverride,omitempty"`
 }
 

--- a/vendor/k8s.io/kops/pkg/util/subnet/subnet.go
+++ b/vendor/k8s.io/kops/pkg/util/subnet/subnet.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subnet
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+)
+
+// Overlap checks if two subnets overlap
+func Overlap(l, r *net.IPNet) bool {
+	return l.Contains(r.IP) || r.Contains(l.IP)
+}
+
+// BelongsTo checks if child is a subnet of parent
+func BelongsTo(parent *net.IPNet, child *net.IPNet) bool {
+	parentOnes, parentBits := parent.Mask.Size()
+	childOnes, childBits := child.Mask.Size()
+	if childBits != parentBits {
+		return false
+	}
+	if parentOnes > childOnes {
+		return false
+	}
+	childMasked := child.IP.Mask(parent.Mask)
+	parentMasked := parent.IP.Mask(parent.Mask)
+	return childMasked.Equal(parentMasked)
+}
+
+// SplitInto8 splits the parent IPNet into 8 subnets
+func SplitInto8(parent *net.IPNet) ([]*net.IPNet, error) {
+	networkLength, _ := parent.Mask.Size()
+	networkLength += 3
+
+	var subnets []*net.IPNet
+	for i := 0; i < 8; i++ {
+		ip4 := parent.IP.To4()
+		if ip4 != nil {
+			n := binary.BigEndian.Uint32(ip4)
+			n += uint32(i) << uint(32-networkLength)
+			subnetIP := make(net.IP, len(ip4))
+			binary.BigEndian.PutUint32(subnetIP, n)
+
+			subnets = append(subnets, &net.IPNet{
+				IP:   subnetIP,
+				Mask: net.CIDRMask(networkLength, 32),
+			})
+		} else {
+			return nil, fmt.Errorf("Unexpected IP address type: %s", parent)
+		}
+	}
+
+	return subnets, nil
+}

--- a/vendor/k8s.io/kops/upup/pkg/fi/cloud.go
+++ b/vendor/k8s.io/kops/upup/pkg/fi/cloud.go
@@ -150,6 +150,7 @@ var zonesToCloud = map[string]kops.CloudProviderID{
 
 	"cn-northwest-1a": kops.CloudProviderAWS,
 	"cn-northwest-1b": kops.CloudProviderAWS,
+	"cn-northwest-1c": kops.CloudProviderAWS,
 
 	"us-gov-west-1a": kops.CloudProviderAWS,
 	"us-gov-west-1b": kops.CloudProviderAWS,


### PR DESCRIPTION
### Description

User-visible feature: `--vpc-cidr` flag.

In terms of code, this follows up on #283, and it does two main things:

- automate splitting of subnets
- create private subnets as well as public

And a little more refactoring, as most of #283 was theoretical - so here come few practical tweaks.

Fork of kops is temporary, until https://github.com/kubernetes/kops/pull/6004 lands.

- close https://github.com/weaveworks/eksctl/issues/158
- close https://github.com/weaveworks/eksctl/issues/279

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)
- [ ] ~Added/modified documentation as required (such as the README)~ (will update separately along with other doc updates)