### PR TITLE
Initialize ObjectMeta in authconfigmap

### DIFF
--- a/pkg/authconfigmap/authconfigmap.go
+++ b/pkg/authconfigmap/authconfigmap.go
@@ -64,6 +64,7 @@ func New(client v1.ConfigMapInterface, cm *corev1.ConfigMap) *AuthConfigMap {
 		}
 	}
 	if cm.Data == nil {
+		cm.ObjectMeta = ObjectMeta()
 		cm.Data = map[string]string{}
 	}
 	return &AuthConfigMap{client: client, cm: cm}

--- a/pkg/authconfigmap/authconfigmap_test.go
+++ b/pkg/authconfigmap/authconfigmap_test.go
@@ -85,10 +85,7 @@ var _ = Describe("AuthConfigMap{}", func() {
 			Expect(cm.Data["mapRoles"]).To(Equal(""))
 		})
 		It("should load an empty configmap", func() {
-			empty := &corev1.ConfigMap{
-				ObjectMeta: ObjectMeta(),
-				Data:       nil,
-			}
+			empty := &corev1.ConfigMap{}
 
 			client := &mockClient{}
 			acm := New(client, empty)


### PR DESCRIPTION
If a ConfigMap doesn't exist we also need to initialize the metadata.

Follow-up to #623 and #629
