### PR TITLE
Fix regression in `getClusterName` helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ coverage.out
 # Test results
 test-results/
 
+integration/kubeconfig-*

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -146,18 +146,23 @@ func (c *StackCollection) AppendNewClusterStackResource(dryRun bool) error {
 }
 
 func getClusterName(s *Stack) string {
-	for _, tag := range s.Tags {
-		if *tag.Key == api.ClusterNameTag {
-			if strings.HasSuffix(*s.StackName, "-cluster") ||
-				strings.Contains(*s.StackName, "-nodegroup-") {
-
-				return *tag.Value
-			}
+	if strings.HasSuffix(*s.StackName, "-cluster") {
+		if v := getClusterNameTag(s); v != "" {
+			return v
 		}
 	}
 
 	if strings.HasPrefix(*s.StackName, "EKS-") && strings.HasSuffix(*s.StackName, "-ControlPlane") {
 		return strings.TrimPrefix("EKS-", strings.TrimSuffix(*s.StackName, "-ControlPlane"))
+	}
+	return ""
+}
+
+func getClusterNameTag(s *Stack) string {
+	for _, tag := range s.Tags {
+		if *tag.Key == api.ClusterNameTag {
+			return *tag.Value
+		}
 	}
 	return ""
 }

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -223,7 +223,7 @@ func (c *StackCollection) mapStackToNodeGroupSummary(stack *Stack) (*NodeGroupSu
 		return nil, errors.Wrapf(err, "error getting Cloudformation template for stack %s", *stack.StackName)
 	}
 
-	cluster := getClusterName(stack)
+	cluster := getClusterNameTag(stack)
 	name := getNodeGroupName(stack)
 	maxSize := gjson.Get(template, maxSizePath)
 	minSize := gjson.Get(template, minSizePath)


### PR DESCRIPTION
### Description

A regression was introduced in #511, it resulted in `DescribeClusterStack` returning nodegroup stack, and that got passed on to the nodegroup validator resulting in shared SG check failing.

It surfaced in the integration test, and this is what it looked like:

```
 $ ./eksctl create nodegroup --cluster=ridiculous-hideout-1549472274 --region=us-west-2 --nodes=4 --node-private-networking ng-1 --verbose=4
2019-02-06T17:18:55Z [ℹ]  using region us-west-2
2019-02-06T17:18:56Z [▶]  role ARN for the current session is "arn:aws:iam::376248598259:user/ilya"
2019-02-06T17:18:57Z [▶]  resolving AMI using StaticGPUResolver for region us-west-2, instanceType m5.large and imageFamily AmazonLinux2
2019-02-06T17:18:57Z [▶]  can't resolve AMI using StaticGPUResolver as instance type m5.large is non-GPU
2019-02-06T17:18:57Z [▶]  resolving AMI using StaticDefaultResolver for region us-west-2, version m5.large, instanceType AmazonLinux2 and imageFamily %!!(MISSING)s(MISSING)
2019-02-06T17:18:58Z [ℹ]  nodegroup "ng-1" will use "ami-0a2abab4107669c1b" [AmazonLinux2/1.11]
2019-02-06T17:19:00Z [▶]  err = no ouput "SharedNodeSecurityGroup" in stack "eksctl-ridiculous-hideout-1549472274-nodegroup-ng-1"
2019-02-06T17:19:00Z [✖]  cluster compatibility check failed: shared node security group missing, to fix this run 'eksctl utils update-cluster-stack --name=ridiculous-hideout-1549472274 --region=us-west-2'
 $
```

Basically it wasn't supposed to look at `eksctl-ridiculous-hideout-1549472274-nodegroup-ng-1`, it was meant to look at `eksctl-ridiculous-hideout-1549472274-cluster` instead.


### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All tests passing (i.e. `make test`)
