### PR TITLE
Add `eksctl update cluster` command

### DIFF
--- a/cmd/eksctl/main.go
+++ b/cmd/eksctl/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/drain"
 	"github.com/weaveworks/eksctl/pkg/ctl/get"
 	"github.com/weaveworks/eksctl/pkg/ctl/scale"
+	"github.com/weaveworks/eksctl/pkg/ctl/update"
 	"github.com/weaveworks/eksctl/pkg/ctl/utils"
 )
 
@@ -75,6 +76,7 @@ func addCommands(g *cmdutils.Grouping) {
 	rootCmd.AddCommand(create.Command(g))
 	rootCmd.AddCommand(delete.Command(g))
 	rootCmd.AddCommand(get.Command(g))
+	rootCmd.AddCommand(update.Command(g))
 	rootCmd.AddCommand(scale.Command(g))
 	rootCmd.AddCommand(drain.Command(g))
 	rootCmd.AddCommand(utils.Command(g))

--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -48,18 +48,6 @@ func updateClusterCmd(g *cmdutils.Grouping) *cobra.Command {
 }
 
 func doUpdateClusterCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg string) error {
-	ctl := eks.New(p, cfg)
-
-	printer := printers.NewJSONPrinter()
-
-	if err := api.Register(); err != nil {
-		return err
-	}
-
-	if err := ctl.CheckAuth(); err != nil {
-		return err
-	}
-
 	if cfg.Metadata.Name != "" && nameArg != "" {
 		return fmt.Errorf("--name=%s and argument %s cannot be used at the same time", cfg.Metadata.Name, nameArg)
 	}
@@ -70,6 +58,18 @@ func doUpdateClusterCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg s
 
 	if cfg.Metadata.Name == "" {
 		return fmt.Errorf("--name must be set")
+	}
+
+	ctl := eks.New(p, cfg)
+
+	printer := printers.NewJSONPrinter()
+
+	if err := api.Register(); err != nil {
+		return err
+	}
+
+	if err := ctl.CheckAuth(); err != nil {
+		return err
 	}
 
 	if err := ctl.GetClusterVPC(cfg); err != nil {

--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -82,7 +82,8 @@ func doUpdateClusterCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg s
 
 	stackManager := ctl.NewStackManager(cfg)
 
-	if err := stackManager.AppendNewClusterStackResource(updateClusterDryRun); err != nil {
+	updateRequired, err := stackManager.AppendNewClusterStackResource(updateClusterDryRun)
+	if err != nil {
 		return err
 	}
 
@@ -90,8 +91,9 @@ func doUpdateClusterCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg s
 		logger.Critical("failed checking nodegroups", err.Error())
 	}
 
-	if updateClusterDryRun {
+	if updateClusterDryRun && updateRequired {
 		logger.Warning("no changes were applied, run again with '--dry-run=false' to apply the changes")
 	}
+
 	return nil
 }

--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -1,0 +1,97 @@
+package update
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kris-nova/logger"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha4"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/eks"
+	"github.com/weaveworks/eksctl/pkg/printers"
+)
+
+var updateClusterDryRun = true
+
+func updateClusterCmd(g *cmdutils.Grouping) *cobra.Command {
+	p := &api.ProviderConfig{}
+	cfg := api.NewClusterConfig()
+
+	cmd := &cobra.Command{
+		Use:   "cluster",
+		Short: "Update cluster",
+		Run: func(_ *cobra.Command, args []string) {
+			if err := doUpdateClusterCmd(p, cfg, cmdutils.GetNameArg(args)); err != nil {
+				logger.Critical("%s\n", err.Error())
+				os.Exit(1)
+			}
+		},
+	}
+
+	group := g.New(cmd)
+
+	group.InFlagSet("General", func(fs *pflag.FlagSet) {
+		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
+		cmdutils.AddRegionFlag(fs, p)
+		cmdutils.AddVersionFlag(fs, cfg.Metadata, "")
+		fs.BoolVar(&updateClusterDryRun, "dry-run", updateClusterDryRun, "do not apply any change, only show what resources would be added")
+	})
+
+	cmdutils.AddCommonFlagsForAWS(group, p, false)
+
+	group.AddTo(cmd)
+	return cmd
+}
+
+func doUpdateClusterCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg string) error {
+	ctl := eks.New(p, cfg)
+
+	printer := printers.NewJSONPrinter()
+
+	if err := api.Register(); err != nil {
+		return err
+	}
+
+	if err := ctl.CheckAuth(); err != nil {
+		return err
+	}
+
+	if cfg.Metadata.Name != "" && nameArg != "" {
+		return fmt.Errorf("--name=%s and argument %s cannot be used at the same time", cfg.Metadata.Name, nameArg)
+	}
+
+	if nameArg != "" {
+		cfg.Metadata.Name = nameArg
+	}
+
+	if cfg.Metadata.Name == "" {
+		return fmt.Errorf("--name must be set")
+	}
+
+	if err := ctl.GetClusterVPC(cfg); err != nil {
+		return errors.Wrapf(err, "getting VPC configuration for cluster %q", cfg.Metadata.Name)
+	}
+
+	if err := printer.LogObj(logger.Debug, "cfg.json = \\\n", cfg); err != nil {
+		return err
+	}
+
+	stackManager := ctl.NewStackManager(cfg)
+
+	if err := stackManager.AppendNewClusterStackResource(updateClusterDryRun); err != nil {
+		return err
+	}
+
+	if err := ctl.ValidateExistingNodeGroupsForCompatibility(cfg, stackManager); err != nil {
+		logger.Critical("failed checking nodegroups", err.Error())
+	}
+
+	if updateClusterDryRun {
+		logger.Warning("no changes were applied, run again with '--dry-run=false' to apply the changes")
+	}
+	return nil
+}

