### PR TITLE
Simplify stack output getters

### DIFF
--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -128,5 +128,5 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 		)
 	}
 
-	n.rs.newOutputFromAtt(cfnOutputInstanceRoleARN, "NodeInstanceRole.Arn", true)
+	n.rs.newOutputFromAtt(cfnOutputNodeGroupInstanceRoleARN, "NodeInstanceRole.Arn", true)
 }

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -21,7 +21,7 @@ type NodeGroupResourceSet struct {
 	securityGroups   []*gfn.Value
 	vpc              *gfn.Value
 	userData         *gfn.Value
-	outputs          *NodeGroupStackOutputs
+	outputs          map[string]string
 }
 
 // NewNodeGroupResourceSet returns a resource set for a node group embedded in a cluster config
@@ -32,7 +32,7 @@ func NewNodeGroupResourceSet(spec *api.ClusterConfig, clusterStackName string, n
 		nodeGroupName:    ng.Name,
 		clusterSpec:      spec,
 		spec:             ng,
-		outputs:          &NodeGroupStackOutputs{},
+		outputs:          make(map[string]string),
 	}
 }
 
@@ -175,7 +175,7 @@ func (n *NodeGroupResourceSet) GetAllOutputs(stack cfn.Stack) error {
 		return err
 	}
 
-	n.spec.IAM.InstanceRoleARN = n.outputs.InstanceRoleARN
+	n.spec.IAM.InstanceRoleARN = n.outputs[cfnOutputNodeGroupInstanceRoleARN]
 
 	return nil
 }

--- a/pkg/cfn/builder/outputs.go
+++ b/pkg/cfn/builder/outputs.go
@@ -1,57 +1,31 @@
 package builder
 
 import (
-	"encoding/base64"
 	"fmt"
-	"reflect"
-	"strings"
 
 	cfn "github.com/aws/aws-sdk-go/service/cloudformation"
 	gfn "github.com/awslabs/goformation/cloudformation"
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha3"
 )
 
-// Outputs of CloudFormation stacks are collected into a struct with fields
-// matching names of the outputs. Here is a set of reflect-based helpers that
-// make this happen. Some data types get special treatment, e.g. string slices
-// and byte slices.
-
 const (
-	// outputs that are destined for ClusterStackOutputs
-	cfnOutputClusterVPC           = "VPC"
-	cfnOutputClusterSecurityGroup = "SecurityGroup"
-	cfnOutputClusterSubnets       = "Subnets"
+	// outputs from cluster stack
+	cfnOutputClusterVPC            = "VPC"
+	cfnOutputClusterSecurityGroup  = "SecurityGroup"
+	cfnOutputClusterSubnets        = "Subnets"
+	cfnOutputClusterSubnetsPrivate = string(cfnOutputClusterSubnets + api.SubnetTopologyPrivate)
+	cfnOutputClusterSubnetsPublic  = string(cfnOutputClusterSubnets + api.SubnetTopologyPublic)
 
 	cfnOutputClusterCertificateAuthorityData = "CertificateAuthorityData"
 	cfnOutputClusterEndpoint                 = "Endpoint"
 	cfnOutputClusterARN                      = "ARN"
 	cfnOutputClusterStackName                = "ClusterStackName"
 
-	// outputs that are destined for NodeGroupStackOutputs
-	cfnOutputInstanceRoleARN = "InstanceRoleARN"
+	// outputs from nodegroup stack
+	cfnOutputNodeGroupInstanceRoleARN = "InstanceRoleARN"
 )
