### PR TITLE
adding external-dns policy support

### DIFF
--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -146,5 +146,19 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 		)
 	}
 
+	if n.clusterSpec.Addons.WithIAM.PolicyExternalDNS {
+		n.rs.attachAllowPolicy("PolicyExternalDNSChangeSet", refIR, "arn:aws:route53:::hostedzone/*",
+			[]string{
+				"route53:ChangeResourceRecordSets",
+			},
+		)
+		n.rs.attachAllowPolicy("PolicyExternalDNSHostedZones", refIR, "*",
+			[]string{
+				"route53:ListHostedZones",
+				"route53:ListResourceRecordSets",
+			},
+		)
+	}
+
 	n.rs.newOutputFromAtt(cfnOutputInstanceRoleARN, "NodeInstanceRole.Arn", true)
 }

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -85,6 +85,7 @@ func createClusterCmd(g *cmdutils.Grouping) *cobra.Command {
 
 	group.InFlagSet("Cluster add-ons", func(fs *pflag.FlagSet) {
 		fs.BoolVar(&cfg.Addons.WithIAM.PolicyAutoScaling, "asg-access", false, "enable iam policy dependency for cluster-autoscaler")
+		fs.BoolVar(&cfg.Addons.WithIAM.PolicyExternalDNS, "external-dns-access", false, "enable iam policy dependency for external-dns")
 		fs.BoolVar(&cfg.Addons.WithIAM.PolicyAmazonEC2ContainerRegistryPowerUser, "full-ecr-access", false, "enable full access to ECR")
 		fs.BoolVar(&cfg.Addons.Storage, "storage-class", true, "if true (default) then a default StorageClass of type gp2 provisioned by EBS will be created")
 	})

--- a/pkg/eks/api/api.go
+++ b/pkg/eks/api/api.go
@@ -193,5 +193,6 @@ type (
 	AddonIAM struct {
 		PolicyAmazonEC2ContainerRegistryPowerUser bool
 		PolicyAutoScaling                         bool
+		PolicyExternalDNS                         bool
 	}
 )


### PR DESCRIPTION
Signed-off-by: Christopher Hein <me@christopherhein.com>

### Description
This adds the `external-dns` project policies so that you can immediately deploy the project. 

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)
- [x] Added/modified documentation as required (such as the README)
- [x] Added yourself to the `humans.txt` file
