### PR TITLE
Improve printers, use Go 1.12

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -7,6 +7,7 @@
         "misspell"
     ],
     "Exclude": [
+        "\/src\/(crypto|internal|net|os|runtime|syscall)\/",
         "^pkg\/nodebootstrap\/assets.go",
         "^pkg\/testutils\/ginkgo.go",
         "^pkg\/drain"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine3.8
+FROM golang:1.12-alpine3.9
 
 RUN apk add --no-cache \
       curl \

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -457,7 +457,7 @@ func doCreateCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 	// we should also make a call to resolve the AMI and write the result, similaraly
 	// the body of the SSH key can be read
 
-	if err := printer.LogObj(logger.Debug, "cfg.json = \\\n", cfg); err != nil {
+	if err := printer.LogObj(logger.Debug, "cfg.json = \\\n%s\n", cfg); err != nil {
 		return err
 	}
 
@@ -565,7 +565,7 @@ func doCreateCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 
 	logger.Success("%s is ready", meta.LogString())
 
-	if err := printer.LogObj(logger.Debug, "cfg.json = \\\n", cfg); err != nil {
+	if err := printer.LogObj(logger.Debug, "cfg.json = \\\n%s\n", cfg); err != nil {
 		return err
 	}
 

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -276,7 +276,7 @@ func doCreateNodeGroups(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg s
 		return err
 	}
 
-	if err := printer.LogObj(logger.Debug, "cfg.json = \\\n", cfg); err != nil {
+	if err := printer.LogObj(logger.Debug, "cfg.json = \\\n%s\n", cfg); err != nil {
 		return err
 	}
 

--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -76,7 +76,7 @@ func doDeleteCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 	}
 
 	logger.Info("deleting EKS cluster %q", meta.Name)
-	if err := printer.LogObj(logger.Debug, "cfg.json = \\\n", cfg); err != nil {
+	if err := printer.LogObj(logger.Debug, "cfg.json = \\\n%s\n", cfg); err != nil {
 		return err
 	}
 

--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -106,7 +106,7 @@ func doUpdateClusterCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg s
 		return errors.Wrapf(err, "getting VPC configuration for cluster %q", cfg.Metadata.Name)
 	}
 
-	if err := printer.LogObj(logger.Debug, "cfg.json = \\\n", cfg); err != nil {
+	if err := printer.LogObj(logger.Debug, "cfg.json = \\\n%s\n", cfg); err != nil {
 		return err
 	}
 

--- a/pkg/printers/json.go
+++ b/pkg/printers/json.go
@@ -27,7 +27,10 @@ func NewJSONPrinter() OutputPrinter {
 // the supplied writer.
 func (j *JSONPrinter) PrintObj(obj interface{}, writer io.Writer) error {
 	if obj, ok := obj.(runtime.Object); ok {
-		return j.runtimePrinter.PrintObj(obj, writer)
+		if err := j.runtimePrinter.PrintObj(obj, writer); err == nil {
+			// if an error occurred, we may still be able to serialise using json package directly
+			return nil
+		}
 	}
 
 	b, err := json.MarshalIndent(obj, "", "    ")

--- a/pkg/printers/json.go
+++ b/pkg/printers/json.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"strings"
 
 	"github.com/kris-nova/logger"
 
@@ -52,13 +53,13 @@ func (j *JSONPrinter) PrintObjWithKind(kind string, obj interface{}, writer io.W
 
 // LogObj will print the passed object formatted as JSON to
 // the logger.
-func (j *JSONPrinter) LogObj(log logger.Logger, prefixFmt string, obj interface{}) error {
+func (j *JSONPrinter) LogObj(log logger.Logger, msgFmt string, obj interface{}) error {
 	b := &bytes.Buffer{}
 	if err := j.PrintObj(obj, b); err != nil {
 		return err
 	}
 
-	log(prefixFmt+"%s", b.String())
+	log(msgFmt, strings.ReplaceAll(b.String(), "%", "%%"))
 
 	return nil
 }

--- a/pkg/printers/printers.go
+++ b/pkg/printers/printers.go
@@ -12,7 +12,7 @@ import (
 type OutputPrinter interface {
 	PrintObjWithKind(kind string, obj interface{}, writer io.Writer) error
 	PrintObj(obj interface{}, writer io.Writer) error
-	LogObj(log logger.Logger, prefixFmt string, obj interface{}) error
+	LogObj(log logger.Logger, msgFmt string, obj interface{}) error
 }
 
 // NewPrinter creates a new printer based in the printer type requested

--- a/pkg/printers/table.go
+++ b/pkg/printers/table.go
@@ -55,13 +55,13 @@ func (t *TablePrinter) PrintObjWithKind(kind string, obj interface{}, writer io.
 
 // LogObj will print the passed object formatted as a table to
 // the logger.
-func (t *TablePrinter) LogObj(log logger.Logger, prefixFmt string, obj interface{}) error {
+func (t *TablePrinter) LogObj(log logger.Logger, msgFmt string, obj interface{}) error {
 	b := &bytes.Buffer{}
 	if err := t.PrintObj(obj, b); err != nil {
 		return err
 	}
 
-	log(prefixFmt+"%s", b.String())
+	log(msgFmt, strings.ReplaceAll(b.String(), "%", "%%"))
 
 	return nil
 }

--- a/pkg/printers/yaml.go
+++ b/pkg/printers/yaml.go
@@ -26,7 +26,10 @@ func NewYAMLPrinter() OutputPrinter {
 // the supplied writer.
 func (y *YAMLPrinter) PrintObj(obj interface{}, writer io.Writer) error {
 	if obj, ok := obj.(runtime.Object); ok {
-		return y.runtimePrinter.PrintObj(obj, writer)
+		if err := y.runtimePrinter.PrintObj(obj, writer); err == nil {
+			// if an error occurred, we may still be able to serialise using yaml package directly
+			return nil
+		}
 	}
 
 	b, err := yaml.Marshal(obj)

--- a/pkg/printers/yaml.go
+++ b/pkg/printers/yaml.go
@@ -3,6 +3,7 @@ package printers
 import (
 	"bytes"
 	"io"
+	"strings"
 
 	"github.com/kris-nova/logger"
 
@@ -51,13 +52,13 @@ func (y *YAMLPrinter) PrintObjWithKind(kind string, obj interface{}, writer io.W
 
 // LogObj will print the passed object formatted as YAML to
 // the logger.
-func (y *YAMLPrinter) LogObj(log logger.Logger, prefixFmt string, obj interface{}) error {
+func (y *YAMLPrinter) LogObj(log logger.Logger, msgFmt string, obj interface{}) error {
 	b := &bytes.Buffer{}
 	if err := y.PrintObj(obj, b); err != nil {
 		return err
 	}
 
-	log(prefixFmt+"%s", b.String())
+	log(msgFmt, strings.ReplaceAll(b.String(), "%", "%%"))
 
 	return nil
 }


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

Turns out Go 1.12 has `strings.ReplaceAll`, which is quite handy. The way `LogObj` worked wasn't particularly great, this allows user to specify full format string (they must include one `%s` for the actual object. We now also ensure that the actual objects in question don't get use as formatting strings (e.g. some Kubernetes field values use `%` character), and we also try to serialise directly whenever API-aware serialiser fails to (e.g. unregistered APIs, missing `apiVersion` etc).

Closes #603.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
