### PR TITLE
make it easy to delete cluster with a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,11 @@ nodeGroups:
         imageBuilder: true
 ```
 
+To delete this cluster, run:
+```
+eksctl delete cluster -f cluster.yaml
+```
+
 See [`examples/`](https://github.com/weaveworks/eksctl/tree/master/examples) directory for more sample config files.
 
 ### GPU Support

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -32,7 +32,7 @@ var (
 	setContext         bool
 	availabilityZones  []string
 
-	configFile = ""
+	clusterConfigFile = ""
 
 	kopsClusterNameForVPC string
 	subnets               map[api.SubnetTopology]*[]string
@@ -67,7 +67,7 @@ func createClusterCmd(g *cmdutils.Grouping) *cobra.Command {
 		cmdutils.AddRegionFlag(fs, p)
 		fs.StringSliceVar(&availabilityZones, "zones", nil, "(auto-select if unspecified)")
 		cmdutils.AddVersionFlag(fs, cfg.Metadata)
-		fs.StringVarP(&configFile, "config-file", "f", "", "load configuration from a file")
+		fs.StringVarP(&clusterConfigFile, "config-file", "f", "", "load configuration from a file")
 	})
 
 	group.InFlagSet("Initial nodegroup", func(fs *pflag.FlagSet) {
@@ -130,8 +130,8 @@ func doCreateCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 		return err
 	}
 
-	if configFile != "" {
-		if err := eks.LoadConfigFromFile(configFile, cfg); err != nil {
+	if clusterConfigFile != "" {
+		if err := eks.LoadConfigFromFile(clusterConfigFile, cfg); err != nil {
 			return err
 		}
 		meta = cfg.Metadata
@@ -535,7 +535,7 @@ func doCreateCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 			// --storage-class flag is only for backwards compatibility,
 			// we always create the storage class when --config-file is
 			// used, as this is 1.10-only
-			if addonsStorageClass || configFile != "" {
+			if addonsStorageClass || clusterConfigFile != "" {
 				if err = ctl.AddDefaultStorageClass(clientSet); err != nil {
 					return err
 				}

--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -11,7 +11,12 @@ import (
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha4"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/eks"
+	"github.com/weaveworks/eksctl/pkg/printers"
 	"github.com/weaveworks/eksctl/pkg/utils/kubeconfig"
+)
+
+var (
+	clusterConfigFile = ""
 )
 
 func deleteClusterCmd(g *cmdutils.Grouping) *cobra.Command {
@@ -21,8 +26,8 @@ func deleteClusterCmd(g *cmdutils.Grouping) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cluster",
 		Short: "Delete a cluster",
-		Run: func(_ *cobra.Command, args []string) {
-			if err := doDeleteCluster(p, cfg, cmdutils.GetNameArg(args)); err != nil {
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := doDeleteCluster(p, cfg, cmdutils.GetNameArg(args), cmd); err != nil {
 				logger.Critical("%s\n", err.Error())
 				os.Exit(1)
 			}
@@ -35,6 +40,7 @@ func deleteClusterCmd(g *cmdutils.Grouping) *cobra.Command {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
 		cmdutils.AddRegionFlag(fs, p)
 		cmdutils.AddWaitFlag(&wait, fs)
+		fs.StringVarP(&clusterConfigFile, "config-file", "f", "", "load configuration from a file")
 	})
 
 	cmdutils.AddCommonFlagsForAWS(group, p, true)
@@ -43,26 +49,69 @@ func deleteClusterCmd(g *cmdutils.Grouping) *cobra.Command {
 	return cmd
 }
 
-func doDeleteCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg string) error {
+func doDeleteCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg string, cmd *cobra.Command) error {
+	meta := cfg.Metadata
+
+	printer := printers.NewJSONPrinter()
+
+	if err := api.Register(); err != nil {
+		return err
+	}
+
+	if clusterConfigFile != "" {
+		if err := eks.LoadConfigFromFile(clusterConfigFile, cfg); err != nil {
+			return err
+		}
+		meta = cfg.Metadata
+
+		incompatibleFlags := []string{
+			"name",
+			"region",
+		}
+
+		for _, f := range incompatibleFlags {
+			if cmd.Flag(f).Changed {
+				return fmt.Errorf("cannot use --%s when --config-file/-f is set", f)
+			}
+		}
+
+		if nameArg != "" {
+			return fmt.Errorf("cannot use name argument %q when --config-file/-f is set", nameArg)
+		}
+
+		if meta.Name == "" {
+			return fmt.Errorf("metadata.name must be set")
+		}
+
+		if meta.Region == "" {
+			return fmt.Errorf("metadata.region must be set")
+		}
+
+		p.Region = meta.Region
+	} else {
+		if meta.Name != "" && nameArg != "" {
+			return cmdutils.ErrNameFlagAndArg(meta.Name, nameArg)
+		}
+
+		if nameArg != "" {
+			meta.Name = nameArg
+		}
+
+		if meta.Name == "" {
+			return fmt.Errorf("--name must be set")
+		}
+	}
+
 	ctl := eks.New(p, cfg)
 
 	if err := ctl.CheckAuth(); err != nil {
 		return err
 	}
 
-	if cfg.Metadata.Name != "" && nameArg != "" {
-		return cmdutils.ErrNameFlagAndArg(cfg.Metadata.Name, nameArg)
+	logger.Info("deleting EKS cluster %q", meta.Name)
+	if err := printer.LogObj(logger.Debug, "cfg.json = \\\n", cfg); err != nil {
+		return err
 	}
-
-	if nameArg != "" {
-		cfg.Metadata.Name = nameArg
-	}
-
-	if cfg.Metadata.Name == "" {
-		return fmt.Errorf("--name must be set")
-	}
-
-	logger.Info("deleting EKS cluster %q", cfg.Metadata.Name)
 
 	var deletedResources []string
 
@@ -100,7 +149,7 @@ func doDeleteCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 	}
 
 	if clusterErr {
-		if handleIfError(ctl.DeprecatedDeleteControlPlane(cfg.Metadata), "control plane") {
+		if handleIfError(ctl.DeprecatedDeleteControlPlane(meta), "control plane") {
 			handleIfError(stackManager.DeprecatedDeleteStackControlPlane(wait), "stack control plane (deprecated)")
 		}
 	}
@@ -109,14 +158,14 @@ func doDeleteCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 	handleIfError(stackManager.DeprecatedDeleteStackVPC(wait), "stack VPC (deprecated)")
 	handleIfError(stackManager.DeprecatedDeleteStackDefaultNodeGroup(wait), "default nodegroup (deprecated)")
 
-	ctl.MaybeDeletePublicSSHKey(cfg.Metadata.Name)
+	ctl.MaybeDeletePublicSSHKey(meta.Name)
 
-	kubeconfig.MaybeDeleteConfig(cfg.Metadata)
+	kubeconfig.MaybeDeleteConfig(meta)
 
 	if len(deletedResources) == 0 {
-		logger.Warning("no EKS cluster resources were found for %q", cfg.Metadata.Name)
+		logger.Warning("no EKS cluster resources were found for %q", meta.Name)
 	} else {
-		logger.Success("the following EKS cluster resource(s) for %q will be deleted: %s. If in doubt, check CloudFormation console", cfg.Metadata.Name, strings.Join(deletedResources, ", "))
+		logger.Success("the following EKS cluster resource(s) for %q will be deleted: %s. If in doubt, check CloudFormation console", meta.Name, strings.Join(deletedResources, ", "))
 	}
 
 	return nil


### PR DESCRIPTION
### Description

This change adds `--config-file/-f` to `eksctl delete cluster` and closes #504.

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] All tests passing (i.e. `make test`)
- [x] Added/modified documentation as required (such as the README)
