### PR TITLE
Import legacy public subnets

### DIFF
--- a/pkg/cfn/outputs/api.go
+++ b/pkg/cfn/outputs/api.go
@@ -17,6 +17,8 @@ const (
 	ClusterSubnetsPrivate = string("Subnets" + api.SubnetTopologyPrivate)
 	ClusterSubnetsPublic  = string("Subnets" + api.SubnetTopologyPublic)
 
+	ClusterSubnetsPublicLegacy = "Subnets"
+
 	ClusterCertificateAuthorityData = "CertificateAuthorityData"
 	ClusterEndpoint                 = "Endpoint"
 	ClusterARN                      = "ARN"

--- a/pkg/cfn/outputs/api.go
+++ b/pkg/cfn/outputs/api.go
@@ -57,15 +57,18 @@ func NewCollectorSet(set map[string]Collector) *CollectorSet {
 	return &CollectorSet{set}
 }
 
+func get(stack cfn.Stack, key string) *string {
+	for _, x := range stack.Outputs {
+		if *x.OutputKey == key {
+			return x.OutputValue
+		}
+	}
+	return nil
+}
+
 func (c *CollectorSet) doCollect(must bool, stack cfn.Stack) error {
 	for key, collector := range c.set {
-		var value *string
-		for _, x := range stack.Outputs {
-			if *x.OutputKey == key {
-				value = x.OutputValue
-				break
-			}
-		}
+		value := get(stack, key)
 		if value == nil {
 			if must {
 				err := fmt.Errorf("no output %q", key)
@@ -81,6 +84,11 @@ func (c *CollectorSet) doCollect(must bool, stack cfn.Stack) error {
 		}
 	}
 	return nil
+}
+
+// Exists check if the stack has give output key
+func Exists(stack cfn.Stack, key string) bool {
+	return get(stack, key) != nil
 }
 
 // Collect the outputs of a stack using required and optional CollectorSets

--- a/pkg/cfn/outputs/api_test.go
+++ b/pkg/cfn/outputs/api_test.go
@@ -40,6 +40,9 @@ var _ = Describe("CloudFormation stack outputs API", func() {
 					return nil
 				},
 			}
+
+			Expect(Exists(stack, ClusterVPC)).To(BeFalse())
+
 			err := Collect(stack, requiredCollectors, nil)
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).To(Equal("no output \"" + ClusterVPC + "\""))
@@ -63,6 +66,8 @@ var _ = Describe("CloudFormation stack outputs API", func() {
 					},
 				}
 
+				Expect(Exists(stack, ClusterVPC)).To(BeTrue())
+
 				err := Collect(stack, requiredCollectors, nil)
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).To(Equal("no output \"" + ClusterSecurityGroup + "\" in stack \"foo\""))
@@ -81,6 +86,10 @@ var _ = Describe("CloudFormation stack outputs API", func() {
 						return nil
 					},
 				}
+
+				Expect(Exists(stack, ClusterVPC)).To(BeTrue())
+				Expect(Exists(stack, ClusterSecurityGroup)).To(BeTrue())
+				Expect(Exists(stack, ClusterSubnetsPublicLegacy)).To(BeFalse())
 
 				err := Collect(stack, requiredCollectors, nil)
 				Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/vpc/vpc.go
+++ b/pkg/vpc/vpc.go
@@ -118,6 +118,9 @@ func UseFromCluster(provider api.ClusterProvider, stack *cfn.Stack, spec *api.Cl
 		outputs.ClusterSubnetsPublic: func(v string) error {
 			return ImportSubnetsFromList(provider, spec, api.SubnetTopologyPublic, strings.Split(v, ","))
 		},
+		outputs.ClusterSubnetsPublicLegacy: func(v string) error {
+			return ImportSubnetsFromList(provider, spec, api.SubnetTopologyPublic, strings.Split(v, ","))
+		},
 	}
 
 	return outputs.Collect(*stack, requiredCollectors, optionalCollectors)

--- a/pkg/vpc/vpc.go
+++ b/pkg/vpc/vpc.go
@@ -118,9 +118,13 @@ func UseFromCluster(provider api.ClusterProvider, stack *cfn.Stack, spec *api.Cl
 		outputs.ClusterSubnetsPublic: func(v string) error {
 			return ImportSubnetsFromList(provider, spec, api.SubnetTopologyPublic, strings.Split(v, ","))
 		},
-		outputs.ClusterSubnetsPublicLegacy: func(v string) error {
+	}
+
+	if !outputs.Exists(*stack, outputs.ClusterSubnetsPublic) &&
+		outputs.Exists(*stack, outputs.ClusterSubnetsPublicLegacy) {
+		optionalCollectors[outputs.ClusterSubnetsPublicLegacy] = func(v string) error {
 			return ImportSubnetsFromList(provider, spec, api.SubnetTopologyPublic, strings.Split(v, ","))
-		},
+		}
 	}
 
 	return outputs.Collect(*stack, requiredCollectors, optionalCollectors)


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

This should make clusters that were created with eksctl between 0.1.2 and 0.1.9 _upgradable_.

It mostly just works around the issue of missing `PublicSubnets` output, and user the equivalent `Subnets` output.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [ ] All integration tests passing (i.e. `make integration-test`)
