### PR TITLE
Delete nodegroups when there are dangling resources

### DIFF
--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -51,14 +51,14 @@ func (c *StackCollection) DescribeClusterStack() (*Stack, error) {
 }
 
 // DeleteCluster deletes the cluster
-func (c *StackCollection) DeleteCluster() error {
-	_, err := c.DeleteStack(c.makeClusterStackName())
+func (c *StackCollection) DeleteCluster(force bool) error {
+	_, err := c.DeleteStack(c.makeClusterStackName(), force)
 	return err
 }
 
 // WaitDeleteCluster waits till the cluster is deleted
-func (c *StackCollection) WaitDeleteCluster() error {
-	return c.BlockingWaitDeleteStack(c.makeClusterStackName())
+func (c *StackCollection) WaitDeleteCluster(force bool) error {
+	return c.BlockingWaitDeleteStack(c.makeClusterStackName(), force)
 }
 
 // AppendNewClusterStackResource will update cluster

--- a/pkg/cfn/manager/deprecated.go
+++ b/pkg/cfn/manager/deprecated.go
@@ -6,9 +6,9 @@ func (c *StackCollection) DeprecatedDeleteStackVPC(wait bool) error {
 	stackName := "EKS-" + c.spec.Metadata.Name + "-VPC"
 
 	if wait {
-		err = c.BlockingWaitDeleteStack(stackName)
+		err = c.BlockingWaitDeleteStack(stackName, true)
 	} else {
-		_, err = c.DeleteStack(stackName)
+		_, err = c.DeleteStack(stackName, true)
 	}
 
 	return err
@@ -20,9 +20,9 @@ func (c *StackCollection) DeprecatedDeleteStackServiceRole(wait bool) error {
 	stackName := "EKS-" + c.spec.Metadata.Name + "-ServiceRole"
 
 	if wait {
-		err = c.BlockingWaitDeleteStack(stackName)
+		err = c.BlockingWaitDeleteStack(stackName, true)
 	} else {
-		_, err = c.DeleteStack(stackName)
+		_, err = c.DeleteStack(stackName, true)
 	}
 
 	return err
@@ -34,9 +34,9 @@ func (c *StackCollection) DeprecatedDeleteStackDefaultNodeGroup(wait bool) error
 	stackName := "EKS-" + c.spec.Metadata.Name + "-DefaultNodeGroup"
 
 	if wait {
-		err = c.BlockingWaitDeleteStack(stackName)
+		err = c.BlockingWaitDeleteStack(stackName, true)
 	} else {
-		_, err = c.DeleteStack(stackName)
+		_, err = c.DeleteStack(stackName, true)
 	}
 
 	return err
@@ -48,9 +48,9 @@ func (c *StackCollection) DeprecatedDeleteStackControlPlane(wait bool) error {
 	stackName := "EKS-" + c.spec.Metadata.Name + "-ControlPlane"
 
 	if wait {
-		err = c.BlockingWaitDeleteStack(stackName)
+		err = c.BlockingWaitDeleteStack(stackName, true)
 	} else {
-		_, err = c.DeleteStack(stackName)
+		_, err = c.DeleteStack(stackName, true)
 	}
 
 	return err

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -116,20 +116,28 @@ func (c *StackCollection) DescribeNodeGroupStacksAndResources() (map[string]Stac
 // DeleteNodeGroup deletes a nodegroup stack
 func (c *StackCollection) DeleteNodeGroup(name string) error {
 	name = c.MakeNodeGroupStackName(name)
-	_, err := c.DeleteStack(name)
+	_, err := c.DeleteStack(name, false)
 	return err
 }
 
-// WaitDeleteNodeGroup waits until the nodegroup is deleted
+// WaitDeleteNodeGroup waits until the nodegroup is deleted,
+// it calls WaitDeleteStack without force
 func (c *StackCollection) WaitDeleteNodeGroup(errs chan error, data interface{}) error {
 	name := c.MakeNodeGroupStackName(data.(string))
-	return c.WaitDeleteStack(name, errs)
+	return c.WaitDeleteStack(name, false, errs)
+}
+
+// WaitForceDeleteNodeGroup waits until the nodegroup is deleted,
+// it calls WaitDeleteStack with force
+func (c *StackCollection) WaitForceDeleteNodeGroup(errs chan error, data interface{}) error {
+	name := c.MakeNodeGroupStackName(data.(string))
+	return c.WaitDeleteStack(name, true, errs)
 }
 
 // BlockingWaitDeleteNodeGroup waits until the nodegroup is deleted
-func (c *StackCollection) BlockingWaitDeleteNodeGroup(name string) error {
+func (c *StackCollection) BlockingWaitDeleteNodeGroup(name string, force bool) error {
 	name = c.MakeNodeGroupStackName(name)
-	return c.BlockingWaitDeleteStack(name)
+	return c.BlockingWaitDeleteStack(name, force)
 }
 
 // ScaleNodeGroup will scale an existing nodegroup

--- a/pkg/cfn/manager/tasks.go
+++ b/pkg/cfn/manager/tasks.go
@@ -122,7 +122,7 @@ func (c *StackCollection) DeleteAllNodeGroups(call taskFunc) []error {
 // WaitDeleteAllNodeGroups runs all tasks required to delete all the nodegroup
 // stacks and wait for all nodegroups to be deleted; any errors will be returned
 // as a slice as soon as the group of tasks is completed
-func (c *StackCollection) WaitDeleteAllNodeGroups() []error {
+func (c *StackCollection) WaitDeleteAllNodeGroups(force bool) []error {
 	nodeGroupStacks, err := c.DescribeNodeGroupStacks()
 	if err != nil {
 		return []error{err}
@@ -138,6 +138,9 @@ func (c *StackCollection) WaitDeleteAllNodeGroups() []error {
 		t := Task{
 			Call: c.WaitDeleteNodeGroup,
 			Data: getNodeGroupName(nodeGroupStacks[i]),
+		}
+		if force {
+			t.Call = c.WaitForceDeleteNodeGroup
 		}
 		deleteAllNodeGroups = append(deleteAllNodeGroups, t)
 	}

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -80,7 +80,7 @@ func doDeleteNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.No
 			verb string
 		)
 		if wait {
-			err = stackManager.BlockingWaitDeleteNodeGroup(ng.Name)
+			err = stackManager.BlockingWaitDeleteNodeGroup(ng.Name, false)
 			verb = "was"
 		} else {
 			err = stackManager.DeleteNodeGroup(ng.Name)

--- a/pkg/vpc/cleanup.go
+++ b/pkg/vpc/cleanup.go
@@ -1,0 +1,78 @@
+package vpc
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/kris-nova/logger"
+	"github.com/pkg/errors"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha4"
+)
+
+func fmtSecurityGroupNameRegexForCluster(name string) string {
+	const ourSecurityGroupNameRegexFmt = "^eksctl-%s-(cluster|nodegroup)-.+$"
+	return fmt.Sprintf(ourSecurityGroupNameRegexFmt, name)
+}
+
+func findAvailableNetworkInterfaces(provider api.ClusterProvider, spec *api.ClusterConfig) ([]string, error) {
+	input := &ec2.DescribeNetworkInterfacesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []*string{&spec.VPC.ID},
+			},
+			{
+				Name:   aws.String("status"),
+				Values: []*string{aws.String("available")},
+			},
+		},
+	}
+	output, err := provider.EC2().DescribeNetworkInterfaces(input)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to list dangling network interfaces in %q", spec.VPC.ID)
+	}
+	securityGroupRE, err := regexp.Compile(fmtSecurityGroupNameRegexForCluster(spec.Metadata.Name))
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to list dangling network interfaces in %q", spec.VPC.ID)
+	}
+	networkInterfaces := []string{}
+	for _, eni := range output.NetworkInterfaces {
+		id := *eni.NetworkInterfaceId
+		for _, sg := range eni.Groups {
+			if securityGroupRE.MatchString(*sg.GroupName) {
+				logger.Debug("found %q, which belongs to our security group %q (%s)", id, *sg.GroupName, *sg.GroupId)
+				networkInterfaces = append(networkInterfaces, id)
+				break
+			} else {
+				logger.Debug("found %q, but it belongs to security group %q (%s), which does not appear to be ours", id, *sg.GroupName, *sg.GroupId)
+				break
+			}
+		}
+	}
+	return networkInterfaces, nil
+}
+
+func deleteNetworkInterfaces(provider api.ClusterProvider, networkInterfaces []string) error {
+	for _, eni := range networkInterfaces {
+		input := &ec2.DeleteNetworkInterfaceInput{
+			NetworkInterfaceId: &eni,
+		}
+		if _, err := provider.EC2().DeleteNetworkInterface(input); err != nil {
+			return errors.Wrapf(err, "unable to delete network interface %q", eni)
+		}
+		logger.Debug("deleted %q", eni)
+	}
+	return nil
+}
+
+// CleanupNetworkInterfaces find and deletes any dangling ENIs
+func CleanupNetworkInterfaces(provider api.ClusterProvider, spec *api.ClusterConfig) error {
+	networkInterfaces, err := findAvailableNetworkInterfaces(provider, spec)
+	if err != nil {
+		return err
+	}
+	return deleteNetworkInterfaces(provider, networkInterfaces)
+}


### PR DESCRIPTION
### Description

This is an initial change towards avoiding deletion issues whenever
we end-up with dangling resources that got created while cluster was
in use, and didn't go away cleanly.

Here we introduce two things:
- `DeleteStack` checks if stack that is about to be deleted already
  has `DELETE_FAILED` status, and bails out if that's the case;
  this behaviour can be controller with `force` argument
- during cluster deletion, if we cannot delete a nodegroup right away,
  we go and try to cleanup danlging ENIs (which somehow didn't used
  to be an issue, but recently this started to cause failures in
  integration tests)
- at the moment, we only try to delete these interfaces during cluster
  deletion, and nodegroup deletion may still fail and we don't have
  cleanup/retry mode there yet

This gets us closer to fixing #103, #274 and other related issue like
#105, #484, #454 etc.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
