### PR TITLE
 Drain nodegroup on deleteion

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,13 @@ You can also enable SSH, ASG access and other feature for each particular nodegr
 eksctl create nodegroup --cluster=cluster-1 --node-labels="autoscaling=enabled,purpose=ci-worker" --asg-access --full-ecr-access --ssh-access
 ```
 
-To cordon a nodegroup and evict all of the pods, run:
+To delete a nodegroup, run:
+```
+eksctl delete nodegroup --cluster=<clusterName> --name=<nodegroupName>
+```
+
+All node are cordoned and all pods are evicted from a nodegroup on deletion,
+but if you need to drain a nodegroup without deleting it, run:
 ```
 eksctl drain nodegroup --cluster=<clusterName> --name=<nodegroupName>
 ```
@@ -253,12 +259,6 @@ eksctl drain nodegroup --cluster=<clusterName> --name=<nodegroupName>
 To uncordon a nodegroup, run:
 ```
 eksctl drain nodegroup --cluster=<clusterName> --name=<nodegroupName> --undo
-```
-
-To delete a nodegroup, run:
-
-```
-eksctl delete nodegroup --cluster=<clusterName> --name=<nodegroupName>
 ```
 
 ### Enable Autoscaling

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -15,18 +15,21 @@ import (
 	"github.com/weaveworks/eksctl/pkg/eks"
 )
 
+var (
+	updateAuthConfigMap bool
+)
+
 func deleteNodeGroupCmd(g *cmdutils.Grouping) *cobra.Command {
 	p := &api.ProviderConfig{}
 	cfg := api.NewClusterConfig()
 	ng := cfg.NewNodeGroup()
-	updateAuthConfigMap := true
 
 	cmd := &cobra.Command{
 		Use:     "nodegroup",
 		Short:   "Delete a nodegroup",
 		Aliases: []string{"ng"},
 		Run: func(_ *cobra.Command, args []string) {
-			if err := doDeleteNodeGroup(p, cfg, ng, cmdutils.GetNameArg(args), updateAuthConfigMap); err != nil {
+			if err := doDeleteNodeGroup(p, cfg, ng, cmdutils.GetNameArg(args)); err != nil {
 				logger.Critical("%s\n", err.Error())
 				os.Exit(1)
 			}
@@ -50,7 +53,7 @@ func deleteNodeGroupCmd(g *cmdutils.Grouping) *cobra.Command {
 	return cmd
 }
 
-func doDeleteNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.NodeGroup, nameArg string, updateAuthConfigMap bool) error {
+func doDeleteNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.NodeGroup, nameArg string) error {
 	ctl := eks.New(p, cfg)
 
 	if err := api.Register(); err != nil {
@@ -81,6 +84,18 @@ func doDeleteNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.No
 		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
 	}
 
+	clientSet, err := ctl.NewStdClientSet(cfg)
+	if err != nil {
+		return err
+	}
+
+	if updateAuthConfigMap {
+		// remove node group from config map
+		if err := authconfigmap.RemoveNodeGroup(clientSet, ng); err != nil {
+			logger.Warning(err.Error())
+		}
+	}
+
 	stackManager := ctl.NewStackManager(cfg)
 
 	if ng.IAM.InstanceRoleARN == "" {
@@ -107,19 +122,6 @@ func doDeleteNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.No
 			return errors.Wrapf(err, "failed to delete nodegroup %q", ng.Name)
 		}
 		logger.Success("nodegroup %q %s deleted", ng.Name, verb)
-	}
-
-	// post-deletion action
-	if updateAuthConfigMap {
-		clientSet, err := ctl.NewStdClientSet(cfg)
-		if err != nil {
-			return err
-		}
-
-		// remove node group from config map
-		if err := authconfigmap.RemoveNodeGroup(clientSet, ng); err != nil {
-			logger.Warning(err.Error())
-		}
 	}
 
 	return nil

--- a/pkg/ctl/drain/nodegroup.go
+++ b/pkg/ctl/drain/nodegroup.go
@@ -3,7 +3,6 @@ package drain
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
@@ -15,9 +14,6 @@ import (
 	"github.com/weaveworks/eksctl/pkg/eks"
 
 	"github.com/weaveworks/eksctl/pkg/drain"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var (
@@ -93,145 +89,5 @@ func doDrainNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.Nod
 		return err
 	}
 
-	drainer := &drain.Helper{
-		Client: clientSet,
-
-		// TODO: Force, DeleteLocalData & IgnoreAllDaemonSets shouldn't
-		// be enabled by default, we need flags to control thes, but that
-		// requires more improvements in the underlying drain package,
-		// as it currently produces errors and warnings with references
-		// to kubectl flags
-		Force:               true,
-		DeleteLocalData:     true,
-		IgnoreAllDaemonSets: true,
-
-		// TODO: ideally only the list of well-known DaemonSets should
-		// be set by default
-		IgnoreDaemonSets: []metav1.ObjectMeta{
-			{
-				Namespace: "kube-system",
-				Name:      "aws-node",
-			},
-			{
-				Namespace: "kube-system",
-				Name:      "kube-proxy",
-			},
-			{
-				Name: "node-exporter",
-			},
-			{
-				Name: "prom-node-exporter",
-			},
-			{
-				Name: "weave-scope",
-			},
-			{
-				Name: "weave-scope-agent",
-			},
-			{
-				Name: "weave-net",
-			},
-		},
-	}
-
-	if err := drainer.CanUseEvictions(); err != nil {
-		return errors.Wrapf(err, "checking if cluster implements policy API")
-	}
-
-	drainedNodes := sets.NewString()
-	// loop until all nodes are drained to handle accidental scale-up
-	// or any other changes in the ASG
-	timer := time.After(ctl.Provider.WaitTimeout())
-	timeout := false
-	for !timeout {
-		select {
-		case <-timer:
-			timeout = true
-		default:
-			nodes, err := clientSet.CoreV1().Nodes().List(ng.ListOptions())
-			if err != nil {
-				return err
-			}
-
-			if len(nodes.Items) == 0 {
-				logger.Warning("no nodes found in nodegroup %q (label selector: %q)", ng.Name, ng.ListOptions().LabelSelector)
-				return nil
-			}
-
-			newPendingNodes := sets.NewString()
-
-			for _, node := range nodes.Items {
-				if drainedNodes.Has(node.Name) {
-					continue // already drained, get next one
-				}
-				newPendingNodes.Insert(node.Name)
-				desired := drain.CordonNode
-				if drainNodeGroupUndo {
-					desired = drain.UncordonNode
-				}
-				c := drain.NewCordonHelper(&node, desired)
-				if c.IsUpdateRequired() {
-					err, patchErr := c.PatchOrReplace(clientSet)
-					if patchErr != nil {
-						logger.Warning(patchErr.Error())
-					}
-					if err != nil {
-						logger.Critical(err.Error())
-					}
-					logger.Info("%s node %q", desired, node.Name)
-				} else {
-					logger.Debug("no need to %s node %q", desired, node.Name)
-				}
-			}
-
-			if drainNodeGroupUndo {
-				return nil // no need to kill any pods
-			}
-
-			if drainedNodes.HasAll(newPendingNodes.List()...) {
-				logger.Success("drained nodes: %v", drainedNodes.List())
-				return nil // no new nodes were seen
-			}
-
-			logger.Debug("already drained: %v", drainedNodes.List())
-			logger.Debug("will drain: %v", newPendingNodes.List())
-
-			for _, node := range nodes.Items {
-				if newPendingNodes.Has(node.Name) {
-					pending, err := evictPods(drainer, &node)
-					if err != nil {
-						return err
-					}
-					logger.Debug("%d pods to be evicted from %s", pending, node.Name)
-					if pending == 0 {
-						drainedNodes.Insert(node.Name)
-					}
-				}
-			}
-		}
-	}
-	if timeout {
-		return fmt.Errorf("timed out (after %s) waiting for nodedroup %q to be drain", ctl.Provider.WaitTimeout(), ng.Name)
-	}
-
-	return nil
-}
-
-func evictPods(drainer *drain.Helper, node *corev1.Node) (int, error) {
-	list, errs := drainer.GetPodsForDeletion(node.Name)
-	if len(errs) > 0 {
-		return 0, fmt.Errorf("errs: %v", errs) // TODO: improve formatting
-	}
-	if w := list.Warnings(); w != "" {
-		logger.Warning(w)
-	}
-	pods := list.Pods()
-	pending := len(pods)
-	for _, pod := range pods {
-		// TODO: handle API rate limitter error
-		if err := drainer.EvictOrDeletePod(pod); err != nil {
-			return pending, err
-		}
-	}
-	return pending, nil
+	return drain.NodeGroup(clientSet, ng, ctl.Provider.WaitTimeout(), drainNodeGroupUndo)
 }

--- a/pkg/drain/nodegroup.go
+++ b/pkg/drain/nodegroup.go
@@ -1,0 +1,164 @@
+package drain
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kris-nova/logger"
+	"github.com/pkg/errors"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha4"
+)
+
+// this is our custom addition, it's not part of the package
+// we copied from Kubernetes
+
+func evictPods(drainer *Helper, node *corev1.Node) (int, error) {
+	list, errs := drainer.GetPodsForDeletion(node.Name)
+	if len(errs) > 0 {
+		return 0, fmt.Errorf("errs: %v", errs) // TODO: improve formatting
+	}
+	if w := list.Warnings(); w != "" {
+		logger.Warning(w)
+	}
+	pods := list.Pods()
+	pending := len(pods)
+	for _, pod := range pods {
+		// TODO: handle API rate limitter error
+		if err := drainer.EvictOrDeletePod(pod); err != nil {
+			return pending, err
+		}
+	}
+	return pending, nil
+}
+
+// NodeGroup drains a nodegroup
+func NodeGroup(clientSet *kubernetes.Clientset, ng *api.NodeGroup, waitTimeout time.Duration, undo bool) error {
+	drainer := &Helper{
+		Client: clientSet,
+
+		// TODO: Force, DeleteLocalData & IgnoreAllDaemonSets shouldn't
+		// be enabled by default, we need flags to control thes, but that
+		// requires more improvements in the underlying drain package,
+		// as it currently produces errors and warnings with references
+		// to kubectl flags
+		Force:               true,
+		DeleteLocalData:     true,
+		IgnoreAllDaemonSets: true,
+
+		// TODO: ideally only the list of well-known DaemonSets should
+		// be set by default
+		IgnoreDaemonSets: []metav1.ObjectMeta{
+			{
+				Namespace: "kube-system",
+				Name:      "aws-node",
+			},
+			{
+				Namespace: "kube-system",
+				Name:      "kube-proxy",
+			},
+			{
+				Name: "node-exporter",
+			},
+			{
+				Name: "prom-node-exporter",
+			},
+			{
+				Name: "weave-scope",
+			},
+			{
+				Name: "weave-scope-agent",
+			},
+			{
+				Name: "weave-net",
+			},
+		},
+	}
+
+	if err := drainer.CanUseEvictions(); err != nil {
+		return errors.Wrapf(err, "checking if cluster implements policy API")
+	}
+
+	drainedNodes := sets.NewString()
+	// loop until all nodes are drained to handle accidental scale-up
+	// or any other changes in the ASG
+	timer := time.After(waitTimeout)
+	timeout := false
+	for !timeout {
+		select {
+		case <-timer:
+			timeout = true
+		default:
+			nodes, err := clientSet.CoreV1().Nodes().List(ng.ListOptions())
+			if err != nil {
+				return err
+			}
+
+			if len(nodes.Items) == 0 {
+				logger.Warning("no nodes found in nodegroup %q (label selector: %q)", ng.Name, ng.ListOptions().LabelSelector)
+				return nil
+			}
+
+			newPendingNodes := sets.NewString()
+
+			for _, node := range nodes.Items {
+				if drainedNodes.Has(node.Name) {
+					continue // already drained, get next one
+				}
+				newPendingNodes.Insert(node.Name)
+				desired := CordonNode
+				if undo {
+					desired = UncordonNode
+				}
+				c := NewCordonHelper(&node, desired)
+				if c.IsUpdateRequired() {
+					err, patchErr := c.PatchOrReplace(clientSet)
+					if patchErr != nil {
+						logger.Warning(patchErr.Error())
+					}
+					if err != nil {
+						logger.Critical(err.Error())
+					}
+					logger.Info("%s node %q", desired, node.Name)
+				} else {
+					logger.Debug("no need to %s node %q", desired, node.Name)
+				}
+			}
+
+			if undo {
+				return nil // no need to kill any pods
+			}
+
+			if drainedNodes.HasAll(newPendingNodes.List()...) {
+				logger.Success("drained nodes: %v", drainedNodes.List())
+				return nil // no new nodes were seen
+			}
+
+			logger.Debug("already drained: %v", drainedNodes.List())
+			logger.Debug("will drain: %v", newPendingNodes.List())
+
+			for _, node := range nodes.Items {
+				if newPendingNodes.Has(node.Name) {
+					pending, err := evictPods(drainer, &node)
+					if err != nil {
+						return err
+					}
+					logger.Debug("%d pods to be evicted from %s", pending, node.Name)
+					if pending == 0 {
+						drainedNodes.Insert(node.Name)
+					}
+				}
+			}
+		}
+	}
+	if timeout {
+		return fmt.Errorf("timed out (after %s) waiting for nodedroup %q to be drain", waitTimeout, ng.Name)
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

This enabled draining of nodes on deletion of a nodegroup. The behaviour can be disable with `--drain=false`.

Close #370.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
