### PR TITLE
Automate flag grouping with and abstraction

### DIFF
--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -27,16 +27,22 @@ func GetNameArg(args []string) string {
 }
 
 // AddCommonFlagsForAWS adds common flags for api.ProviderConfig
-func AddCommonFlagsForAWS(fs *pflag.FlagSet, p *api.ProviderConfig) {
-	fs.StringVarP(&p.Region, "region", "r", "", "AWS region")
-	fs.StringVarP(&p.Profile, "profile", "p", "", "AWS credentials profile to use (overrides the AWS_PROFILE environment variable)")
+func AddCommonFlagsForAWS(group *NamedFlagSetGroup, p *api.ProviderConfig) {
+	group.InFlagSet("AWS client", func(fs *pflag.FlagSet) {
+		fs.StringVarP(&p.Profile, "profile", "p", "", "AWS credentials profile to use (overrides the AWS_PROFILE environment variable)")
 
-	fs.DurationVar(&p.WaitTimeout, "aws-api-timeout", api.DefaultWaitTimeout, "")
-	// TODO deprecate in 0.2.0
-	if err := fs.MarkHidden("aws-api-timeout"); err != nil {
-		logger.Debug("ignoring error %q", err.Error())
-	}
-	fs.DurationVar(&p.WaitTimeout, "timeout", api.DefaultWaitTimeout, "max wait time in any polling operations")
+		fs.DurationVar(&p.WaitTimeout, "aws-api-timeout", api.DefaultWaitTimeout, "")
+		// TODO deprecate in 0.2.0
+		if err := fs.MarkHidden("aws-api-timeout"); err != nil {
+			logger.Debug("ignoring error %q", err.Error())
+		}
+		fs.DurationVar(&p.WaitTimeout, "timeout", api.DefaultWaitTimeout, "max wait time in any polling operations")
+	})
+
+	group.InFlagSet("General", func(fs *pflag.FlagSet) {
+		fs.StringVarP(&p.Region, "region", "r", "", "AWS region")
+	})
+
 }
 
 // AddCommonFlagsForKubeconfig adds common flags for controlling how output kubeconfig is written

--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -38,18 +38,18 @@ func AddCommonFlagsForAWS(group *NamedFlagSetGroup, p *api.ProviderConfig) {
 		}
 		fs.DurationVar(&p.WaitTimeout, "timeout", api.DefaultWaitTimeout, "max wait time in any polling operations")
 	})
+}
 
-	group.InFlagSet("General", func(fs *pflag.FlagSet) {
-		fs.StringVarP(&p.Region, "region", "r", "", "AWS region")
-	})
-
+// AddRegionFlag adds common --region flag
+func AddRegionFlag(fs *pflag.FlagSet, p *api.ProviderConfig) {
+	fs.StringVarP(&p.Region, "region", "r", "", "AWS region")
 }
 
 // AddCommonFlagsForKubeconfig adds common flags for controlling how output kubeconfig is written
 func AddCommonFlagsForKubeconfig(fs *pflag.FlagSet, outputPath *string, setContext, autoPath *bool, exampleName string) {
-	fs.BoolVar(autoPath, "auto-kubeconfig", false, fmt.Sprintf("save kubeconfig file by cluster name, e.g. %q", kubeconfig.AutoPath(exampleName)))
 	fs.StringVar(outputPath, "kubeconfig", kubeconfig.DefaultPath, "path to write kubeconfig (incompatible with --auto-kubeconfig)")
 	fs.BoolVar(setContext, "set-kubeconfig-context", true, "if true then current-context will be set in kubeconfig; if a context is already set then it will be overwritten")
+	fs.BoolVar(autoPath, "auto-kubeconfig", false, fmt.Sprintf("save kubeconfig file by cluster name, e.g. %q", kubeconfig.AutoPath(exampleName)))
 }
 
 // ErrUnsupportedRegion is a common error message

