### PR TITLE
updating to remove 'csi' from EBSCSI Policy Name

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha4/types.go
+++ b/pkg/apis/eksctl.io/v1alpha4/types.go
@@ -312,7 +312,7 @@ func (c *ClusterConfig) NewNodeGroup() *NodeGroup {
 				AutoScaler:   NewBoolFalse(),
 				ExternalDNS:  NewBoolFalse(),
 				AppMesh:      NewBoolFalse(),
-				EBSCSI:       NewBoolFalse(),
+				EBS:          NewBoolFalse(),
 			},
 		},
 	}
@@ -422,6 +422,6 @@ type (
 		// +optional
 		AppMesh *bool `json:"appMesh"`
 		// +optional
-		EBSCSI *bool `json:"ebsCSI"`
+		EBS *bool `json:"ebs"`
 	}
 )

--- a/pkg/apis/eksctl.io/v1alpha4/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha4/validation.go
@@ -28,8 +28,8 @@ func validateNodeGroupIAM(i int, ng *NodeGroup, value, fieldName, path string) e
 		if v := ng.IAM.WithAddonPolicies.AppMesh; v != nil && *v {
 			return fmt.Errorf("%s.AppMesh cannot be set at the same time", p)
 		}
-		if v := ng.IAM.WithAddonPolicies.EBSCSI; v != nil && *v {
-			return fmt.Errorf("%s.ebsCSI cannot be set at the same time", p)
+		if v := ng.IAM.WithAddonPolicies.EBS; v != nil && *v {
+			return fmt.Errorf("%s.ebs cannot be set at the same time", p)
 		}
 	}
 	return nil

--- a/pkg/apis/eksctl.io/v1alpha4/zz_generated.deepcopy.go
+++ b/pkg/apis/eksctl.io/v1alpha4/zz_generated.deepcopy.go
@@ -377,8 +377,8 @@ func (in *NodeGroupIAMAddonPolicies) DeepCopyInto(out *NodeGroupIAMAddonPolicies
 		*out = new(bool)
 		**out = **in
 	}
-	if in.EBSCSI != nil {
-		in, out := &in.EBSCSI, &out.EBSCSI
+	if in.EBS != nil {
+		in, out := &in.EBS, &out.EBS
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -342,7 +342,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 							AutoScaler:   api.NewBoolFalse(),
 							ExternalDNS:  api.NewBoolFalse(),
 							AppMesh:      api.NewBoolFalse(),
-							EBSCSI:       api.NewBoolFalse(),
+							EBS:          api.NewBoolFalse(),
 						},
 					},
 				},
@@ -560,19 +560,19 @@ var _ = Describe("CloudFormation template builder API", func() {
 				"appmesh:*",
 			}))
 
-			Expect(obj.Resources).ToNot(HaveKey("PolicyEBSCSI"))
+			Expect(obj.Resources).ToNot(HaveKey("PolicyEBS"))
 			Expect(obj.Resources).ToNot(HaveKey("PolicyAutoScaling"))
 		})
 
 	})
 
-	Context("NodeGroupEBSCSI", func() {
+	Context("NodeGroupEBS", func() {
 		cfg, ng := newClusterConfigAndNodegroup(true)
 
 		ng.VolumeSize = 0
-		ng.IAM.WithAddonPolicies.EBSCSI = api.NewBoolTrue()
+		ng.IAM.WithAddonPolicies.EBS = api.NewBoolTrue()
 
-		build(cfg, "eksctl-test-ebscsi-cluster", ng)
+		build(cfg, "eksctl-test-ebs-cluster", ng)
 
 		roundtript()
 
@@ -582,11 +582,11 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Expect(obj.Resources).To(HaveKey("NodeLaunchConfig"))
 			Expect(obj.Resources["NodeLaunchConfig"].Properties.BlockDeviceMappings).To(HaveLen(0))
 
-			Expect(obj.Resources).To(HaveKey("PolicyEBSCSI"))
-			Expect(obj.Resources["PolicyEBSCSI"].Properties.PolicyDocument.Statement).To(HaveLen(1))
-			Expect(obj.Resources["PolicyEBSCSI"].Properties.PolicyDocument.Statement[0].Effect).To(Equal("Allow"))
-			Expect(obj.Resources["PolicyEBSCSI"].Properties.PolicyDocument.Statement[0].Resource).To(Equal("*"))
-			Expect(obj.Resources["PolicyEBSCSI"].Properties.PolicyDocument.Statement[0].Action).To(Equal([]string{
+			Expect(obj.Resources).To(HaveKey("PolicyEBS"))
+			Expect(obj.Resources["PolicyEBS"].Properties.PolicyDocument.Statement).To(HaveLen(1))
+			Expect(obj.Resources["PolicyEBS"].Properties.PolicyDocument.Statement[0].Effect).To(Equal("Allow"))
+			Expect(obj.Resources["PolicyEBS"].Properties.PolicyDocument.Statement[0].Resource).To(Equal("*"))
+			Expect(obj.Resources["PolicyEBS"].Properties.PolicyDocument.Statement[0].Action).To(Equal([]string{
 				"ec2:AttachVolume",
 				"ec2:CreateSnapshot",
 				"ec2:CreateTags",

--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -217,8 +217,8 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 		)
 	}
 
-	if v := n.spec.IAM.WithAddonPolicies.EBSCSI; v != nil && *v {
-		n.rs.attachAllowPolicy("PolicyEBSCSI", refIR, "*",
+	if v := n.spec.IAM.WithAddonPolicies.EBS; v != nil && *v {
+		n.rs.attachAllowPolicy("PolicyEBS", refIR, "*",
 			[]string{
 				"ec2:AttachVolume",
 				"ec2:CreateSnapshot",


### PR DESCRIPTION
Signed-off-by: Christopher Hein <me@chrishein.com>

### Description
Removes the CSI name from the EBS CSI Driver Policy

<!-- Please explain the changes you made here. -->

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Added yourself to the `humans.txt` file
