### PR TITLE
Allow nodes to write CloudWatch metrics

### DIFF
--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -72,6 +72,9 @@ func (c *ClusterResourceSet) addResourcesForIAM() {
 		"ec2:CreateSecurityGroup",
 		"ec2:Describe*",
 	})
+	c.rs.attachAllowPolicy("PolicyCloudWatchMetrics", refSR, "*", []string{
+		"cloudwatch:PutMetricData",
+	})
 }
 
 // WithIAM states, if IAM roles will be created or not


### PR DESCRIPTION
### Description

This is primarily in order to facilitate exporting CNI metrics (ref #278)

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)