### PR TITLE
Add functionality to increment control plane version

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha4/types.go
+++ b/pkg/apis/eksctl.io/v1alpha4/types.go
@@ -103,7 +103,7 @@ const (
 
 var (
 	// DefaultWaitTimeout defines the default wait timeout
-	DefaultWaitTimeout = 20 * time.Minute
+	DefaultWaitTimeout = 25 * time.Minute
 )
 
 // NewBoolTrue return pointer to true value

--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -15,11 +15,16 @@ import (
 	"github.com/weaveworks/eksctl/pkg/printers"
 )
 
-var updateClusterDryRun = true
+var (
+	updateClusterDryRun = true
+	updateClusterWait   = true
+)
 
 func updateClusterCmd(g *cmdutils.Grouping) *cobra.Command {
 	p := &api.ProviderConfig{}
 	cfg := api.NewClusterConfig()
+
+	// cfg.Metadata.Version = "next"
 
 	cmd := &cobra.Command{
 		Use:   "cluster",
@@ -37,8 +42,9 @@ func updateClusterCmd(g *cmdutils.Grouping) *cobra.Command {
 	group.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
 		cmdutils.AddRegionFlag(fs, p)
-		cmdutils.AddVersionFlag(fs, cfg.Metadata, "")
+		// cmdutils.AddVersionFlag(fs, cfg.Metadata, `"next" and "latest" can be used to automatically increment version by one, or force latest`)
 		fs.BoolVar(&updateClusterDryRun, "dry-run", updateClusterDryRun, "do not apply any change, only show what resources would be added")
+		cmdutils.AddWaitFlag(&updateClusterWait, fs, "all update operations to complete")
 	})
 
 	cmdutils.AddCommonFlagsForAWS(group, p, false)
@@ -62,6 +68,11 @@ func doUpdateClusterCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg s
 
 	ctl := eks.New(p, cfg)
 
+	if !ctl.IsSupportedRegion() {
+		return cmdutils.ErrUnsupportedRegion(p)
+	}
+	logger.Info("using region %s", cfg.Metadata.Region)
+
 	printer := printers.NewJSONPrinter()
 
 	if err := api.Register(); err != nil {
@@ -71,6 +82,25 @@ func doUpdateClusterCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg s
 	if err := ctl.CheckAuth(); err != nil {
 		return err
 	}
+
+	if err := ctl.GetCredentials(cfg); err != nil {
+		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
+	}
+
+	currentVersion := ctl.ControlPlaneVersion()
+	// determine next version based on what's currently deployed
+	switch currentVersion {
+	case "":
+		return fmt.Errorf("unable to get control plane version")
+	case api.Version1_10:
+		cfg.Metadata.Version = api.Version1_11
+	case api.LatestVersion:
+		cfg.Metadata.Version = api.LatestVersion
+	default:
+		// version of control is not known to us, maybe we are just too old...
+		return fmt.Errorf("control plane version version %q is known to this version of eksctl, try to upgrade eksctl first", currentVersion)
+	}
+	versionUpdateRequired := cfg.Metadata.Version != currentVersion
 
 	if err := ctl.GetClusterVPC(cfg); err != nil {
 		return errors.Wrapf(err, "getting VPC configuration for cluster %q", cfg.Metadata.Name)
@@ -82,7 +112,7 @@ func doUpdateClusterCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg s
 
 	stackManager := ctl.NewStackManager(cfg)
 
-	updateRequired, err := stackManager.AppendNewClusterStackResource(updateClusterDryRun)
+	stackUpdateRequired, err := stackManager.AppendNewClusterStackResource(updateClusterDryRun)
 	if err != nil {
 		return err
 	}
@@ -91,7 +121,32 @@ func doUpdateClusterCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg s
 		logger.Critical("failed checking nodegroups", err.Error())
 	}
 
-	if updateClusterDryRun && updateRequired {
+	if versionUpdateRequired {
+		msg := func(verb string) {
+			logger.Info("cluster %q control plane %s upgraded from current version %q to %q", cfg.Metadata.Name, verb, currentVersion, cfg.Metadata.Version)
+		}
+		msgNodeGroupsAndAddons := "you will need to follow the upgrade procedure for all of nodegroups and add-ons"
+		if updateClusterDryRun {
+			msg("can be")
+		} else {
+			msg("will be")
+			if updateClusterWait {
+				if err := ctl.UpdateClusterVersionBlocking(cfg); err != nil {
+					return err
+				}
+				logger.Success("cluster %q control plan e has been upgraded to version %q", cfg.Metadata.Name, cfg.Metadata.Version)
+				logger.Info(msgNodeGroupsAndAddons)
+			} else {
+				if _, err := ctl.UpdateClusterVersion(cfg); err != nil {
+					return err
+				}
+				logger.Success("a version update operation has been requested for cluster %q", cfg.Metadata.Name)
+				logger.Info("once it has been updated, %s", cfg.Metadata.Name, msgNodeGroupsAndAddons)
+			}
+		}
+	}
+
+	if updateClusterDryRun && (stackUpdateRequired || versionUpdateRequired) {
 		logger.Warning("no changes were applied, run again with '--dry-run=false' to apply the changes")
 	}
 

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
 
+	"github.com/aws/aws-sdk-go/aws/request"
 	awseks "github.com/aws/aws-sdk-go/service/eks"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -18,6 +19,7 @@ import (
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha4"
 	"github.com/weaveworks/eksctl/pkg/printers"
+	"github.com/weaveworks/eksctl/pkg/utils/waiters"
 	"github.com/weaveworks/eksctl/pkg/vpc"
 )
 
@@ -259,6 +261,51 @@ func (c *ClusterProvider) WaitForControlPlane(id *api.ClusterMeta, clientSet *ku
 			return fmt.Errorf("timed out waiting for control plane %q after %s", id.Name, c.Provider.WaitTimeout())
 		}
 	}
+}
+
+// UpdateClusterVersion calls eks.UpdateClusterVersion and updates to cfg.Metadata.Version,
+// it will return update ID along with an error (if it occurrs)
+func (c *ClusterProvider) UpdateClusterVersion(cfg *api.ClusterConfig) (string, error) {
+	input := &awseks.UpdateClusterVersionInput{
+		Name:    &cfg.Metadata.Name,
+		Version: &cfg.Metadata.Version,
+	}
+	output, err := c.Provider.EKS().UpdateClusterVersion(input)
+	if err != nil {
+		return "", err
+	}
+	return *output.Update.Id, nil
+}
+
+// UpdateClusterVersionBlocking calls UpdateClusterVersion and blocks until update
+// operation is successful
+func (c *ClusterProvider) UpdateClusterVersionBlocking(cfg *api.ClusterConfig) error {
+	id, err := c.UpdateClusterVersion(cfg)
+	if err != nil {
+		return err
+	}
+
+	newRequest := func() *request.Request {
+		input := &awseks.DescribeUpdateInput{
+			Name:     &cfg.Metadata.Name,
+			UpdateId: &id,
+		}
+		req, _ := c.Provider.EKS().DescribeUpdateRequest(input)
+		return req
+	}
+
+	msg := fmt.Sprintf("waiting for control plane %q version update", cfg.Metadata.Name)
+
+	acceptors := waiters.MakeAcceptors(
+		"Update.Status",
+		awseks.UpdateStatusSuccessful,
+		[]string{
+			awseks.UpdateStatusCancelled,
+			awseks.UpdateStatusFailed,
+		},
+	)
+
+	return waiters.Wait(cfg.Metadata.Name, msg, acceptors, newRequest, c.Provider.WaitTimeout(), nil)
 }
 
 func addSummaryTableColumns(printer *printers.TablePrinter) {


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

This carries some refactoring, but crucially it adds a call to `eks.UpdateClusterVersion` from `eksctl update cluster`.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [ ] ~Added tests that cover your change (if possible)~ - should look testing upgrades separately
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
- [ ] ~Added/modified documentation as required (such as the `README.md`, and `examples` directory)~ - will make another PR
