### PR TITLE
Enable use of existing subnets

### DIFF
--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -85,6 +85,7 @@ func (c *ClusterResourceSet) addResourcesForVPC() {
 
 func (c *ClusterResourceSet) importResourcesForVPC() {
 	c.vpc = gfn.NewString(c.spec.VPC.ID)
+	c.subnets = make(map[api.SubnetTopology][]*gfn.Value)
 	for topology := range c.spec.VPC.Subnets {
 		for _, subnet := range c.spec.SubnetIDs(topology) {
 			c.subnets[topology] = append(c.subnets[topology], gfn.NewString(subnet))


### PR DESCRIPTION
### Description

This should sufficient to close #40. As discussed in #303, there will be more logical features to add, but this should enable most folks.

This adds `--vpc-{private,public}-subnets` flags. It's entirely up to the user which ones they specify as private or public. This is very clearly defined in #303, but we need to come up with a concise statement to put in the docs. We also have a waning message now, to make sure we don't get too many bug reports because of bad VPC configurations, but we still need to make it crystal clear in the docs.

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] All tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the README)