### PR TITLE
Allow to create nodegroups in clusters with non-default VPC CIDR

### DIFF
--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -359,7 +359,9 @@ func doCreateCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 			if len(availabilityZones) != 0 {
 				return fmt.Errorf("--vpc-from-kops-cluster and --zones %s", cmdutils.IncompatibleFlags)
 			}
-
+			if cmd.Flag("vpc-cidr").Changed {
+				return fmt.Errorf("--vpc-from-kops-cluster and --vpc-cidr %s", cmdutils.IncompatibleFlags)
+			}
 			if subnetsGiven {
 				return fmt.Errorf("--vpc-from-kops-cluster and --vpc-private-subnets/--vpc-public-subnets %s", cmdutils.IncompatibleFlags)
 			}
@@ -386,6 +388,9 @@ func doCreateCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 
 		if len(availabilityZones) != 0 {
 			return fmt.Errorf("--vpc-private-subnets/--vpc-public-subnets and --zones %s", cmdutils.IncompatibleFlags)
+		}
+		if cmd.Flag("vpc-cidr").Changed {
+			return fmt.Errorf("--vpc-private-subnets/--vpc-public-subnets and --vpc-cidr %s", cmdutils.IncompatibleFlags)
 		}
 
 		if err := vpc.UseSubnets(ctl.Provider, cfg); err != nil {

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -98,6 +98,12 @@ func (c *ClusterProvider) GetClusterVPC(spec *api.ClusterConfig, ignoreMissingKe
 	if spec.VPC == nil {
 		spec.VPC = &api.ClusterVPC{}
 	}
+	if spec.VPC.CIDR != nil {
+		// CIDR has to be reset, as otherwise it will error
+		// as the default value may be different from that
+		// cluster actually uses
+		spec.VPC.CIDR = nil
+	}
 
 	requiredCollectors := map[string]outputs.Collector{
 		outputs.ClusterVPC: func(v string) error {


### PR DESCRIPTION
### Description

Fixes #473.

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] All tests passing (i.e. `make test`)
