### PR TITLE
Fix and improve integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ UNIT_TEST_ARGS ?= -v -ginkgo.v
 INTEGRATION_TEST_ARGS ?= -test.v -ginkgo.v
 endif
 
+ifneq ($(INTEGRATION_TEST_FOCUS),)
+INTEGRATION_TEST_ARGS ?= -test.v -ginkgo.v -ginkgo.focus "$(INTEGRATION_TEST_FOCUS)"
+endif
+
 LINTER ?= gometalinter ./pkg/... ./cmd/... ./integration/...
 .PHONY: lint
 lint: ## Run linter over the codebase
@@ -51,7 +55,7 @@ build-integration-test: ## Build integration test binary
 
 .PHONY: integration-test
 integration-test: build build-integration-test ## Run the integration tests (with cluster creation and cleanup)
-	@./eksctl-integration-test -test.timeout 60m \
+	@cd integration; ../eksctl-integration-test -test.timeout 60m \
 		$(INTEGRATION_TEST_ARGS)
 
 .PHONY: integration-test-container
@@ -72,9 +76,8 @@ integration-test-dev: build build-integration-test ## Run the integration tests 
 	@./eksctl utils write-kubeconfig \
 		--auto-kubeconfig \
 		--name=$(TEST_CLUSTER)
-	@./eksctl-integration-test -test.timeout 21m \
+	@cd integration ; ../eksctl-integration-test -test.timeout 21m \
 		$(INTEGRATION_TEST_ARGS) \
-		-args \
 		-eksctl.cluster=$(TEST_CLUSTER) \
 		-eksctl.create=false \
 		-eksctl.delete=false \

--- a/integration/common_test.go
+++ b/integration/common_test.go
@@ -35,7 +35,9 @@ func newKubeTest() (*harness.Test, error) {
 	if err := h.SetKubeconfig(kubeconfigPath); err != nil {
 		return nil, err
 	}
-	return h.NewTest(t), nil
+	test := h.NewTest(t)
+	test.Setup()
+	return test, nil
 }
 
 func eksctl(args ...string) *gexec.Session {

--- a/integration/creategetdelete_test.go
+++ b/integration/creategetdelete_test.go
@@ -155,7 +155,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				Expect(len(nodes.Items)).To(Equal(8))
 			})
 
-			Context("and we create a deployment and access pods via proxy", func() {
+			Context("create test workloads", func() {
 				var (
 					err  error
 					test *harness.Test
@@ -164,14 +164,13 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				BeforeEach(func() {
 					test, err = newKubeTest()
 					Expect(err).ShouldNot(HaveOccurred())
-					test.CreateNamespace(test.Namespace)
 				})
 
 				AfterEach(func() {
 					test.Close()
 				})
 
-				It("should deploy podinfo service to the cluster", func() {
+				It("should deploy podinfo service to the cluster and access it via proxy", func() {
 					d := test.CreateDeploymentFromFile(test.Namespace, "podinfo.yaml")
 					test.WaitForDeploymentReady(d, 1*time.Minute)
 
@@ -194,10 +193,6 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				})
 
 				It("should have functional DNS", func() {
-					test, err := newKubeTest()
-					Expect(err).ShouldNot(HaveOccurred())
-					defer test.Close()
-
 					d := test.CreateDaemonSetFromFile(test.Namespace, "test-dns.yaml")
 
 					test.WaitForDaemonSetReady(d, 3*time.Minute)
@@ -210,10 +205,6 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				})
 
 				It("should have access to HTTP(S) sites", func() {
-					test, err := newKubeTest()
-					Expect(err).ShouldNot(HaveOccurred())
-					defer test.Close()
-
 					d := test.CreateDaemonSetFromFile(test.Namespace, "test-http.yaml")
 
 					test.WaitForDaemonSetReady(d, 3*time.Minute)


### PR DESCRIPTION
### Description

- fix make targets, as cwd has changed
- remove extronous `newKubeTest`
- ensure test namespace is created at the right time (close #524)
- provide a way to run a subset of tests

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
