### PR TITLE
Create cluster cfgfile w/o nodegroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@ using `--config-file`:
 eksctl create cluster --config-file=<path>
 ```
 
+To create a cluster using a configuration file and skip creating
+nodegroups until later:
+
+```
+eksctl create cluster --config-file=<path> --without-nodegroup
+```
+
 To delete a cluster, run:
 
 ```

--- a/humans.txt
+++ b/humans.txt
@@ -34,6 +34,7 @@ tiffany jernigan        @tiffanyfay
 Silvio Gutierrez        @silviogutierrez
 Yandy Ramirez           @IPyandy
 Jerry Jackson           @jrryjcksn
+Dann Church             @D3nn
 
 /* Thanks */
 


### PR DESCRIPTION
### Description

- Made cluster create command with option --without-nodegroup work also using config files
- added example to README
- added myself to humans.txt

Resolves #555 

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Added yourself to the `humans.txt` file
