### PR TITLE
Shared nodegroup SG

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha3/types.go
+++ b/pkg/apis/eksctl.io/v1alpha3/types.go
@@ -256,11 +256,12 @@ func (c *ClusterConfig) AppendAvailabilityZone(newAZ string) {
 // it returns pointer to the nodegroup for convenience
 func (c *ClusterConfig) NewNodeGroup() *NodeGroup {
 	ng := &NodeGroup{
-		PrivateNetworking: false,
-		DesiredCapacity:   DefaultNodeCount,
-		InstanceType:      DefaultNodeType,
-		VolumeSize:        0,
-		VolumeType:        DefaultNodeVolumeType,
+		PrivateNetworking:   false,
+		SharedSecurityGroup: true,
+		DesiredCapacity:     DefaultNodeCount,
+		InstanceType:        DefaultNodeType,
+		VolumeSize:          0,
+		VolumeType:          DefaultNodeVolumeType,
 	}
 
 	c.NodeGroups = append(c.NodeGroups, ng)
@@ -280,6 +281,8 @@ type NodeGroup struct {
 	InstanceType string `json:"instanceType,omitempty"`
 	// +optional
 	AvailabilityZones []string `json:"availabilityZones,omitempty"`
+	// +optional
+	SharedSecurityGroup bool `json:"sharedSecurityGroup,omitempty"`
 	// +optional
 	SecurityGroups []string `json:"securityGroups,omitempty"`
 	// +optional

--- a/pkg/apis/eksctl.io/v1alpha3/vpc.go
+++ b/pkg/apis/eksctl.io/v1alpha3/vpc.go
@@ -22,6 +22,8 @@ type (
 		// private subnets or any ad-hoc subnets
 		// +optional
 		ExtraCIDRs []*ipnet.IPNet `json:"extraCIDRs,omitempty"`
+		// for pre-defined shared node SG
+		SharedNodeSecurityGroup string `json:"sharedNodeSecurityGroup,omitempty"`
 	}
 	// SubnetTopology can be SubnetTopologyPrivate or SubnetTopologyPublic
 	SubnetTopology string

--- a/pkg/cfn/builder/cluster.go
+++ b/pkg/cfn/builder/cluster.go
@@ -106,6 +106,7 @@ func (c *ClusterResourceSet) GetAllOutputs(stack cfn.Stack) error {
 
 	c.spec.VPC.ID = c.outputs[CfnOutputClusterVPC]
 	c.spec.VPC.SecurityGroup = c.outputs[CfnOutputClusterSecurityGroup]
+	c.spec.VPC.SharedNodeSecurityGroup = c.outputs[CfnOutputClusterSharedNodeSecurityGroup]
 
 	if err := vpc.UseSubnets(c.provider, c.spec, api.SubnetTopologyPrivate, strings.Split(c.outputs[CfnOutputClusterSubnetsPrivate], ",")); err != nil {
 		return err

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -44,6 +44,9 @@ func (n *NodeGroupResourceSet) AddAllResources() error {
 		n.spec.AMIFamily, n.spec.AllowSSH, n.spec.SubnetTopology(),
 		templateDescriptionSuffix)
 
+	n.rs.newOutput(CfnOutputNodeGroupFeaturePrivateNetworking, n.spec.PrivateNetworking, false)
+	n.rs.newOutput(CfnOutputNodeGroupFeatureSharedSecurityGroup, n.spec.SharedSecurityGroup, false)
+
 	n.vpc = makeImportValue(n.clusterStackName, CfnOutputClusterVPC)
 
 	userData, err := nodebootstrap.NewUserData(n.clusterSpec, n.spec)

--- a/pkg/cfn/builder/outputs.go
+++ b/pkg/cfn/builder/outputs.go
@@ -27,6 +27,11 @@ const (
 
 	// outputs from nodegroup stack
 	CfnOutputNodeGroupInstanceRoleARN = "InstanceRoleARN"
+	// outputs to indicate configuration attributes that may have critical effect
+	// on integration with the rest of the cluster and/or forward-compatibility
+	// with respect to e.g. upgrades
+	CfnOutputNodeGroupFeaturePrivateNetworking   = "FeaturePrivateNetworking"
+	CfnOutputNodeGroupFeatureSharedSecurityGroup = "FeatureSharedSecurityGroup"
 )
 
 // newOutput defines a new output and optionally exports it

--- a/pkg/cfn/builder/outputs.go
+++ b/pkg/cfn/builder/outputs.go
@@ -23,6 +23,7 @@ const (
 	CfnOutputClusterEndpoint                 = "Endpoint"
 	CfnOutputClusterARN                      = "ARN"
 	CfnOutputClusterStackName                = "ClusterStackName"
+	CfnOutputClusterSharedNodeSecurityGroup  = "SharedNodeSecurityGroup"
 
 	// outputs from nodegroup stack
 	CfnOutputNodeGroupInstanceRoleARN = "InstanceRoleARN"

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -83,15 +83,21 @@ func (c *StackCollection) DescribeNodeGroupStacks() ([]*Stack, error) {
 	return nodeGroupStacks, nil
 }
 
-// DescribeResourcesOfNodeGroupStacks calls DescribeNodeGroupStacks and fetches all resources,
+// NodeGroupStacksAndResources hold the stack along with resources
+type NodeGroupStacksAndResources struct {
+	Stack     *Stack
+	Resources []*cfn.StackResource
+}
+
+// DescribeNodeGroupStacksAndResources calls DescribeNodeGroupStacks and fetches all resources,
 // then returns it in a map by nodegroup name
-func (c *StackCollection) DescribeResourcesOfNodeGroupStacks() (map[string]cfn.DescribeStackResourcesOutput, error) {
+func (c *StackCollection) DescribeNodeGroupStacksAndResources() (map[string]NodeGroupStacksAndResources, error) {
 	stacks, err := c.DescribeNodeGroupStacks()
 	if err != nil {
 		return nil, err
 	}
 
-	allResources := make(map[string]cfn.DescribeStackResourcesOutput)
+	allResources := make(map[string]NodeGroupStacksAndResources)
 
 	for _, s := range stacks {
 		input := &cfn.DescribeStackResourcesInput{
@@ -101,7 +107,10 @@ func (c *StackCollection) DescribeResourcesOfNodeGroupStacks() (map[string]cfn.D
 		if err != nil {
 			return nil, errors.Wrapf(err, "getting all resources for %q stack", *s.StackName)
 		}
-		allResources[getNodeGroupName(s)] = *resources
+		allResources[getNodeGroupName(s)] = NodeGroupStacksAndResources{
+			Resources: resources.StackResources,
+			Stack:     s,
+		}
 	}
 
 	return allResources, nil

--- a/pkg/eks/compatibility.go
+++ b/pkg/eks/compatibility.go
@@ -1,0 +1,71 @@
+package eks
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kris-nova/logger"
+	"github.com/pkg/errors"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha3"
+	"github.com/weaveworks/eksctl/pkg/cfn/builder"
+	"github.com/weaveworks/eksctl/pkg/cfn/manager"
+)
+
+// ValidateClusterForCompatibility looks at the cluster stack and check if it's
+// compatible with current nodegroup configuration, if it find issues it returns an error
+func (c *ClusterProvider) ValidateClusterForCompatibility(cfg *api.ClusterConfig, stackManager *manager.StackCollection) error {
+	// TODO: must move this before we try to create the nodegroup actually
+	cluster, err := stackManager.DescribeClusterStack()
+	if err != nil {
+		return errors.Wrap(err, "getting cluster stacks")
+	}
+
+	sharedClusterNodeSG := ""
+	for _, x := range cluster.Outputs {
+		if *x.OutputKey == builder.CfnOutputClusterSharedNodeSecurityGroup {
+			sharedClusterNodeSG = *x.OutputValue
+		}
+	}
+
+	if sharedClusterNodeSG == "" {
+		return fmt.Errorf("cluster %q does not have shared node security group", cfg.Metadata.Name)
+	}
+
+	return nil
+}
+
+// ValidateExistingNodeGroupsForCompatibility looks at each of the existing nodegroups and
+// validates configuration, if it find issues it logs messages
+func (c *ClusterProvider) ValidateExistingNodeGroupsForCompatibility(cfg *api.ClusterConfig, stackManager *manager.StackCollection) error {
+	resourcesByNodeGroup, err := stackManager.DescribeNodeGroupStacksAndResources()
+	if err != nil {
+		return errors.Wrap(err, "getting resources for of all nodegroup stacks")
+	}
+
+	incompatibleNodeGroups := []string{}
+	for ng, resources := range resourcesByNodeGroup {
+		compatible := false
+		for _, x := range resources.Stack.Outputs {
+			if *x.OutputKey == builder.CfnOutputNodeGroupFeatureSharedSecurityGroup {
+				compatible = true
+			}
+		}
+		if !compatible {
+			incompatibleNodeGroups = append(incompatibleNodeGroups, ng)
+		}
+	}
+
+	numIncompatibleNodeGroups := len(incompatibleNodeGroups)
+	if numIncompatibleNodeGroups == 0 {
+		return nil
+	}
+
+	logger.Critical("found %d nodegroup(s) (%s) without shared security group, cluster networking maybe be broken",
+		numIncompatibleNodeGroups, strings.Join(incompatibleNodeGroups, ", "))
+	logger.Critical("it's recommended to delete these nodegroups and create new ones instead")
+	logger.Critical("as a temporary fix, you can patch the configuration and add each of these nodegroup(s) to %q",
+		cfg.VPC.SharedNodeSecurityGroup)
+
+	return nil
+}

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -116,6 +116,12 @@ func (c *ClusterProvider) GetClusterVPC(spec *api.ClusterConfig) error {
 		return fmt.Errorf(requiredKeyErrFmt, builder.CfnOutputClusterSecurityGroup)
 	}
 
+	if sharedNodeSecurityGroup, ok := outputs[builder.CfnOutputClusterSharedNodeSecurityGroup]; ok {
+		spec.VPC.SharedNodeSecurityGroup = sharedNodeSecurityGroup
+	} else {
+		return fmt.Errorf(requiredKeyErrFmt, builder.CfnOutputClusterSharedNodeSecurityGroup)
+	}
+
 	for _, topology := range api.SubnetTopologies() {
 		// either of subnet topologies are optional
 		if subnets, ok := outputs[builder.CfnOutputClusterSubnets+string(topology)]; ok {


### PR DESCRIPTION
### Description

Initial changes to addresses cross-nodegroup SG configuration (see #419).

We will need to add something like `eksctl utils create-shared-node-security-group` to help users, it's still TBD. This version only adds checks that produce error messages.

There are two main secenarios:

1. old cluster without a shared SG: cannot create new nodegroup

```
 [0] >> ./eksctl create nodegroup --nodes=1 --region=eu-north-1  --cluster=test-shared-nodegroup-check
[ℹ]  using region eu-north-1
[ℹ]  nodegroup "ng-6d61935c" will use "ami-06ee67302ab7cf838" [AmazonLinux2/1.11]
[✖]  cluster compatibility check failed: cluster "test-shared-nodegroup-check" does not not have shared node security group
 [1] >>
```

2. cluster has shared SG, but some nodegroups are still old - not the end of the world issue

```
 [0] >> ./eksctl create nodegroup --nodes=1 --region=eu-north-1  --cluster=test-shared-nodegroup-new  
[ℹ]  using region eu-north-1
[ℹ]  nodegroup "ng-74c42138" will use "ami-06ee67302ab7cf838" [AmazonLinux2/1.11]
[ℹ]  will create a Cloudformation stack for nodegroup ng-74c42138 in cluster test-shared-nodegroup-new
[ℹ]  creating nodegroup stack "eksctl-test-shared-nodegroup-new-nodegroup-ng-74c42138"
[ℹ]  nodegroup "ng-74c42138" has 0 node(s)
[ℹ]  waiting for at least 1 node(s) to become ready in "ng-74c42138"
[ℹ]  nodegroup "ng-74c42138" has 1 node(s)
[ℹ]  node "ip-192-168-62-219.eu-north-1.compute.internal" is ready
[✔]  created nodegroup "ng-74c42138" in cluster "test-shared-nodegroup-new"
[ℹ]  will inspect security group configuration for all nodegroups
[✖]  2 nodegroups (ng-57c4c5a0, ng-dad92af5) don't use shared security group, so cluster networking maybe be broken
[✖]  it's recommended to delete these nodegroup and create new ones instead
[✖]  alternatively, you can patch the configuration and add each of these nodegroups to "sg-0252c495955e6af96"
 [0] >> 
```

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] All tests passing (i.e. `make test`)
