### PR TITLE
Some refactoring

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -16,7 +16,7 @@ const (
 	deleteTimeout = 15 * time.Minute
 	getTimeout    = 1 * time.Minute
 	scaleTimeout  = 5 * time.Minute
-	region        = api.DefaultEKSRegion
+	region        = api.DefaultRegion
 )
 
 var (

--- a/pkg/cfn/builder/cluster.go
+++ b/pkg/cfn/builder/cluster.go
@@ -86,7 +86,7 @@ func (c *ClusterResourceSet) addResourcesForControlPlane() {
 	c.newResource("ControlPlane", &gfn.AWSEKSCluster{
 		Name:               gfn.NewString(c.spec.Metadata.Name),
 		RoleArn:            gfn.MakeFnGetAttString("ServiceRole.Arn"),
-		Version:            gfn.NewString(c.provider.Version()),
+		Version:            gfn.NewString(c.spec.Metadata.Version),
 		ResourcesVpcConfig: clusterVPC,
 	})
 

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -62,9 +62,6 @@ func (p ProviderServices) STS() stsiface.STSAPI { return p.sts }
 // Region returns provider-level region setting
 func (p ProviderServices) Region() string { return p.spec.Region }
 
-// Version returns provider-level version setting
-func (p ProviderServices) Version() string { return p.spec.Version }
-
 // Profile returns provider-level profile name
 func (p ProviderServices) Profile() string { return p.spec.Profile }
 
@@ -168,19 +165,19 @@ func (c *ClusterProvider) CheckAuth() error {
 }
 
 // EnsureAMI ensures that the node AMI is set and is available
-func (c *ClusterProvider) EnsureAMI(ng *api.NodeGroup) error {
+func (c *ClusterProvider) EnsureAMI(version string, ng *api.NodeGroup) error {
 	// TODO: https://github.com/weaveworks/eksctl/issues/28
 	// - improve validation of parameter set overall, probably in another package
 	if ng.AMI == ami.ResolverAuto {
 		ami.DefaultResolvers = []ami.Resolver{ami.NewAutoResolver(c.Provider.EC2())}
 	}
 	if ng.AMI == ami.ResolverStatic || ng.AMI == ami.ResolverAuto {
-		id, err := ami.Resolve(c.Provider.Region(), c.Provider.Version(), ng.InstanceType, ng.AMIFamily)
+		id, err := ami.Resolve(c.Provider.Region(), version, ng.InstanceType, ng.AMIFamily)
 		if err != nil {
 			return errors.Wrap(err, "Unable to determine AMI to use")
 		}
 		if id == "" {
-			return ami.NewErrFailedResolution(c.Provider.Region(), c.Provider.Version(), ng.InstanceType, ng.AMIFamily)
+			return ami.NewErrFailedResolution(c.Provider.Region(), version, ng.InstanceType, ng.AMIFamily)
 		}
 		ng.AMI = id
 	}

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -205,7 +205,7 @@ func (c *ClusterProvider) SetAvailabilityZones(spec *api.ClusterConfig, given []
 	if len(given) == 0 {
 		logger.Debug("determining availability zones")
 		azSelector := az.NewSelectorWithDefaults(c.Provider.EC2())
-		if c.Provider.Region() == api.EKSRegionUSEast1 {
+		if c.Provider.Region() == api.RegionUSEast1 {
 			azSelector = az.NewSelectorWithMinRequired(c.Provider.EC2())
 		}
 		zones, err := azSelector.SelectZones(c.Provider.Region())
@@ -278,8 +278,8 @@ func (c *ClusterProvider) newSession(spec *api.ProviderConfig, endpoint string, 
 			spec.Region = *s.Config.Region
 		} else {
 			// if session config doesn't have region set, make recursive call forcing default region
-			logger.Debug("no region specified in flags or config, setting to %s", api.DefaultEKSRegion)
-			spec.Region = api.DefaultEKSRegion
+			logger.Debug("no region specified in flags or config, setting to %s", api.DefaultRegion)
+			spec.Region = api.DefaultRegion
 			return c.newSession(spec, endpoint, credentials)
 		}
 	}

--- a/pkg/eks/api/api.go
+++ b/pkg/eks/api/api.go
@@ -14,33 +14,33 @@ const (
 	// AWSDebugLevel defines the LogLevel for AWS produced logs
 	AWSDebugLevel = 5
 
-	// EKSRegionUSWest2 represents the US West Region Oregon
-	EKSRegionUSWest2 = "us-west-2"
+	// RegionUSWest2 represents the US West Region Oregon
+	RegionUSWest2 = "us-west-2"
 
-	// EKSRegionUSEast1 represents the US East Region North Virgina
-	EKSRegionUSEast1 = "us-east-1"
+	// RegionUSEast1 represents the US East Region North Virgina
+	RegionUSEast1 = "us-east-1"
 
-	// EKSRegionUSEast2 represents the US East Region Ohio
-	EKSRegionUSEast2 = "us-east-2"
+	// RegionUSEast2 represents the US East Region Ohio
+	RegionUSEast2 = "us-east-2"
 
-	// EKSRegionEUWest1 represents the EU West Region Ireland
-	EKSRegionEUWest1 = "eu-west-1"
+	// RegionEUWest1 represents the EU West Region Ireland
+	RegionEUWest1 = "eu-west-1"
 
-	// EKSRegionEUNorth1 represents the EU North Region Stockholm
-	EKSRegionEUNorth1 = "eu-north-1"
+	// RegionEUNorth1 represents the EU North Region Stockholm
+	RegionEUNorth1 = "eu-north-1"
 
-	// DefaultEKSRegion defines the default region, where to deploy the EKS cluster
-	DefaultEKSRegion = EKSRegionUSWest2
+	// DefaultRegion defines the default region, where to deploy the EKS cluster
+	DefaultRegion = RegionUSWest2
 )
 
 // SupportedRegions are the regions where EKS is available
 func SupportedRegions() []string {
 	return []string{
-		EKSRegionUSWest2,
-		EKSRegionUSEast1,
-		EKSRegionUSEast2,
-		EKSRegionEUWest1,
-		EKSRegionEUNorth1,
+		RegionUSWest2,
+		RegionUSEast1,
+		RegionUSEast2,
+		RegionEUWest1,
+		RegionEUNorth1,
 	}
 }
 

--- a/pkg/eks/api/api.go
+++ b/pkg/eks/api/api.go
@@ -31,6 +31,15 @@ const (
 
 	// DefaultRegion defines the default region, where to deploy the EKS cluster
 	DefaultRegion = RegionUSWest2
+
+	// Version1_10 represents Kubernetes version 1.10.x
+	Version1_10 = "1.10"
+
+	// Version1_11 represents Kubernetes version 1.11.x
+	Version1_11 = "1.11"
+
+	// LatestVersion represents latest Kubernetes version supported by EKS
+	LatestVersion = Version1_11
 )
 
 // SupportedRegions are the regions where EKS is available
@@ -41,6 +50,14 @@ func SupportedRegions() []string {
 		RegionUSEast2,
 		RegionEUWest1,
 		RegionEUNorth1,
+	}
+}
+
+// SupportedVersions are the versions of Kubernetes that EKS supports
+func SupportedVersions() []string {
+	return []string{
+		Version1_10,
+		Version1_11,
 	}
 }
 
@@ -75,7 +92,6 @@ type ClusterProvider interface {
 	EC2() ec2iface.EC2API
 	STS() stsiface.STSAPI
 	Region() string
-	Version() string
 	Profile() string
 	WaitTimeout() time.Duration
 }
@@ -84,7 +100,6 @@ type ClusterProvider interface {
 type ProviderConfig struct {
 	Region      string
 	Profile     string
-	Version     string
 	WaitTimeout time.Duration
 }
 

--- a/pkg/testutils/mock_provider.go
+++ b/pkg/testutils/mock_provider.go
@@ -33,7 +33,6 @@ func NewMockProvider() *MockProvider {
 var ProviderConfig = &api.ProviderConfig{
 	Region:      api.DefaultRegion,
 	Profile:     "default",
-	Version:     "1.10",
 	WaitTimeout: 1200000000000,
 }
 
@@ -68,9 +67,6 @@ func (m MockProvider) Profile() string { return ProviderConfig.Profile }
 
 // Region returns current region setting
 func (m MockProvider) Region() string { return ProviderConfig.Region }
-
-// Version returns current version setting
-func (m MockProvider) Version() string { return ProviderConfig.Version }
 
 // WaitTimeout returns current timeout setting
 func (m MockProvider) WaitTimeout() time.Duration { return ProviderConfig.WaitTimeout }

--- a/pkg/testutils/mock_provider.go
+++ b/pkg/testutils/mock_provider.go
@@ -31,7 +31,7 @@ func NewMockProvider() *MockProvider {
 
 // ProviderConfig holds current global config
 var ProviderConfig = &api.ProviderConfig{
-	Region:      api.DefaultEKSRegion,
+	Region:      api.DefaultRegion,
 	Profile:     "default",
 	Version:     "1.10",
 	WaitTimeout: 1200000000000,


### PR DESCRIPTION
### Description

- move `Version` out of `ClusterProvider` into `ClusterMeta`-only
- consistent naming of region constants

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] All tests passing (i.e. `make test`)