### PR TITLE
 Add `eksctl utils install-coredns`

### DIFF
--- a/pkg/addons/default/aws_node.go
+++ b/pkg/addons/default/aws_node.go
@@ -24,13 +24,13 @@ const (
 
 // UpdateAWSNode will update the `aws-node` add-on
 func UpdateAWSNode(rawClient kubernetes.RawClientInterface, region string) error {
-	_, err := rawClient.ClientSet().Apps().DaemonSets(metav1.NamespaceSystem).Get(AWSNode, metav1.GetOptions{})
+	_, err := rawClient.ClientSet().AppsV1().DaemonSets(metav1.NamespaceSystem).Get(AWSNode, metav1.GetOptions{})
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			logger.Warning("%q was not found", AWSNode)
 			return nil
 		}
-		return errors.Wrapf(err, "getting %s", AWSNode)
+		return errors.Wrapf(err, "getting %q", AWSNode)
 	}
 
 	// if DaemonSets is present, go through our list of assets

--- a/pkg/addons/default/coredns.go
+++ b/pkg/addons/default/coredns.go
@@ -1,8 +1,158 @@
 package defaultaddons
 
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/kris-nova/logger"
+	"github.com/pkg/errors"
+
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/weaveworks/eksctl/pkg/kubernetes"
+)
+
 const (
 	// CoreDNS is the name of the coredns addon
 	CoreDNS = "coredns"
 	// KubeDNS is the name of the kube-dns addon
 	KubeDNS = "kube-dns"
+
+	componentLabel = "eks.amazonaws.com/component"
+
+	coreDNSImagePrefix = "602401143452.dkr.ecr."
+	coreDNSImageSuffix = ".amazonaws.com/eks/coredns"
 )
+
+// InstallCoreDNS will install the `coredns` add-on in place of `kube-dns`
+func InstallCoreDNS(rawClient kubernetes.RawClientInterface, region string, waitTimeout *time.Duration) error {
+	coreClient := rawClient.ClientSet().CoreV1()
+	deploymentsClient := rawClient.ClientSet().AppsV1().Deployments(metav1.NamespaceSystem)
+
+	kubeDNSSevice, err := coreClient.Services(metav1.NamespaceSystem).Get(KubeDNS, metav1.GetOptions{})
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			logger.Warning("%q service was not found", KubeDNS)
+			return nil
+		}
+		return errors.Wrapf(err, "getting %q service", KubeDNS)
+	}
+
+	kubeDNSDeployment, err := deploymentsClient.Get(KubeDNS, metav1.GetOptions{})
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			logger.Warning("%q deployment was not found", KubeDNS)
+			return nil
+		}
+		return errors.Wrapf(err, "getting %q deployment", KubeDNS)
+	}
+
+	if v, ok := kubeDNSDeployment.Spec.Selector.MatchLabels[componentLabel]; !ok || v != KubeDNS {
+		logger.Debug("adding %q label to %q", componentLabel, KubeDNS)
+		kubeDNSDeployment.Spec.Selector.MatchLabels[componentLabel] = KubeDNS
+		if _, err := deploymentsClient.Update(kubeDNSDeployment); err != nil {
+			return errors.Wrapf(err, "patching %q", KubeDNS)
+		}
+	}
+
+	// if kube-dns is present, go ahead and try to replace it with coredns
+	list, err := LoadAsset(CoreDNS, "yaml")
+	if err != nil {
+		return err
+	}
+
+	listPodsOptions := metav1.ListOptions{}
+	replicas := 0
+	for _, rawObj := range list.Items {
+		resource, err := rawClient.NewRawResource(rawObj)
+		if err != nil {
+			return err
+		}
+		switch resource.GVK.Kind {
+		case "Deployment":
+			coreDNSDeployemnt := resource.Info.Object.(*extensionsv1beta1.Deployment)
+			listPodsOptions.LabelSelector = labels.FormatLabels(coreDNSDeployemnt.Spec.Selector.MatchLabels)
+			replicas = int(*coreDNSDeployemnt.Spec.Replicas)
+			image := &coreDNSDeployemnt.Spec.Template.Spec.Containers[0].Image
+			imageParts := strings.Split(*image, ":")
+
+			if len(imageParts) != 2 {
+				return fmt.Errorf("unexpected image format %q for %q", *image, KubeProxy)
+			}
+
+			if strings.HasPrefix(imageParts[0], coreDNSImagePrefix) &&
+				strings.HasSuffix(imageParts[0], coreDNSImageSuffix) {
+				*image = coreDNSImagePrefix + region + coreDNSImageSuffix + ":" + imageParts[1]
+			}
+		case "Service":
+			resource.Info.Object.(*corev1.Service).Spec.ClusterIP = kubeDNSSevice.Spec.ClusterIP
+		}
+
+		status, err := resource.CreateOrReplace()
+		if err != nil {
+			return err
+		}
+		logger.Info(status)
+	}
+
+	if waitTimeout != nil {
+		timer := time.After(*waitTimeout)
+		timeout := false
+		readyPods := sets.NewString()
+		watcher, err := coreClient.Pods(metav1.NamespaceSystem).Watch(listPodsOptions)
+		if err != nil {
+			return errors.Wrapf(err, "creating %q pod watcher", CoreDNS)
+		}
+
+		podList, err := coreClient.Pods(metav1.NamespaceSystem).List(listPodsOptions)
+		if err != nil {
+			return errors.Wrapf(err, "listing %q pods", CoreDNS)
+		}
+		for _, pod := range podList.Items {
+			if pod.Status.Phase == corev1.PodRunning {
+				readyPods.Insert(pod.Name)
+			}
+		}
+
+		logger.Info("waiting for %d of %q pods to become ready", replicas, CoreDNS)
+		for !timeout && readyPods.Len() < replicas {
+			select {
+			case event := <-watcher.ResultChan():
+				logger.Debug("event = %#v", event)
+				if event.Object != nil && event.Type != watch.Deleted {
+					if pod, ok := event.Object.(*corev1.Pod); ok {
+						if pod.Status.Phase == corev1.PodRunning {
+							readyPods.Insert(pod.Name)
+							logger.Debug("pod %q is ready", pod.Name)
+						} else {
+							logger.Debug("pod %q seen, but not ready yet", pod.Name)
+							logger.Debug("node = %#v", *pod)
+						}
+					}
+				}
+			case <-timer:
+				timeout = true
+			}
+		}
+		watcher.Stop()
+		if timeout {
+			return fmt.Errorf("timed out (after %s) waiting for %q pods to become ready", waitTimeout, CoreDNS)
+		}
+	}
+
+	if err := deploymentsClient.Delete(KubeDNS, &metav1.DeleteOptions{}); err != nil {
+		return errors.Wrapf(err, "deleting %q", KubeDNS)
+	}
+
+	logger.Info("deleted %q", KubeDNS)
+
+	logger.Info("%q is now up-to-date", CoreDNS)
+	return nil
+}

