### PR TITLE
Import VPC config when creating nodegroup

### DIFF
--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -103,6 +103,10 @@ func doCreateNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.No
 		return err
 	}
 
+	if err := ctl.GetClusterVPC(cfg); err != nil {
+		return errors.Wrapf(err, "getting VPC configuration for cluster %q", cfg.Metadata.Name)
+	}
+
 	if err := ctl.GetCredentials(cfg); err != nil {
 		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
 	}

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -12,6 +12,7 @@ import (
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha3"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/eks"
+	"github.com/weaveworks/eksctl/pkg/printers"
 	"github.com/weaveworks/eksctl/pkg/utils"
 )
 
@@ -61,6 +62,12 @@ func doCreateNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.No
 	ctl := eks.New(p, cfg)
 	meta := cfg.Metadata
 
+	printer := printers.NewJSONPrinter()
+
+	if err := api.Register(); err != nil {
+		return err
+	}
+
 	if !ctl.IsSupportedRegion() {
 		return cmdutils.ErrUnsupportedRegion(p)
 	}
@@ -96,10 +103,12 @@ func doCreateNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.No
 		return err
 	}
 
-	logger.Debug("cfg = %#v", cfg)
-
 	if err := ctl.GetCredentials(cfg); err != nil {
 		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
+	}
+
+	if err := printer.LogObj(logger.Debug, "cfg.json = \\\n", cfg); err != nil {
+		return err
 	}
 
 	{


### PR DESCRIPTION
### Description

Fixes #428.

```
> ./eksctl create nodegroup --cluster=unique-creature-1547454454 --region=eu-north-1  --verbose=4
2019-01-14T09:13:22Z [ℹ]  using region eu-north-1
2019-01-14T09:13:23Z [▶]  role ARN for the current session is "arn:aws:iam::376248598259:user/ilya"
2019-01-14T09:13:23Z [▶]  resolving AMI using StaticGPUResolver for region eu-north-1, instanceType m5.large and imageFamily AmazonLinux2
2019-01-14T09:13:23Z [▶]  can't resolve AMI using StaticGPUResolver as instance type m5.large is non-GPU
2019-01-14T09:13:23Z [▶]  resolving AMI using StaticDefaultResolver for region eu-north-1, version m5.large, instanceType AmazonLinux2 and imageFamily %!!(MISSING)s(MISSING)
2019-01-14T09:13:24Z [ℹ]  nodegroup "ng-41930442" will use "ami-06ee67302ab7cf838" [AmazonLinux2/1.11]
...
2019-01-14T09:13:24Z [▶]  cfg.json = \
{
    "kind": "ClusterConfig",
    "apiVersion": "eksctl.io/v1alpha3",
    "metadata": {
        "name": "unique-creature-1547454454",
        "region": "eu-north-1",
        "version": "1.11"
    },
    "vpc": {
        "id": "vpc-0144ca05e5902e3d8",
        "cidr": "192.168.0.0/16",
        "securityGroup": "sg-0771b5a335b2e144e"
    },
    "nodeGroups": [
        {
            "name": "ng-41930442",
            "ami": "ami-06ee67302ab7cf838",
            "amiFamily": "AmazonLinux2",
            "instanceType": "m5.large",
            "privateNetworking": false,
            "desiredCapacity": 2,
            "volumeSize": 0,
            "volumeType": "gp2",
            "labels": {
                "alpha.eksctl.io/cluster-name": "unique-creature-1547454454",
                "alpha.eksctl.io/nodegroup-name": "ng-41930442"
            },
            "allowSSH": false,
            "sshPublicKeyPath": "~/.ssh/id_rsa.pub",
            "iam": {
                "withAddonPolicies": {
                    "imageBuilder": false,
                    "autoScaler": false,
                    "externalDNS": false
                }
            }
        }
    ],
    "status": {
        "endpoint": "https://79B7B638962232A643DBC5AE6398EFE2.sk1.eu-north-1.eks.amazonaws.com",
        "certificateAuthorityData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRFNU1ERXhOREE0TXpRek9Wb1hEVEk1TURFeE1UQTRNelF6T1Zvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTGtvCmNaWmxxNStucFNDd0xTQytoaldiQ01hcWRUZjFVTmh3UTVVODhCc3Z2NDRROWlOME5jUU9YNFQyTFpVVnM2UFIKN3VOU2sxcHl4cnI4NEd0MDQvM21sWXJDSkxCS2M4OHpIYVJDNXd0YUZxckVwZDE3U2dKbkhBMER4QW5NUURaLwpXcWtIWVh6YkZtcElLajVNYWhBMm1ET0dlOGtOZFdhZCtJMkNkeTJjZ0EyNWloa21Gai9kTFFhMEN1UjZJdWxJCkNYeHdoODdZaE4vWXpZSW1hd0VtMEZGekMxU3hTUGxNSEhCQlpQenN3cSs2NXdacjhiaVZXekpraGZOUmE4Z0IKbitpZUVlZVc0L3ZIZ21EMzgrS0FlQ2hxMTdRaFZUTHIzZmlhODlCR21BOUhVTXdNK3huM1Y2cmRyQm5yVHljWgpxY0NIaGpCQ2ppQXlSSXk3QkFFQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFLQXlSdVBESFpwTllCT3MwUlpJMFFWb0dDV2IKa3VQYU55dkxRalZjbXVGRGptaGczSHF0OGpwQ1VyVXkvNUlBbEh2TGFRMGJENVVESVVhbXNXdTk4VFQvT1p6TQo1dWVySkx5UTVkVHNoTVRqY0hNVmg2NGVQVVhHelZ2TUdIS25zbU5jblArK2VxY3ZaZnNyUm5DWU41dmhJSGdpCkppN3BIMjJPSllndzNQN012SWpFMVBzbTFZd2hoRE9BaXVJYW1vN3JjbDdNYXFWbmwwOS9XNnl1aEZkQ0xSL0UKNnpZK0Nmcm8xMWp2Z2dDdjYwYWtDc3ZsTWNFVHA4ajkvTGw0UFZDR0ptTmU4L0tyanhndmFnOTFPTithak5hMwpOdmI5NFhaYTlzd1B2cUxVenhiTmQ5TkVjVURtWjhsUURJSU04Q3hRUjB3MVVEdjU3TU4yNHE3QXJ1QT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
        "arn": "arn:aws:eks:eu-north-1:376248598259:cluster/unique-creature-1547454454"
    }
}
2019-01-14T09:13:24Z [ℹ]  will create a Cloudformation stack for nodegroup ng-41930442 in cluster unique-creature-1547454454
...
```

As seen above, `cfg.VPC.ID` and `cfg.VPC.CIDR` are not populated.

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] All tests passing (i.e. `make test`)