### PR TITLE
Add `--all-regions` flag for `get cluster`

### DIFF
--- a/pkg/ctl/get/cluster.go
+++ b/pkg/ctl/get/cluster.go
@@ -21,18 +21,10 @@ func getClusterCmd() *cobra.Command {
 		Short:   "Get cluster(s)",
 		Aliases: []string{"clusters"},
 		Run: func(_ *cobra.Command, args []string) {
-			if listAllRegions {
-				if err := doGetClusterForAllRegions(cfg); err != nil {
-					logger.Critical("%s\n", err.Error())
-					os.Exit(1)
-				}
-			} else {
-				if err := doGetCluster(cfg, ctl.GetNameArg(args)); err != nil {
-					logger.Critical("%s\n", err.Error())
-					os.Exit(1)
-				}
+			if err := doGetCluster(cfg, ctl.GetNameArg(args)); err != nil {
+				logger.Critical("%s\n", err.Error())
+				os.Exit(1)
 			}
-
 		},
 	}
 
@@ -64,27 +56,5 @@ func doGetCluster(cfg *api.ClusterConfig, name string) error {
 		cfg.ClusterName = name
 	}
 
-	if err := ctl.ListClusters(chunkSize, output); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func doGetClusterForAllRegions(cfg *api.ClusterConfig) error {
-	for _, region := range api.SupportedRegions() {
-		logger.Info("using region %s", region)
-		cfg.Region = region
-		ctl := eks.New(cfg)
-
-		if err := ctl.CheckAuth(); err != nil {
-			return err
-		}
-
-		if err := ctl.ListClusters(chunkSize, output); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return ctl.ListClusters(chunkSize, output, listAllRegions)
 }

--- a/pkg/eks/eks_test.go
+++ b/pkg/eks/eks_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Eks", func() {
 				})
 
 				JustBeforeEach(func() {
-					err = c.ListClusters(100, output)
+					err = c.ListClusters(100, output, false)
 				})
 
 				It("should not error", func() {
@@ -92,7 +92,7 @@ var _ = Describe("Eks", func() {
 				})
 
 				JustBeforeEach(func() {
-					err = c.ListClusters(100, output)
+					err = c.ListClusters(100, output, false)
 				})
 
 				It("should not error", func() {
@@ -143,7 +143,7 @@ var _ = Describe("Eks", func() {
 			})
 
 			JustBeforeEach(func() {
-				err = c.ListClusters(100, output)
+				err = c.ListClusters(100, output, false)
 			})
 
 			AfterEach(func() {
@@ -222,7 +222,7 @@ var _ = Describe("Eks", func() {
 				})
 
 				JustBeforeEach(func() {
-					err = c.ListClusters(chunkSize, output)
+					err = c.ListClusters(chunkSize, output, false)
 				})
 
 				It("should not error", func() {
@@ -257,7 +257,7 @@ var _ = Describe("Eks", func() {
 				})
 
 				JustBeforeEach(func() {
-					err = c.ListClusters(chunkSize, output)
+					err = c.ListClusters(chunkSize, output, false)
 				})
 
 				It("should not error", func() {


### PR DESCRIPTION
Allows listing of clusters across all supported regions.

### Description
User-visible feature: `--all-regions` (or `-a`)  flag.

```bash
$ ./eksctl get cluster -a
2018-11-02T17:49:30Z [i]  using region us-west-2
No clusters found
2018-11-02T17:49:32Z [i]  using region us-east-1
NAME				REGION
wonderful-mushroom-1541180762	us-east-1
2018-11-02T17:49:32Z [i]  using region eu-west-1
NAME				REGION
unique-mushroom-1541178349	eu-west-1
wonderful-rainbow-1541180697	eu-west-1
```

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added/modified documentation as required (such as the README)

### Open questions
- #300 removes the log line `using region X`. I think we need something similar once it gets merged. When we have clusters to list, the table is very clear but otherwise is not obvious. 
- Do I need to update any documentation? Our README only documents `--name` and `--region`
- For the re-use of the session, I tried two routes which yielded unsuccessful results. I'm open to ideas/opinions
    - Changing the current `ClusterConfig` with the instance of `ClusterProvider`. Does not work due to the config being used as part of `newSession`.
    - Including the current `session` as part of the instance of `ClusterProvider` and then modifying AWS options at runtime. This didn't work either as `ProviderServices` is instantiated with the session as part of `New`