--- a/pkg/ctl/cmdutils/group.go
+++ b/pkg/ctl/cmdutils/group.go
@@ -1,0 +1,106 @@
+package cmdutils
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// Grouping holds a superset of all flagsets for all commands
+type Grouping struct {
+	groups map[*cobra.Command]*NamedFlagSetGroup
+}
+
+type namedFlagSet struct {
+	name string
+	fs   *pflag.FlagSet
+}
+
+// NamedFlagSetGroup holds a single group of flagsets
+type NamedFlagSetGroup struct {
+	list []namedFlagSet
+}
+
+// NewGrouping creates an instance of Grouping
+func NewGrouping() *Grouping {
+	return &Grouping{
+		make(map[*cobra.Command]*NamedFlagSetGroup),
+	}
+}
+
+// New creates a new group of flagsets for use with a subcommand
+func (g *Grouping) New(cmd *cobra.Command) *NamedFlagSetGroup {
+	n := &NamedFlagSetGroup{}
+	g.groups[cmd] = n
+	return n
+}
+
+// InFlagSet returs new or existing named GlagSet in a group
+func (n *NamedFlagSetGroup) InFlagSet(name string, cb func(*pflag.FlagSet)) {
+	for _, nfs := range n.list {
+		if nfs.name == name {
+			cb(nfs.fs)
+			return
+		}
+	}
+
+	nfs := namedFlagSet{
+		name: name,
+		fs:   &pflag.FlagSet{},
+	}
+	cb(nfs.fs)
+	n.list = append(n.list, nfs)
+}
+
+// AddTo mixes all flagsets in the given group into another flagset
+func (n *NamedFlagSetGroup) AddTo(cmd *cobra.Command) {
+	for _, nfs := range n.list {
+		cmd.Flags().AddFlagSet(nfs.fs)
+	}
+}
+
+// Usage is for use with (*cobra.Command).SetUsageFunc
+func (g *Grouping) Usage(cmd *cobra.Command) error {
+	if cmd == nil {
+		return fmt.Errorf("nil command")
+	}
+
+	group := g.groups[cmd]
+
+	usage := []string{fmt.Sprintf("Usage: %s", cmd.UseLine())}
+
+	if cmd.HasAvailableSubCommands() {
+		usage = append(usage, "\nCommands:")
+		for _, subCommand := range cmd.Commands() {
+			usage = append(usage, fmt.Sprintf("  %s %-10s  %s", cmd.CommandPath(), subCommand.Name(), subCommand.Short))
+		}
+	}
+
+	if len(cmd.Aliases) > 0 {
+		usage = append(usage, "\nAliases: "+cmd.NameAndAliases())
+	}
+
+	if group != nil {
+		for _, nfs := range group.list {
+			usage = append(usage, fmt.Sprintf("\n%s flags:", nfs.name))
+			usage = append(usage, strings.TrimRightFunc(nfs.fs.FlagUsages(), unicode.IsSpace))
+		}
+	}
+
+	usage = append(usage, "\nCommon flags:")
+	if len(cmd.PersistentFlags().FlagUsages()) != 0 {
+		usage = append(usage, strings.TrimRightFunc(cmd.PersistentFlags().FlagUsages(), unicode.IsSpace))
+	}
+	if len(cmd.InheritedFlags().FlagUsages()) != 0 {
+		usage = append(usage, strings.TrimRightFunc(cmd.InheritedFlags().FlagUsages(), unicode.IsSpace))
+	}
+
+	usage = append(usage, fmt.Sprintf("\nUse '%s [command] --help' for more information about a command.\n", cmd.CommandPath()))
+
+	cmd.Println(strings.Join(usage, "\n"))
+
+	return nil
+}

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -57,49 +57,51 @@ func createClusterCmd(g *cmdutils.Grouping) *cobra.Command {
 	group.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", fmt.Sprintf("EKS cluster name (generated if unspecified, e.g. %q)", exampleClusterName))
 		fs.StringToStringVarP(&cfg.Metadata.Tags, "tags", "", map[string]string{}, `A list of KV pairs used to tag the AWS resources (e.g. "Owner=John Doe,Team=Some Team")`)
+		cmdutils.AddRegionFlag(fs, p)
 		fs.StringSliceVar(&availabilityZones, "zones", nil, "(auto-select if unspecified)")
 	})
 
 	group.InFlagSet("Initial nodegroup", func(fs *pflag.FlagSet) {
-		fs.StringVarP(&ng.InstanceType, "node-type", "t", defaultNodeType, "node instance type")
 		fs.IntVarP(&ng.DesiredCapacity, "nodes", "N", api.DefaultNodeCount, "total number of nodes (desired capacity of ASG)")
 
 		// TODO: https://github.com/weaveworks/eksctl/issues/28
 		fs.IntVarP(&ng.MinSize, "nodes-min", "m", 0, "minimum nodes in ASG (leave unset for a static nodegroup)")
 		fs.IntVarP(&ng.MaxSize, "nodes-max", "M", 0, "maximum nodes in ASG (leave unset for a static nodegroup)")
 
+		fs.StringVarP(&ng.InstanceType, "node-type", "t", defaultNodeType, "node instance type")
+
 		fs.IntVarP(&ng.VolumeSize, "node-volume-size", "", 0, "Node volume size (in GB)")
 		fs.IntVar(&ng.MaxPodsPerNode, "max-pods-per-node", 0, "maximum number of pods per node (set automatically if unspecified)")
 
-		fs.BoolVar(&ng.AllowSSH, "ssh-access", false, "control SSH access for nodes")
-		fs.StringVar(&ng.SSHPublicKeyPath, "ssh-public-key", defaultSSHPublicKey, "SSH public key to use for nodes (import from local path, or use existing EC2 key pair)")
-
 		fs.StringVar(&ng.AMI, "node-ami", ami.ResolverStatic, "Advanced use cases only. If 'static' is supplied (default) then eksctl will use static AMIs; if 'auto' is supplied then eksctl will automatically set the AMI based on region/instance type; if any other value is supplied it will override the AMI to use for the nodes. Use with extreme care.")
 		fs.StringVar(&ng.AMIFamily, "node-ami-family", ami.ImageFamilyAmazonLinux2, "Advanced use cases only. If 'AmazonLinux2' is supplied (default), then eksctl will use the offical AWS EKS AMIs (Amazon Linux 2); if 'Ubuntu1804' is supplied, then eksctl will use the offical Canonical EKS AMIs (Ubuntu 18.04).")
+
+		fs.BoolVar(&ng.AllowSSH, "ssh-access", false, "control SSH access for nodes")
+		fs.StringVar(&ng.SSHPublicKeyPath, "ssh-public-key", defaultSSHPublicKey, "SSH public key to use for nodes (import from local path, or use existing EC2 key pair)")
 
 		fs.BoolVarP(&ng.PrivateNetworking, "node-private-networking", "P", false, "whether to make initial nodegroup networking private")
 	})
 
 	group.InFlagSet("Cluster add-ons", func(fs *pflag.FlagSet) {
-		fs.BoolVar(&cfg.Addons.WithIAM.PolicyAmazonEC2ContainerRegistryPowerUser, "full-ecr-access", false, "enable full access to ECR")
 		fs.BoolVar(&cfg.Addons.WithIAM.PolicyAutoScaling, "asg-access", false, "enable iam policy dependency for cluster-autoscaler")
+		fs.BoolVar(&cfg.Addons.WithIAM.PolicyAmazonEC2ContainerRegistryPowerUser, "full-ecr-access", false, "enable full access to ECR")
 		fs.BoolVar(&cfg.Addons.Storage, "storage-class", true, "if true (default) then a default StorageClass of type gp2 provisioned by EBS will be created")
 	})
 
 	group.InFlagSet("VPC networking", func(fs *pflag.FlagSet) {
-		fs.StringVar(&kopsClusterNameForVPC, "vpc-from-kops-cluster", "", "re-use VPC from a given kops cluster")
 		fs.IPNetVar(cfg.VPC.CIDR, "vpc-cidr", api.DefaultCIDR(), "global CIDR to use for VPC")
 		subnets = map[api.SubnetTopology]*[]string{
 			api.SubnetTopologyPrivate: fs.StringSlice("vpc-private-subnets", nil, "re-use private subnets of an existing VPC"),
 			api.SubnetTopologyPublic:  fs.StringSlice("vpc-public-subnets", nil, "re-use public subnets of an existing VPC"),
 		}
+		fs.StringVar(&kopsClusterNameForVPC, "vpc-from-kops-cluster", "", "re-use VPC from a given kops cluster")
 	})
 
 	cmdutils.AddCommonFlagsForAWS(group, p)
 
 	group.InFlagSet("Output kubeconfig", func(fs *pflag.FlagSet) {
-		fs.BoolVar(&writeKubeconfig, "write-kubeconfig", true, "toggle writing of kubeconfig")
 		cmdutils.AddCommonFlagsForKubeconfig(fs, &kubeconfigPath, &setContext, &autoKubeconfigPath, exampleClusterName)
+		fs.BoolVar(&writeKubeconfig, "write-kubeconfig", true, "toggle writing of kubeconfig")
 	})
 
 	group.AddTo(cmd)

