### PR TITLE
Allow configuring node volume type

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ To add custom tags for all resources, use `--tags`.
 eksctl create cluster --tags environment=staging --region=us-east-1
 ```
 
-To configure node volume size, use the `--node-volume-size` flag.
+To configure node root volume, use the `--node-volume-size` (and optionally `--node-volume-type`), e.g.:
 
 ```
-eksctl create cluster --node-volume-size=50
+eksctl create cluster --node-volume-size=50 --node-volume-type=io1
 ```
 
 > NOTE: In `us-east-1` you are likely to get `UnsupportedAvailabilityZoneException`. If you do, copy the suggested zones and pass `--zones` flag, e.g. `eksctl create cluster --region=us-east-1 --zones=us-east-1a,us-east-1b,us-east-1d`. This may occur in other regions, but less likely. You shouldn't need to use `--zone` flag otherwise.

--- a/pkg/apis/eksctl.io/v1alpha3/types.go
+++ b/pkg/apis/eksctl.io/v1alpha3/types.go
@@ -58,6 +58,20 @@ const (
 	// DefaultNodeType is the default instance type to use for nodes
 	DefaultNodeType = "m5.large"
 
+	// DefaultNodeCount defines the default number of nodes to be created
+	DefaultNodeCount = 2
+
+	// DefaultNodeVolumeType defines the default root volume type to use
+	DefaultNodeVolumeType = NodeVolumeTypeGP2
+	// NodeVolumeTypeGP2 is General Purpose SSD
+	NodeVolumeTypeGP2 = "gp2"
+	// NodeVolumeTypeIO1 is Provisioned IOPS SSD
+	NodeVolumeTypeIO1 = "io1"
+	// NodeVolumeTypeSC1 is Throughput Optimized HDD
+	NodeVolumeTypeSC1 = "sc1"
+	// NodeVolumeTypeST1 is Cold HDD
+	NodeVolumeTypeST1 = "st1"
+
 	// ClusterNameTag defines the tag of the clsuter name
 	ClusterNameTag = "eksctl.cluster.k8s.io/v1alpha1/cluster-name"
 
@@ -71,6 +85,11 @@ const (
 
 	// NodeGroupNameLabel defines the label of the node group name
 	NodeGroupNameLabel = "alpha.eksctl.io/nodegroup-name"
+)
+
+var (
+	// DefaultWaitTimeout defines the default wait timeout
+	DefaultWaitTimeout = 20 * time.Minute
 )
 
 // SupportedRegions are the regions where EKS is available
@@ -96,11 +115,15 @@ func SupportedVersions() []string {
 	}
 }
 
-// DefaultWaitTimeout defines the default wait timeout
-var DefaultWaitTimeout = 20 * time.Minute
-
-// DefaultNodeCount defines the default number of nodes to be created
-const DefaultNodeCount = 2
+// SupportedNodeVolumeTypes are the volume types that can be used for a node root volume
+func SupportedNodeVolumeTypes() []string {
+	return []string{
+		NodeVolumeTypeGP2,
+		NodeVolumeTypeIO1,
+		NodeVolumeTypeSC1,
+		NodeVolumeTypeST1,
+	}
+}
 
 // ClusterMeta is what identifies a cluster
 type ClusterMeta struct {
@@ -232,6 +255,8 @@ func (c *ClusterConfig) NewNodeGroup() *NodeGroup {
 		PrivateNetworking: false,
 		DesiredCapacity:   DefaultNodeCount,
 		InstanceType:      DefaultNodeType,
+		VolumeSize:        0,
+		VolumeType:        DefaultNodeVolumeType,
 	}
 
 	c.NodeGroups = append(c.NodeGroups, ng)
@@ -265,6 +290,8 @@ type NodeGroup struct {
 
 	// +optional
 	VolumeSize int `json:"volumeSize"`
+	// +optional
+	VolumeType string `json:"volumeType"`
 	// +optional
 	MaxPodsPerNode int `json:"maxPodsPerNode,omitempty"`
 

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -214,6 +214,8 @@ var _ = Describe("CloudFormation template builder API", func() {
 		ng.Name = "ng-abcd1234"
 		ng.InstanceType = "t2.medium"
 		ng.AMIFamily = "AmazonLinux2"
+		ng.VolumeSize = 2
+		ng.VolumeType = api.NodeVolumeTypeIO1
 
 		*cfg.VPC.CIDR = api.DefaultCIDR()
 
@@ -288,6 +290,8 @@ var _ = Describe("CloudFormation template builder API", func() {
 					Name:              "ng-abcd1234",
 					PrivateNetworking: false,
 					DesiredCapacity:   2,
+					VolumeSize:        2,
+					VolumeType:        api.NodeVolumeTypeIO1,
 				},
 			},
 		}

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -115,6 +115,7 @@ func (n *NodeGroupResourceSet) addResourcesForNodeGroup() error {
 				DeviceName: gfn.NewString("/dev/xvda"),
 				Ebs: &gfn.AWSAutoScalingLaunchConfiguration_BlockDevice{
 					VolumeSize: gfn.NewInteger(n.spec.VolumeSize),
+					VolumeType: gfn.NewString(n.spec.VolumeType),
 				},
 			},
 		}

--- a/pkg/ctl/cmdutils/nodegroup.go
+++ b/pkg/ctl/cmdutils/nodegroup.go
@@ -1,6 +1,9 @@
 package cmdutils
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/spf13/pflag"
 
 	"github.com/weaveworks/eksctl/pkg/ami"
@@ -21,7 +24,9 @@ func AddCommonCreateNodeGroupFlags(fs *pflag.FlagSet, p *api.ProviderConfig, cfg
 	fs.IntVarP(&ng.MinSize, "nodes-min", "m", 0, "minimum nodes in ASG")
 	fs.IntVarP(&ng.MaxSize, "nodes-max", "M", 0, "maximum nodes in ASG")
 
-	fs.IntVarP(&ng.VolumeSize, "node-volume-size", "", 0, "Node volume size (in GB)")
+	fs.IntVar(&ng.VolumeSize, "node-volume-size", ng.VolumeSize, "node volume size in GB")
+	fs.StringVar(&ng.VolumeType, "node-volume-type", ng.VolumeType, fmt.Sprintf("node volume type (valid options: %s)", strings.Join(api.SupportedNodeVolumeTypes(), ", ")))
+
 	fs.IntVar(&ng.MaxPodsPerNode, "max-pods-per-node", 0, "maximum number of pods per node (set automatically if unspecified)")
 
 	fs.BoolVar(&ng.AllowSSH, "ssh-access", false, "control SSH access for nodes")

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -140,6 +140,7 @@ func doCreateCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 			"nodes-max",
 			"node-type",
 			"node-volume-size",
+			"node-volume-type",
 			"max-pods-per-node",
 			"node-ami",
 			"node-ami-family",
@@ -198,6 +199,11 @@ func doCreateCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 				}
 			}
 
+			if ng.VolumeSize > 0 {
+				if ng.VolumeType == "" {
+					ng.VolumeType = api.DefaultNodeVolumeType
+				}
+			}
 			return nil
 		})
 		if err != nil {


### PR DESCRIPTION
### Description
Allow specifying the node volume type when configuring a non-default node volume size. Related to #333

### Checklist
- [X] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [X] All tests passing (i.e. `make test`)
- [X] Added/modified documentation as required (such as the README)
- [X] Added yourself to the `humans.txt` file
