### PR TITLE
Ensure to wait for test pods to get deleted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ integration-test-dev: build build-integration-test ## Run the integration tests 
 	@./eksctl utils write-kubeconfig \
 		--auto-kubeconfig \
 		--name=$(TEST_CLUSTER)
+	$(info it is recommended to watch events with "kubectl get events --watch --all-namespaces --kubeconfig=$(HOME)/.kube/eksctl/clusters/$(TEST_CLUSTER)")
 	@cd integration ; ../eksctl-integration-test -test.timeout 21m \
 		$(INTEGRATION_TEST_ARGS) \
 		-eksctl.cluster=$(TEST_CLUSTER) \

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,10 @@ integration-test: build build-integration-test ## Run the integration tests (wit
 
 .PHONY: integration-test-container
 integration-test-container: eksctl-image ## Run the integration tests inside a Docker container
+	$(MAKE) integration-test-container-pre-built
+
+.PHONY: integration-test-container-pre-built
+integration-test-container-pre-built: ## Run the integration tests inside a Docker container
 	@docker run \
 	  --env=AWS_PROFILE \
 	  --volume=$(HOME)/.aws:/root/.aws \

--- a/integration/creategetdelete_test.go
+++ b/integration/creategetdelete_test.go
@@ -168,6 +168,9 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 
 				AfterEach(func() {
 					test.Close()
+					Eventually(func() int {
+						return len(test.ListPods(test.Namespace, metav1.ListOptions{}).Items)
+					}, "3m", "1s").Should(BeZero())
 				})
 
 				It("should deploy podinfo service to the cluster and access it via proxy", func() {


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

It turned out that test library doesn't wait for namespace to go away. It's fine most of the time, except for the deletion edge-case that we are seeing in #526.

Fixes #526.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)