### PR TITLE
Test private networking

### DIFF
--- a/integration/creategetdelete_test.go
+++ b/integration/creategetdelete_test.go
@@ -112,23 +112,23 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					"--verbose", "4",
 					"--cluster", clusterName,
 					"--region", region,
-					"--nodes", "2",
+					"--nodes", "4",
 					"--name", initNG,
 				)
 			})
 
-			It("should make it 2 nodes total", func() {
+			It("should make it 4 nodes total", func() {
 				test, err := newKubeTest()
 				Expect(err).ShouldNot(HaveOccurred())
 				defer test.Close()
 
-				test.WaitForNodesReady(2, commonTimeout)
+				test.WaitForNodesReady(4, commonTimeout)
 
 				nodes := test.ListNodes((metav1.ListOptions{
 					LabelSelector: api.NodeGroupNameLabel + "=" + initNG,
 				}))
 
-				Expect(len(nodes.Items)).To(Equal(2))
+				Expect(len(nodes.Items)).To(Equal(4))
 			})
 		})
 
@@ -137,25 +137,25 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				eksctl("create", "nodegroup",
 					"--cluster", clusterName,
 					"--region", region,
-					"--nodes", "1",
+					"--nodes", "4",
 					"--node-private-networking",
 					testNG,
 				)
 			})
 
