### PR TITLE
 Fix an issue with referencing of a map in `ctl.ImportSubnet`

### DIFF
--- a/pkg/ctl/utils/update_cluster_stack.go
+++ b/pkg/ctl/utils/update_cluster_stack.go
@@ -12,6 +12,7 @@ import (
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha4"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/eks"
+	"github.com/weaveworks/eksctl/pkg/printers"
 )
 
 var updateClusterStackDryRun = true
@@ -49,6 +50,12 @@ func updateClusterStackCmd(g *cmdutils.Grouping) *cobra.Command {
 func doUpdateClusterStacksCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg string) error {
 	ctl := eks.New(p, cfg)
 
+	printer := printers.NewJSONPrinter()
+
+	if err := api.Register(); err != nil {
+		return err
+	}
+
 	if err := ctl.CheckAuth(); err != nil {
 		return err
 	}
@@ -67,6 +74,10 @@ func doUpdateClusterStacksCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nam
 
 	if err := ctl.GetClusterVPC(cfg); err != nil {
 		return errors.Wrapf(err, "getting VPC configuration for cluster %q", cfg.Metadata.Name)
+	}
+
+	if err := printer.LogObj(logger.Debug, "cfg.json = \\\n", cfg); err != nil {
+		return err
 	}
 
 	stackManager := ctl.NewStackManager(cfg)


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

This fixes #518, which is a bug that got introduced as part of #513.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [ ] All integration tests passing (i.e. `make integration-test`)
