### PR TITLE
Lower minimum subnets and AZs to 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ export KOPS_STATE_STORE=s3://kops
 kops create cluster cluster-1.k8s.local --zones=us-west-2c,us-west-2b,us-west-2a --networking=weave --yes
 ```
 
-You can create an EKS cluster in the same AZs using the same VPC subnets (NOTE: at least 3 subnets are required):
+You can create an EKS cluster in the same AZs using the same VPC subnets (NOTE: at least 2 AZs/subnets are required):
 ```
 eksctl create cluster --name=cluster-2 --region=us-west-2 --vpc-from-kops-cluster=cluster-1.k8s.local
 ```

--- a/pkg/az/az.go
+++ b/pkg/az/az.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// DefaultRequiredAvailabilityZones defines the number of required availability zones
-	DefaultRequiredAvailabilityZones = 3
+	DefaultRequiredAvailabilityZones = 2
 )
 
 // SelectionStrategy provides an interface to allow changing the strategy used to

--- a/pkg/az/az.go
+++ b/pkg/az/az.go
@@ -11,8 +11,10 @@ import (
 )
 
 const (
-	// DefaultRequiredAvailabilityZones defines the number of required availability zones
-	DefaultRequiredAvailabilityZones = 2
+	// DefaultRequiredAvailabilityZones defines the default number of required availability zones
+	DefaultRequiredAvailabilityZones = 3
+	// MinRequiredAvailabilityZones defines the minimum number of required availability zones
+	MinRequiredAvailabilityZones = 2
 )
 
 // SelectionStrategy provides an interface to allow changing the strategy used to
@@ -43,10 +45,14 @@ func (r *RequiredNumberRandomStrategy) Select(availableZones []string) []string 
 	return zones
 }
 
-// NewRequiredNumberRandomStrategy returns a RequiredNumberRandomStrategy that
+// NewDefaultRequiredNumberRandomStrategy returns a RequiredNumberRandomStrategy that
 // has the number of required zones set to the default (DefaultRequiredAvailabilityZones)
-func NewRequiredNumberRandomStrategy() *RequiredNumberRandomStrategy {
+func NewDefaultRequiredNumberRandomStrategy() *RequiredNumberRandomStrategy {
 	return &RequiredNumberRandomStrategy{RequiredAvailabilityZones: DefaultRequiredAvailabilityZones}
+}
+
+func NewMinRequiredNumberRandomStrategy() *RequiredNumberRandomStrategy {
+	return &RequiredNumberRandomStrategy{RequiredAvailabilityZones: MinRequiredAvailabilityZones}
 }
 
 // ZoneUsageRule provides an interface to enable rules to determine if a
@@ -91,7 +97,17 @@ func NewSelectorWithDefaults(ec2api ec2iface.EC2API) *AvailabilityZoneSelector {
 
 	return &AvailabilityZoneSelector{
 		ec2api:   ec2api,
-		strategy: NewRequiredNumberRandomStrategy(),
+		strategy: NewDefaultRequiredNumberRandomStrategy(),
+		rules:    []ZoneUsageRule{NewZonesToAvoidRule(avoidZones)},
+	}
+}
+
+func NewSelectorWithMinRequired(ec2api ec2iface.EC2API) *AvailabilityZoneSelector {
+	avoidZones := map[string]bool{}
+
+	return &AvailabilityZoneSelector{
+		ec2api:   ec2api,
+		strategy: NewMinRequiredNumberRandomStrategy(),
 		rules:    []ZoneUsageRule{NewZonesToAvoidRule(avoidZones)},
 	}
 }

--- a/pkg/az/az_test.go
+++ b/pkg/az/az_test.go
@@ -70,7 +70,7 @@ var _ = Describe("AZ", func() {
 				})
 
 				It("should have returned 3 availability zones", func() {
-					Expect(len(selectedZones)).To(Equal(3))
+					Expect(len(selectedZones)).To(Equal(2))
 				})
 			})
 
@@ -112,7 +112,7 @@ var _ = Describe("AZ", func() {
 				})
 
 				It("should have returned 3 identical availability zones", func() {
-					Expect(len(selectedZones)).To(Equal(3))
+					Expect(len(selectedZones)).To(Equal(2))
 
 					for _, actualZoneName := range selectedZones {
 						Expect(actualZoneName).To(Equal(*expectedZoneName))
@@ -161,7 +161,7 @@ var _ = Describe("AZ", func() {
 			})
 
 			It("should have returned 3 availability zones", func() {
-				Expect(len(selectedZones)).To(Equal(3))
+				Expect(len(selectedZones)).To(Equal(2))
 			})
 
 			It("should have returned none of the zones to avoid", func() {

--- a/pkg/az/az_test.go
+++ b/pkg/az/az_test.go
@@ -70,7 +70,7 @@ var _ = Describe("AZ", func() {
 				})
 
 				It("should have returned 3 availability zones", func() {
-					Expect(len(selectedZones)).To(Equal(2))
+					Expect(len(selectedZones)).To(Equal(3))
 				})
 			})
 
@@ -112,7 +112,7 @@ var _ = Describe("AZ", func() {
 				})
 
 				It("should have returned 3 identical availability zones", func() {
-					Expect(len(selectedZones)).To(Equal(2))
+					Expect(len(selectedZones)).To(Equal(3))
 
 					for _, actualZoneName := range selectedZones {
 						Expect(actualZoneName).To(Equal(*expectedZoneName))
@@ -161,7 +161,7 @@ var _ = Describe("AZ", func() {
 			})
 
 			It("should have returned 3 availability zones", func() {
-				Expect(len(selectedZones)).To(Equal(2))
+				Expect(len(selectedZones)).To(Equal(3))
 			})
 
 			It("should have returned none of the zones to avoid", func() {
@@ -203,6 +203,48 @@ var _ = Describe("AZ", func() {
 
 			It("should have called AWS EC2 DescribeAvailabilityZones", func() {
 				Expect(p.MockEC2().AssertNumberOfCalls(GinkgoT(), "DescribeAvailabilityZones", 1)).To(BeTrue())
+			})
+		})
+
+		Context("with min required zones selector", func() {
+			var (
+				region        *string
+				selectedZones []string
+				azSelector    *AvailabilityZoneSelector
+				zones         []*ec2.AvailabilityZone
+			)
+
+			BeforeEach(func() {
+				region = aws.String("us-east-1")
+				zones = usEast1Zones(ec2.AvailabilityZoneStateAvailable)
+				_, p = createProviders()
+
+				p.MockEC2().On("DescribeAvailabilityZones",
+					mock.MatchedBy(func(input *ec2.DescribeAvailabilityZonesInput) bool {
+						filter := input.Filters[0]
+						return *filter.Name == "region-name" && *filter.Values[0] == *region
+					}),
+				).Return(&ec2.DescribeAvailabilityZonesOutput{
+					AvailabilityZones: zones,
+				}, nil)
+
+				azSelector = NewSelectorWithMinRequired(p.MockEC2())
+			})
+
+			JustBeforeEach(func() {
+				selectedZones, err = azSelector.SelectZones(*region)
+			})
+
+			It("should not error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should have called AWS EC2 DescribeAvailabilityZones", func() {
+				Expect(p.MockEC2().AssertNumberOfCalls(GinkgoT(), "DescribeAvailabilityZones", 1)).To(BeTrue())
+			})
+
+			It("should have returned 2 availability zones", func() {
+				Expect(len(selectedZones)).To(Equal(2))
 			})
 		})
 	})

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -187,8 +187,8 @@ func (c *ClusterProvider) SetAvailabilityZones(given []string) error {
 		c.Spec.AvailabilityZones = zones
 		return nil
 	}
-	if len(given) < az.DefaultRequiredAvailabilityZones {
-		return fmt.Errorf("only %d zones specified %v, %d are required (can be non-unque)", len(given), given, az.DefaultRequiredAvailabilityZones)
+	if len(given) < az.MinRequiredAvailabilityZones {
+		return fmt.Errorf("only %d zones specified %v, %d are required (can be non-unque)", len(given), given, az.MinRequiredAvailabilityZones)
 	}
 	c.Spec.AvailabilityZones = given
 	return nil

--- a/pkg/eks/api/vpc.go
+++ b/pkg/eks/api/vpc.go
@@ -65,11 +65,11 @@ func (c *ClusterConfig) ImportSubnet(topology SubnetTopology, az, subnetID strin
 // HasSufficientPublicSubnets validates if there is a sufficient
 // number of public subnets available to create a cluster
 func (c *ClusterConfig) HasSufficientPublicSubnets() bool {
-	return len(c.SubnetIDs(SubnetTopologyPublic)) >= 3
+	return len(c.SubnetIDs(SubnetTopologyPublic)) >= 2
 }
 
 // HasSufficientPrivateSubnets validates if there is a sufficient
 // number of private subnets available to create a cluster
 func (c *ClusterConfig) HasSufficientPrivateSubnets() bool {
-	return len(c.SubnetIDs(SubnetTopologyPrivate)) >= 3
+	return len(c.SubnetIDs(SubnetTopologyPrivate)) >= 2
 }

--- a/pkg/kops/kops.go
+++ b/pkg/kops/kops.go
@@ -68,7 +68,7 @@ func (k *Wrapper) UseVPC(spec *api.ClusterConfig) error {
 	}
 	logger.Debug("subnets = %#v", spec.VPC.Subnets)
 	if !spec.HasSufficientPublicSubnets() {
-		return fmt.Errorf("cannot use VPC from kops cluster with less then 3 subnets")
+		return fmt.Errorf("cannot use VPC from kops cluster with less then 2 subnets")
 	}
 
 	return nil


### PR DESCRIPTION
### Description
EKS docs suggest that the minimum required subnets/AZs is now 2. Also
updated tests and logging that reference the minimum subnets/AZs.

Fixes Issue #290

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the README)
- [ ] Added yourself to the `humans.txt` file
