### PR TITLE
Allow node-role.kubernetes.io domain prefix in node labeling

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha4/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha4/validation.go
@@ -65,7 +65,7 @@ func ValidateNodeGroupLabels(ng *NodeGroup) error {
 				}
 			}
 
-			for _, domain := range []string{"kubelet.kubernetes.io", "node.kubernetes.io"} {
+			for _, domain := range []string{"kubelet.kubernetes.io", "node.kubernetes.io", "node-role.kubernetes.io"} {
 				if ns == domain || strings.HasSuffix(ns, "."+domain) {
 					allowedKubeletNamespace = true
 				}


### PR DESCRIPTION
Solution for issue #580

### Description

Very simple change to allow node-role.kubernetes.io domain prefix in node labeling.

### Checklist
- [X] Code compiles correctly (i.e `make build`)

