### PR TITLE
Enable to declare AttachIDs, WithShared and WithLocal in config file

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -27,6 +27,7 @@ Josue Abreu             @gotjosh
 Timothy Mukaibo         @mukaibot
 Yusuke Kuoka            @mumoshu
 Daniel Herman           @dcherman
+Takuma Hashimoto        @af12066
 
 /* Thanks */
 

--- a/pkg/apis/eksctl.io/v1alpha4/types.go
+++ b/pkg/apis/eksctl.io/v1alpha4/types.go
@@ -377,11 +377,11 @@ type (
 	// NodeGroupSGs holds all SG attributes of a NodeGroup
 	NodeGroupSGs struct {
 		// +optional
-		AttachIDs []string
+		AttachIDs []string `json:"attachIDs,omitempty"`
 		// +optional
-		WithShared *bool
+		WithShared *bool `json:"withShared"`
 		// +optional
-		WithLocal *bool
+		WithLocal *bool `json:"withLocal"`
 	}
 	// NodeGroupIAM holds all IAM attributes of a NodeGroup
 	NodeGroupIAM struct {


### PR DESCRIPTION
### Description

We have made it possible to declare `attachIDs`, `withShared` and/or `withLocal` for security groups in `cluster.yaml`

e.g.
```yaml
apiVersion: eksctl.io/v1alpha4
kind: ClusterConfig

nodeGroups:
  - name: nodegroup1
    securityGroups:
      attachIDs:
        - sg-abcd1234
        - sg-567890ef
    ...
```

cf. #460 

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the README)
- [x] Added yourself to the `humans.txt` file