--- a/pkg/addons/default/coredns_test.go
+++ b/pkg/addons/default/coredns_test.go
@@ -1,0 +1,107 @@
+package defaultaddons_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/weaveworks/eksctl/pkg/addons/default"
+
+	"github.com/weaveworks/eksctl/pkg/testutils"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ = Describe("default addons - coredns", func() {
+	Describe("can update coredns add-on", func() {
+		var (
+			rawClient *testutils.FakeRawClient
+			ct        *testutils.CollectionTracker
+		)
+
+		It("can load sample for 1.10 and create objests that don't exist", func() {
+			sampleAddons := testutils.LoadSamples("testdata/sample-1.10.json")
+
+			rawClient = testutils.NewFakeRawClient()
+
+			rawClient.UseUnionTracker = true
+
+			for _, item := range sampleAddons {
+				rc, err := rawClient.NewRawResource(runtime.RawExtension{Object: item})
+				Expect(err).ToNot(HaveOccurred())
+				_, err = rc.CreateOrReplace()
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			ct = rawClient.Collection
+
+			Expect(ct.Updated()).To(BeEmpty())
+			Expect(ct.Created()).ToNot(BeEmpty())
+			Expect(ct.CreatedItems()).To(HaveLen(6))
+
+			Expect(ct.CreatedItems()).To(HaveLen(6))
+		})
+
+		It("has newly created objects", func() {
+			kubeDNS, err := rawClient.ClientSet().AppsV1().Deployments(metav1.NamespaceSystem).Get(KubeDNS, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kubeDNS.Spec.Template.Spec.Containers).To(HaveLen(3))
+			Expect(kubeDNS.Spec.Template.Spec.Containers[0].Image).To(
+				Equal("602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/kube-dns/kube-dns:1.14.10"),
+			)
+			Expect(kubeDNS.Spec.Template.Spec.Containers[1].Image).To(
+				Equal("602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/kube-dns/dnsmasq-nanny:1.14.10"),
+			)
+			Expect(kubeDNS.Spec.Template.Spec.Containers[2].Image).To(
+				Equal("602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/kube-dns/sidecar:1.14.10"),
+			)
+		})
+
+		It("can update 1.10 sample to latest", func() {
+			svcOld, err := rawClient.ClientSet().CoreV1().Services(metav1.NamespaceSystem).Get(KubeDNS, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// test client doesn't support watching, and we would have to create some pods, so we set nil timeout
+			err = InstallCoreDNS(rawClient, "eu-west-1", nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			updateReqs := []string{
+				"POST [/namespaces/kube-system/deployments] (kube-dns)",
+				"POST [/clusterrolebindings] (aws-node)",
+				"POST [/namespaces/kube-system/serviceaccounts] (coredns)",
+				"POST [/namespaces/kube-system/configmaps] (coredns)",
+				"POST [/namespaces/kube-system/services] (kube-dns)",
+				"POST [/namespaces/kube-system/daemonsets] (aws-node)",
+				"POST [/clusterroles] (system:coredns)",
+				"POST [/clusterrolebindings] (system:coredns)",
+				"POST [/namespaces/kube-system/deployments] (coredns)",
+				"POST [/namespaces/kube-system/daemonsets] (kube-proxy)",
+				"POST [/clusterroles] (aws-node)",
+			}
+			Expect(rawClient.Collection.Created()).To(HaveLen(len(updateReqs)))
+			for _, k := range updateReqs {
+				Expect(rawClient.Collection.Created()).To(HaveKey(k))
+			}
+
+			Expect(rawClient.Collection.UpdatedItems()).To(HaveLen(1))
+			Expect(rawClient.Collection.Updated()).To(HaveKey(
+				"PUT [/namespaces/kube-system/services/kube-dns] (kube-dns)",
+			))
+
+			svcNew, err := rawClient.ClientSet().CoreV1().Services(metav1.NamespaceSystem).Get(KubeDNS, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(svcNew.Spec.ClusterIP).To(Equal(svcOld.Spec.ClusterIP))
+
+			coreDNS, err := rawClient.ClientSet().ExtensionsV1beta1().Deployments(metav1.NamespaceSystem).Get(CoreDNS, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(coreDNS.Spec.Replicas).ToNot(BeNil())
+			Expect(*coreDNS.Spec.Replicas == 2).To(BeTrue())
+			Expect(coreDNS.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(coreDNS.Spec.Template.Spec.Containers[0].Image).To(
+				Equal("602401143452.dkr.ecr.eu-west-1.amazonaws.com/eks/coredns:v1.1.3"),
+			)
+		})
+
+	})
+})

--- a/pkg/addons/default/kube_proxy.go
+++ b/pkg/addons/default/kube_proxy.go
@@ -23,13 +23,13 @@ const (
 func UpdateKubeProxyImageTag(clientSet kubernetes.Interface, controlPlaneVersion string, dryRun bool) error {
 	printer := printers.NewJSONPrinter()
 
-	d, err := clientSet.Apps().DaemonSets(metav1.NamespaceSystem).Get(KubeProxy, metav1.GetOptions{})
+	d, err := clientSet.AppsV1().DaemonSets(metav1.NamespaceSystem).Get(KubeProxy, metav1.GetOptions{})
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			logger.Warning("%q was not found", KubeProxy)
 			return nil
 		}
-		return errors.Wrapf(err, "getting %s", KubeProxy)
+		return errors.Wrapf(err, "getting %q", KubeProxy)
 	}
 	if numContainers := len(d.Spec.Template.Spec.Containers); !(numContainers >= 1) {
 		return fmt.Errorf("%s has %d containers, expected at least 1", KubeProxy, numContainers)
@@ -65,7 +65,7 @@ func UpdateKubeProxyImageTag(clientSet kubernetes.Interface, controlPlaneVersion
 	if err := printer.LogObj(logger.Debug, KubeProxy+" [updated] = \\\n%s\n", d); err != nil {
 		return err
 	}
-	if _, err := clientSet.Apps().DaemonSets(metav1.NamespaceSystem).Update(d); err != nil {
+	if _, err := clientSet.AppsV1().DaemonSets(metav1.NamespaceSystem).Update(d); err != nil {
 		return err
 	}
 

--- a/pkg/ctl/utils/install_corends.go
+++ b/pkg/ctl/utils/install_corends.go
@@ -1,0 +1,88 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kris-nova/logger"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	defaultaddons "github.com/weaveworks/eksctl/pkg/addons/default"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha4"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/eks"
+)
+
+func installCoreDNSCmd(g *cmdutils.Grouping) *cobra.Command {
+	p := &api.ProviderConfig{}
+	cfg := api.NewClusterConfig()
+
+	cmd := &cobra.Command{
+		Use:   "install-coredns",
+		Short: "Installs latest version of CoreDNS add-on into clusters, replacing kube-dns",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := doInstallCoreDNS(p, cfg, cmdutils.GetNameArg(args), cmd); err != nil {
+				logger.Critical("%s\n", err.Error())
+				os.Exit(1)
+			}
+		},
+	}
+
+	group := g.New(cmd)
+
+	group.InFlagSet("General", func(fs *pflag.FlagSet) {
+		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name (required)")
+		cmdutils.AddRegionFlag(fs, p)
+		cmdutils.AddConfigFileFlag(&clusterConfigFile, fs)
+	})
+
+	cmdutils.AddCommonFlagsForAWS(group, p, false)
+
+	group.AddTo(cmd)
+
+	return cmd
+}
+
+func doInstallCoreDNS(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg string, cmd *cobra.Command) error {
+	if err := api.Register(); err != nil {
+		return err
+	}
+
+	if err := cmdutils.LoadMetadata(p, cfg, clusterConfigFile, nameArg, cmd); err != nil {
+		return err
+	}
+
+	ctl := eks.New(p, cfg)
+	meta := cfg.Metadata
+
+	if !ctl.IsSupportedRegion() {
+		return cmdutils.ErrUnsupportedRegion(p)
+	}
+	logger.Info("using region %s", meta.Region)
+
+	if err := ctl.CheckAuth(); err != nil {
+		return err
+	}
+
+	if err := ctl.GetCredentials(cfg); err != nil {
+		return errors.Wrapf(err, "getting credentials for cluster %q", meta.Name)
+	}
+
+	switch ctl.ControlPlaneVersion() {
+	case "":
+		return fmt.Errorf("unable to get control plane version")
+	case api.Version1_10:
+		return fmt.Errorf("%q is not supported on 1.10 cluster, run 'eksctl update cluster' first", defaultaddons.CoreDNS)
+	}
+
+	rawClient, err := ctl.NewRawClient(cfg)
+	if err != nil {
+		return err
+	}
+
+	waitTimeout := ctl.Provider.WaitTimeout()
+
+	return defaultaddons.InstallCoreDNS(rawClient, meta.Region, &waitTimeout)
+}

--- a/pkg/ctl/utils/update_aws_node.go
+++ b/pkg/ctl/utils/update_aws_node.go
@@ -74,5 +74,5 @@ func doUpdateAWSNode(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 		return err
 	}
 
-	return defaultaddons.UpdateAWSNode(rawClient, p.Region)
+	return defaultaddons.UpdateAWSNode(rawClient, meta.Region)
 }

--- a/pkg/ctl/utils/utils.go
+++ b/pkg/ctl/utils/utils.go
@@ -28,6 +28,7 @@ func Command(g *cmdutils.Grouping) *cobra.Command {
 	cmd.AddCommand(updateClusterStackCmd(g))
 	cmd.AddCommand(updateKubeProxyCmd(g))
 	cmd.AddCommand(updateAWSNodeCmd(g))
+	cmd.AddCommand(installCoreDNSCmd(g))
 
 	return cmd
 }

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -4,20 +4,22 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/weaveworks/eksctl/pkg/testutils"
 )
 
-var _ = Describe("default addons", func() {
+var _ = Describe("kubernets client wrappers", func() {
 	Describe("can create or replace missing objects", func() {
 		It("can update objects that already exist", func() {
 			sampleAddons := testutils.LoadSamples("../addons/default/testdata/sample-1.10.json")
 			ct := testutils.NewCollectionTracker()
 
 			for _, item := range sampleAddons {
-				rc, track := testutils.NewFakeRawResource(item, false, ct)
+				rc, track := testutils.NewFakeRawResource(item, false, false, ct)
 				_, err := rc.CreateOrReplace()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(track).ToNot(BeNil())
@@ -35,7 +37,7 @@ var _ = Describe("default addons", func() {
 			ct := testutils.NewCollectionTracker()
 
 			for _, item := range sampleAddons {
-				rc, track := testutils.NewFakeRawResource(item, true, ct)
+				rc, track := testutils.NewFakeRawResource(item, true, false, ct)
 				_, err := rc.CreateOrReplace()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(track).ToNot(BeNil())
@@ -48,12 +50,30 @@ var _ = Describe("default addons", func() {
 			Expect(ct.UpdatedItems()).To(BeEmpty())
 		})
 
-		It("can create objests that don't exist, and convert into a clientset", func() {
+		It("can update objects that already exist", func() {
+			sampleAddons := testutils.LoadSamples("../addons/default/testdata/sample-1.10.json")
+			ct := testutils.NewCollectionTracker()
+
+			for _, item := range sampleAddons {
+				rc, track := testutils.NewFakeRawResource(item, false, false, ct)
+				_, err := rc.CreateOrReplace()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(track).ToNot(BeNil())
+				Expect(track.Methods()).To(Equal([]string{"GET", "GET", "PUT"}))
+			}
+
+			Expect(ct.Updated()).ToNot(BeEmpty())
+			Expect(ct.UpdatedItems()).To(HaveLen(6))
+			Expect(ct.Created()).To(BeEmpty())
+			Expect(ct.CreatedItems()).To(BeEmpty())
+		})
+
+		It("can create objects and update objects in a union", func() {
 			sampleAddons := testutils.LoadSamples("../addons/default/testdata/sample-1.10.json")
 
 			rawClient := testutils.NewFakeRawClient()
 
-			rawClient.AssumeObjectsMissing = true
+			rawClient.UseUnionTracker = true
 
 			for _, item := range sampleAddons {
 				rc, err := rawClient.NewRawResource(runtime.RawExtension{Object: item})
@@ -64,9 +84,10 @@ var _ = Describe("default addons", func() {
 
 			ct := rawClient.Collection
 
-			Expect(ct.Updated()).To(BeEmpty())
 			Expect(ct.Created()).ToNot(BeEmpty())
 			Expect(ct.CreatedItems()).To(HaveLen(6))
+			Expect(ct.Updated()).To(BeEmpty())
+			Expect(ct.UpdatedItems()).To(BeEmpty())
 
 			dsl, err := rawClient.ClientSet().AppsV1().DaemonSets(metav1.NamespaceSystem).List(metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -78,6 +99,81 @@ var _ = Describe("default addons", func() {
 			Expect(awsNode.Spec.Template.Spec.Containers[0].Image).To(
 				Equal("602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazon-k8s-cni:v1.3.2"),
 			)
+
+			saTest1 := &corev1.ServiceAccount{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ServiceAccount",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test1",
+					Namespace: metav1.NamespaceDefault,
+				},
+			}
+
+			saTest2a := &corev1.ServiceAccount{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ServiceAccount",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test2",
+					Namespace: metav1.NamespaceDefault,
+					Labels:    map[string]string{"test": "2a"},
+				},
+			}
+			saTest2b := &corev1.ServiceAccount{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ServiceAccount",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test2",
+					Namespace: metav1.NamespaceDefault,
+					Labels:    map[string]string{"test": "2b"},
+				},
+			}
+
+			for _, item := range []runtime.Object{saTest1, saTest2a, saTest2b} {
+				rc, err := rawClient.NewRawResource(runtime.RawExtension{Object: item})
+				Expect(err).ToNot(HaveOccurred())
+				_, err = rc.CreateOrReplace()
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			Expect(ct.Created()).ToNot(BeEmpty())
+			Expect(ct.CreatedItems()).To(HaveLen(6 + 2))
+			Expect(ct.UpdatedItems()).ToNot(BeEmpty())
+			Expect(ct.UpdatedItems()).To(HaveLen(1))
+
+			_, err = rawClient.ClientSet().CoreV1().ServiceAccounts(metav1.NamespaceDefault).Get("test1", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = rawClient.ClientSet().CoreV1().ServiceAccounts(metav1.NamespaceDefault).Get("test2", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = rawClient.ClientSet().CoreV1().ServiceAccounts(metav1.NamespaceDefault).Create(saTest1)
+			Expect(err).To(HaveOccurred())
+
+			err = rawClient.ClientSet().CoreV1().ServiceAccounts(metav1.NamespaceDefault).Delete("test1", &metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// saving a clientset instance results in objects being trackable,
+			// but only as far as the clientset instance is concerned
+			// we need to find a way to fix this, the test is only to document
+			// this limitation
+			c := rawClient.ClientSet().CoreV1().ServiceAccounts(metav1.NamespaceDefault)
+			err = c.Delete("test1", &metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			err = c.Delete("test1", &metav1.DeleteOptions{})
+			Expect(err).To(HaveOccurred())
+
+			// however deletions of raw resources are trackable
+			rc, err := rawClient.NewRawResource(runtime.RawExtension{Object: saTest1})
+			_, err = rc.Helper.Delete(rc.Info.Namespace, rc.Info.Name)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = rawClient.ClientSet().CoreV1().ServiceAccounts(metav1.NamespaceDefault).Get("test1", metav1.GetOptions{})
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

Add `eksctl utils install-coredns` to facilitate switching from `kube-proxy` to CoreDNS during upgrades from 1.10 to 1.11.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
