### PR TITLE
Node private networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,12 @@ change it. You cannot use just any sort of CIDR, there only certain ranges that 
 
 [vpcsizing]: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html#VPC_Sizing
 
+
+#### use private subnets for initial nodegroup
+
+If you prefer to isolate initial nodegroup from the public internet, you can use `--node-private-networking` flag.
+When used in conjunction with `--ssh-access` flag, SSH port can only be accessed inside the VPC.
+
 #### use existing VPC: shared with kops
 
 You can use a VPC of an existing Kubernetes cluster managed by kops. This is feature is provided to facilitate migration and/or

--- a/pkg/cfn/builder/api.go
+++ b/pkg/cfn/builder/api.go
@@ -18,6 +18,13 @@ const (
 	templateDescriptionSuffix = " [created and managed by eksctl]"
 )
 
+type awsCloudFormationResource struct {
+	Type         string
+	Properties   map[string]interface{}
+	UpdatePolicy map[string]map[string]string `json:",omitempty"`
+	DependsOn    []string                     `json:",omitempty"`
+}
+
 // ResourceSet is an interface which cluster and nodegroup builders
 // must implement
 type ResourceSet interface {

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -181,10 +181,10 @@ var _ = Describe("CloudFormation template builder API", func() {
 			},
 			NodeGroups: []*api.NodeGroup{
 				{
-					AMI:            "",
-					AMIFamily:      "AmazonLinux2",
-					InstanceType:   "t2.medium",
-					SubnetTopology: "Public",
+					AMI:               "",
+					AMIFamily:         "AmazonLinux2",
+					InstanceType:      "t2.medium",
+					PrivateNetworking: false,
 				},
 			},
 		}

--- a/pkg/cfn/builder/cluster.go
+++ b/pkg/cfn/builder/cluster.go
@@ -106,7 +106,7 @@ func (c *ClusterResourceSet) GetAllOutputs(stack cfn.Stack) error {
 	c.spec.VPC.ID = c.outputs.VPC
 	c.spec.VPC.SecurityGroup = c.outputs.SecurityGroup
 
-	// TODO: shouldn't assume the order is the same, can probably do an API lookup
+	// TODO: shouldn't assume the order - https://github.com/weaveworks/eksctl/issues/293
 	for i, subnet := range c.outputs.SubnetsPrivate {
 		c.spec.ImportSubnet(api.SubnetTopologyPrivate, c.spec.AvailabilityZones[i], subnet)
 	}

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -93,6 +93,8 @@ func createClusterCmd() *cobra.Command {
 
 	fs.IPNetVar(cfg.VPC.CIDR, "vpc-cidr", api.DefaultCIDR(), "global CIDR to use for VPC")
 
+	fs.BoolVarP(&ng.PrivateNetworking, "node-private-networking", "P", false, "whether to make initial nodegroup networking private")
+
 	return cmd
 }
 

--- a/pkg/eks/api/api.go
+++ b/pkg/eks/api/api.go
@@ -89,8 +89,8 @@ func NewClusterConfig() *ClusterConfig {
 // it returns pointer to the nodegroup for convenience
 func (c *ClusterConfig) NewNodeGroup() *NodeGroup {
 	ng := &NodeGroup{
-		ID:             len(c.NodeGroups),
-		SubnetTopology: SubnetTopologyPublic,
+		ID:                len(c.NodeGroups),
+		PrivateNetworking: false,
 	}
 
 	c.NodeGroups = append(c.NodeGroups, ng)
@@ -108,7 +108,7 @@ type NodeGroup struct {
 	InstanceType      string
 	AvailabilityZones []string
 	Tags              map[string]string
-	SubnetTopology    SubnetTopology
+	PrivateNetworking bool
 
 	DesiredCapacity int
 	MinSize         int
@@ -125,6 +125,15 @@ type NodeGroup struct {
 	SSHPublicKeyPath string
 	SSHPublicKey     []byte
 	SSHPublicKeyName string
+}
+
+// SubnetTopology check which topology is used for the subnet of
+// the given nodegroup
+func (n *NodeGroup) SubnetTopology() SubnetTopology {
+	if n.PrivateNetworking {
+		return SubnetTopologyPrivate
+	}
+	return SubnetTopologyPublic
 }
 
 type (

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Kubeconfig", func() {
 					AMI:               "",
 					InstanceType:      "m5.large",
 					AvailabilityZones: []string{"us-west-2b", "us-west-2a", "us-west-2c"},
-					SubnetTopology:    "Public",
+					PrivateNetworking: false,
 					AllowSSH:          false,
 					SSHPublicKeyPath:  "~/.ssh/id_rsa.pub",
 					SSHPublicKey:      []uint8(nil),


### PR DESCRIPTION
### Description

Add `--node-private-networking` flag, which will make initial nodegroup use private subnet.

- close #120 

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)
