### PR TITLE
Simplify clientset/kubeconfig handling

### DIFF
--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -276,7 +276,7 @@ func doCreateNodeGroups(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg s
 	}
 
 	{ // post-creation action
-		clientSet, err := ctl.NewStandardClientSet(cfg)
+		clientSet, err := ctl.NewStdClientSet(cfg)
 		if err != nil {
 			return err
 		}

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -111,7 +111,7 @@ func doDeleteNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.No
 
 	// post-deletion action
 	if updateAuthConfigMap {
-		clientSet, err := ctl.NewStandardClientSet(cfg)
+		clientSet, err := ctl.NewStdClientSet(cfg)
 		if err != nil {
 			return err
 		}

--- a/pkg/ctl/utils/write_kubeconfig.go
+++ b/pkg/ctl/utils/write_kubeconfig.go
@@ -83,13 +83,12 @@ func doWriteKubeconfigCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg
 		return err
 	}
 
-	clientConfigBase, err := ctl.NewClientConfig(cfg)
+	config, err := ctl.NewClientConfig(cfg, false)
 	if err != nil {
 		return err
 	}
 
-	config := clientConfigBase.WithExecAuthenticator()
-	filename, err := kubeconfig.Write(writeKubeconfigOutputPath, config.Client, writeKubeconfigSetContext)
+	filename, err := kubeconfig.Write(writeKubeconfigOutputPath, *config.Client, writeKubeconfigSetContext)
 	if err != nil {
 		return errors.Wrap(err, "writing kubeconfig")
 	}

--- a/pkg/eks/auth_test.go
+++ b/pkg/eks/auth_test.go
@@ -1,0 +1,104 @@
+package eks_test
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha4"
+	. "github.com/weaveworks/eksctl/pkg/eks"
+	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
+)
+
+var _ = Describe("eks auth helpers", func() {
+	var ctl *ClusterProvider
+
+	Describe("constuct client configs", func() {
+		Context("with a mock provider", func() {
+			clusterName := "auth-test-cluster"
+
+			BeforeEach(func() {
+
+				p := mockprovider.NewMockProvider()
+
+				ctl = &ClusterProvider{
+					Provider: p,
+					Status:   &ProviderStatus{},
+				}
+
+			})
+
+			Context("for a cluster", func() {
+				cfg := &api.ClusterConfig{
+					Metadata: &api.ClusterMeta{
+						Name:   clusterName,
+						Region: "eu-west-3",
+					},
+					Status: &api.ClusterStatus{
+						Endpoint:                 "https://TEST.aws",
+						CertificateAuthorityData: []byte("123"),
+					},
+				}
+
+				It("should create config with authenticator", func() {
+					clientConfig, err := ctl.NewClientConfig(cfg, false)
+
+					Expect(err).To(Not(HaveOccurred()))
+
+					Expect(clientConfig).To(Not(BeNil()))
+					ctx := clientConfig.ContextName
+					cluster := strings.Split(ctx, "@")[1]
+					Expect(ctx).To(Equal("iam-root-account@auth-test-cluster.eu-west-3.eksctl.io"))
+
+					k := clientConfig.Client
+
+					Expect(k.CurrentContext).To(Equal(ctx))
+
+					Expect(k.Contexts).To(HaveKey(ctx))
+					Expect(k.Contexts).To(HaveLen(1))
+
+					Expect(k.Contexts[ctx].Cluster).To(Equal(cluster))
+					Expect(k.Contexts[ctx].AuthInfo).To(Equal(ctx))
+
+					Expect(k.Contexts[ctx].LocationOfOrigin).To(BeEmpty())
+					Expect(k.Contexts[ctx].Namespace).To(BeEmpty())
+					Expect(k.Contexts[ctx].Extensions).To(BeNil())
+
+					Expect(k.AuthInfos).To(HaveKey(ctx))
+					Expect(k.AuthInfos).To(HaveLen(1))
+
+					Expect(k.AuthInfos[ctx].Token).To(BeEmpty())
+					Expect(k.AuthInfos[ctx].Exec).To(Not(BeNil()))
+
+					Expect(k.AuthInfos[ctx].Exec.Command).To(MatchRegexp("(heptio-authenticator-aws|aws-iam-authenticator)"))
+
+					Expect(strings.Join(k.AuthInfos[ctx].Exec.Args, " ")).To(Equal("token -i auth-test-cluster"))
+
+					Expect(k.Clusters).To(HaveKey(cluster))
+					Expect(k.Clusters).To(HaveLen(1))
+
+					Expect(k.Clusters[cluster].InsecureSkipTLSVerify).To(BeFalse())
+					Expect(k.Clusters[cluster].Server).To(Equal(cfg.Status.Endpoint))
+					Expect(k.Clusters[cluster].CertificateAuthorityData).To(Equal(cfg.Status.CertificateAuthorityData))
+				})
+
+				It("should create config with embedded token", func() {
+					// TODO: cannot test this, as token generator uses STS directly, we cannot pass the interface
+					// we can probably fix the package itself
+				})
+
+				It("should create clientset", func() {
+					clientConfig, err := ctl.NewClientConfig(cfg, false)
+
+					Expect(err).To(Not(HaveOccurred()))
+					Expect(clientConfig).To(Not(BeNil()))
+
+					clientSet, err := clientConfig.NewClientSet()
+
+					Expect(err).To(Not(HaveOccurred()))
+					Expect(clientSet).To(Not(BeNil()))
+				})
+			})
+		})
+	})
+})