-			It("should make it 3 nodes total", func() {
+			It("should make it 8 nodes total", func() {
 				test, err := newKubeTest()
 				Expect(err).ShouldNot(HaveOccurred())
 				defer test.Close()
 
-				test.WaitForNodesReady(3, commonTimeout)
+				test.WaitForNodesReady(8, commonTimeout)
 
 				nodes := test.ListNodes(metav1.ListOptions{})
 
-				Expect(len(nodes.Items)).To(Equal(3))
+				Expect(len(nodes.Items)).To(Equal(8))
 			})
 
-			Context("and we create a deployment using kubectl", func() {
+			Context("and we create a deployment and access pods via proxy", func() {
 				var (
 					err  error
 					test *harness.Test
@@ -171,7 +171,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					test.Close()
 				})
 
-				It("should deploy the service to the cluster", func() {
+				It("should deploy podinfo service to the cluster", func() {
 					d := test.CreateDeploymentFromFile(test.Namespace, "podinfo.yaml")
 					test.WaitForDeploymentReady(d, 1*time.Minute)
 
@@ -220,18 +220,19 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					)
 				})
 
-				It("should make it 2 nodes total", func() {
+				It("should make it 4 nodes total", func() {
 					test, err := newKubeTest()
 					Expect(err).ShouldNot(HaveOccurred())
 					defer test.Close()
 
-					test.WaitForNodesReady(2, commonTimeout)
+					test.WaitForNodesReady(4, commonTimeout)
 
 					nodes := test.ListNodes((metav1.ListOptions{
 						LabelSelector: api.NodeGroupNameLabel + "=" + initNG,
 					}))
-
-					Expect(len(nodes.Items)).To(Equal(2))
+					allNodes := test.ListNodes((metav1.ListOptions{}))
+					Expect(len(nodes.Items)).To(Equal(4))
+					Expect(len(allNodes.Items)).To(Equal(4))
 				})
 			})
 		})

--- a/integration/creategetdelete_test.go
+++ b/integration/creategetdelete_test.go
@@ -138,6 +138,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					"--cluster", clusterName,
 					"--region", region,
 					"--nodes", "1",
+					"--node-private-networking",
 					testNG,
 				)
 			})

--- a/integration/creategetdelete_test.go
+++ b/integration/creategetdelete_test.go
@@ -198,7 +198,23 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 					defer test.Close()
 
-					d := test.CreateDaemonSetFromFile(test.Namespace, "dns-test.yaml")
+					d := test.CreateDaemonSetFromFile(test.Namespace, "test-dns.yaml")
+
+					test.WaitForDaemonSetReady(d, 3*time.Minute)
+
+					{
+						ds, err := test.GetDaemonSet(test.Namespace, d.Name)
+						Expect(err).ShouldNot(HaveOccurred())
+						fmt.Fprintf(GinkgoWriter, "ds.Status = %#v", ds.Status)
+					}
+				})
+
+				It("should have access to HTTP(S) sites", func() {
+					test, err := newKubeTest()
+					Expect(err).ShouldNot(HaveOccurred())
+					defer test.Close()
+
+					d := test.CreateDaemonSetFromFile(test.Namespace, "test-http.yaml")
 
 					test.WaitForDaemonSetReady(d, 3*time.Minute)
 

--- a/integration/dns-test.yaml
+++ b/integration/dns-test.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
-        name: dns-test
+        name: dns-test-cluster
         stdin: true
         tty: true
         readinessProbe:
@@ -28,4 +28,95 @@ spec:
             command:
             - nslookup
             - kubernetes.default.svc.cluster.local.
+      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+        name: dns-test-eksctl
+        stdin: true
+        tty: true
+        readinessProbe:
+          initialDelaySeconds: 0
+          periodSeconds: 3
+          failureThreshold: 3
+          timeoutSeconds: 1
+          exec:
+            command:
+            - nslookup
+            - eksctl.io
+      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+        name: dns-test-k8s
+        stdin: true
+        tty: true
+        readinessProbe:
+          initialDelaySeconds: 0
+          periodSeconds: 3
+          failureThreshold: 3
+          timeoutSeconds: 1
+          exec:
+            command:
+            - nslookup
+            - k8s.io
+      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+        name: dns-test-kubernetes
+        stdin: true
+        tty: true
+        readinessProbe:
+          initialDelaySeconds: 0
+          periodSeconds: 3
+          failureThreshold: 3
+          timeoutSeconds: 1
+          exec:
+            command:
+            - nslookup
+            - kubernetes.io
+      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+        name: dns-test-eks-us
+        stdin: true
+        tty: true
+        readinessProbe:
+          initialDelaySeconds: 0
+          periodSeconds: 3
+          failureThreshold: 3
+          timeoutSeconds: 1
+          exec:
+            command:
+            - nslookup
+            - EKS.us-east-1.amazonaws.com
+      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+        name: dns-test-eks-eu
+        stdin: true
+        tty: true
+        readinessProbe:
+          initialDelaySeconds: 0
+          periodSeconds: 3
+          failureThreshold: 3
+          timeoutSeconds: 1
+          exec:
+            command:
+            - nslookup
+            - EKS.eu-west-1.amazonaws.com
+      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+        name: dns-test-ec2-us
+        stdin: true
+        tty: true
+        readinessProbe:
+          initialDelaySeconds: 0
+          periodSeconds: 3
+          failureThreshold: 3
+          timeoutSeconds: 1
+          exec:
+            command:
+            - nslookup
+            - ec2.us-east-2.amazonaws.com
+      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+        name: dns-test-ec2-eu
+        stdin: true
+        tty: true
+        readinessProbe:
+          initialDelaySeconds: 0
+          periodSeconds: 3
+          failureThreshold: 3
+          timeoutSeconds: 1
+          exec:
+            command:
+            - nslookup
+            - ec2.eu-west-2.amazonaws.com
 

--- a/integration/test-dns.yaml
+++ b/integration/test-dns.yaml
@@ -1,18 +1,14 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  labels:
-    run: dns-test
-  name: dns-test
+  name: test-dns
+  labels: {test: dns}
 spec:
   selector:
-    matchLabels:
-      run: dns-test
+    matchLabels: {test: dns}
   template:
     metadata:
-      creationTimestamp: null
-      labels:
-        run: dns-test
+      labels: {test: dns}
     spec:
       containers:
       - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
@@ -119,4 +115,16 @@ spec:
             command:
             - nslookup
             - ec2.eu-west-2.amazonaws.com
-
+      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+        name: dns-test-ifconfig
+        stdin: true
+        tty: true
+        readinessProbe:
+          initialDelaySeconds: 0
+          periodSeconds: 3
+          failureThreshold: 3
+          timeoutSeconds: 1
+          exec:
+            command:
+            - nslookup
+            - ifconfig.co

--- a/integration/test-http.yaml
+++ b/integration/test-http.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-http
+  labels: {test: http}
+spec:
+  selector:
+    matchLabels: {test: http}
+  template:
+    metadata:
+      labels: {test: http}
+    spec:
+      containers:
+      - image: tutum/curl@sha256:b6f16e88387acd4e6326176b212b3dae63f5b2134e69560d0b0673cfb0fb976f
+        name: https-test-eksctl
+        stdin: true
+        tty: true
+        readinessProbe:
+          initialDelaySeconds: 0
+          periodSeconds: 3
+          failureThreshold: 3
+          timeoutSeconds: 1
+          exec:
+            command:
+            - curl
+            - --fail
+            - --silent
+            - --head
+            - eksctl.io
+      - image: tutum/curl@sha256:b6f16e88387acd4e6326176b212b3dae63f5b2134e69560d0b0673cfb0fb976f
+        name: https-test-kubernetes
+        stdin: true
+        tty: true
+        readinessProbe:
+          initialDelaySeconds: 0
+          periodSeconds: 3
+          failureThreshold: 3
+          timeoutSeconds: 1
+          exec:
+            command:
+            - curl
+            - --fail
+            - --silent
+            - --head
+            - kubernetes.io
+      - image: tutum/curl@sha256:b6f16e88387acd4e6326176b212b3dae63f5b2134e69560d0b0673cfb0fb976f
+        name: https-test-ifconfig
+        stdin: true
+        tty: true
+        readinessProbe:
+          initialDelaySeconds: 0
+          periodSeconds: 3
+          failureThreshold: 3
+          timeoutSeconds: 1
+          exec:
+            command:
+            - curl
+            - --fail
+            - --silent
+            - https://ifconfig.co/
+      - image: tutum/curl@sha256:b6f16e88387acd4e6326176b212b3dae63f5b2134e69560d0b0673cfb0fb976f
+        name: https-test-metadata
+        stdin: true
+        tty: true
+        readinessProbe:
+          initialDelaySeconds: 0
+          periodSeconds: 3
+          failureThreshold: 3
+          timeoutSeconds: 1
+          exec:
+            command:
+            - curl
+            - --fail
+            - --silent
+            - http://169.254.169.254/latest/meta-data/local-ipv4
+        


### PR DESCRIPTION
### Description

This adds a test to make sure private networking functions as expected.
That is done by extending the DNS test to make queries against multiple different domains, in order to verify that cluster DNS is accessible and fully functional from all nodes.
To make sure that is the case, we also scale up both nodegroups to more nodes, as with only a few nodes there is a chance we hit local DNS pod. We also need to make sure all of the subnets are functional.
In addition to that, we test some common HTTPS servers are accessible.

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)
