### PR TITLE
 Export more stack manipulation functions

### DIFF
--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -133,10 +133,10 @@ func (c *StackCollection) UpdateStack(stackName string, changeSetName string, de
 	if err := c.doCreateChangeSetRequest(i, changeSetName, description, template, parameters, true); err != nil {
 		return err
 	}
-	if err := c.doWaitUntilChangeSetIsCreated(i, &changeSetName); err != nil {
+	if err := c.doWaitUntilChangeSetIsCreated(i, changeSetName); err != nil {
 		return err
 	}
-	changeSet, err := c.DescribeStackChangeSet(i, &changeSetName)
+	changeSet, err := c.DescribeStackChangeSet(i, changeSetName)
 	if err != nil {
 		return err
 	}
@@ -391,17 +391,17 @@ func (c *StackCollection) doExecuteChangeSet(stackName string, changeSetName str
 }
 
 // DescribeStackChangeSet gets a cloudformation changeset.
-func (c *StackCollection) DescribeStackChangeSet(i *Stack, changeSetName *string) (*ChangeSet, error) {
+func (c *StackCollection) DescribeStackChangeSet(i *Stack, changeSetName string) (*ChangeSet, error) {
 	input := &cloudformation.DescribeChangeSetInput{
 		StackName:     i.StackName,
-		ChangeSetName: changeSetName,
+		ChangeSetName: &changeSetName,
 	}
 	if i.StackId != nil {
 		input.StackName = i.StackId
 	}
 	resp, err := c.provider.CloudFormation().DescribeChangeSet(input)
 	if err != nil {
-		return nil, errors.Wrapf(err, "describing CloudFormation ChangeSet %s for stack %s", *changeSetName, *i.StackName)
+		return nil, errors.Wrapf(err, "describing CloudFormation ChangeSet %s for stack %s", changeSetName, *i.StackName)
 	}
 	return resp, nil
 }

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
@@ -14,6 +15,11 @@ import (
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha4"
 	"github.com/weaveworks/eksctl/pkg/cfn/builder"
 )
+
+// MakeChangeSetName builds a consistent name for a changeset.
+func (c *StackCollection) MakeChangeSetName(action string) string {
+	return fmt.Sprintf("eksctl-%s-%d", action, time.Now().Unix())
+}
 
 func (c *StackCollection) makeClusterStackName() string {
 	return "eksctl-" + c.spec.Metadata.Name + "-cluster"
@@ -142,7 +148,7 @@ func (c *StackCollection) AppendNewClusterStackResource(dryRun bool) (bool, erro
 		logger.Info("(dry-run) %s", describeUpdate)
 		return false, nil
 	}
-	return true, c.UpdateStack(name, "update-cluster", describeUpdate, []byte(currentTemplate), nil)
+	return true, c.UpdateStack(name, c.MakeChangeSetName("update-cluster"), describeUpdate, []byte(currentTemplate), nil)
 }
 
 func getClusterName(s *Stack) string {

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -212,7 +212,7 @@ func (c *StackCollection) ScaleNodeGroup(ng *api.NodeGroup) error {
 	}
 	logger.Debug("stack template (post-scale change): %s", template)
 
-	return c.UpdateStack(name, "scale-nodegroup", descriptionBuffer.String(), []byte(template), nil)
+	return c.UpdateStack(name, c.MakeChangeSetName("scale-nodegroup"), descriptionBuffer.String(), []byte(template), nil)
 }
 
 // GetNodeGroupSummaries returns a list of summaries for the nodegroups of a cluster

--- a/pkg/cfn/manager/waiters.go
+++ b/pkg/cfn/manager/waiters.go
@@ -48,13 +48,13 @@ func (c *StackCollection) waitWithAcceptors(i *Stack, acceptors []request.Waiter
 	return waiters.Wait(*i.StackName, msg, acceptors, newRequest, c.provider.WaitTimeout(), troubleshoot)
 }
 
-func (c *StackCollection) waitWithAcceptorsChangeSet(i *Stack, changesetName *string, acceptors []request.WaiterAcceptor) error {
-	msg := fmt.Sprintf("waiting for CloudFormation changeset %q for stack %q", *changesetName, *i.StackName)
+func (c *StackCollection) waitWithAcceptorsChangeSet(i *Stack, changesetName string, acceptors []request.WaiterAcceptor) error {
+	msg := fmt.Sprintf("waiting for CloudFormation changeset %q for stack %q", changesetName, *i.StackName)
 
 	newRequest := func() *request.Request {
 		input := &cfn.DescribeChangeSetInput{
 			StackName:     i.StackName,
-			ChangeSetName: changesetName,
+			ChangeSetName: &changesetName,
 		}
 		req, _ := c.provider.CloudFormation().DescribeChangeSetRequest(input)
 		return req
@@ -222,7 +222,7 @@ func (c *StackCollection) doWaitUntilStackIsUpdated(i *Stack) error {
 	)
 }
 
-func (c *StackCollection) doWaitUntilChangeSetIsCreated(i *Stack, changesetName *string) error {
+func (c *StackCollection) doWaitUntilChangeSetIsCreated(i *Stack, changesetName string) error {
 	return c.waitWithAcceptorsChangeSet(i, changesetName,
 		waiters.MakeAcceptors(
 			changesetStatus,

--- a/pkg/cfn/manager/waiters.go
+++ b/pkg/cfn/manager/waiters.go
@@ -36,7 +36,7 @@ func (c *StackCollection) waitWithAcceptors(i *Stack, acceptors []request.Waiter
 	}
 
 	troubleshoot := func(desiredStatus string) {
-		s, err := c.describeStack(i)
+		s, err := c.DescribeStack(i)
 		if err != nil {
 			logger.Debug("describeErr=%v", err)
 		} else {
@@ -61,7 +61,7 @@ func (c *StackCollection) waitWithAcceptorsChangeSet(i *Stack, changesetName *st
 	}
 
 	troubleshoot := func(desiredStatus string) {
-		s, err := c.describeStackChangeSet(i, changesetName)
+		s, err := c.DescribeStackChangeSet(i, changesetName)
 		if err != nil {
 			logger.Debug("describeChangeSetErr=%v", err)
 		} else {
@@ -109,7 +109,9 @@ func (c *StackCollection) troubleshootStackFailureCause(i *Stack, desiredStatus 
 	}
 }
 
-func (c *StackCollection) doWaitUntilStackIsCreated(i *Stack) error {
+// DoWaitUntilStackIsCreated blocks until the given stack's
+// creation has completed.
+func (c *StackCollection) DoWaitUntilStackIsCreated(i *Stack) error {
 	return c.waitWithAcceptors(i,
 		waiters.MakeAcceptors(
 			stackStatus,
@@ -135,11 +137,11 @@ func (c *StackCollection) doWaitUntilStackIsCreated(i *Stack) error {
 func (c *StackCollection) waitUntilStackIsCreated(i *Stack, stack builder.ResourceSet, errs chan error) {
 	defer close(errs)
 
-	if err := c.doWaitUntilStackIsCreated(i); err != nil {
+	if err := c.DoWaitUntilStackIsCreated(i); err != nil {
 		errs <- err
 		return
 	}
-	s, err := c.describeStack(i)
+	s, err := c.DescribeStack(i)
 	if err != nil {
 		errs <- err
 		return

--- a/pkg/cfn/manager/waiters.go
+++ b/pkg/cfn/manager/waiters.go
@@ -65,7 +65,7 @@ func (c *StackCollection) waitWithAcceptorsChangeSet(i *Stack, changesetName *st
 		if err != nil {
 			logger.Debug("describeChangeSetErr=%v", err)
 		} else {
-			logger.Critical("unexpected status %q while %s, reason %s", *s.Status, msg, *s.StatusReason)
+			logger.Critical("unexpected status %q while %s, reason: %s", *s.Status, msg, *s.StatusReason)
 		}
 	}
 


### PR DESCRIPTION
### Description

This PR exports a couple cloudformation stack manipulation functions to be used outside of this package. It also moves the changeset name generation out of `UpdateStack()` which now takes an argument with the name. This allows to call `DescribeStackChangeSet()` on the generated changeset in `UpdateStack()`.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [ ] All integration tests passing (i.e. `make integration-test`)