--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -76,7 +76,7 @@ func makeClientConfigData(spec *api.ClusterConfig, ng *api.NodeGroup) ([]byte, e
 	if ng.AMIFamily == ami.ImageFamilyUbuntu1804 {
 		authenticator = kubeconfig.HeptioAuthenticatorAWS
 	}
-	kubeconfig.AppendAuthenticator(clientConfig, spec, authenticator)
+	kubeconfig.AppendAuthenticator(clientConfig, spec, authenticator, "")
 	clientConfigData, err := clientcmd.Write(*clientConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "serialising kubeconfig for nodegroup")

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Kubeconfig", func() {
 	}
 
 	It("creating new Kubeconfig", func() {
-		filename, err := kubeconfig.Write(configFile.Name(), &testConfig, false)
+		filename, err := kubeconfig.Write(configFile.Name(), testConfig, false)
 		Expect(err).To(BeNil())
 
 		readConfig, err := clientcmd.LoadFromFile(filename)
@@ -66,7 +66,7 @@ var _ = Describe("Kubeconfig", func() {
 		testConfigContext := testConfig
 		testConfigContext.CurrentContext = "test-context"
 
-		filename, err := kubeconfig.Write(configFile.Name(), &testConfigContext, true)
+		filename, err := kubeconfig.Write(configFile.Name(), testConfigContext, true)
 		Expect(err).To(BeNil())
 
 		readConfig, err := clientcmd.LoadFromFile(filename)
@@ -79,7 +79,7 @@ var _ = Describe("Kubeconfig", func() {
 		err := writeConfig(configFile.Name())
 		Expect(err).To(BeNil())
 
-		filename, err := kubeconfig.Write(configFile.Name(), &testConfig, false)
+		filename, err := kubeconfig.Write(configFile.Name(), testConfig, false)
 		Expect(err).To(BeNil())
 
 		readConfig, err := clientcmd.LoadFromFile(filename)
@@ -105,7 +105,7 @@ var _ = Describe("Kubeconfig", func() {
 		testConfigContext := testConfig
 		testConfigContext.CurrentContext = "test-context"
 
-		filename, err := kubeconfig.Write(configFile.Name(), &testConfigContext, true)
+		filename, err := kubeconfig.Write(configFile.Name(), testConfigContext, true)
 		Expect(err).To(BeNil())
 
 		readConfig, err := clientcmd.LoadFromFile(filename)
@@ -121,7 +121,7 @@ var _ = Describe("Kubeconfig", func() {
 		testConfigContext := testConfig
 		testConfigContext.CurrentContext = "test-context"
 
-		filename, err := kubeconfig.Write(configFile.Name(), &testConfigContext, false)
+		filename, err := kubeconfig.Write(configFile.Name(), testConfigContext, false)
 		Expect(err).To(BeNil())
 
 		readConfig, err := clientcmd.LoadFromFile(filename)


### PR DESCRIPTION
### Description

- fix issue with accidential use of authenticator
  - it was causing infinite loops when authenticator not present
  - it was due to too many deep references
- reduce overall code complexity

- Close #347 
- Close #520

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)