### PR TITLE
feat: associate additional security groups on node creation

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha3/types.go
+++ b/pkg/apis/eksctl.io/v1alpha3/types.go
@@ -252,6 +252,8 @@ type NodeGroup struct {
 	// +optional
 	AvailabilityZones []string `json:"availabilityZones,omitempty"`
 	// +optional
+	SecurityGroups []string `json:"securityGroups,omitempty"`
+	// +optional
 	Tags map[string]string `json:"tags,omitempty"`
 	// +optional
 	PrivateNetworking bool `json:"privateNetworking"`

--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -135,6 +135,12 @@ func (n *NodeGroupResourceSet) addResourcesForSecurityGroups() {
 	})
 	n.securityGroups = []*gfn.Value{refSG}
 
+	if len(n.spec.SecurityGroups) > 0 {
+		for _, arn := range n.spec.SecurityGroups {
+			n.securityGroups = append(n.securityGroups, gfn.NewString(arn))
+		}
+	}
+
 	n.newResource("IngressInterSG", &gfn.AWSEC2SecurityGroupIngress{
 		GroupId:               refSG,
 		SourceSecurityGroupId: refSG,

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -51,6 +51,10 @@ func (c *StackCollection) CreateNodeGroup(errs chan error, data interface{}) err
 		return err
 	}
 
+	if ng.SecurityGroups == nil {
+		ng.SecurityGroups = []string{}
+	}
+
 	if ng.Tags == nil {
 		ng.Tags = make(map[string]string)
 	}

--- a/pkg/ctl/cmdutils/nodegroup.go
+++ b/pkg/ctl/cmdutils/nodegroup.go
@@ -32,6 +32,8 @@ func AddCommonCreateNodeGroupFlags(fs *pflag.FlagSet, p *api.ProviderConfig, cfg
 
 	fs.BoolVarP(&ng.PrivateNetworking, "node-private-networking", "P", false, "whether to make nodegroup networking private")
 
+	fs.StringSliceVar(&ng.SecurityGroups, "node-security-groups", []string{}, "Attach additional security groups to nodes, so that it can be used to allow extra ingress/egress access from/to pods")
+
 	fs.Var(&ng.Labels, "node-labels", `Extra labels to add when registering the nodes in the nodegroup, e.g. "partition=backend,nodeclass=hugememory"`)
 	fs.StringSliceVar(&ng.AvailabilityZones, "node-zones", nil, "(inherited from the cluster if unspecified)")
 }


### PR DESCRIPTION
Adds the `--node-security-groups` flag, along with the corresponding config key `securityGroups`, that accepts ARNs of the additional security groups attached to the nodes.

The additional security groups can be used for allowing extra egress from/ingress to pods running on the nodes.

Resolves #397