### PR TITLE
Improve region validation, only print log message in create cluster command

### DIFF
--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -3,6 +3,7 @@ package create
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/kubicorn/kubicorn/pkg/logger"
 	"github.com/pkg/errors"
@@ -101,9 +102,10 @@ func createClusterCmd() *cobra.Command {
 func doCreateCluster(cfg *api.ClusterConfig, ng *api.NodeGroup, name string) error {
 	ctl := eks.New(cfg)
 
-	if cfg.Region != api.EKSRegionUSWest2 && cfg.Region != api.EKSRegionUSEast1 && cfg.Region != api.EKSRegionEUWest1 {
-		return fmt.Errorf("%s is not supported only %s, %s and %s are supported", cfg.Region, api.EKSRegionUSWest2, api.EKSRegionUSEast1, api.EKSRegionEUWest1)
+	if !cfg.IsSupportedRegion() {
+		return fmt.Errorf("--region=%s is not supported - use one of: %s", cfg.Region, strings.Join(api.SupportedRegions(), ", "))
 	}
+	logger.Info("using region %s", cfg.Region)
 
 	if err := ctl.CheckAuth(); err != nil {
 		return err

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -248,7 +248,6 @@ func newSession(clusterConfig *api.ClusterConfig, endpoint string, credentials *
 		}
 	}
 
-	logger.Info("using region %s", clusterConfig.Region)
 	return s
 }
 

--- a/pkg/eks/api/api.go
+++ b/pkg/eks/api/api.go
@@ -27,10 +27,12 @@ const (
 )
 
 // SupportedRegions are the regions where EKS is available
-var SupportedRegions = []string{
-	EKSRegionUSWest2,
-	EKSRegionUSEast1,
-	EKSRegionEUWest1,
+func SupportedRegions() []string {
+	return []string{
+		EKSRegionUSWest2,
+		EKSRegionUSEast1,
+		EKSRegionEUWest1,
+	}
 }
 
 // DefaultWaitTimeout defines the default wait timeout
@@ -83,6 +85,16 @@ func NewClusterConfig() *ClusterConfig {
 	cfg.VPC.CIDR = &cidr
 
 	return cfg
+}
+
+// IsSupportedRegion check if given region is supported
+func (c *ClusterConfig) IsSupportedRegion() bool {
+	for _, supportedRegion := range SupportedRegions() {
+		if c.Region == supportedRegion {
+			return true
+		}
+	}
+	return false
 }
 
 // NewNodeGroup crears new nodegroup inside cluster config,


### PR DESCRIPTION
### Description

Improve region validation, only print log message in create cluster command

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] All tests passing (i.e. `make test`)
