### PR TITLE
 Enable access from control plane to all node/pod ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,8 +456,7 @@ By default, `eksctl create cluster` will build a dedicated VPC, in order to avoi
 variety of reasons, including security, but also because it's challenging to detect all the settings in an existing VPC.
 Default VPC CIDR used by `eksctl` is `192.168.0.0/16`, it is divided into 8 (`/19`) subnets (3 private, 3 public & 2 reserved).
 Initial nodegroup is create in public subnets, with SSH access disabled unless `--allow-ssh` is specified. However, this implies
-that each of the EC2 instances in the initial nodegroup gets a public IP and can be accessed on ports 1025 - 65535, which is
-not insecure in principle, but some compromised workload could risk an access violation.
+that each of the EC2 instances in the initial nodegroup gets a public IP.
 
 If that functionality doesn't suit you, the following options are currently available.
 


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

Fixes #699.

This had been copied from the original nodegroup template, arguably it breaks Kubernetes proxy feature.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [ ] All unit tests passing (i.e. `make test`)
- [ ] All integration tests passing (i.e. `make integration-test`)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
