### PR TITLE
Print out the region when listing clusters

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -23,6 +23,7 @@ Karinna Iniguez         @karinnainiguez
 Michael Seiwald         @mseiwald
 Anton Gruebel           @gruebel
 Bryan Peterson          @lazyshot
+Josue Abreu             @gotjosh
 
 /* Thanks */
 


### PR DESCRIPTION
### Description

Adds the region as part of the print output when listing clusters with `eksctl get cluster`. I wanted to try and take a stab at the bonus feature: Add a `--all-regions` option but noticed we have #251 which might make things easier (or harder 😆). Perhaps we should try and lay that one out first?

Happy to create a separate issue for `--all-regions` should we decide to untangle it and close #256 . 

Partially fixes #256

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)
- [x] Added/modified documentation as required (such as the README)
- [x] Added yourself to the `humans.txt` file
