### PR TITLE
feat: Node-local DNS cache support

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha4/types.go
+++ b/pkg/apis/eksctl.io/v1alpha4/types.go
@@ -358,6 +358,9 @@ type NodeGroup struct {
 
 	// +optional
 	OverrideBootstrapCommand *string `json:"overrideBootstrapCommand,omitempty"`
+
+	// +optional
+	ClusterDNS string `json:"clusterDNS,omitempty"`
 }
 
 // ListOptions returns metav1.ListOptions with label selector for the nodegroup

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -835,6 +835,8 @@ var _ = Describe("CloudFormation template builder API", func() {
 
 		cfg.NodeGroups[0].OverrideBootstrapCommand = &overrideBootstrapCommand
 
+		cfg.NodeGroups[0].ClusterDNS = "169.254.20.10"
+
 		rs := NewNodeGroupResourceSet(p, cfg, "eksctl-test-123-cluster", ng)
 		err := rs.AddAllResources()
 		It("should add all resources without errors", func() {
@@ -868,7 +870,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Expect(kubeletEnv.Permissions).To(Equal("0644"))
 			Expect(strings.Split(kubeletEnv.Content, "\n")).To(Equal([]string{
 				"MAX_PODS=29",
-				"CLUSTER_DNS=10.100.0.10",
+				"CLUSTER_DNS=169.254.20.10",
 				"NODE_LABELS=os=al2",
 			}))
 
@@ -977,6 +979,8 @@ var _ = Describe("CloudFormation template builder API", func() {
 			"os": "ubuntu",
 		}
 
+		cfg.NodeGroups[0].ClusterDNS = "169.254.20.10"
+
 		cfg.NodeGroups[0].OverrideBootstrapCommand = &overrideBootstrapCommand
 
 		rs := NewNodeGroupResourceSet(p, cfg, "eksctl-test-123-cluster", ng)
@@ -1018,7 +1022,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Expect(kubeletEnv.Permissions).To(Equal("0644"))
 			Expect(strings.Split(kubeletEnv.Content, "\n")).To(Equal([]string{
 				"MAX_PODS=29",
-				"CLUSTER_DNS=172.20.0.10",
+				"CLUSTER_DNS=169.254.20.10",
 				"NODE_LABELS=os=ubuntu",
 			}))
 

--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -84,7 +84,10 @@ func makeClientConfigData(spec *api.ClusterConfig, ng *api.NodeGroup) ([]byte, e
 	return clientConfigData, nil
 }
 
-func clusterDNS(spec *api.ClusterConfig) string {
+func clusterDNS(spec *api.ClusterConfig, ng *api.NodeGroup) string {
+	if ng.ClusterDNS != "" {
+		return ng.ClusterDNS
+	}
 	// Default service network is 10.100.0.0, but it gets set 172.20.0.0 automatically when pod network
 	// is anywhere within 10.0.0.0/8
 	if spec.VPC.CIDR != nil && spec.VPC.CIDR.IP[0] == 10 {
@@ -106,7 +109,7 @@ func makeKubeletParamsCommon(spec *api.ClusterConfig, ng *api.NodeGroup) []strin
 	// TODO: use componentconfig or kubelet config file – https://github.com/weaveworks/eksctl/issues/156
 	return []string{
 		fmt.Sprintf("MAX_PODS=%d", ng.MaxPodsPerNode),
-		fmt.Sprintf("CLUSTER_DNS=%s", clusterDNS(spec)),
+		fmt.Sprintf("CLUSTER_DNS=%s", clusterDNS(spec, ng)),
 		fmt.Sprintf("NODE_LABELS=%s", strings.Join(labels, ",")),
 	}
 }


### PR DESCRIPTION
TL;DR; This is the smallest change to allow enabling node-local DNS cache on eksctl-created nodes.

## What

Add a new field named `clusterDNS` that accepts the IP address to the DNS server used for all the internal/external DNS lookups a.k.a the `--cluster-dns` flag of `kubelet`.

```yaml
nodeGroups:
- name: nodegroup1
  clusterDNS: 169.254.20.10
  # snip
```

This, in combination with `k8s-dns-node-cache` deployed as a daemonset on your cluster, allows all the DNS lookups from your pods to firstly routed to the node-local DNS server, which adds more reliability.

## Notes

The configuration key `clusterDNS` is intentionally made per-nodegroup, not per-cluster, so that you can selectively use the node-local DNS. It, in combination with the proper use of node labels/taints, allows you to test the node-local DNS in only a subet of your workload.
It would also be nice to add `clusterDNS` as a cluster-level config key later. But I believe it isn't a must-have in this change.

## Usage

See the [cluster/addons/dns/nodelocaldns](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns/nodelocaldns) in the upstream repository for more details.

A concrete steps to enable node-local DNS would look like the below:

- Decide the which IP addr to be used for binding the node-local DNS. Typically this is `169.254.20.10`
- Add `clusterDNS: 169.254.20.10` to your nodegroup in the cluster config
- Deploy [nodelocaldns.yaml](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml), replacing:
  `__PILLAR__LOCAL__DNS__` with `169.254.169.254`, `__PILLAR__DNS__DOMAIN__` with `cluster.local`, `__PILLAR__DNS__SERVER__` with [`10.100.0.10` or `172.20.0.10`](https://github.com/weaveworks/eksctl/blob/master/pkg/nodebootstrap/userdata.go#L87-L94) according to your VPC CIDR

Resolves #542 