### PR TITLE
Set tags for cluster autoscaler to discover nodegroups with AGS access

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ You can create a cluster (or nodegroup in an existing cluster) with IAM role tha
 eksctl create cluster --asg-access
 ```
 
-Once cluster is running, you will need to install [cluster autoscaler][] itself.
+Once cluster is running, you will need to install [cluster autoscaler][] itself. This flag also sets `k8s.io/cluster-autoscaler/enabled`
+and `k8s.io/cluster-autoscaler/<clusterName>` tags, so nodegroup discovery should work.
 
 [cluster autoscaler]: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md
 


### PR DESCRIPTION
### Description

This adds automatic EC2 tags that cluster autoscaler examples mandate.

cc @prageethw @mumoshu 

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] All tests passing (i.e. `make test`)
- [x] Added/modified documentation as required (such as the README)