### PR TITLE
Accept clientset interface over concrete type

### DIFF
--- a/pkg/authconfigmap/authconfigmap.go
+++ b/pkg/authconfigmap/authconfigmap.go
@@ -86,7 +86,7 @@ func AddRole(cm *corev1.ConfigMap, arn string) error {
 }
 
 // AddNodeGroup creates or adds a nodegroup IAM role in the auth config map for the given nodegroup
-func AddNodeGroup(clientSet *clientset.Clientset, ng *api.NodeGroup) error {
+func AddNodeGroup(clientSet clientset.Interface, ng *api.NodeGroup) error {
 	cm := &corev1.ConfigMap{}
 	client := clientSet.CoreV1().ConfigMaps(objectNamespace)
 	create := false
@@ -167,7 +167,7 @@ func RemoveRole(cm *corev1.ConfigMap, ngInstanceRoleARN string) error {
 }
 
 // RemoveNodeGroup removes a nodegroup from the config map and does a client update
-func RemoveNodeGroup(clientSet *clientset.Clientset, ng *api.NodeGroup) error {
+func RemoveNodeGroup(clientSet clientset.Interface, ng *api.NodeGroup) error {
 	client := clientSet.CoreV1().ConfigMaps(objectNamespace)
 
 	cm, err := client.Get(objectName, metav1.GetOptions{})

--- a/pkg/drain/nodegroup.go
+++ b/pkg/drain/nodegroup.go
@@ -38,7 +38,7 @@ func evictPods(drainer *Helper, node *corev1.Node) (int, error) {
 }
 
 // NodeGroup drains a nodegroup
-func NodeGroup(clientSet *kubernetes.Clientset, ng *api.NodeGroup, waitTimeout time.Duration, undo bool) error {
+func NodeGroup(clientSet kubernetes.Interface, ng *api.NodeGroup, waitTimeout time.Duration, undo bool) error {
 	drainer := &Helper{
 		Client: clientSet,
 

--- a/pkg/eks/nodegroup.go
+++ b/pkg/eks/nodegroup.go
@@ -24,7 +24,7 @@ func isNodeReady(node *corev1.Node) bool {
 	return false
 }
 
-func getNodes(clientSet *clientset.Clientset, ng *api.NodeGroup) (int, error) {
+func getNodes(clientSet clientset.Interface, ng *api.NodeGroup) (int, error) {
 	nodes, err := clientSet.CoreV1().Nodes().List(ng.ListOptions())
 	if err != nil {
 		return 0, err
@@ -42,7 +42,7 @@ func getNodes(clientSet *clientset.Clientset, ng *api.NodeGroup) (int, error) {
 }
 
 // WaitForNodes waits till the nodes are ready
-func (c *ClusterProvider) WaitForNodes(clientSet *clientset.Clientset, ng *api.NodeGroup) error {
+func (c *ClusterProvider) WaitForNodes(clientSet clientset.Interface, ng *api.NodeGroup) error {
 	if ng.MinSize == nil || *ng.MinSize == 0 {
 		return nil
 	}

--- a/pkg/eks/storageclass.go
+++ b/pkg/eks/storageclass.go
@@ -10,7 +10,7 @@ import (
 )
 
 // AddDefaultStorageClass adds the default EBS gp2 storage class to the cluster
-func (c *ClusterProvider) AddDefaultStorageClass(clientSet *clientset.Clientset) error {
+func (c *ClusterProvider) AddDefaultStorageClass(clientSet clientset.Interface) error {
 
 	rp := corev1.PersistentVolumeReclaimRetain
 


### PR DESCRIPTION
The concrete type `*kubernetes.Clientset` implements
`kubernetes.Interface` and can as such be replaced in function
arguments. It allows to pass in the k8s fake client when doing tests.