### PR TITLE
fix: `get nodegroup` should return blank CLUSTER fields

### DIFF
--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -148,7 +148,9 @@ func (c *StackCollection) AppendNewClusterStackResource(dryRun bool) error {
 func getClusterName(s *Stack) string {
 	for _, tag := range s.Tags {
 		if *tag.Key == api.ClusterNameTag {
-			if strings.HasSuffix(*s.StackName, "-cluster") {
+			if strings.HasSuffix(*s.StackName, "-cluster") ||
+				strings.Contains(*s.StackName, "-nodegroup-") {
+
 				return *tag.Value
 			}
 		}


### PR DESCRIPTION
This change is verified manually by running `eksctl get nodegroup` like:

```console
./eksctl get nodegroup --cluster mycluster
CLUSTER		NODEGROUP	CREATED			MIN SIZE	MAX SIZE	DESIRED CAPACITY	INSTANCE TYPE	IMAGE ID
mycluster	nodegroup1	2019-02-02T13:06:24Z	2		2		0			t3.large	ami-0f0e8066383e7a2cb
```

Fixes #510