### PR TITLE
Ensure that all IAM fileds get populated on cluster creation

### DIFF
--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -296,6 +296,9 @@ var _ = Describe("CloudFormation template builder API", func() {
 			},
 			AvailabilityZones: testAZs,
 			VPC:               testVPC(),
+			IAM: api.ClusterIAM{
+				ServiceRoleARN: arn,
+			},
 			NodeGroups: []*api.NodeGroup{
 				{
 					AMI:               "",
@@ -353,6 +356,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			"ARN":                      arn,
 			"ClusterStackName":         "",
 			"SharedNodeSecurityGroup":  "sg-shared",
+			"ServiceRoleARN":           arn,
 		}
 
 		sampleStack := newStackWithOutputs(sampleOutputs)

--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -71,6 +71,7 @@ func (c *ClusterResourceSet) addResourcesForIAM() {
 
 	if c.spec.IAM.ServiceRoleARN != "" {
 		c.rs.withIAM = false
+		c.rs.defineOutputWithoutCollector(outputs.ClusterServiceRoleARN, c.spec.IAM.ServiceRoleARN, true)
 		return
 	}
 
@@ -90,6 +91,10 @@ func (c *ClusterResourceSet) addResourcesForIAM() {
 	})
 	c.rs.attachAllowPolicy("PolicyCloudWatchMetrics", refSR, "*", []string{
 		"cloudwatch:PutMetricData",
+	})
+	c.rs.defineOutputFromAtt(outputs.ClusterServiceRoleARN, "ServiceRole.Arn", true, func(v string) error {
+		c.spec.IAM.ServiceRoleARN = v
+		return nil
 	})
 }
 
@@ -135,6 +140,10 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 		n.instanceProfile = n.newResource("NodeInstanceProfile", &gfn.AWSIAMInstanceProfile{
 			Path:  gfn.NewString("/"),
 			Roles: makeStringSlice(n.spec.IAM.InstanceRoleARN),
+		})
+		n.rs.defineOutputFromAtt(outputs.NodeGroupInstanceProfileARN, "NodeInstanceProfile.Arn", true, func(v string) error {
+			n.spec.IAM.InstanceProfileARN = v
+			return nil
 		})
 		n.rs.defineOutputWithoutCollector(outputs.NodeGroupInstanceRoleARN, n.spec.IAM.InstanceRoleARN, true)
 		return
@@ -196,6 +205,10 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 		)
 	}
 
+	n.rs.defineOutputFromAtt(outputs.NodeGroupInstanceProfileARN, "NodeInstanceProfile.Arn", true, func(v string) error {
+		n.spec.IAM.InstanceProfileARN = v
+		return nil
+	})
 	n.rs.defineOutputFromAtt(outputs.NodeGroupInstanceRoleARN, "NodeInstanceRole.Arn", true, func(v string) error {
 		n.spec.IAM.InstanceRoleARN = v
 		return nil

--- a/pkg/cfn/outputs/api.go
+++ b/pkg/cfn/outputs/api.go
@@ -23,6 +23,7 @@ const (
 	ClusterARN                      = "ARN"
 	ClusterStackName                = "ClusterStackName"
 	ClusterSharedNodeSecurityGroup  = "SharedNodeSecurityGroup"
+	ClusterServiceRoleARN           = "ServiceRoleARN"
 
 	// outputs from nodegroup stack
 	NodeGroupInstanceRoleARN    = "InstanceRoleARN"


### PR DESCRIPTION
### Description

This change ensures that all IAM fields are populated, so that once cluster is created the config object fully represents the remote state. It closes #506.

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] All tests passing (i.e. `make test`)
