### PR TITLE
Use an existing vpc, generate subnets (WIP)

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha3/vpc.go
+++ b/pkg/apis/eksctl.io/v1alpha3/vpc.go
@@ -22,6 +22,7 @@ type (
 		// private subnets or any ad-hoc subnets
 		// +optional
 		ExtraCIDRs []*ipnet.IPNet `json:"extraCIDRs,omitempty"`
+		IGW        InternetGateway
 	}
 	// SubnetTopology can be SubnetTopologyPrivate or SubnetTopologyPublic
 	SubnetTopology string
@@ -31,6 +32,10 @@ type (
 		ID string `json:"id,omitempty"`
 		// +optional
 		CIDR *ipnet.IPNet `json:"cidr,omitempty"`
+	}
+	// InternetGateway holds the ID of the Internet Gateway for that VPC
+	InternetGateway struct {
+		ID string
 	}
 )
 

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -277,7 +277,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Status: &api.ClusterStatus{
 				Endpoint:                 endpoint,
 				CertificateAuthorityData: caCertData,
-				ARN: arn,
+				ARN:                      arn,
 			},
 			AvailabilityZones: testAZs,
 			VPC:               testVPC(),
@@ -310,8 +310,8 @@ var _ = Describe("CloudFormation template builder API", func() {
 			"VPC":                      vpcID,
 			"Endpoint":                 endpoint,
 			"CertificateAuthorityData": caCert,
-			"ARN":              arn,
-			"ClusterStackName": "",
+			"ARN":                      arn,
+			"ClusterStackName":         "",
 		}
 
 		sampleStack := newStackWithOutputs(sampleOutputs)

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/weaveworks/eksctl/pkg/nodebootstrap"
 	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
 	"github.com/weaveworks/eksctl/pkg/utils/ipnet"
-	"github.com/weaveworks/eksctl/pkg/vpc"
 )
 
 const (
@@ -278,7 +277,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Status: &api.ClusterStatus{
 				Endpoint:                 endpoint,
 				CertificateAuthorityData: caCertData,
-				ARN:                      arn,
+				ARN: arn,
 			},
 			AvailabilityZones: testAZs,
 			VPC:               testVPC(),
@@ -298,19 +297,6 @@ var _ = Describe("CloudFormation template builder API", func() {
 
 		cfg := newClusterConfig()
 
-		It("should not error when calling SetSubnets", func() {
-			err := vpc.SetSubnets(cfg)
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-
-		It("should have public and private subnets", func() {
-			Expect(len(cfg.VPC.Subnets)).To(Equal(2))
-			for _, k := range []api.SubnetTopology{"Public", "Private"} {
-				Expect(cfg.VPC.Subnets).To(HaveKey(k))
-				Expect(len(cfg.VPC.Subnets[k])).To(Equal(3))
-			}
-		})
-
 		rs := NewClusterResourceSet(p, cfg)
 		It("should add all resources without error", func() {
 			err := rs.AddAllResources()
@@ -324,8 +310,8 @@ var _ = Describe("CloudFormation template builder API", func() {
 			"VPC":                      vpcID,
 			"Endpoint":                 endpoint,
 			"CertificateAuthorityData": caCert,
-			"ARN":                      arn,
-			"ClusterStackName":         "",
+			"ARN":              arn,
+			"ClusterStackName": "",
 		}
 
 		sampleStack := newStackWithOutputs(sampleOutputs)

--- a/pkg/cfn/builder/cluster.go
+++ b/pkg/cfn/builder/cluster.go
@@ -38,7 +38,7 @@ func NewClusterResourceSet(provider api.ClusterProvider, spec *api.ClusterConfig
 // AddAllResources adds all the information about the cluster to the resource set
 func (c *ClusterResourceSet) AddAllResources() error {
 	dedicatedVPC := c.spec.VPC.ID == ""
-	internetGatewayGiven := c.spec.VPC.IGW.ID == ""
+	internetGatewayGiven := c.spec.VPC.IGW.ID != ""
 	dedicatedSubnets := len(c.subnets[api.SubnetTopologyPrivate])+len(c.subnets[api.SubnetTopologyPublic]) == 0
 
 	c.rs.template.Description = fmt.Sprintf(
@@ -97,7 +97,7 @@ func (c *ClusterResourceSet) addResourcesForControlPlane() {
 	clusterVPC := &gfn.AWSEKSCluster_ResourcesVpcConfig{
 		SecurityGroupIds: c.securityGroups,
 	}
-	for topology := range c.spec.VPC.Subnets {
+	for topology := range c.subnets {
 		clusterVPC.SubnetIds = append(clusterVPC.SubnetIds, c.subnets[topology]...)
 	}
 

--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -98,7 +98,7 @@ func (c *ClusterResourceSet) addResourcesForSubnets() error {
 	if (prefix < 16) || (prefix > 24) {
 		return fmt.Errorf("VPC CIDR prefix must be betwee /16 and /24")
 	}
-	zoneCIDRs, err := subnet.SplitInto8(c.spec.VPC.CIDR)
+	zoneCIDRs, err := subnet.SplitInto8(&c.spec.VPC.CIDR.IPNet)
 	if err != nil {
 		return err
 	}

--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -81,7 +81,7 @@ func (c *ClusterResourceSet) addResourcesForRouting() {
 	})
 	for topology, subnets := range c.subnets {
 		for i, subnet := range subnets {
-			c.newResource("RouteTableAssociation"+string(topology)+string(i), &gfn.AWSEC2SubnetRouteTableAssociation{
+			c.newResource(fmt.Sprintf("RouteTableAssociation%s%v", string(topology), i), &gfn.AWSEC2SubnetRouteTableAssociation{
 				SubnetId:     subnet,
 				RouteTableId: routeTables[topology],
 			})

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -84,6 +84,8 @@ func createClusterCmd(g *cmdutils.Grouping) *cobra.Command {
 
 	group.InFlagSet("VPC networking", func(fs *pflag.FlagSet) {
 		fs.IPNetVar(&cfg.VPC.CIDR.IPNet, "vpc-cidr", cfg.VPC.CIDR.IPNet, "global CIDR to use for VPC")
+		fs.StringVar(&cfg.VPC.ID, "vpc-id", "", "ID of existing VPC to use (can be omitted if providing existing subnets)")
+		fs.StringVar(&cfg.VPC.IGW.ID, "igw-id", "", "use existing Internet Gateway (must be supplied if using an existing VPC which has an Internet Gateway), and not providing subnets")
 		subnets = map[api.SubnetTopology]*[]string{
 			api.SubnetTopologyPrivate: fs.StringSlice("vpc-private-subnets", nil, "re-use private subnets of an existing VPC"),
 			api.SubnetTopologyPublic:  fs.StringSlice("vpc-public-subnets", nil, "re-use public subnets of an existing VPC"),
@@ -296,9 +298,6 @@ func doCreateCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 		if !subnetsGiven && kopsClusterNameForVPC == "" {
 			// default: create dedicated VPC
 			if err := ctl.SetAvailabilityZones(cfg, availabilityZones); err != nil {
-				return err
-			}
-			if err := vpc.SetSubnets(cfg); err != nil {
 				return err
 			}
 			return nil


### PR DESCRIPTION
### Description
Added support for providing --vpc-id without providing subnets, ie the fourth item in #306. Subnets will be auto-generated as if this is a new VPC. To do this, I had to move things around a bit, to cleanly separate management of the subnets and routing from the VPC itself. Also, since only one InternetGateway can be attached to a VPC at once, if one exists for the given VPC it must also be passed to eksctl so it will be used.

Tested with:
```
docker build -t eks --build-arg EKSCTL_BUILD_IMAGE=eksbuild .
docker run --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY --env AWS_REGION=$AWS_REGION eks eksctl create cluster -n $NAME --vpc-cidr $VPC_CIDR --vpc-id $VPC_ID --igw-id $IGW_ID 
```
If the approach makes sense, I can polish the various edges, eg get the CIDR from the VPC, add handling for default VPC, add test cases and documentation etc. But first let me know if this looks useful.
### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the README)
- [ ] Added yourself to the `humans.txt` file
