### PR TITLE
fix(circleci): goreleaser should not break the entire CI build just due to the CGO dependency

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -24,6 +24,6 @@ RUN dep ensure
 RUN ./install.sh
 
 WORKDIR $EKSCTL_BUILD/vendor/github.com/goreleaser/goreleaser
-RUN make build && go install
+RUN CGO_ENABLED=0 make build && go install
 
 WORKDIR $GOPATH


### PR DESCRIPTION
Fixes #374