### PR TITLE
Add "name" field to nodeGroups in example config

### DIFF
--- a/examples/05-all-fields.yaml
+++ b/examples/05-all-fields.yaml
@@ -42,7 +42,8 @@ availabilityZones: ["eu-north-1a", "eu-north-1b", "eu-north-1c"]
 
 nodeGroups:
 
-  - instanceType: m5.xlarge
+  - name: build
+    instanceType: m5.xlarge
     tags: {purpose: build}
     volumeSize: 30
     desiredCapacity: 10
@@ -58,7 +59,8 @@ nodeGroups:
     allowSSH: true
     sshPublicKeyPath: ~/.id_rsa/eks_node_key.pem
 
-  - instanceType: m5.24xlarge
+  - name: production
+    instanceType: m5.24xlarge
     tags: {purpose: production}
     volumeSize: 8
     desiredCapacity: 100


### PR DESCRIPTION
The "name" field is required for nodeGroups and should be in the all-fields example

### Checklist
- [ ] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [ ] All tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the README)
- [ ] Added yourself to the `humans.txt` file
