### PR TITLE
Tweaking the README to fix a typo (delete Vs create) and add the nodegroup name to the command. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,12 +330,12 @@ In general terms, you are looking to:
 
 To create a new nodegroup:
 ```
-eksctl create nodegroup --cluster=<clusterName>
+eksctl create nodegroup --cluster=<clusterName> --name=<newNodeGroupName>
 ```
 
 To delete old nodegroup:
 ```
-eksctl create nodegroup --cluster=<clusterName>
+eksctl delete nodegroup --cluster=<clusterName> --name=<oldNodeGroupName>
 ```
 
 ##### Updating multiple nodegroups with config file


### PR DESCRIPTION
### Description

I have tweaked the README file to correct what came across as a typo in a command example. I also added the explicit name of the nodegroup at creation time. 
