### PR TITLE
feat: kube2iam/kiam/kube-aws-iam-controller support

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha3/types.go
+++ b/pkg/apis/eksctl.io/v1alpha3/types.go
@@ -345,6 +345,8 @@ type (
 		// +optional
 		InstanceRoleARN string `json:"instanceRoleARN,omitempty"`
 		// +optional
+		InstanceRoleName string `json:"instanceRoleName,omitempty"`
+		// +optional
 		WithAddonPolicies NodeGroupIAMAddonPolicies `json:"withAddonPolicies,omitempty"`
 	}
 	// NodeGroupIAMAddonPolicies holds all IAM addon policies

--- a/pkg/cfn/builder/api.go
+++ b/pkg/cfn/builder/api.go
@@ -26,6 +26,7 @@ type awsCloudFormationResource struct {
 type ResourceSet interface {
 	AddAllResources() error
 	WithIAM() bool
+	WithNamedIAM() bool
 	RenderJSON() ([]byte, error)
 	GetAllOutputs(cfn.Stack) error
 }
@@ -34,6 +35,7 @@ type resourceSet struct {
 	template *gfn.Template
 	outputs  []string
 	withIAM  bool
+	withNamedIAM bool
 }
 
 func newResourceSet() *resourceSet {

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	stackCapabilitiesIAM = aws.StringSlice([]string{cloudformation.CapabilityCapabilityIam})
+	stackCapabilitiesNamedIAM = aws.StringSlice([]string{cloudformation.CapabilityCapabilityNamedIam})
 )
 
 // Stack represents the CloudFormation stack
@@ -49,7 +50,7 @@ func NewStackCollection(provider api.ClusterProvider, spec *api.ClusterConfig) *
 	}
 }
 
-func (c *StackCollection) doCreateStackRequest(i *Stack, templateBody []byte, tags, parameters map[string]string, withIAM bool) error {
+func (c *StackCollection) doCreateStackRequest(i *Stack, templateBody []byte, tags, parameters map[string]string, withIAM bool, withNamedIAM bool) error {
 	input := &cloudformation.CreateStackInput{
 		StackName: i.StackName,
 	}
@@ -65,6 +66,10 @@ func (c *StackCollection) doCreateStackRequest(i *Stack, templateBody []byte, ta
 
 	if withIAM {
 		input.SetCapabilities(stackCapabilitiesIAM)
+	}
+
+	if withNamedIAM {
+		input.SetCapabilities(stackCapabilitiesNamedIAM)
 	}
 
 	if cfnRole := c.provider.CloudFormationRoleARN(); cfnRole != "" {
@@ -99,7 +104,7 @@ func (c *StackCollection) CreateStack(name string, stack builder.ResourceSet, ta
 		return errors.Wrapf(err, "rendering template for %q stack", *i.StackName)
 	}
 
-	if err := c.doCreateStackRequest(i, templateBody, tags, parameters, stack.WithIAM()); err != nil {
+	if err := c.doCreateStackRequest(i, templateBody, tags, parameters, stack.WithIAM(), stack.WithNamedIAM()); err != nil {
 		return err
 	}
 

--- a/pkg/ctl/cmdutils/nodegroup.go
+++ b/pkg/ctl/cmdutils/nodegroup.go
@@ -45,6 +45,13 @@ func AddCommonCreateNodeGroupFlags(fs *pflag.FlagSet, p *api.ProviderConfig, cfg
 
 // AddCommonCreateNodeGroupIAMAddonsFlags adds flags to set ng.IAM.WithAddonPolicies
 func AddCommonCreateNodeGroupIAMAddonsFlags(fs *pflag.FlagSet, ng *api.NodeGroup) {
+	fs.StringSliceVar(&ng.IAM.AttachPolicyARNs, "temp-node-role-policies", []string{}, "Advanced use cases only. " +
+		"All the IAM policies to be associated to the node's instance role. " +
+		"Beware that you MUST include the policies for EKS and CNI related AWS API Access, like `arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy` and `arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy` that are used by default when this flag is omitted.")
+	fs.MarkHidden("temp-node-role-policies")
+	fs.StringVar(&ng.IAM.InstanceRoleName, "temp-node-role-name", "", "Advanced use cases only. Specify the exact name of the node's instance role for easier integration with K8S-IAM integrations like kube2iam. See https://github.com/weaveworks/eksctl/issues/398 for more information.")
+	fs.MarkHidden("temp-node-role-name")
+
 	fs.BoolVar(&ng.IAM.WithAddonPolicies.AutoScaler, "asg-access", false, "enable IAM policy for cluster-autoscaler")
 	fs.BoolVar(&ng.IAM.WithAddonPolicies.ExternalDNS, "external-dns-access", false, "enable IAM policy for external-dns")
 	fs.BoolVar(&ng.IAM.WithAddonPolicies.ImageBuilder, "full-ecr-access", false, "enable full access to ECR")

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -153,6 +153,7 @@ var _ = Describe("Kubeconfig", func() {
 					IAM: eksctlapi.NodeGroupIAM{
 						AttachPolicyARNs: []string(nil),
 						InstanceRoleARN:  "",
+						InstanceRoleName:  "",
 					},
 				},
 			},


### PR DESCRIPTION
This adds two flags and one nodegroup config key to `eksctl`:

- `--node-role-policies` for replacing the whole set of IAM policies associated to the eksctl-managed node role.
  This just exposes the existing configuration key `attachPolicyARNs` for a little ease-of-use, like other advanced flags.
- `--node-role-name` for specifying the exact name of the IAM role for nodes, as well as the corresponding nodegroup config key `instanceRoleName`.

Resolves #398