### PR TITLE
Make scaling operations for nodegroups idempotent

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -26,6 +26,7 @@ Bryan Peterson          @lazyshot
 Josue Abreu             @gotjosh
 Timothy Mukaibo         @mukaibot
 Yusuke Kuoka            @mumoshu
+Daniel Herman           @dcherman
 
 /* Thanks */
 

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -158,6 +158,11 @@ func (c *StackCollection) ScaleNodeGroup(ng *api.NodeGroup) error {
 	currentMaxSize := gjson.Get(template, maxSizePath)
 	currentMinSize := gjson.Get(template, minSizePath)
 
+	if int64(ng.DesiredCapacity) == currentCapacity.Int() {
+		logger.Info("desired capacity of nodegroup %q in cluster %q is already %d", ng.Name, clusterName, ng.DesiredCapacity)
+		return nil
+	}
+
 	// Set the new values
 	newCapacity := fmt.Sprintf("%d", ng.DesiredCapacity)
 	template, err = sjson.Set(template, desiredCapacityPath, newCapacity)


### PR DESCRIPTION
### Description

CloudFormation throws an error when attempting to submit a changeset to a
stack that contains no actual changes.  This can occur when you attempt to
scale a NodeGroup to the same size that it already is.  To work-around
that, we can detect if you're attempting to scale the NodeGroup to the
existing DesiredCapacity and turn that action into a no-op in order to
make this API call idempotent.

- fixes #430 

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)
- [x] Added/modified documentation as required (such as the README)
- [x] Added yourself to the `humans.txt` file