-
-// ClusterStackOutputs is a struct that hold all of cluster stack outputs,
-// it's needed because some of the destination fields in ClusterConfig are
-// deeply nested and we would need to do something complicated to handle
-// those otherwise
-type ClusterStackOutputs struct {
-	VPC            string
-	SecurityGroup  string
-	SubnetsPrivate []string
-	SubnetsPublic  []string
-
-	ClusterStackName         string
-	Endpoint                 string
-	CertificateAuthorityData []byte
-	ARN                      string
-}
-
-// NodeGroupStackOutputs is a struct that hold all of nodegroup stack outputs
-type NodeGroupStackOutputs struct {
-	InstanceRoleARN string
-}
 
 // newOutput defines a new output and optionally exports it
 func (r *resourceSet) newOutput(name string, value interface{}, export bool) {
@@ -80,82 +54,23 @@ func makeImportValue(stackName, output string) *gfn.Value {
 	return gfn.MakeFnImportValueString(fmt.Sprintf("%s::%s", stackName, output))
 }
 
-// setOutput is the entrypoint that validates destination object
-// and upon successful validation passes it to doSetOutput
-func setOutput(obj interface{}, key, value string) error {
-	e := reflect.ValueOf(obj).Elem()
-	if e.Kind() != reflect.Struct {
-		return fmt.Errorf("cannot use destination interface of type %q", e.Kind())
-	}
-	f := e.FieldByName(key)
-	if !f.IsValid() && !f.CanSet() {
-		return fmt.Errorf("cannot set destination field for %q", key)
-	}
-	return doSetOutput(f, key, value)
-}
-
-// doSetOutput handles string or slice output values
-func doSetOutput(field reflect.Value, key, value string) error {
-	switch field.Kind() {
-	case reflect.String:
-		field.SetString(value)
-		return nil
-	case reflect.Slice:
-		return doSetOutputAsSlice(field, key, value)
-	default:
-		return fmt.Errorf("unexpected kind %q of destination field for %q", field.Kind(), key)
-	}
-}
-
-// doSetOutputAsSlice sets output for fields of slice kind, it supports
-// []string (for comma-separated lists defined with newJoinedOutput)
-// and []byte (for BASE64-encoded values)
-func doSetOutputAsSlice(field reflect.Value, key, value string) error {
-	switch field.Type() {
-	case reflect.ValueOf([]string{}).Type():
-		// split comma-separated list and use the resulting slice
-		field.Set(reflect.ValueOf(strings.Split(value, ",")))
-		return nil
-	case reflect.ValueOf([]byte{}).Type():
-		// try to decode a string from BASE64, as certificates
-		// are the only case where we expect []bytes
-		data, err := base64.StdEncoding.DecodeString(value)
-		if err != nil {
-			return errors.Wrapf(err, "decoding value of %q", key)
-		}
-		field.Set(reflect.ValueOf(data))
-		return nil
-	default:
-		return fmt.Errorf("unexpected type %q of destination field for %q", field.Type(), key)
-	}
-}
-
 // GetAllOutputs collects all outputs from an instance of an active stack,
 // the outputs are defined by the current resourceSet, and are generally
-// private to how builder chooses to define them. The destination obj is
-// where outputs will be stored, it's fields are expected to match those
-// that are known to the builder (namely, those are the cfnOutput* contants).
-func (r *resourceSet) GetAllOutputs(stack cfn.Stack, obj interface{}) error {
+// private to how builder chooses to define them
+func (r *resourceSet) GetAllOutputs(stack cfn.Stack, outputs map[string]string) error {
 	logger.Debug("processing stack outputs")
 	for _, key := range r.outputs {
-		value := doGetOutput(&stack, key)
+		var value *string
+		for _, x := range stack.Outputs {
+			if *x.OutputKey == key {
+				value = x.OutputValue
+				break
+			}
+		}
 		if value == nil {
 			return fmt.Errorf("%s is nil", key)
 		}
-		if err := setOutput(obj, key, *value); err != nil {
-			return errors.Wrap(err, "processing stack outputs")
-		}
-	}
-	return nil
-}
-
-// doGetOutput gets a value for a given output name, when output is not
-// found in the given instance of an active stack, it will return nil
-func doGetOutput(stack *cfn.Stack, key string) *string {
-	for _, x := range stack.Outputs {
-		if *x.OutputKey == key {
-			return x.OutputValue
-		}
+		outputs[key] = *value
 	}
 	return nil
 }


### PR DESCRIPTION
### Description

Originally it was assumed this will need to be generic, as the number
of outputs was assumed to increase over time and evolve a lot.
However, as ClusterConfig destination struct has evolved, this was no
longer useful and we needed an intermediary struct.
NodeGroup struct has evolved also and needed intermediary struct too.
The number of outputs turned out to stabilise over time and this kind
complexity is pretty useless now.

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] All tests passing (i.e. `make test`)