### PR TITLE
README: Add note about cluster-autoscaler not supporting multiple AZs

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -36,6 +36,7 @@ Yandy Ramirez           @IPyandy
 Jerry Jackson           @jrryjcksn
 Dann Church             @D3nn
 Roli Schilter           @rndstr
+Mitchel Humpherys       @mgalgs
 
 /* Thanks */
 


### PR DESCRIPTION
### Description

As discussed [on slack](https://weave-community.slack.com/archives/CAYBZBWGL/p1553030418232800), `cluster-autoscaler` [doesn't support ASGs which span multiple AZs](https://github.com/kubernetes/autoscaler/pull/1802#issuecomment-474295002).  Made a few clarifying notes in the README to that effect.

### Checklist

- [X] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [X] Added yourself to the `humans.txt` file
