### PR TITLE
Clarify auto scaling docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ To use a 3-5 node Auto Scaling Group, run:
 eksctl create cluster --name=cluster-5 --nodes-min=3 --nodes-max=5
 ```
 
+> NOTE: You will still need to install and configure autoscaling. See the "Enable Autoscaling" section below.
+
 To use 30 `c4.xlarge` nodes and prevent updating current context in `~/.kube/config`, run:
 
 ```

--- a/humans.txt
+++ b/humans.txt
@@ -31,6 +31,7 @@ Takuma Hashimoto        @af12066
 Yasuhiro Hara           @toricls
 Jiaxin Shan             @Jeffwan
 tiffany jernigan        @tiffanyfay
+Silvio Gutierrez        @silviogutierrez
 
 /* Thanks */
 


### PR DESCRIPTION
Clarify autoscaling.

### Description

Based on a Slack discussion, clarify that the nodes-max and nodes-min flags do not automatically turn on autoscaling.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Added yourself to the `humans.txt` file