--- a/pkg/ctl/create/create.go
+++ b/pkg/ctl/create/create.go
@@ -3,10 +3,11 @@ package create
 import (
 	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
 // Command will create the `create` commands
-func Command() *cobra.Command {
+func Command(g *cmdutils.Grouping) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create resource(s)",
@@ -17,7 +18,7 @@ func Command() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(createClusterCmd())
+	cmd.AddCommand(createClusterCmd(g))
 
 	return cmd
 }

--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/eks/api"
@@ -28,14 +29,16 @@ func deleteClusterCmd() *cobra.Command {
 		},
 	}
 
-	fs := cmd.Flags()
+	group := &cmdutils.NamedFlagSetGroup{}
 
-	fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
+	group.InFlagSet("General", func(fs *pflag.FlagSet) {
+		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
+		fs.BoolVarP(&waitDelete, "wait", "w", false, "Wait for deletion of all resources before exiting")
+	})
 
-	cmdutils.AddCommonFlagsForAWS(fs, p)
+	cmdutils.AddCommonFlagsForAWS(group, p)
 
-	fs.BoolVarP(&waitDelete, "wait", "w", false, "Wait for deletion of all resources before exiting")
-
+	group.AddTo(cmd)
 	return cmd
 }
 

--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -33,6 +33,7 @@ func deleteClusterCmd() *cobra.Command {
 
 	group.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
+		cmdutils.AddRegionFlag(fs, p)
 		fs.BoolVarP(&waitDelete, "wait", "w", false, "Wait for deletion of all resources before exiting")
 	})
 

