### PR TITLE
Fix shared SG issue for an existing cluster

### DIFF
--- a/pkg/cfn/builder/outputs.go
+++ b/pkg/cfn/builder/outputs.go
@@ -28,8 +28,8 @@ const (
 	// outputs from nodegroup stack
 	CfnOutputNodeGroupInstanceRoleARN = "InstanceRoleARN"
 	// outputs to indicate configuration attributes that may have critical effect
-	// on integration with the rest of the cluster and/or forward-compatibility
-	// with respect to e.g. upgrades
+	// on critical effect on forward-compatibility with respect to overal functionality
+	// and integrity, e.g. networking
 	CfnOutputNodeGroupFeaturePrivateNetworking   = "FeaturePrivateNetworking"
 	CfnOutputNodeGroupFeatureSharedSecurityGroup = "FeatureSharedSecurityGroup"
 )

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -108,8 +108,7 @@ func (c *StackCollection) CreateStack(name string, stack builder.ResourceSet, ta
 	return nil
 }
 
-// UpdateStack will update a cloudformation stack. It uses changeSets and if in debug it will log the changes.
-// This is used bu things like nodegroup scaling
+// UpdateStack will update a cloudformation stack by creating and executing a ChangeSet.
 func (c *StackCollection) UpdateStack(stackName string, action string, description string, template []byte, parameters map[string]string) error {
 	logger.Info(description)
 	i := &Stack{StackName: &stackName}
@@ -138,9 +137,6 @@ func (c *StackCollection) describeStack(i *Stack) (*Stack, error) {
 		StackName: i.StackName,
 	}
 	if i.StackId != nil && *i.StackId != "" {
-		input.StackName = i.StackId
-	}
-	if i.StackId != nil {
 		input.StackName = i.StackId
 	}
 	resp, err := c.provider.CloudFormation().DescribeStacks(input)
@@ -269,9 +265,11 @@ func (c *StackCollection) DescribeStacks() ([]*Stack, error) {
 // DescribeStackEvents describes the occurred stack events
 func (c *StackCollection) DescribeStackEvents(i *Stack) ([]*cloudformation.StackEvent, error) {
 	input := &cloudformation.DescribeStackEventsInput{
-		StackName: i.StackId,
+		StackName: i.StackName,
 	}
-
+	if i.StackId != nil && *i.StackId != "" {
+		input.StackName = i.StackId
+	}
 	resp, err := c.provider.CloudFormation().DescribeStackEvents(input)
 	if err != nil {
 		return nil, errors.Wrapf(err, "describing CloudFormation stack %q events", *i.StackName)

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -13,7 +13,10 @@ import (
 	"github.com/weaveworks/eksctl/pkg/cfn/builder"
 )
 
-const resourcesRootPath = "Resources"
+const (
+	resourcesRootPath = "Resources"
+	outputsRootPath   = "Outputs"
+)
 
 var (
 	stackCapabilitiesIAM = aws.StringSlice([]string{cloudformation.CapabilityCapabilityIam})

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -13,6 +13,8 @@ import (
 	"github.com/weaveworks/eksctl/pkg/cfn/builder"
 )
 
+const resourcesRootPath = "Resources"
+
 var (
 	stackCapabilitiesIAM = aws.StringSlice([]string{cloudformation.CapabilityCapabilityIam})
 )

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -63,7 +63,7 @@ func (c *StackCollection) WaitDeleteCluster() error {
 
 // AppendNewClusterStackResource will update cluster
 // stack with new resources in append-only way
-func (c *StackCollection) AppendNewClusterStackResource() error {
+func (c *StackCollection) AppendNewClusterStackResource(dryRun bool) error {
 	name := c.makeClusterStackName()
 
 	// NOTE: currently we can only append new resources to the stack,
@@ -138,6 +138,10 @@ func (c *StackCollection) AppendNewClusterStackResource() error {
 	logger.Debug("currentTemplate = %s", currentTemplate)
 
 	describeUpdate := fmt.Sprintf("updating stack to add new resources %v and ouputs %v", addResources, addOutputs)
+	if dryRun {
+		logger.Info("(dry-run) %s", describeUpdate)
+		return nil
+	}
 	return c.UpdateStack(name, "update-cluster", describeUpdate, []byte(currentTemplate), nil)
 }
 

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -1,12 +1,19 @@
 package manager
 
 import (
+	"fmt"
 	"strings"
 
-	cfn "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/kris-nova/logger"
+	"github.com/pkg/errors"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	cfn "github.com/aws/aws-sdk-go/service/cloudformation"
+
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha3"
 	"github.com/weaveworks/eksctl/pkg/cfn/builder"
+	"github.com/weaveworks/eksctl/pkg/utils/ipnet"
 )
 
 func (c *StackCollection) makeClusterStackName() string {
@@ -53,6 +60,138 @@ func (c *StackCollection) DeleteCluster() error {
 // WaitDeleteCluster waits till the cluster is deleted
 func (c *StackCollection) WaitDeleteCluster() error {
 	return c.BlockingWaitDeleteStack(c.makeClusterStackName())
+}
+
+// UpdateClusterForCompability will update cluster
+// with new resources based on features that have
+// a critical effect on forward-compatibility with
+// respect to overal functionality and integrity
+func (c *StackCollection) UpdateClusterForCompability() error {
+	const resourceRootPath = "Resources"
+
+	name := c.makeClusterStackName()
+
+	currentStack, err := c.DescribeClusterStack()
+	if err != nil {
+		return err
+	}
+
+	// NOTE: currently we can only append new
+	// resources to the stack, as there are a
+	// few limitations;
+	// we don't have a way of recompiling the
+	// definition of the stack from it's current
+	// template and we don't have all feature
+	// indicators we would need (e.g. when
+	// existing VPC is used);
+	// to do that in a sensible manner we would
+	// have to thoroughly insepect the current
+	// template and see if e.g. VPC or SGs are
+	// imported or managed by us;
+	// addtionally, the EKS control plane itself
+	// cannot yet be updated via CloudFormation
+
+	missingSharedNodeSecurityGroup := true
+
+	for _, x := range currentStack.Outputs {
+		switch *x.OutputKey {
+		case builder.CfnOutputClusterSharedNodeSecurityGroup:
+			missingSharedNodeSecurityGroup = false
+		}
+	}
+
+	// Get current stack
+	currentTemplate, err := c.GetStackTemplate(name)
+	if err != nil {
+		return errors.Wrapf(err, "error getting stack template %s", name)
+	}
+
+	updateFeatureList := []string{}
+	addResources := []string{}
+
+	if missingSharedNodeSecurityGroup {
+		updateFeatureList = append(updateFeatureList, "shared node security group")
+		addResources = append(addResources,
+			"ClusterSharedNodeSecurityGroup",
+			"IngressInterNodeGroupSG",
+		)
+	}
+
+	if len(addResources) == 0 {
+		logger.Success("all resources in cluster stack %q are up-to-date", name)
+		return nil
+	}
+
+	currentResources := gjson.Get(currentTemplate, resourceRootPath)
+	if !currentResources.IsObject() {
+		return fmt.Errorf("unexpected template format of the current stack ")
+	}
+
+	{
+		// We need to use same subnet CIDRs in order to recompile the template
+		// with all of default resources
+		vpc := c.spec.VPC
+		vpc.Subnets = map[api.SubnetTopology]map[string]api.Network{
+			api.SubnetTopologyPublic:  map[string]api.Network{},
+			api.SubnetTopologyPrivate: map[string]api.Network{},
+		}
+		currentResources.ForEach(func(resourceKey, resource gjson.Result) bool {
+			if resource.Get("Type").Value() == "AWS::EC2::Subnet" {
+				az := resource.Get("Properties.AvailabilityZone").String()
+				cidr, _ := ipnet.ParseCIDR(resource.Get("Properties.CidrBlock").String())
+				k := resourceKey.String()
+				if strings.HasPrefix(k, "SubnetPrivate") {
+					vpc.Subnets[api.SubnetTopologyPrivate][az] = api.Network{
+						CIDR: cidr,
+					}
+				}
+				if strings.HasPrefix(k, "SubnetPublic") {
+					vpc.Subnets[api.SubnetTopologyPublic][az] = api.Network{
+						CIDR: cidr,
+					}
+				}
+			}
+			return true
+		})
+	}
+
+	logger.Info("creating cluster stack %q", name)
+	newStack := builder.NewClusterResourceSet(c.provider, c.spec)
+	if err := newStack.AddAllResources(); err != nil {
+		return err
+	}
+
+	newTemplate, err := newStack.RenderJSON()
+	if err != nil {
+		return errors.Wrapf(err, "rendering template for %q stack", name)
+	}
+	logger.Debug("newTemplate = %s", newTemplate)
+
+	newResources := gjson.Get(string(newTemplate), resourceRootPath)
+
+	if !newResources.IsObject() {
+		return fmt.Errorf("unexpected template format of the new version of the stack ")
+	}
+
+	logger.Debug("currentTemplate = %s", currentTemplate)
+
+	for _, resourceKey := range addResources {
+		var err error
+		resource := newResources.Get(resourceKey)
+		if !resource.Exists() {
+			return fmt.Errorf("resource with key %q doesn't exist in the new version of the stack", resourceKey)
+		}
+		currentTemplate, err = sjson.Set(currentTemplate, resourceRootPath+"."+resourceKey, resource.Value())
+		if err != nil {
+			return errors.Wrapf(err, "unable to add resource with key %q to cluster stack", resourceKey)
+		}
+	}
+
+	logger.Debug("currentTemplate = %s", currentTemplate)
+
+	describeUpdate := fmt.Sprintf("updating stack to add new features: %s;",
+		strings.Join(updateFeatureList, ", "))
+	return c.UpdateStack(name, "update-cluster", describeUpdate, []byte(currentTemplate), nil)
 }
 
 func getClusterName(s *Stack) string {

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -51,10 +51,6 @@ func (c *StackCollection) CreateNodeGroup(errs chan error, data interface{}) err
 		return err
 	}
 
-	if ng.SecurityGroups == nil {
-		ng.SecurityGroups = []string{}
-	}
-
 	if ng.Tags == nil {
 		ng.Tags = make(map[string]string)
 	}

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -18,11 +18,11 @@ import (
 )
 
 const (
-	desiredCapacityPath = "Resources.NodeGroup.Properties.DesiredCapacity"
-	maxSizePath         = "Resources.NodeGroup.Properties.MaxSize"
-	minSizePath         = "Resources.NodeGroup.Properties.MinSize"
-	instanceTypePath    = "Resources.NodeLaunchConfig.Properties.InstanceType"
-	imageIDPath         = "Resources.NodeLaunchConfig.Properties.ImageId"
+	desiredCapacityPath = resourcesRootPath + ".NodeGroup.Properties.DesiredCapacity"
+	maxSizePath         = resourcesRootPath + ".NodeGroup.Properties.MaxSize"
+	minSizePath         = resourcesRootPath + ".NodeGroup.Properties.MinSize"
+	instanceTypePath    = resourcesRootPath + ".NodeLaunchConfig.Properties.InstanceType"
+	imageIDPath         = resourcesRootPath + ".NodeLaunchConfig.Properties.ImageId"
 )
 
 // NodeGroupSummary represents a summary of a nodegroup stack

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -6,11 +6,13 @@ import (
 	"strings"
 	"time"
 
-	cfn "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+
+	cfn "github.com/aws/aws-sdk-go/service/cloudformation"
+
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha3"
 	"github.com/weaveworks/eksctl/pkg/cfn/builder"
 )

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -161,7 +161,6 @@ func doCreateNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.No
 	}
 	logger.Success("created nodegroup %q in cluster %q", ng.Name, cfg.Metadata.Name)
 
-	logger.Info("will inspect security group configuration for all nodegroups")
 	if err := ctl.ValidateExistingNodeGroupsForCompatibility(cfg, stackManager); err != nil {
 		logger.Critical("failed checking nodegroups", err.Error())
 	}

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -109,7 +109,7 @@ func doCreateNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.No
 		return errors.Wrap(err, "cluster compatibility check failed")
 	}
 
-	if err := ctl.GetClusterVPC(cfg); err != nil {
+	if err := ctl.GetClusterVPC(cfg, false); err != nil {
 		return errors.Wrapf(err, "getting VPC configuration for cluster %q", cfg.Metadata.Name)
 	}
 

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -109,7 +109,7 @@ func doCreateNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.No
 		return errors.Wrap(err, "cluster compatibility check failed")
 	}
 
-	if err := ctl.GetClusterVPC(cfg, false); err != nil {
+	if err := ctl.GetClusterVPC(cfg); err != nil {
 		return errors.Wrapf(err, "getting VPC configuration for cluster %q", cfg.Metadata.Name)
 	}
 

--- a/pkg/ctl/utils/update_cluster_stack.go
+++ b/pkg/ctl/utils/update_cluster_stack.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha3"
+	"github.com/weaveworks/eksctl/pkg/cfn/builder"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/eks"
 )
@@ -62,7 +63,7 @@ func doUpdateClusterStacksCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nam
 		return fmt.Errorf("--name must be set")
 	}
 
-	if err := ctl.GetClusterVPC(cfg); err != nil {
+	if err := ctl.GetClusterVPC(cfg, builder.CfnOutputClusterSharedNodeSecurityGroup); err != nil {
 		return errors.Wrapf(err, "getting VPC configuration for cluster %q", cfg.Metadata.Name)
 	}
 

--- a/pkg/ctl/utils/update_cluster_stack.go
+++ b/pkg/ctl/utils/update_cluster_stack.go
@@ -1,0 +1,96 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha3"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/eks"
+)
+
+func updateClusterStackCmd(g *cmdutils.Grouping) *cobra.Command {
+	p := &api.ProviderConfig{}
+	cfg := api.NewClusterConfig()
+
+	cmd := &cobra.Command{
+		Use:   "update-cluster-stack",
+		Short: "Update cluster stack based on latest configuration",
+		Run: func(_ *cobra.Command, args []string) {
+			if err := doUpdateClusterStacksCmd(p, cfg, cmdutils.GetNameArg(args)); err != nil {
+				logger.Critical("%s\n", err.Error())
+				os.Exit(1)
+			}
+		},
+	}
+
+	group := g.New(cmd)
+
+	group.InFlagSet("General", func(fs *pflag.FlagSet) {
+		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
+		cmdutils.AddRegionFlag(fs, p)
+		cmdutils.AddVersionFlag(fs, cfg.Metadata)
+	})
+
+	cmdutils.AddCommonFlagsForAWS(group, p, false)
+
+	group.AddTo(cmd)
+	return cmd
+}
+
+func doUpdateClusterStacksCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg string) error {
+	ctl := eks.New(p, cfg)
+
+	if err := ctl.CheckAuth(); err != nil {
+		return err
+	}
+
+	if cfg.Metadata.Name != "" && nameArg != "" {
+		return fmt.Errorf("--name=%s and argument %s cannot be used at the same time", cfg.Metadata.Name, nameArg)
+	}
+
+	if nameArg != "" {
+		cfg.Metadata.Name = nameArg
+	}
+
+	if cfg.Metadata.Name == "" {
+		return fmt.Errorf("--name must be set")
+	}
+
+	stackManager := ctl.NewStackManager(cfg)
+
+	{
+		stack, err := stackManager.DescribeClusterStack()
+		if err != nil {
+			return err
+		}
+		logger.Info("cluster = %#v", stack)
+	}
+
+	// if err := ctl.GetClusterVPC(cfg); err != nil {
+	// 	return errors.Wrapf(err, "getting VPC configuration for cluster %q", cfg.Metadata.Name)
+	// }
+
+	if err := stackManager.UpdateClusterForCompability(); err != nil {
+		return err
+	}
+
+	{
+		stack, err := stackManager.DescribeClusterStack()
+		if err != nil {
+			return err
+		}
+		logger.Info("cluster = %#v", stack)
+	}
+
+	logger.Info("will inspect security group configuration for all nodegroups")
+	if err := ctl.ValidateExistingNodeGroupsForCompatibility(cfg, stackManager); err != nil {
+		logger.Critical("failed checking nodegroups", err.Error())
+	}
+
+	return nil
+}

--- a/pkg/ctl/utils/update_cluster_stack.go
+++ b/pkg/ctl/utils/update_cluster_stack.go
@@ -87,7 +87,6 @@ func doUpdateClusterStacksCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nam
 		logger.Info("cluster = %#v", stack)
 	}
 
-	logger.Info("will inspect security group configuration for all nodegroups")
 	if err := ctl.ValidateExistingNodeGroupsForCompatibility(cfg, stackManager); err != nil {
 		logger.Critical("failed checking nodegroups", err.Error())
 	}

--- a/pkg/ctl/utils/utils.go
+++ b/pkg/ctl/utils/utils.go
@@ -21,6 +21,7 @@ func Command(g *cmdutils.Grouping) *cobra.Command {
 	cmd.AddCommand(waitNodesCmd(g))
 	cmd.AddCommand(writeKubeconfigCmd(g))
 	cmd.AddCommand(describeStacksCmd(g))
+	cmd.AddCommand(updateClusterStackCmd(g))
 
 	return cmd
 }

--- a/pkg/eks/compatibility.go
+++ b/pkg/eks/compatibility.go
@@ -29,7 +29,11 @@ func (c *ClusterProvider) ValidateClusterForCompatibility(cfg *api.ClusterConfig
 	}
 
 	if sharedClusterNodeSG == "" {
-		return fmt.Errorf("cluster %q does not have shared node security group", cfg.Metadata.Name)
+		return fmt.Errorf(
+			"shared node security group missing, to fix this run 'eksctl utils update-cluster-stack --name=%s --region=%s'",
+			cfg.Metadata.Name,
+			cfg.Metadata.Region,
+		)
 	}
 
 	return nil

--- a/pkg/eks/compatibility.go
+++ b/pkg/eks/compatibility.go
@@ -72,9 +72,11 @@ func (c *ClusterProvider) ValidateExistingNodeGroupsForCompatibility(cfg *api.Cl
 
 	logger.Critical("found %d nodegroup(s) (%s) without shared security group, cluster networking maybe be broken",
 		numIncompatibleNodeGroups, strings.Join(incompatibleNodeGroups, ", "))
-	logger.Critical("it's recommended to delete these nodegroups and create new ones instead")
-	logger.Critical("as a temporary fix, you can patch the configuration and add each of these nodegroup(s) to %q",
-		cfg.VPC.SharedNodeSecurityGroup)
+	logger.Critical("it's recommended to create new nodegroups, then delete old ones")
+	if cfg.VPC.SharedNodeSecurityGroup != "" {
+		logger.Critical("as a temporary fix, you can patch the configuration and add each of these nodegroup(s) to %q",
+			cfg.VPC.SharedNodeSecurityGroup)
+	}
 
 	return nil
 }

--- a/pkg/eks/compatibility.go
+++ b/pkg/eks/compatibility.go
@@ -42,7 +42,11 @@ func (c *ClusterProvider) ValidateExistingNodeGroupsForCompatibility(cfg *api.Cl
 	if err != nil {
 		return errors.Wrap(err, "getting resources for of all nodegroup stacks")
 	}
+	if len(resourcesByNodeGroup) == 0 {
+		return nil
+	}
 
+	logger.Info("checking security group configuration for all nodegroups")
 	incompatibleNodeGroups := []string{}
 	for ng, resources := range resourcesByNodeGroup {
 		compatible := false
@@ -58,6 +62,7 @@ func (c *ClusterProvider) ValidateExistingNodeGroupsForCompatibility(cfg *api.Cl
 
 	numIncompatibleNodeGroups := len(incompatibleNodeGroups)
 	if numIncompatibleNodeGroups == 0 {
+		logger.Info("all security group nodegroups have up-to-date configuration")
 		return nil
 	}
 

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -87,7 +87,7 @@ func (c *ClusterProvider) GetCredentials(spec *api.ClusterConfig) error {
 }
 
 // GetClusterVPC retrieves the VPC configuration
-func (c *ClusterProvider) GetClusterVPC(spec *api.ClusterConfig, withSecurityGroups bool) error {
+func (c *ClusterProvider) GetClusterVPC(spec *api.ClusterConfig) error {
 	cluster, err := c.NewStackManager(spec).DescribeClusterStack()
 	if err != nil {
 		return err
@@ -110,18 +110,16 @@ func (c *ClusterProvider) GetClusterVPC(spec *api.ClusterConfig, withSecurityGro
 		return fmt.Errorf(requiredKeyErrFmt, builder.CfnOutputClusterVPC)
 	}
 
-	if withSecurityGroups {
-		if securityGroup, ok := outputs[builder.CfnOutputClusterSecurityGroup]; ok {
-			spec.VPC.SecurityGroup = securityGroup
-		} else {
-			return fmt.Errorf(requiredKeyErrFmt, builder.CfnOutputClusterSecurityGroup)
-		}
+	if securityGroup, ok := outputs[builder.CfnOutputClusterSecurityGroup]; ok {
+		spec.VPC.SecurityGroup = securityGroup
+	} else {
+		return fmt.Errorf(requiredKeyErrFmt, builder.CfnOutputClusterSecurityGroup)
+	}
 
-		if sharedNodeSecurityGroup, ok := outputs[builder.CfnOutputClusterSharedNodeSecurityGroup]; ok {
-			spec.VPC.SharedNodeSecurityGroup = sharedNodeSecurityGroup
-		} else {
-			return fmt.Errorf(requiredKeyErrFmt, builder.CfnOutputClusterSharedNodeSecurityGroup)
-		}
+	if sharedNodeSecurityGroup, ok := outputs[builder.CfnOutputClusterSharedNodeSecurityGroup]; ok {
+		spec.VPC.SharedNodeSecurityGroup = sharedNodeSecurityGroup
+	} else {
+		return fmt.Errorf(requiredKeyErrFmt, builder.CfnOutputClusterSharedNodeSecurityGroup)
 	}
 
 	for _, topology := range api.SubnetTopologies() {

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -87,7 +87,7 @@ func (c *ClusterProvider) GetCredentials(spec *api.ClusterConfig) error {
 }
 
 // GetClusterVPC retrieves the VPC configuration
-func (c *ClusterProvider) GetClusterVPC(spec *api.ClusterConfig) error {
+func (c *ClusterProvider) GetClusterVPC(spec *api.ClusterConfig, withSecurityGroups bool) error {
 	cluster, err := c.NewStackManager(spec).DescribeClusterStack()
 	if err != nil {
 		return err
@@ -110,16 +110,18 @@ func (c *ClusterProvider) GetClusterVPC(spec *api.ClusterConfig) error {
 		return fmt.Errorf(requiredKeyErrFmt, builder.CfnOutputClusterVPC)
 	}
 
-	if securityGroup, ok := outputs[builder.CfnOutputClusterSecurityGroup]; ok {
-		spec.VPC.SecurityGroup = securityGroup
-	} else {
-		return fmt.Errorf(requiredKeyErrFmt, builder.CfnOutputClusterSecurityGroup)
-	}
+	if withSecurityGroups {
+		if securityGroup, ok := outputs[builder.CfnOutputClusterSecurityGroup]; ok {
+			spec.VPC.SecurityGroup = securityGroup
+		} else {
+			return fmt.Errorf(requiredKeyErrFmt, builder.CfnOutputClusterSecurityGroup)
+		}
 
-	if sharedNodeSecurityGroup, ok := outputs[builder.CfnOutputClusterSharedNodeSecurityGroup]; ok {
-		spec.VPC.SharedNodeSecurityGroup = sharedNodeSecurityGroup
-	} else {
-		return fmt.Errorf(requiredKeyErrFmt, builder.CfnOutputClusterSharedNodeSecurityGroup)
+		if sharedNodeSecurityGroup, ok := outputs[builder.CfnOutputClusterSharedNodeSecurityGroup]; ok {
+			spec.VPC.SharedNodeSecurityGroup = sharedNodeSecurityGroup
+		} else {
+			return fmt.Errorf(requiredKeyErrFmt, builder.CfnOutputClusterSharedNodeSecurityGroup)
+		}
 	}
 
 	for _, topology := range api.SubnetTopologies() {


### PR DESCRIPTION
### Description

This is a follow-up to #438, it adds new `eksctl update-cluster-stack` command that updates an existing cluster stack with new resources that are missing (append-only).

Closes #419.

A cluster was created using an old version (0.1.18):
```
 [0] >> eksctl create cluster --name=test-missing-node-sg
[ℹ]  using region us-west-2
[ℹ]  setting availability zones to [us-west-2c us-west-2a us-west-2b]
[ℹ]  subnets for us-west-2c - public:192.168.0.0/19 private:192.168.96.0/19
[ℹ]  subnets for us-west-2a - public:192.168.32.0/19 private:192.168.128.0/19
[ℹ]  subnets for us-west-2b - public:192.168.64.0/19 private:192.168.160.0/19
[ℹ]  nodegroup "ng-fba6638e" will use "ami-0a2abab4107669c1b" [AmazonLinux2/1.11]
[ℹ]  creating EKS cluster "test-missing-node-sg" in "us-west-2" region
[ℹ]  will create 2 separate CloudFormation stacks for cluster itself and the initial nodegroup
[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-west-2 --name=test-missing-node-sg'
[ℹ]  creating cluster stack "eksctl-test-missing-node-sg-cluster"
[ℹ]  creating nodegroup stack "eksctl-test-missing-node-sg-nodegroup-ng-fba6638e"
[✔]  all EKS cluster resource for "test-missing-node-sg" had been created
[✔]  saved kubeconfig as "/Users/ilya/.kube/config"
[ℹ]  nodegroup "ng-fba6638e" has 1 node(s)
[ℹ]  node "ip-192-168-36-245.us-west-2.compute.internal" is not ready
[ℹ]  waiting for at least 2 node(s) to become ready in "ng-fba6638e"
[ℹ]  nodegroup "ng-fba6638e" has 2 node(s)
[ℹ]  node "ip-192-168-36-245.us-west-2.compute.internal" is ready
[ℹ]  node "ip-192-168-90-139.us-west-2.compute.internal" is ready
[ℹ]  kubectl command should work with "/Users/ilya/.kube/config", try 'kubectl get nodes'
[✔]  EKS cluster "test-missing-node-sg" in "us-west-2" region is ready
```

Trying to add a nodegroup with the new version fails:
```
 [0] >> ./eksctl create nodegroup --cluster=test-missing-node-sg      
[ℹ]  using region us-west-2
[ℹ]  nodegroup "ng-318da8b7" will use "ami-0a2abab4107669c1b" [AmazonLinux2/1.11]
[✖]  cluster compatibility check failed: shared node security group missing, to fix this run 'eksctl utils update-cluster-stack --name=test-missing-node-sg --region=us-west-2'
 [1] >> 
```

Fix the problem:
```
 [0] >> ./eksctl utils update-cluster-stack --name=test-missing-node-sg --region=us-west-2
[ℹ]  creating cluster stack "eksctl-test-missing-node-sg-cluster"
[ℹ]  (dry-run) updating stack to add new resources [ClusterSharedNodeSecurityGroup IngressInterNodeGroupSG] and ouputs [SharedNodeSecurityGroup]
[ℹ]  checking security group configuration for all nodegroups
[✖]  found 1 nodegroup(s) (ng-fba6638e) without shared security group, cluster networking maybe be broken
[✖]  it's recommended to create new nodegroups, then delete old ones
[!]  no changes were applied, run again with '--dry-run=false' to apply the changes
 [0] >> ./eksctl utils update-cluster-stack --name=test-missing-node-sg --region=us-west-2 --dry-run=false
[ℹ]  creating cluster stack "eksctl-test-missing-node-sg-cluster"
[ℹ]  updating stack to add new resources [ClusterSharedNodeSecurityGroup IngressInterNodeGroupSG] and ouputs [SharedNodeSecurityGroup]
[ℹ]  checking security group configuration for all nodegroups
[✖]  found 1 nodegroup(s) (ng-fba6638e) without shared security group, cluster networking maybe be broken
[✖]  it's recommended to create new nodegroups, then delete old ones
 [0] >> ./eksctl utils update-cluster-stack --name=test-missing-node-sg --region=us-west-2 --dry-run=false
[ℹ]  creating cluster stack "eksctl-test-missing-node-sg-cluster"
[✔]  all resources in cluster stack "eksctl-test-missing-node-sg-cluster" are up-to-date
[ℹ]  checking security group configuration for all nodegroups
[✖]  found 1 nodegroup(s) (ng-fba6638e) without shared security group, cluster networking maybe be broken
[✖]  it's recommended to create new nodegroups, then delete old ones
[✖]  as a temporary fix, you can patch the configuration and add each of these nodegroup(s) to "sg-034c1a4f4b0bbea77"
 [0] >>
```

Create new nodegroup, delete old one:
```
 [0] >> ./eksctl create nodegroup --cluster=test-missing-node-sg 
[ℹ]  using region us-west-2
[ℹ]  nodegroup "ng-d6ae625f" will use "ami-0a2abab4107669c1b" [AmazonLinux2/1.11]
[ℹ]  will create a Cloudformation stack for nodegroup ng-d6ae625f in cluster test-missing-node-sg
[ℹ]  creating nodegroup stack "eksctl-test-missing-node-sg-nodegroup-ng-d6ae625f"
[ℹ]  nodegroup "ng-d6ae625f" has 0 node(s)
[ℹ]  waiting for at least 2 node(s) to become ready in "ng-d6ae625f"
[ℹ]  nodegroup "ng-d6ae625f" has 2 node(s)
[ℹ]  node "ip-192-168-28-8.us-west-2.compute.internal" is ready
[ℹ]  node "ip-192-168-70-86.us-west-2.compute.internal" is ready
[✔]  created nodegroup "ng-d6ae625f" in cluster "test-missing-node-sg"
[ℹ]  checking security group configuration for all nodegroups
[✖]  found 1 nodegroup(s) (ng-fba6638e) without shared security group, cluster networking maybe be broken
[✖]  it's recommended to create new nodegroups, then delete old ones
[✖]  as a temporary fix, you can patch the configuration and add each of these nodegroup(s) to "sg-034c1a4f4b0bbea77"
 [0] >> ./eksctl delete nodegroup --cluster=test-missing-node-sg ng-fba6638e
[ℹ]  deleting nodegroup "ng-fba6638e" in cluster "test-missing-node-sg"
[ℹ]  will delete stack "eksctl-test-missing-node-sg-nodegroup-ng-fba6638e"
[✔]  nodegroup "ng-fba6638e" will be deleted
 [0] >> 
```

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [ ] All tests passing (i.e. `make test`)