### PR TITLE
fix logger.Success message

### DIFF
--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -133,7 +133,7 @@ func doCreateNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.No
 			return err
 		}
 	}
-	logger.Success("created nodegroup %q in cluster %q", cfg.Metadata.Name, ng.Name)
+	logger.Success("created nodegroup %q in cluster %q", ng.Name, cfg.Metadata.Name)
 
 	return nil
 


### PR DESCRIPTION
### Description
When running eksctl, in the output there appeared to be a very small typo. The cluster and nodegroup names were swapped. Refer to the commit for more details. 

### Checklist
- [ ] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [ ] All tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the README)
- [ ] Added yourself to the `humans.txt` file
