### PR TITLE
Allow setting `--update-auth-config-map` on nodegroup creation

### DIFF
--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -62,6 +62,11 @@ func AddWaitFlag(wait *bool, fs *pflag.FlagSet, description string) {
 	fs.BoolVarP(wait, "wait", "w", *wait, fmt.Sprintf("wait for %s before exiting", description))
 }
 
+// AddUpdateAuthConfigMap adds common --update-auth-configmap flag
+func AddUpdateAuthConfigMap(updateAuthConfigMap *bool, fs *pflag.FlagSet, description string) {
+	fs.BoolVar(updateAuthConfigMap, "update-auth-configmap", true, description)
+}
+
 // AddCommonFlagsForKubeconfig adds common flags for controlling how output kubeconfig is written
 func AddCommonFlagsForKubeconfig(fs *pflag.FlagSet, outputPath *string, setContext, autoPath *bool, exampleName string) {
 	fs.StringVar(outputPath, "kubeconfig", kubeconfig.DefaultPath, "path to write kubeconfig (incompatible with --auto-kubeconfig)")

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -45,7 +45,7 @@ func deleteNodeGroupCmd(g *cmdutils.Grouping) *cobra.Command {
 		cmdutils.AddRegionFlag(fs, p)
 		fs.StringVarP(&ng.Name, "name", "n", "", "Name of the nodegroup to delete (required)")
 		cmdutils.AddWaitFlag(&wait, fs, "deletion of all resources")
-		fs.BoolVar(&updateAuthConfigMap, "update-auth-config-map", true, "Remove nodegroup IAM role from aws-auth config map")
+		cmdutils.AddUpdateAuthConfigMap(&updateAuthConfigMap, fs, "Remove nodegroup IAM role from aws-auth configmap")
 		fs.BoolVar(&deleteNodeGroupDrain, "drain", true, "Drain and cordon all nodes in the nodegroup before deletion")
 	})
 


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

We have it in `eksctl delete ng`, so it makes sense to add it in `eksctl create ng` also. It would allow user to have a way to opt-out from automatic configmap management entirely, perhaps they could use separate commands (see #625) or do something else.

- close #634 
- xref #544

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