--- a/pkg/ctl/update/update.go
+++ b/pkg/ctl/update/update.go
@@ -1,0 +1,24 @@
+package update
+
+import (
+	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+// Command will create the `create` commands
+func Command(g *cmdutils.Grouping) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update resource(s)",
+		Run: func(c *cobra.Command, _ []string) {
+			if err := c.Help(); err != nil {
+				logger.Debug("ignoring error %q", err.Error())
+			}
+		},
+	}
+
+	cmd.AddCommand(updateClusterCmd(g))
+
+	return cmd
+}

--- a/pkg/ctl/utils/update_cluster_stack.go
+++ b/pkg/ctl/utils/update_cluster_stack.go
@@ -1,97 +1,21 @@
 package utils
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
-	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha4"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
-	"github.com/weaveworks/eksctl/pkg/eks"
-	"github.com/weaveworks/eksctl/pkg/printers"
 )
 
-var updateClusterStackDryRun = true
-
-func updateClusterStackCmd(g *cmdutils.Grouping) *cobra.Command {
-	p := &api.ProviderConfig{}
-	cfg := api.NewClusterConfig()
-
-	cmd := &cobra.Command{
+func updateClusterStackCmd(_ *cmdutils.Grouping) *cobra.Command {
+	return &cobra.Command{
 		Use:   "update-cluster-stack",
-		Short: "Update cluster stack based on latest configuration (append-only)",
-		Run: func(_ *cobra.Command, args []string) {
-			if err := doUpdateClusterStacksCmd(p, cfg, cmdutils.GetNameArg(args)); err != nil {
-				logger.Critical("%s\n", err.Error())
-				os.Exit(1)
-			}
+		Short: "DEPRECATED: Use 'eksctl update cluster' instead",
+		Run: func(cmd *cobra.Command, _ []string) {
+			logger.Critical(cmd.Short)
+			os.Exit(1)
 		},
 	}
-
-	group := g.New(cmd)
-
-	group.InFlagSet("General", func(fs *pflag.FlagSet) {
-		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
-		cmdutils.AddRegionFlag(fs, p)
-		cmdutils.AddVersionFlag(fs, cfg.Metadata, "")
-		fs.BoolVar(&updateClusterStackDryRun, "dry-run", updateClusterStackDryRun, "do not apply any change, only show what resources would be added")
-	})
-
-	cmdutils.AddCommonFlagsForAWS(group, p, false)
-
-	group.AddTo(cmd)
-	return cmd
-}
-
-func doUpdateClusterStacksCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg string) error {
-	ctl := eks.New(p, cfg)
-
-	printer := printers.NewJSONPrinter()
-
-	if err := api.Register(); err != nil {
-		return err
-	}
-
-	if err := ctl.CheckAuth(); err != nil {
-		return err
-	}
-
-	if cfg.Metadata.Name != "" && nameArg != "" {
-		return fmt.Errorf("--name=%s and argument %s cannot be used at the same time", cfg.Metadata.Name, nameArg)
-	}
-
-	if nameArg != "" {
-		cfg.Metadata.Name = nameArg
-	}
-
-	if cfg.Metadata.Name == "" {
-		return fmt.Errorf("--name must be set")
-	}
-
-	if err := ctl.GetClusterVPC(cfg); err != nil {
-		return errors.Wrapf(err, "getting VPC configuration for cluster %q", cfg.Metadata.Name)
-	}
-
-	if err := printer.LogObj(logger.Debug, "cfg.json = \\\n", cfg); err != nil {
-		return err
-	}
-
-	stackManager := ctl.NewStackManager(cfg)
-
-	if err := stackManager.AppendNewClusterStackResource(updateClusterStackDryRun); err != nil {
-		return err
-	}
-
-	if err := ctl.ValidateExistingNodeGroupsForCompatibility(cfg, stackManager); err != nil {
-		logger.Critical("failed checking nodegroups", err.Error())
-	}
-
-	if updateClusterStackDryRun {
-		logger.Warning("no changes were applied, run again with '--dry-run=false' to apply the changes")
-	}
-	return nil
 }

--- a/pkg/eks/compatibility.go
+++ b/pkg/eks/compatibility.go
@@ -33,7 +33,7 @@ func (c *ClusterProvider) ValidateClusterForCompatibility(cfg *api.ClusterConfig
 	if err != nil {
 		logger.Debug("err = %s", err.Error())
 		return fmt.Errorf(
-			"shared node security group missing, to fix this run 'eksctl utils update-cluster-stack --name=%s --region=%s'",
+			"shared node security group missing, to fix this run 'eksctl update cluster --name=%s --region=%s'",
 			cfg.Metadata.Name,
 			cfg.Metadata.Region,
 		)


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

This is first cut, it moves `eksctl utils update-cluster-stack` functionality to `eksctl update cluster`.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
