### PR TITLE
Clear separation between `api.ClusterConfig` and `api.ClusterProvider`

### DIFF
--- a/pkg/ami/auto_resolver_test.go
+++ b/pkg/ami/auto_resolver_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	. "github.com/weaveworks/eksctl/pkg/ami"
 	"github.com/weaveworks/eksctl/pkg/eks"
-	"github.com/weaveworks/eksctl/pkg/eks/api"
 	"github.com/weaveworks/eksctl/pkg/testutils"
 )
 
@@ -170,9 +169,6 @@ func createProviders() (*eks.ClusterProvider, *testutils.MockProvider) {
 
 	c := &eks.ClusterProvider{
 		Provider: p,
-		Spec: &api.ClusterConfig{
-			Region: "eu-west-1",
-		},
 	}
 
 	return c, p

--- a/pkg/az/az_test.go
+++ b/pkg/az/az_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/weaveworks/eksctl/pkg/az"
 	"github.com/weaveworks/eksctl/pkg/eks"
-	"github.com/weaveworks/eksctl/pkg/eks/api"
 	"github.com/weaveworks/eksctl/pkg/testutils"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -255,9 +254,6 @@ func createProviders() (*eks.ClusterProvider, *testutils.MockProvider) {
 
 	c := &eks.ClusterProvider{
 		Provider: p,
-		Spec: &api.ClusterConfig{
-			Region: "us-west-1",
-		},
 	}
 
 	return c, p

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/eks/api"
 	"github.com/weaveworks/eksctl/pkg/nodebootstrap"
+	"github.com/weaveworks/eksctl/pkg/testutils"
 )
 
 const (
@@ -105,8 +106,8 @@ var _ = Describe("CloudFormation template builder API", func() {
 		cfg := api.NewClusterConfig()
 		ng := cfg.NewNodeGroup()
 
-		cfg.Region = "us-west-2"
-		cfg.ClusterName = clusterName
+		cfg.Metadata.Region = "us-west-2"
+		cfg.Metadata.Name = clusterName
 		cfg.AvailabilityZones = testAZs
 		ng.InstanceType = "t2.medium"
 		ng.AMIFamily = "AmazonLinux2"
@@ -121,8 +122,10 @@ var _ = Describe("CloudFormation template builder API", func() {
 		It("should not error", func() { Expect(err).ShouldNot(HaveOccurred()) })
 
 		expected := &api.ClusterConfig{
-			Region:                   "us-west-2",
-			ClusterName:              clusterName,
+			Metadata: &api.ClusterMeta{
+				Region: "us-west-2",
+				Name:   clusterName,
+			},
 			Endpoint:                 endpoint,
 			CertificateAuthorityData: caCertData,
 			ARN:                      arn,
@@ -197,10 +200,10 @@ var _ = Describe("CloudFormation template builder API", func() {
 		}
 
 		cfg := newClusterConfig()
-		ctl := eks.New(cfg)
+		ctl := eks.New(testutils.ProviderConfig, cfg)
 
 		It("should not error when calling SetSubnets", func() {
-			err := ctl.SetSubnets()
+			err := ctl.SetSubnets(cfg)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -286,8 +289,8 @@ var _ = Describe("CloudFormation template builder API", func() {
 		cfg := api.NewClusterConfig()
 		ng := cfg.NewNodeGroup()
 
-		cfg.Region = "us-west-2"
-		cfg.ClusterName = clusterName
+		cfg.Metadata.Region = "us-west-2"
+		cfg.Metadata.Name = clusterName
 		cfg.AvailabilityZones = testAZs
 		ng.InstanceType = "t2.medium"
 
@@ -359,8 +362,8 @@ var _ = Describe("CloudFormation template builder API", func() {
 		cfg := api.NewClusterConfig()
 		ng := cfg.NewNodeGroup()
 
-		cfg.Region = "us-west-2"
-		cfg.ClusterName = clusterName
+		cfg.Metadata.Region = "us-west-2"
+		cfg.Metadata.Name = clusterName
 		cfg.AvailabilityZones = testAZs
 		ng.AllowSSH = true
 		ng.InstanceType = "t2.medium"
@@ -410,8 +413,8 @@ var _ = Describe("CloudFormation template builder API", func() {
 		cfg := api.NewClusterConfig()
 		ng := cfg.NewNodeGroup()
 
-		cfg.Region = "us-west-2"
-		cfg.ClusterName = clusterName
+		cfg.Metadata.Region = "us-west-2"
+		cfg.Metadata.Name = clusterName
 		cfg.AvailabilityZones = testAZs
 		ng.AllowSSH = true
 		ng.InstanceType = "t2.medium"
@@ -463,8 +466,8 @@ var _ = Describe("CloudFormation template builder API", func() {
 		cfg := api.NewClusterConfig()
 		ng := cfg.NewNodeGroup()
 
-		cfg.Region = "us-west-2"
-		cfg.ClusterName = clusterName
+		cfg.Metadata.Region = "us-west-2"
+		cfg.Metadata.Name = clusterName
 		cfg.AvailabilityZones = testAZs
 		cfg.VPC = &api.ClusterVPC{
 			Network: api.Network{

--- a/pkg/cfn/builder/cluster.go
+++ b/pkg/cfn/builder/cluster.go
@@ -79,7 +79,7 @@ func (c *ClusterResourceSet) addResourcesForControlPlane(version string) {
 	}
 
 	c.newResource("ControlPlane", &gfn.AWSEKSCluster{
-		Name:               gfn.NewString(c.spec.ClusterName),
+		Name:               gfn.NewString(c.spec.Metadata.Name),
 		RoleArn:            gfn.MakeFnGetAttString("ServiceRole.Arn"),
 		Version:            gfn.NewString(version),
 		ResourcesVpcConfig: clusterVPC,

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -33,7 +33,7 @@ func NewNodeGroupResourceSet(spec *api.ClusterConfig, clusterStackName string, i
 		rs:               newResourceSet(),
 		id:               id,
 		clusterStackName: clusterStackName,
-		nodeGroupName:    fmt.Sprintf("%s-%d", spec.ClusterName, id),
+		nodeGroupName:    fmt.Sprintf("%s-%d", spec.Metadata.Name, id),
 		clusterSpec:      spec,
 		spec:             spec.NodeGroups[id],
 	}
@@ -156,7 +156,7 @@ func (n *NodeGroupResourceSet) addResourcesForNodeGroup() error {
 			"VPCZoneIdentifier":       vpcZoneIdentifier,
 			"Tags": []map[string]interface{}{
 				{"Key": "Name", "Value": fmt.Sprintf("%s-Node", n.nodeGroupName), "PropagateAtLaunch": "true"},
-				{"Key": "kubernetes.io/cluster/" + n.clusterSpec.ClusterName, "Value": "owned", "PropagateAtLaunch": "true"},
+				{"Key": "kubernetes.io/cluster/" + n.clusterSpec.Metadata.Name, "Value": "owned", "PropagateAtLaunch": "true"},
 			},
 		},
 		UpdatePolicy: map[string]map[string]string{

--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -129,7 +129,7 @@ func (n *NodeGroupResourceSet) addResourcesForSecurityGroups() {
 		VpcId:            makeImportValue(n.clusterStackName, cfnOutputClusterVPC),
 		GroupDescription: gfn.NewString("Communication between the control plane and " + desc),
 		Tags: []gfn.Tag{{
-			Key:   gfn.NewString("kubernetes.io/cluster/" + n.clusterSpec.ClusterName),
+			Key:   gfn.NewString("kubernetes.io/cluster/" + n.clusterSpec.Metadata.Name),
 			Value: gfn.NewString("owned"),
 		}},
 	})

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (c *StackCollection) makeClusterStackName() string {
-	return "eksctl-" + c.spec.ClusterName + "-cluster"
+	return "eksctl-" + c.spec.Metadata.Name + "-cluster"
 }
 
 // CreateCluster creates the cluster

--- a/pkg/cfn/manager/deprecated.go
+++ b/pkg/cfn/manager/deprecated.go
@@ -3,7 +3,7 @@ package manager
 // DeprecatedDeleteStackVPC deletes the VPC stack
 func (c *StackCollection) DeprecatedDeleteStackVPC(wait bool) error {
 	var err error
-	stackName := "EKS-" + c.spec.ClusterName + "-VPC"
+	stackName := "EKS-" + c.spec.Metadata.Name + "-VPC"
 
 	if wait {
 		err = c.WaitDeleteStack(stackName)
@@ -17,7 +17,7 @@ func (c *StackCollection) DeprecatedDeleteStackVPC(wait bool) error {
 // DeprecatedDeleteStackServiceRole deletes the service role stack
 func (c *StackCollection) DeprecatedDeleteStackServiceRole(wait bool) error {
 	var err error
-	stackName := "EKS-" + c.spec.ClusterName + "-ServiceRole"
+	stackName := "EKS-" + c.spec.Metadata.Name + "-ServiceRole"
 
 	if wait {
 		err = c.WaitDeleteStack(stackName)
@@ -31,7 +31,7 @@ func (c *StackCollection) DeprecatedDeleteStackServiceRole(wait bool) error {
 // DeprecatedDeleteStackDefaultNodeGroup deletes the default node group stack
 func (c *StackCollection) DeprecatedDeleteStackDefaultNodeGroup(wait bool) error {
 	var err error
-	stackName := "EKS-" + c.spec.ClusterName + "-DefaultNodeGroup"
+	stackName := "EKS-" + c.spec.Metadata.Name + "-DefaultNodeGroup"
 
 	if wait {
 		err = c.WaitDeleteStack(stackName)
@@ -45,7 +45,7 @@ func (c *StackCollection) DeprecatedDeleteStackDefaultNodeGroup(wait bool) error
 // DeprecatedDeleteStackControlPlane deletes the control plane stack
 func (c *StackCollection) DeprecatedDeleteStackControlPlane(wait bool) error {
 	var err error
-	stackName := "EKS-" + c.spec.ClusterName + "-ControlPlane"
+	stackName := "EKS-" + c.spec.Metadata.Name + "-ControlPlane"
 
 	if wait {
 		err = c.WaitDeleteStack(stackName)

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -22,7 +22,7 @@ const (
 )
 
 func (c *StackCollection) makeNodeGroupStackName(id int) string {
-	return fmt.Sprintf("eksctl-%s-nodegroup-%d", c.spec.ClusterName, id)
+	return fmt.Sprintf("eksctl-%s-nodegroup-%d", c.spec.Metadata.Name, id)
 }
 
 // CreateNodeGroup creates the nodegroup
@@ -45,7 +45,7 @@ func (c *StackCollection) CreateNodeGroup(errs chan error, data interface{}) err
 }
 
 func (c *StackCollection) listAllNodeGroups() ([]string, error) {
-	stacks, err := c.ListStacks(fmt.Sprintf("^eksctl-%s-nodegroup-\\d$", c.spec.ClusterName))
+	stacks, err := c.ListStacks(fmt.Sprintf("^eksctl-%s-nodegroup-\\d$", c.spec.Metadata.Name))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cfn/manager/waiters.go
+++ b/pkg/cfn/manager/waiters.go
@@ -73,7 +73,7 @@ func (c *StackCollection) waitWithAcceptors(i *Stack, acceptors []request.Waiter
 	desiredStatus := fmt.Sprintf("%v", acceptors[0].Expected)
 	msg := fmt.Sprintf("waiting for CloudFormation stack %q to reach %q status", *i.StackName, desiredStatus)
 
-	ctx, cancel := context.WithTimeout(context.Background(), c.spec.WaitTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), c.waitTimeout)
 	defer cancel()
 
 	startTime := time.Now()
@@ -118,7 +118,7 @@ func (c *StackCollection) waitWithAcceptors(i *Stack, acceptors []request.Waiter
 func (c *StackCollection) waitWithAcceptorsChangeSet(i *Stack, changesetName *string, acceptors []request.WaiterAcceptor) error {
 	desiredStatus := fmt.Sprintf("%v", acceptors[0].Expected)
 	msg := fmt.Sprintf("waiting for CloudFormation changeset %q for stack %q to reach %q status", *changesetName, *i.StackName, desiredStatus)
-	ctx, cancel := context.WithTimeout(context.Background(), c.spec.WaitTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), c.waitTimeout)
 	defer cancel()
 	startTime := time.Now()
 	w := request.Waiter{

--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -14,13 +14,14 @@ import (
 )
 
 func deleteClusterCmd() *cobra.Command {
+	p := &api.ProviderConfig{}
 	cfg := api.NewClusterConfig()
 
 	cmd := &cobra.Command{
 		Use:   "cluster",
 		Short: "Delete a cluster",
 		Run: func(_ *cobra.Command, args []string) {
-			if err := doDeleteCluster(cfg, ctl.GetNameArg(args)); err != nil {
+			if err := doDeleteCluster(p, cfg, ctl.GetNameArg(args)); err != nil {
 				logger.Critical("%s\n", err.Error())
 				os.Exit(1)
 			}
@@ -29,38 +30,38 @@ func deleteClusterCmd() *cobra.Command {
 
 	fs := cmd.Flags()
 
-	fs.StringVarP(&cfg.ClusterName, "name", "n", "", "EKS cluster name (required)")
+	fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
 
-	fs.StringVarP(&cfg.Region, "region", "r", "", "AWS region")
-	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS credentials profile to use (overrides the AWS_PROFILE environment variable)")
+	fs.StringVarP(&p.Region, "region", "r", "", "AWS region")
+	fs.StringVarP(&p.Profile, "profile", "p", "", "AWS credentials profile to use (overrides the AWS_PROFILE environment variable)")
 
 	fs.BoolVarP(&waitDelete, "wait", "w", false, "Wait for deletion of all resources before exiting")
 
-	fs.DurationVar(&cfg.WaitTimeout, "timeout", api.DefaultWaitTimeout, "max wait time in any polling operations")
+	fs.DurationVar(&p.WaitTimeout, "timeout", api.DefaultWaitTimeout, "max wait time in any polling operations")
 
 	return cmd
 }
 
-func doDeleteCluster(cfg *api.ClusterConfig, name string) error {
-	ctl := eks.New(cfg)
+func doDeleteCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, name string) error {
+	ctl := eks.New(p, cfg)
 
 	if err := ctl.CheckAuth(); err != nil {
 		return err
 	}
 
-	if cfg.ClusterName != "" && name != "" {
-		return fmt.Errorf("--name=%s and argument %s cannot be used at the same time", cfg.ClusterName, name)
+	if cfg.Metadata.Name != "" && name != "" {
+		return fmt.Errorf("--name=%s and argument %s cannot be used at the same time", cfg.Metadata.Name, name)
 	}
 
 	if name != "" {
-		cfg.ClusterName = name
+		cfg.Metadata.Name = name
 	}
 
-	if cfg.ClusterName == "" {
+	if cfg.Metadata.Name == "" {
 		return fmt.Errorf("--name must be set")
 	}
 
-	logger.Info("deleting EKS cluster %q", cfg.ClusterName)
+	logger.Info("deleting EKS cluster %q", cfg.Metadata.Name)
 
 	var deletedResources []string
 
@@ -76,7 +77,7 @@ func doDeleteCluster(cfg *api.ClusterConfig, name string) error {
 
 	// We can remove all 'DeprecatedDelete*' calls in 0.2.0
 
-	stackManager := ctl.NewStackManager()
+	stackManager := ctl.NewStackManager(cfg)
 
 	{
 		errs := stackManager.WaitDeleteAllNodeGroups()
@@ -98,7 +99,7 @@ func doDeleteCluster(cfg *api.ClusterConfig, name string) error {
 	}
 
 	if clusterErr {
-		if handleIfError(ctl.DeprecatedDeleteControlPlane(), "control plane") {
+		if handleIfError(ctl.DeprecatedDeleteControlPlane(cfg.Metadata), "control plane") {
 			handleIfError(stackManager.DeprecatedDeleteStackControlPlane(waitDelete), "stack control plane (deprecated)")
 		}
 	}
@@ -107,14 +108,14 @@ func doDeleteCluster(cfg *api.ClusterConfig, name string) error {
 	handleIfError(stackManager.DeprecatedDeleteStackVPC(waitDelete), "stack VPC (deprecated)")
 	handleIfError(stackManager.DeprecatedDeleteStackDefaultNodeGroup(waitDelete), "default nodegroup (deprecated)")
 
-	ctl.MaybeDeletePublicSSHKey()
+	ctl.MaybeDeletePublicSSHKey(cfg.Metadata.Name)
 
-	kubeconfig.MaybeDeleteConfig(cfg)
+	kubeconfig.MaybeDeleteConfig(cfg.Metadata)
 
 	if len(deletedResources) == 0 {
-		logger.Warning("no EKS cluster resources were found for %q", ctl.Spec.ClusterName)
+		logger.Warning("no EKS cluster resources were found for %q", cfg.Metadata.Name)
 	} else {
-		logger.Success("the following EKS cluster resource(s) for %q will be deleted: %s. If in doubt, check CloudFormation console", ctl.Spec.ClusterName, strings.Join(deletedResources, ", "))
+		logger.Success("the following EKS cluster resource(s) for %q will be deleted: %s. If in doubt, check CloudFormation console", cfg.Metadata.Name, strings.Join(deletedResources, ", "))
 	}
 
 	return nil

--- a/pkg/ctl/get/cluster.go
+++ b/pkg/ctl/get/cluster.go
@@ -15,6 +15,7 @@ import (
 var listAllRegions bool
 
 func getClusterCmd() *cobra.Command {
+	p := &api.ProviderConfig{}
 	cfg := api.NewClusterConfig()
 
 	cmd := &cobra.Command{
@@ -22,7 +23,7 @@ func getClusterCmd() *cobra.Command {
 		Short:   "Get cluster(s)",
 		Aliases: []string{"clusters"},
 		Run: func(_ *cobra.Command, args []string) {
-			if err := doGetCluster(cfg, ctl.GetNameArg(args)); err != nil {
+			if err := doGetCluster(p, cfg, ctl.GetNameArg(args)); err != nil {
 				logger.Critical("%s\n", err.Error())
 				os.Exit(1)
 			}
@@ -31,38 +32,39 @@ func getClusterCmd() *cobra.Command {
 
 	fs := cmd.Flags()
 
-	fs.StringVarP(&cfg.ClusterName, "name", "n", "", "EKS cluster name")
+	fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name")
 	fs.BoolVarP(&listAllRegions, "all-regions", "A", false, "List clusters across all supported regions")
 	fs.IntVar(&chunkSize, "chunk-size", defaultChunkSize, "Return large lists in chunks rather than all at once. Pass 0 to disable.")
 
-	fs.StringVarP(&cfg.Region, "region", "r", "", "AWS region")
-	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS credentials profile to use (overrides the AWS_PROFILE environment variable)")
+	fs.StringVarP(&p.Region, "region", "r", "", "AWS region")
+	fs.StringVarP(&p.Profile, "profile", "p", "", "AWS credentials profile to use (overrides the AWS_PROFILE environment variable)")
 
 	fs.StringVarP(&output, "output", "o", "table", "Specifies the output format. Choose from table,json,yaml. Defaults to table.")
+
 	return cmd
 }
 
-func doGetCluster(cfg *api.ClusterConfig, name string) error {
-	regionGiven := cfg.Region != "" // eks.New resets this field, so we need to check if it was set in the fist place
-	ctl := eks.New(cfg)
+func doGetCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, name string) error {
+	regionGiven := cfg.Metadata.Region != "" // eks.New resets this field, so we need to check if it was set in the fist place
+	ctl := eks.New(p, cfg)
 
-	if !cfg.IsSupportedRegion() {
-		return fmt.Errorf("--region=%s is not supported - use one of: %s", cfg.Region, strings.Join(api.SupportedRegions(), ", "))
+	if !ctl.IsSupportedRegion() {
+		return fmt.Errorf("--region=%s is not supported - use one of: %s", cfg.Metadata.Region, strings.Join(api.SupportedRegions(), ", "))
 	}
 
 	if regionGiven && listAllRegions {
-		logger.Warning("--region=%s is ignored, as --all-regions is given", cfg.Region)
+		logger.Warning("--region=%s is ignored, as --all-regions is given", cfg.Metadata.Region)
 	}
 
-	if cfg.ClusterName != "" && name != "" {
-		return fmt.Errorf("--name=%s and argument %s cannot be used at the same time", cfg.ClusterName, name)
+	if cfg.Metadata.Name != "" && name != "" {
+		return fmt.Errorf("--name=%s and argument %s cannot be used at the same time", cfg.Metadata.Name, name)
 	}
 
 	if name != "" {
-		cfg.ClusterName = name
+		cfg.Metadata.Name = name
 	}
 
-	if cfg.ClusterName != "" && listAllRegions {
+	if cfg.Metadata.Name != "" && listAllRegions {
 		return fmt.Errorf("--all-regions is for listing all clusters, it must be used without cluster name flag/argument")
 	}
 
@@ -70,5 +72,5 @@ func doGetCluster(cfg *api.ClusterConfig, name string) error {
 		return err
 	}
 
-	return ctl.ListClusters(chunkSize, output, listAllRegions)
+	return ctl.ListClusters(cfg.Metadata.Name, chunkSize, output, listAllRegions)
 }

--- a/pkg/ctl/utils/describe_stacks.go
+++ b/pkg/ctl/utils/describe_stacks.go
@@ -18,13 +18,14 @@ var (
 )
 
 func describeStacksCmd() *cobra.Command {
+	p := &api.ProviderConfig{}
 	cfg := api.NewClusterConfig()
 
 	cmd := &cobra.Command{
 		Use:   "describe-stacks",
 		Short: "Describe CloudFormation stack for a given cluster",
 		Run: func(_ *cobra.Command, args []string) {
-			if err := doDescribeStacksCmd(cfg, ctl.GetNameArg(args)); err != nil {
+			if err := doDescribeStacksCmd(p, cfg, ctl.GetNameArg(args)); err != nil {
 				logger.Critical("%s\n", err.Error())
 				os.Exit(1)
 			}
@@ -33,10 +34,10 @@ func describeStacksCmd() *cobra.Command {
 
 	fs := cmd.Flags()
 
-	fs.StringVarP(&cfg.ClusterName, "name", "n", "", "EKS cluster name (required)")
+	fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
 
-	fs.StringVarP(&cfg.Region, "region", "r", "", "AWS region")
-	fs.StringVarP(&cfg.Profile, "profile", "p", "", "AWS credentials profile to use (overrides the AWS_PROFILE environment variable)")
+	fs.StringVarP(&p.Region, "region", "r", "", "AWS region")
+	fs.StringVarP(&p.Profile, "profile", "p", "", "AWS credentials profile to use (overrides the AWS_PROFILE environment variable)")
 
 	fs.BoolVar(&utilsDescribeStackAll, "all", false, "include deleted stacks")
 	fs.BoolVar(&utilsDescribeStackEvents, "events", false, "include stack events")
@@ -44,28 +45,28 @@ func describeStacksCmd() *cobra.Command {
 	return cmd
 }
 
-func doDescribeStacksCmd(cfg *api.ClusterConfig, name string) error {
-	ctl := eks.New(cfg)
+func doDescribeStacksCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, name string) error {
+	ctl := eks.New(p, cfg)
 
 	if err := ctl.CheckAuth(); err != nil {
 		return err
 	}
 
-	if cfg.ClusterName != "" && name != "" {
-		return fmt.Errorf("--name=%s and argument %s cannot be used at the same time", cfg.ClusterName, name)
+	if cfg.Metadata.Name != "" && name != "" {
+		return fmt.Errorf("--name=%s and argument %s cannot be used at the same time", cfg.Metadata.Name, name)
 	}
 
 	if name != "" {
-		cfg.ClusterName = name
+		cfg.Metadata.Name = name
 	}
 
-	if cfg.ClusterName == "" {
+	if cfg.Metadata.Name == "" {
 		return fmt.Errorf("--name must be set")
 	}
 
-	stackManager := ctl.NewStackManager()
+	stackManager := ctl.NewStackManager(cfg)
 
-	stacks, err := stackManager.DescribeStacks(cfg.ClusterName)
+	stacks, err := stackManager.DescribeStacks(cfg.Metadata.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/wait_nodes.go
+++ b/pkg/ctl/utils/wait_nodes.go
@@ -13,6 +13,7 @@ import (
 )
 
 func waitNodesCmd() *cobra.Command {
+	p := &api.ProviderConfig{}
 	cfg := api.NewClusterConfig()
 	ng := cfg.NewNodeGroup()
 
@@ -20,7 +21,7 @@ func waitNodesCmd() *cobra.Command {
 		Use:   "wait-nodes",
 		Short: "Wait for nodes",
 		Run: func(_ *cobra.Command, _ []string) {
-			if err := doWaitNodes(cfg, ng); err != nil {
+			if err := doWaitNodes(p, cfg, ng); err != nil {
 				logger.Critical("%s\n", err.Error())
 				os.Exit(1)
 			}
@@ -31,13 +32,13 @@ func waitNodesCmd() *cobra.Command {
 
 	fs.StringVar(&utilsKubeconfigInputPath, "kubeconfig", "kubeconfig", "path to read kubeconfig")
 	fs.IntVarP(&ng.MinSize, "nodes-min", "m", api.DefaultNodeCount, "minimum number of nodes to wait for")
-	fs.DurationVar(&cfg.WaitTimeout, "timeout", api.DefaultWaitTimeout, "how long to wait")
+	fs.DurationVar(&p.WaitTimeout, "timeout", api.DefaultWaitTimeout, "how long to wait")
 
 	return cmd
 }
 
-func doWaitNodes(cfg *api.ClusterConfig, ng *api.NodeGroup) error {
-	ctl := eks.New(cfg)
+func doWaitNodes(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.NodeGroup) error {
+	ctl := eks.New(p, cfg)
 
 	if utilsKubeconfigInputPath == "" {
 		return fmt.Errorf("--kubeconfig must be set")

--- a/pkg/eks/eks_test.go
+++ b/pkg/eks/eks_test.go
@@ -14,7 +14,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	. "github.com/weaveworks/eksctl/pkg/eks"
-	"github.com/weaveworks/eksctl/pkg/eks/api"
 	"github.com/weaveworks/eksctl/pkg/testutils"
 )
 
@@ -42,9 +41,6 @@ var _ = Describe("Eks", func() {
 				p = testutils.NewMockProvider()
 
 				c = &ClusterProvider{
-					Spec: &api.ClusterConfig{
-						ClusterName: clusterName,
-					},
 					Provider: p,
 				}
 
@@ -61,7 +57,7 @@ var _ = Describe("Eks", func() {
 				})
 
 				JustBeforeEach(func() {
-					err = c.ListClusters(100, output, false)
+					err = c.ListClusters(clusterName, 100, output, false)
 				})
 
 				It("should not error", func() {
@@ -92,7 +88,7 @@ var _ = Describe("Eks", func() {
 				})
 
 				JustBeforeEach(func() {
-					err = c.ListClusters(100, output, false)
+					err = c.ListClusters(clusterName, 100, output, false)
 				})
 
 				It("should not error", func() {
@@ -129,9 +125,6 @@ var _ = Describe("Eks", func() {
 				p = testutils.NewMockProvider()
 
 				c = &ClusterProvider{
-					Spec: &api.ClusterConfig{
-						ClusterName: clusterName,
-					},
 					Provider: p,
 				}
 
@@ -143,7 +136,7 @@ var _ = Describe("Eks", func() {
 			})
 
 			JustBeforeEach(func() {
-				err = c.ListClusters(100, output, false)
+				err = c.ListClusters(clusterName, 100, output, false)
 			})
 
 			AfterEach(func() {
@@ -199,11 +192,10 @@ var _ = Describe("Eks", func() {
 					p = testutils.NewMockProvider()
 
 					c = &ClusterProvider{
-						Spec:     &api.ClusterConfig{},
 						Provider: p,
 					}
 
-					mockResultFn := func(input *awseks.ListClustersInput) *awseks.ListClustersOutput {
+					mockResultFn := func(_ *awseks.ListClustersInput) *awseks.ListClustersOutput {
 						clusterName := fmt.Sprintf("cluster-%d", callNumber)
 						output := &awseks.ListClustersOutput{
 							Clusters: []*string{aws.String(clusterName)},
@@ -212,7 +204,7 @@ var _ = Describe("Eks", func() {
 							output.NextToken = aws.String("SOMERANDOMTOKEN")
 						}
 
-						callNumber = callNumber + 1
+						callNumber++
 						return output
 					}
 
@@ -222,7 +214,7 @@ var _ = Describe("Eks", func() {
 				})
 
 				JustBeforeEach(func() {
-					err = c.ListClusters(chunkSize, output, false)
+					err = c.ListClusters("", chunkSize, output, false)
 				})
 
 				It("should not error", func() {
@@ -240,11 +232,10 @@ var _ = Describe("Eks", func() {
 					p = testutils.NewMockProvider()
 
 					c = &ClusterProvider{
-						Spec:     &api.ClusterConfig{},
 						Provider: p,
 					}
 
-					mockResultFn := func(input *awseks.ListClustersInput) *awseks.ListClustersOutput {
+					mockResultFn := func(_ *awseks.ListClustersInput) *awseks.ListClustersOutput {
 						output := &awseks.ListClustersOutput{
 							Clusters: []*string{aws.String("cluster-1"), aws.String("cluster-2")},
 						}
@@ -257,7 +248,7 @@ var _ = Describe("Eks", func() {
 				})
 
 				JustBeforeEach(func() {
-					err = c.ListClusters(chunkSize, output, false)
+					err = c.ListClusters("", chunkSize, output, false)
 				})
 
 				It("should not error", func() {

--- a/pkg/eks/nodegroup.go
+++ b/pkg/eks/nodegroup.go
@@ -87,7 +87,7 @@ func (c *ClusterProvider) WaitForNodes(clientSet *clientset.Clientset, ng *api.N
 	if ng.MinSize == 0 {
 		return nil
 	}
-	timer := time.After(c.Spec.WaitTimeout)
+	timer := time.After(c.Provider.WaitTimeout())
 	timeout := false
 	watcher, err := clientSet.CoreV1().Nodes().Watch(metav1.ListOptions{})
 	if err != nil {
@@ -120,7 +120,7 @@ func (c *ClusterProvider) WaitForNodes(clientSet *clientset.Clientset, ng *api.N
 		}
 	}
 	if timeout {
-		return fmt.Errorf("timed out (after %s) waitiing for at least %d nodes to join the cluster and become ready", c.Spec.WaitTimeout, ng.MinSize)
+		return fmt.Errorf("timed out (after %s) waitiing for at least %d nodes to join the cluster and become ready", c.Provider.WaitTimeout(), ng.MinSize)
 	}
 
 	if _, err = getNodes(clientSet); err != nil {

--- a/pkg/eks/vpc.go
+++ b/pkg/eks/vpc.go
@@ -14,31 +14,31 @@ import (
 
 // SetSubnets defines CIDRs for each of the subnets,
 // it must be called after SetAvailabilityZones
-func (c *ClusterProvider) SetSubnets() error {
+func (c *ClusterProvider) SetSubnets(spec *api.ClusterConfig) error {
 	var err error
 
-	vpc := c.Spec.VPC
+	vpc := spec.VPC
 	vpc.Subnets = map[api.SubnetTopology]map[string]api.Network{
 		api.SubnetTopologyPublic:  map[string]api.Network{},
 		api.SubnetTopologyPrivate: map[string]api.Network{},
 	}
-	prefix, _ := c.Spec.VPC.CIDR.Mask.Size()
+	prefix, _ := spec.VPC.CIDR.Mask.Size()
 	if (prefix < 16) || (prefix > 24) {
 		return fmt.Errorf("VPC CIDR prefix must be betwee /16 and /24")
 	}
-	zoneCIDRs, err := subnet.SplitInto8(c.Spec.VPC.CIDR)
+	zoneCIDRs, err := subnet.SplitInto8(spec.VPC.CIDR)
 	if err != nil {
 		return err
 	}
 
 	logger.Debug("VPC CIDR (%s) was divided into 8 subnets %v", vpc.CIDR.String(), zoneCIDRs)
 
-	zonesTotal := len(c.Spec.AvailabilityZones)
+	zonesTotal := len(spec.AvailabilityZones)
 	if 2*zonesTotal > len(zoneCIDRs) {
 		return fmt.Errorf("insufficient number of subnets (have %d, but need %d) for %d availability zones", len(zoneCIDRs), 2*zonesTotal, zonesTotal)
 	}
 
-	for i, zone := range c.Spec.AvailabilityZones {
+	for i, zone := range spec.AvailabilityZones {
 		public := zoneCIDRs[i]
 		private := zoneCIDRs[i+zonesTotal]
 		vpc.Subnets[api.SubnetTopologyPublic][zone] = api.Network{
@@ -54,7 +54,7 @@ func (c *ClusterProvider) SetSubnets() error {
 }
 
 // UseSubnets imports
-func (c *ClusterProvider) UseSubnets(topology api.SubnetTopology, subnetIDs []string) error {
+func (c *ClusterProvider) UseSubnets(spec *api.ClusterConfig, topology api.SubnetTopology, subnetIDs []string) error {
 	if len(subnetIDs) == 0 {
 		return nil
 	}
@@ -67,14 +67,14 @@ func (c *ClusterProvider) UseSubnets(topology api.SubnetTopology, subnetIDs []st
 	}
 
 	for _, subnet := range output.Subnets {
-		if c.Spec.VPC.ID == "" {
-			c.Spec.VPC.ID = *subnet.VpcId
-		} else if c.Spec.VPC.ID != *subnet.VpcId {
+		if spec.VPC.ID == "" {
+			spec.VPC.ID = *subnet.VpcId
+		} else if spec.VPC.ID != *subnet.VpcId {
 			return fmt.Errorf("given subnets (%s) are not in the same VPC", strings.Join(subnetIDs, ", "))
 		}
 
-		c.Spec.ImportSubnet(topology, *subnet.AvailabilityZone, *subnet.SubnetId)
-		c.Spec.AppendAvailabilityZone(*subnet.AvailabilityZone)
+		spec.ImportSubnet(topology, *subnet.AvailabilityZone, *subnet.SubnetId)
+		spec.AppendAvailabilityZone(*subnet.AvailabilityZone)
 	}
 
 	return nil

--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -106,8 +106,8 @@ func makeKubeletParams(spec *api.ClusterConfig, nodeGroupID int) []string {
 
 func makeMetadata(spec *api.ClusterConfig) []string {
 	return []string{
-		fmt.Sprintf("AWS_DEFAULT_REGION=%s", spec.Region),
-		fmt.Sprintf("AWS_EKS_CLUSTER_NAME=%s", spec.ClusterName),
+		fmt.Sprintf("AWS_DEFAULT_REGION=%s", spec.Metadata.Region),
+		fmt.Sprintf("AWS_EKS_CLUSTER_NAME=%s", spec.Metadata.Name),
 		fmt.Sprintf("AWS_EKS_ENDPOINT=%s", spec.Endpoint),
 	}
 }

--- a/pkg/testutils/mock_provider.go
+++ b/pkg/testutils/mock_provider.go
@@ -1,10 +1,13 @@
 package testutils
 
 import (
+	"time"
+
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+	"github.com/weaveworks/eksctl/pkg/eks/api"
 	"github.com/weaveworks/eksctl/pkg/eks/mocks"
 )
 
@@ -24,6 +27,13 @@ func NewMockProvider() *MockProvider {
 		ec2: &mocks.EC2API{},
 		sts: &mocks.STSAPI{},
 	}
+}
+
+// ProviderConfig holds current global config
+var ProviderConfig = &api.ProviderConfig{
+	Region:      api.DefaultEKSRegion,
+	Profile:     "default",
+	WaitTimeout: 1200000000000,
 }
 
 // CloudFormation returns a representation of the CloudFormation API
@@ -51,3 +61,12 @@ func (m MockProvider) STS() stsiface.STSAPI { return m.sts }
 
 // MockSTS returns a mocked STS API
 func (m MockProvider) MockSTS() *mocks.STSAPI { return m.STS().(*mocks.STSAPI) }
+
+// Profile returns current profile setting
+func (m MockProvider) Profile() string { return ProviderConfig.Profile }
+
+// Region returns current region setting
+func (m MockProvider) Region() string { return ProviderConfig.Region }
+
+// WaitTimeout returns current timeout setting
+func (m MockProvider) WaitTimeout() time.Duration { return ProviderConfig.WaitTimeout }

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -131,10 +131,11 @@ var _ = Describe("Kubeconfig", func() {
 	Context("delete config", func() {
 		// Default cluster name is 'foo' and region is 'us-west-2'
 		var apiClusterConfigSample = eksctlapi.ClusterConfig{
-			Region:      "us-west-2",
-			Profile:     "",
-			Tags:        map[string]string{},
-			ClusterName: "foo",
+			Metadata: &eksctlapi.ClusterMeta{
+				Region: "us-west-2",
+				Name:   "foo",
+				Tags:   map[string]string{},
+			},
 			NodeGroups: []*eksctlapi.NodeGroup{
 				{
 					AMI:               "",
@@ -160,7 +161,6 @@ var _ = Describe("Kubeconfig", func() {
 				},
 				SecurityGroup: "",
 			},
-			WaitTimeout:              1200000000000,
 			Endpoint:                 "",
 			CertificateAuthorityData: []uint8(nil),
 			ARN:                      "",
@@ -179,7 +179,7 @@ var _ = Describe("Kubeconfig", func() {
 		// Returns an ClusterConfig with a cluster name equal to the provided clusterName.
 		GetClusterConfig := func(clusterName string) *eksctlapi.ClusterConfig {
 			apiClusterConfig := apiClusterConfigSample
-			apiClusterConfig.ClusterName = clusterName
+			apiClusterConfig.Metadata.Name = clusterName
 			return &apiClusterConfig
 		}
 
@@ -223,7 +223,7 @@ var _ = Describe("Kubeconfig", func() {
 
 		It("removes a cluster from the kubeconfig if the kubeconfig file includes the cluster", func() {
 			existingClusterConfig := GetClusterConfig("cluster-two")
-			kubeconfig.MaybeDeleteConfig(existingClusterConfig)
+			kubeconfig.MaybeDeleteConfig(existingClusterConfig.Metadata)
 
 			configFileAsBytes, err := ioutil.ReadFile(configFile.Name())
 			Expect(err).To(BeNil())
@@ -232,7 +232,7 @@ var _ = Describe("Kubeconfig", func() {
 
 		It("not change the kubeconfig if the kubeconfig does not include the cluster", func() {
 			nonExistentClusterConfig := GetClusterConfig("not-a-cluster")
-			kubeconfig.MaybeDeleteConfig(nonExistentClusterConfig)
+			kubeconfig.MaybeDeleteConfig(nonExistentClusterConfig.Metadata)
 
 			configFileAsBytes, err := ioutil.ReadFile(configFile.Name())
 			Expect(err).To(BeNil())


### PR DESCRIPTION
### Description

This refactors how we separate provider configuration and it's recievers
from cluster configuration. We no longer copy cluster configuration in
every places where we need it, instead we pass it explicitly every time.

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [ ] All tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the README)
- [ ] Added yourself to the `humans.txt` file
