### PR TITLE
Support updated GPU AMI naming convention

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -28,6 +28,7 @@ Timothy Mukaibo         @mukaibot
 Yusuke Kuoka            @mumoshu
 Daniel Herman           @dcherman
 Takuma Hashimoto        @af12066
+Yasuhiro Hara           @toricls
 
 /* Thanks */
 

--- a/pkg/ami/auto_resolver.go
+++ b/pkg/ami/auto_resolver.go
@@ -13,7 +13,7 @@ var ImageSearchPatterns = map[string]map[string]map[int]string{
 	"1.10": {
 		ImageFamilyAmazonLinux2: {
 			ImageClassGeneral: "amazon-eks-node-1.10-v*",
-			ImageClassGPU:     "amazon-eks-gpu-node-1.10-v*",
+			ImageClassGPU:     "amazon-eks-gpu-node-1.10-*",
 		},
 		ImageFamilyUbuntu1804: {
 			ImageClassGeneral: "ubuntu-eks/1.10.3/*",
@@ -22,7 +22,7 @@ var ImageSearchPatterns = map[string]map[string]map[int]string{
 	"1.11": {
 		ImageFamilyAmazonLinux2: {
 			ImageClassGeneral: "amazon-eks-node-1.11-v*",
-			ImageClassGPU:     "amazon-eks-gpu-node-1.11-v*",
+			ImageClassGPU:     "amazon-eks-gpu-node-1.11-*",
 		},
 		ImageFamilyUbuntu1804: {
 			ImageClassGeneral: "ubuntu-eks/1.11.5/*",

--- a/pkg/ami/auto_resolver_test.go
+++ b/pkg/ami/auto_resolver_test.go
@@ -143,7 +143,7 @@ var _ = Describe("AMI Auto Resolution", func() {
 						imageState = "available"
 
 						_, p = createProviders()
-						addMockDescribeImages(p, "amazon-eks-gpu-node-1.10-v*", expectedAmi, imageState, "2018-08-20T23:25:53.000Z")
+						addMockDescribeImages(p, "amazon-eks-gpu-node-1.10-*", expectedAmi, imageState, "2018-08-20T23:25:53.000Z")
 
 						resolver := NewAutoResolver(p.MockEC2())
 						resolvedAmi, err = resolver.Resolve(region, version, instanceType, imageFamily)


### PR DESCRIPTION
### Description

It seems that the new GPU AMIs naming convention has been changed by AWS side. They're named with timestamp value instead of “v{YYYYMMDD}” format.
This PR fixes the problem that the AMI resolver cannot find the new GPU AMIs due to the change above.

### Checklist

- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
- [x] Added yourself to the `humans.txt` file
