### PR TITLE
Fix flag groups by adding them to the command

### DIFF
--- a/pkg/ctl/get/cluster.go
+++ b/pkg/ctl/get/cluster.go
@@ -43,6 +43,8 @@ func getClusterCmd(g *cmdutils.Grouping) *cobra.Command {
 		fs.StringVarP(&output, "output", "o", "table", "Specifies the output format. Choose from table,json,yaml. Defaults to table.")
 	})
 
+	group.AddTo(cmd)
+
 	return cmd
 }
 

--- a/pkg/ctl/scale/nodegroup.go
+++ b/pkg/ctl/scale/nodegroup.go
@@ -41,6 +41,8 @@ func scaleNodeGroupCmd(g *cmdutils.Grouping) *cobra.Command {
 		fs.DurationVar(&p.WaitTimeout, "timeout", api.DefaultWaitTimeout, "max wait time in any polling operations")
 	})
 
+	group.AddTo(cmd)
+
 	return cmd
 }
 

--- a/pkg/ctl/utils/wait_nodes.go
+++ b/pkg/ctl/utils/wait_nodes.go
@@ -40,6 +40,8 @@ func waitNodesCmd(g *cmdutils.Grouping) *cobra.Command {
 		fs.DurationVar(&p.WaitTimeout, "timeout", api.DefaultWaitTimeout, "how long to wait")
 	})
 
+	group.AddTo(cmd)
+
 	return cmd
 }
 


### PR DESCRIPTION
### Description

Some flags were converted to the new group mechanism, but missed the
AddTo command functionality.

Fixes #366

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)
- [x] Added/modified documentation as required (such as the README)
- [ ] Added yourself to the `humans.txt` file