--- a/pkg/ctl/utils/describe_stacks.go
+++ b/pkg/ctl/utils/describe_stacks.go
@@ -38,7 +38,7 @@ func describeStacksCmd() *cobra.Command {
 
 	group.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
-
+		cmdutils.AddRegionFlag(fs, p)
 		fs.BoolVar(&describeStacksAll, "all", false, "include deleted stacks")
 		fs.BoolVar(&describeStacksEvents, "events", false, "include stack events")
 	})

--- a/pkg/ctl/utils/describe_stacks.go
+++ b/pkg/ctl/utils/describe_stacks.go
@@ -7,6 +7,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/eks/api"
@@ -32,15 +34,18 @@ func describeStacksCmd() *cobra.Command {
 		},
 	}
 
-	fs := cmd.Flags()
+	group := &cmdutils.NamedFlagSetGroup{}
 
-	cmdutils.AddCommonFlagsForAWS(fs, p)
+	group.InFlagSet("General", func(fs *pflag.FlagSet) {
+		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
 
-	fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
+		fs.BoolVar(&describeStacksAll, "all", false, "include deleted stacks")
+		fs.BoolVar(&describeStacksEvents, "events", false, "include stack events")
+	})
 
-	fs.BoolVar(&describeStacksAll, "all", false, "include deleted stacks")
-	fs.BoolVar(&describeStacksEvents, "events", false, "include stack events")
+	cmdutils.AddCommonFlagsForAWS(group, p)
 
+	group.AddTo(cmd)
 	return cmd
 }
 

--- a/pkg/ctl/utils/write_kubeconfig.go
+++ b/pkg/ctl/utils/write_kubeconfig.go
@@ -7,6 +7,8 @@ import (
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/eks/api"
@@ -34,14 +36,19 @@ func writeKubeconfigCmd() *cobra.Command {
 		},
 	}
 
-	fs := cmd.Flags()
+	group := &cmdutils.NamedFlagSetGroup{}
 
-	fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
+	group.InFlagSet("General", func(fs *pflag.FlagSet) {
+		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
+	})
 
-	cmdutils.AddCommonFlagsForAWS(fs, p)
+	group.InFlagSet("Output kubeconfig", func(fs *pflag.FlagSet) {
+		cmdutils.AddCommonFlagsForKubeconfig(fs, &writeKubeconfigOutputPath, &writeKubeconfigSetContext, &writeKubeconfigAutoPath, "<name>")
+	})
 
-	cmdutils.AddCommonFlagsForKubeconfig(fs, &writeKubeconfigOutputPath, &writeKubeconfigSetContext, &writeKubeconfigAutoPath, "<name>")
+	cmdutils.AddCommonFlagsForAWS(group, p)
 
+	group.AddTo(cmd)
 	return cmd
 }
 

--- a/pkg/ctl/utils/write_kubeconfig.go
+++ b/pkg/ctl/utils/write_kubeconfig.go
@@ -40,6 +40,7 @@ func writeKubeconfigCmd() *cobra.Command {
 
 	group.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
+		cmdutils.AddRegionFlag(fs, p)
 	})
 
 	group.InFlagSet("Output kubeconfig", func(fs *pflag.FlagSet) {


### PR DESCRIPTION
### Description

This is a follow-up to @mumoshu's change, allowing us to easily implement flag grouping for all commands. This is also changes the grouping itself (as discussed in #328), and introduces a custom function for rendering the usage text, so we are in full control of it.

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] All tests passing (i.e. `make test`)
