### PR TITLE
Add config file helpers in cmdutils

### DIFF
--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -4,10 +4,16 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha4"
 	"github.com/weaveworks/eksctl/pkg/eks"
 )
+
+// AddConfigFileFlag adds common --config-file flag
+func AddConfigFileFlag(path *string, fs *pflag.FlagSet) {
+	fs.StringVarP(path, "config-file", "f", "", "load configuration from a file")
+}
 
 // LoadMetadata handles loading of clusterConfigFile vs using flags for all commands that require only
 // metadata fileds, e.g. `eksctl delete cluster` or `eksctl utils update-kube-proxy` and other similar

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -1,0 +1,71 @@
+package cmdutils
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha4"
+	"github.com/weaveworks/eksctl/pkg/eks"
+)
+
+// LoadMetadata handles loading of clusterConfigFile vs using flags for all commands that require only
+// metadata fileds, e.g. `eksctl delete cluster` or `eksctl utils update-kube-proxy` and other similar
+// commands that do simple operations against existing clusters
+func LoadMetadata(p *api.ProviderConfig, cfg *api.ClusterConfig, clusterConfigFile, nameArg string, cmd *cobra.Command) error {
+	meta := cfg.Metadata
+
+	if clusterConfigFile != "" {
+		if err := eks.LoadConfigFromFile(clusterConfigFile, cfg); err != nil {
+			return err
+		}
+		meta = cfg.Metadata
+
+		incompatibleFlags := []string{
+			"name",
+			"region",
+			"version",
+		}
+
+		for _, f := range incompatibleFlags {
+			if flag := cmd.Flag(f); flag != nil && flag.Changed {
+				return fmt.Errorf("cannot use --%s when --config-file/-f is set", f)
+			}
+		}
+
+		if nameArg != "" {
+			return fmt.Errorf("cannot use name argument %q when --config-file/-f is set", nameArg)
+		}
+
+		if meta.Name == "" {
+			return fmt.Errorf("metadata.name must be set")
+		}
+
+		// region is always required when config file is used
+		if meta.Region == "" {
+			return fmt.Errorf("metadata.region must be set")
+		}
+
+		p.Region = meta.Region
+
+		// version has different default values in some command
+		// we don't check it here
+	} else {
+		if meta.Name != "" && nameArg != "" {
+			return ErrNameFlagAndArg(meta.Name, nameArg)
+		}
+
+		if nameArg != "" {
+			meta.Name = nameArg
+		}
+
+		if meta.Name == "" {
+			return fmt.Errorf("--name must be set")
+		}
+
+		// default region will get picked by eks.New, and
+		// version validation gets handled separately
+	}
+
+	return nil
+}

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -68,7 +68,7 @@ func createClusterCmd(g *cmdutils.Grouping) *cobra.Command {
 		cmdutils.AddRegionFlag(fs, p)
 		fs.StringSliceVar(&availabilityZones, "zones", nil, "(auto-select if unspecified)")
 		cmdutils.AddVersionFlag(fs, cfg.Metadata, "")
-		fs.StringVarP(&clusterConfigFile, "config-file", "f", "", "load configuration from a file")
+		cmdutils.AddConfigFileFlag(&clusterConfigFile, fs)
 	})
 
 	group.InFlagSet("Initial nodegroup", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -43,7 +43,7 @@ func deleteClusterCmd(g *cmdutils.Grouping) *cobra.Command {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
 		cmdutils.AddRegionFlag(fs, p)
 		cmdutils.AddWaitFlag(&wait, fs, "deletion of all resources")
-		fs.StringVarP(&clusterConfigFile, "config-file", "f", "", "load configuration from a file")
+		cmdutils.AddConfigFileFlag(&clusterConfigFile, fs)
 	})
 
 	cmdutils.AddCommonFlagsForAWS(group, p, true)


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

This should make it easier to add config file supports to more of the commands without having to copy the boilerplate.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
