### PR TITLE
fix(doc): `brew tap weaveworks/tap`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ sudo mv /tmp/eksctl /usr/local/bin
 
 Alternatively, macOS users can use [Homebrew](https://brew.sh):
 ```
+brew tap weaveworks/tap
 brew install weaveworks/tap/eksctl
 ```
 


### PR DESCRIPTION
Is required before installing `eksctl` with Homebrew. Otherwise `brew install` fails like:

```console
Error: No available formula with the name "weaveworks/tap/eksctl"
Please tap it and then try again: brew tap weaveworks/tap
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
```