### PR TITLE
make new nodegroups inherit control plane version

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ To create an additional nodegroup, use:
 eksctl create nodegroup --cluster=<clusterName> [--name=<nodegroupName>]
 ```
 
+> NOTE: By default, new nodegroups inherit the version from the control plane (`--version=auto`), but you can specify a different
+> version e.g. `--version=1.10`, you can also use `--version=latest` to force use of whichever is the latest version.
+
 Additionally, you can use the same config file used for `eksctl create cluster`:
 
 ```

--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -48,9 +48,13 @@ func AddRegionFlag(fs *pflag.FlagSet, p *api.ProviderConfig) {
 	fs.StringVarP(&p.Region, "region", "r", "", "AWS region")
 }
 
-// AddVersionFlag adds common --region flag
-func AddVersionFlag(fs *pflag.FlagSet, meta *api.ClusterMeta) {
-	fs.StringVar(&meta.Version, "version", meta.Version, fmt.Sprintf("Kubernetes version (valid options: %s)", strings.Join(api.SupportedVersions(), ", ")))
+// AddVersionFlag adds common --version flag
+func AddVersionFlag(fs *pflag.FlagSet, meta *api.ClusterMeta, extraUsageInfo string) {
+	usage := fmt.Sprintf("Kubernetes version (valid options: %s)", strings.Join(api.SupportedVersions(), ", "))
+	if extraUsageInfo != "" {
+		usage = fmt.Sprintf("%s [%s]", usage, extraUsageInfo)
+	}
+	fs.StringVar(&meta.Version, "version", meta.Version, usage)
 }
 
 // AddWaitFlag adds common --wait flag

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -67,7 +67,7 @@ func createClusterCmd(g *cmdutils.Grouping) *cobra.Command {
 		fs.StringToStringVarP(&cfg.Metadata.Tags, "tags", "", map[string]string{}, `A list of KV pairs used to tag the AWS resources (e.g. "Owner=John Doe,Team=Some Team")`)
 		cmdutils.AddRegionFlag(fs, p)
 		fs.StringSliceVar(&availabilityZones, "zones", nil, "(auto-select if unspecified)")
-		cmdutils.AddVersionFlag(fs, cfg.Metadata)
+		cmdutils.AddVersionFlag(fs, cfg.Metadata, "")
 		fs.StringVarP(&clusterConfigFile, "config-file", "f", "", "load configuration from a file")
 	})
 
@@ -311,7 +311,7 @@ func doCreateCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 			}
 		}
 		if !validVersion {
-			return fmt.Errorf("invalid version, supported values: %s", strings.Join(api.SupportedVersions(), ","))
+			return fmt.Errorf("invalid version, supported values: %s", strings.Join(api.SupportedVersions(), ", "))
 		}
 	}
 

--- a/pkg/ctl/utils/update_cluster_stack.go
+++ b/pkg/ctl/utils/update_cluster_stack.go
@@ -37,7 +37,7 @@ func updateClusterStackCmd(g *cmdutils.Grouping) *cobra.Command {
 	group.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
 		cmdutils.AddRegionFlag(fs, p)
-		cmdutils.AddVersionFlag(fs, cfg.Metadata)
+		cmdutils.AddVersionFlag(fs, cfg.Metadata, "")
 		fs.BoolVar(&updateClusterStackDryRun, "dry-run", updateClusterStackDryRun, "do not apply any change, only show what resources would be added")
 	})
 

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -82,8 +82,9 @@ func (p ProviderServices) WaitTimeout() time.Duration { return p.spec.WaitTimeou
 
 // ProviderStatus stores information about the used IAM role and the resulting session
 type ProviderStatus struct {
-	iamRoleARN   string
-	sessionCreds *credentials.Credentials
+	iamRoleARN        string
+	sessionCreds      *credentials.Credentials
+	cachedClusterInfo *awseks.Cluster
 }
 
 // New creates a new setup of the used AWS APIs

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -62,7 +62,7 @@ func (c *ClusterProvider) DeprecatedDeleteControlPlane(cl *api.ClusterMeta) erro
 	return nil
 }
 
-// GetCredentials retrieves the certificate authority data
+// GetCredentials retrieves cluster endpoint and the certificate authority data
 func (c *ClusterProvider) GetCredentials(spec *api.ClusterConfig) error {
 	// Check the cluster exists and is active
 	cluster, err := c.DescribeControlPlaneMustBeActive(spec.Metadata)
@@ -84,7 +84,17 @@ func (c *ClusterProvider) GetCredentials(spec *api.ClusterConfig) error {
 	spec.Status.CertificateAuthorityData = data
 	spec.Status.ARN = *cluster.Arn
 
+	c.Status.cachedClusterInfo = cluster
+
 	return nil
+}
+
+// ControlPlaneVersion returns cached version
+func (c *ClusterProvider) ControlPlaneVersion() string {
+	if c.Status.cachedClusterInfo == nil || c.Status.cachedClusterInfo.Version == nil {
+		return ""
+	}
+	return *c.Status.cachedClusterInfo.Version
 }
 
 // GetClusterVPC retrieves the VPC configuration


### PR DESCRIPTION
### Description

- this allow two new modes:
  - `--version=auto` (new default) will inherit version of CP
  - `--version=latest` forces use of latest known version

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
