### PR TITLE
Adding IAM policies for the EBS CSI driver

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha4/types.go
+++ b/pkg/apis/eksctl.io/v1alpha4/types.go
@@ -312,6 +312,7 @@ func (c *ClusterConfig) NewNodeGroup() *NodeGroup {
 				AutoScaler:   NewBoolFalse(),
 				ExternalDNS:  NewBoolFalse(),
 				AppMesh:      NewBoolFalse(),
+				EBSCSI:       NewBoolFalse(),
 			},
 		},
 	}

--- a/pkg/apis/eksctl.io/v1alpha4/types.go
+++ b/pkg/apis/eksctl.io/v1alpha4/types.go
@@ -420,5 +420,7 @@ type (
 		ExternalDNS *bool `json:"externalDNS"`
 		// +optional
 		AppMesh *bool `json:"appMesh"`
+		// +optional
+		EBSCSI *bool `json:"ebsCSI"`
 	}
 )

--- a/pkg/apis/eksctl.io/v1alpha4/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha4/validation.go
@@ -28,6 +28,9 @@ func validateNodeGroupIAM(i int, ng *NodeGroup, value, fieldName, path string) e
 		if v := ng.IAM.WithAddonPolicies.AppMesh; v != nil && *v {
 			return fmt.Errorf("%s.AppMesh cannot be set at the same time", p)
 		}
+		if v := ng.IAM.WithAddonPolicies.EBSCSI; v != nil && *v {
+			return fmt.Errorf("%s.ebsCSI cannot be set at the same time", p)
+		}
 	}
 	return nil
 }

--- a/pkg/apis/eksctl.io/v1alpha4/zz_generated.deepcopy.go
+++ b/pkg/apis/eksctl.io/v1alpha4/zz_generated.deepcopy.go
@@ -377,6 +377,11 @@ func (in *NodeGroupIAMAddonPolicies) DeepCopyInto(out *NodeGroupIAMAddonPolicies
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EBSCSI != nil {
+		in, out := &in.EBSCSI, &out.EBSCSI
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -342,6 +342,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 							AutoScaler:   api.NewBoolFalse(),
 							ExternalDNS:  api.NewBoolFalse(),
 							AppMesh:      api.NewBoolFalse(),
+							EBSCSI:       api.NewBoolFalse(),
 						},
 					},
 				},

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -520,11 +520,12 @@ var _ = Describe("CloudFormation template builder API", func() {
 		})
 	})
 
-	Context("NodeGroupAppMeshExternalDNS", func() {
+	Context("NodeGroupAppMeshExternalDNSEBSCSI", func() {
 		cfg, ng := newClusterConfigAndNodegroup(true)
 
 		ng.IAM.WithAddonPolicies.AppMesh = api.NewBoolTrue()
 		ng.IAM.WithAddonPolicies.ExternalDNS = api.NewBoolTrue()
+		ng.IAM.WithAddonPolicies.EBSCSI = api.NewBoolTrue()
 
 		build(cfg, "eksctl-test-megaapps-cluster", ng)
 
@@ -556,6 +557,25 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Expect(obj.Resources["PolicyAppMesh"].Properties.PolicyDocument.Statement[0].Resource).To(Equal("*"))
 			Expect(obj.Resources["PolicyAppMesh"].Properties.PolicyDocument.Statement[0].Action).To(Equal([]string{
 				"appmesh:*",
+			}))
+
+			Expect(obj.Resources["PolicyEBSCSI"]).ToNot(BeNil())
+			Expect(obj.Resources["PolicyEBSCSI"].Properties.PolicyDocument.Statement).To(HaveLen(1))
+			Expect(obj.Resources["PolicyEBSCSI"].Properties.PolicyDocument.Statement[0].Effect).To(Equal("Allow"))
+			Expect(obj.Resources["PolicyEBSCSI"].Properties.PolicyDocument.Statement[0].Resource).To(Equal("*"))
+			Expect(obj.Resources["PolicyEBSCSI"].Properties.PolicyDocument.Statement[0].Action).To(Equal([]string{
+				"ec2:AttachVolume",
+				"ec2:CreateSnapshot",
+				"ec2:CreateTags",
+				"ec2:CreateVolume",
+				"ec2:DeleteSnapshot",
+				"ec2:DeleteTags",
+				"ec2:DeleteVolume",
+				"ec2:DescribeInstances",
+				"ec2:DescribeSnapshots",
+				"ec2:DescribeTags",
+				"ec2:DescribeVolumes",
+				"ec2:DetachVolume",
 			}))
 		})
 	})

--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -217,6 +217,25 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 		)
 	}
 
+	if v := n.spec.IAM.WithAddonPolicies.EBSCSI; v != nil && *v {
+		n.rs.attachAllowPolicy("PolicyEBSCSI", refIR, "*",
+			[]string{
+				"ec2:AttachVolume",
+				"ec2:CreateSnapshot",
+				"ec2:CreateTags",
+				"ec2:CreateVolume",
+				"ec2:DeleteSnapshot",
+				"ec2:DeleteTags",
+				"ec2:DeleteVolume",
+				"ec2:DescribeInstances",
+				"ec2:DescribeSnapshots",
+				"ec2:DescribeTags",
+				"ec2:DescribeVolumes",
+				"ec2:DetachVolume",
+			},
+		)
+	}
+
 	n.rs.defineOutputFromAtt(outputs.NodeGroupInstanceProfileARN, "NodeInstanceProfile.Arn", true, func(v string) error {
 		n.spec.IAM.InstanceProfileARN = v
 		return nil


### PR DESCRIPTION
Signed-off-by: Christopher Hein <me@chrishein.com>

### Description
This adds an attribute that automatically applies the EBS CSI driver IAM policies.
<!-- Please explain the changes you made here. -->

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Added yourself to the `humans.txt` file
