### PR TITLE
delete nodegroups with config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,13 +349,9 @@ eksctl delete nodegroup --cluster=<clusterName> --name=<oldNodeGroupName>
 
 If you are using config file, you will need to do the following.
 
-Get the list of old nodegroups:
-```
-old_nodegroups="$(eksctl get ng --cluster=<clusterName> --output=json | jq -r '.[].Name')"
-```
-
-Edit config file to add new nodegroups. You can remove old nodegroups from the config file now
-or do it later.
+Edit config file to add new nodegroups, and remove old nodegroups.
+If you just want to update nodegroups and keep the same configuration,
+you can just change nodegroup names, e.g. append `-v2` to the name.
 
 To create all of new nodegroups defined in the config file, run:
 ```
@@ -364,9 +360,10 @@ eksctl create nodegroup --config-file=<path>
 
 Once you have new nodegroups in place, you can delete old ones:
 ```
-for ng in $old_nodegroups ; do eksctl delete nodegroup --cluster=<clusterName> --name=$ng ; done
+eksctl delete nodegroup --config-file=<path> --only-missing
 ```
-> NOTE: all pods will be drained.
+> NOTE: first run is in plan mode, if you are happy with the proposed
+> changes, re-run with `--approve`.
 
 #### Updating default add-ons
 
@@ -374,6 +371,9 @@ There are 3 default add-ons that get included in each EKS cluster, the process f
 there are 3 distinct commands that you will need to run.
 
 > NOTE: all of the following commands accept `--config-file`.
+
+> NOTE: by default each of these commands runs in plan mode,
+> if you are happy with the proposed changes, re-run with `--approve`.
 
 To update `kube-proxy`, run:
 ```

--- a/integration/podinfo.yaml
+++ b/integration/podinfo.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: podinfod
-        image: quay.io/stefanprodan/podinfo:1.0.1
+        image: stefanprodan/podinfo:1.5.1@sha256:702633d438950f3675d0763a4ca6cfcf21a4d065cd7f470446c67607b1a26750
         command:
         - ./podinfo
         - --port=8080

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -219,10 +219,35 @@ func nonTransitionalReadyStackStatuses() []string {
 	return []string{
 		cloudformation.StackStatusCreateComplete,
 		cloudformation.StackStatusUpdateComplete,
-		cloudformation.StackStatusUpdateCompleteCleanupInProgress,
 		cloudformation.StackStatusRollbackComplete,
-		cloudformation.StackStatusUpdateRollbackCompleteCleanupInProgress,
 		cloudformation.StackStatusUpdateRollbackComplete,
+	}
+}
+
+// StackStatusIsNotReady will return true when stack statate is non-ready
+func (*StackCollection) StackStatusIsNotReady(s *Stack) bool {
+	for _, state := range nonReadyStackStatuses() {
+		if *s.StackStatus == state {
+			return true
+		}
+	}
+	return false
+}
+
+func nonReadyStackStatuses() []string {
+	return []string{
+		cloudformation.StackStatusCreateInProgress,
+		cloudformation.StackStatusCreateFailed,
+		cloudformation.StackStatusRollbackInProgress,
+		cloudformation.StackStatusRollbackFailed,
+		cloudformation.StackStatusDeleteInProgress,
+		cloudformation.StackStatusDeleteFailed,
+		cloudformation.StackStatusUpdateInProgress,
+		cloudformation.StackStatusUpdateCompleteCleanupInProgress,
+		cloudformation.StackStatusUpdateRollbackInProgress,
+		cloudformation.StackStatusUpdateRollbackFailed,
+		cloudformation.StackStatusUpdateRollbackCompleteCleanupInProgress,
+		cloudformation.StackStatusReviewInProgress,
 	}
 }
 

--- a/pkg/cfn/manager/delete_tasks.go
+++ b/pkg/cfn/manager/delete_tasks.go
@@ -57,7 +57,7 @@ func (c *StackCollection) NewTasksToDeleteNodeGroups(onlySubset sets.String, wai
 	tasks := &TaskTree{Parallel: true}
 
 	for _, s := range nodeGroupStacks {
-		name := getNodeGroupName(s)
+		name := c.GetNodeGroupName(s)
 		if onlySubset != nil && !onlySubset.Has(name) {
 			continue
 		}

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -72,7 +72,7 @@ func (c *StackCollection) DescribeNodeGroupStacks() ([]*Stack, error) {
 		if *s.StackStatus == cfn.StackStatusDeleteComplete {
 			continue
 		}
-		if getNodeGroupName(s) != "" {
+		if c.GetNodeGroupName(s) != "" {
 			nodeGroupStacks = append(nodeGroupStacks, s)
 		}
 	}
@@ -89,7 +89,7 @@ func (c *StackCollection) ListNodeGroupStacks() ([]string, error) {
 
 	names := []string{}
 	for _, s := range stacks {
-		names = append(names, getNodeGroupName(s))
+		names = append(names, c.GetNodeGroupName(s))
 	}
 	return names, nil
 }
@@ -116,7 +116,7 @@ func (c *StackCollection) DescribeNodeGroupStacksAndResources() (map[string]Stac
 		if err != nil {
 			return nil, errors.Wrapf(err, "getting all resources for %q stack", *s.StackName)
 		}
-		allResources[getNodeGroupName(s)] = StackInfo{
+		allResources[c.GetNodeGroupName(s)] = StackInfo{
 			Resources: resources.StackResources,
 			Template:  &template,
 			Stack:     s,
@@ -218,7 +218,7 @@ func (c *StackCollection) mapStackToNodeGroupSummary(stack *Stack) (*NodeGroupSu
 	}
 
 	cluster := getClusterNameTag(stack)
-	name := getNodeGroupName(stack)
+	name := c.GetNodeGroupName(stack)
 	maxSize := gjson.Get(template, maxSizePath)
 	minSize := gjson.Get(template, minSizePath)
 	desired := gjson.Get(template, desiredCapacityPath)
@@ -240,7 +240,8 @@ func (c *StackCollection) mapStackToNodeGroupSummary(stack *Stack) (*NodeGroupSu
 	return summary, nil
 }
 
-func getNodeGroupName(s *Stack) string {
+// GetNodeGroupName will return nodegroup name based on tags
+func (*StackCollection) GetNodeGroupName(s *Stack) string {
 	for _, tag := range s.Tags {
 		if *tag.Key == api.NodeGroupNameTag {
 			return *tag.Value

--- a/pkg/ctl/delete/delete.go
+++ b/pkg/ctl/delete/delete.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	wait = false
+	plan = true
 )
 
 // Command will create the `delete` commands

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha4"
 	"github.com/weaveworks/eksctl/pkg/authconfigmap"
@@ -19,6 +18,11 @@ import (
 var (
 	updateAuthConfigMap  bool
 	deleteNodeGroupDrain bool
+
+	includeNodeGroups []string
+	excludeNodeGroups []string
+
+	deleteOnlyMissingNodeGroups bool
 )
 
 func deleteNodeGroupCmd(g *cmdutils.Grouping) *cobra.Command {
@@ -30,8 +34,8 @@ func deleteNodeGroupCmd(g *cmdutils.Grouping) *cobra.Command {
 		Use:     "nodegroup",
 		Short:   "Delete a nodegroup",
 		Aliases: []string{"ng"},
-		Run: func(_ *cobra.Command, args []string) {
-			if err := doDeleteNodeGroup(p, cfg, ng, cmdutils.GetNameArg(args)); err != nil {
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := doDeleteNodeGroup(p, cfg, ng, cmdutils.GetNameArg(args), cmd); err != nil {
 				logger.Critical("%s\n", err.Error())
 				os.Exit(1)
 			}
@@ -43,10 +47,14 @@ func deleteNodeGroupCmd(g *cmdutils.Grouping) *cobra.Command {
 	group.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")
 		cmdutils.AddRegionFlag(fs, p)
-		fs.StringVarP(&ng.Name, "name", "n", "", "Name of the nodegroup to delete (required)")
-		cmdutils.AddWaitFlag(&wait, fs, "deletion of all resources")
+		fs.StringVarP(&ng.Name, "name", "n", "", "Name of the nodegroup to delete")
+		cmdutils.AddConfigFileFlag(&clusterConfigFile, fs)
+		cmdutils.AddApproveFlag(&plan, cmd, fs)
+		cmdutils.AddNodeGroupFilterFlags(&includeNodeGroups, &excludeNodeGroups, fs)
+		fs.BoolVar(&deleteOnlyMissingNodeGroups, "only-missing", false, "Only delete nodegroups that are not defined in the given config file")
 		cmdutils.AddUpdateAuthConfigMap(&updateAuthConfigMap, fs, "Remove nodegroup IAM role from aws-auth configmap")
 		fs.BoolVar(&deleteNodeGroupDrain, "drain", true, "Drain and cordon all nodes in the nodegroup before deletion")
+		cmdutils.AddWaitFlag(&wait, fs, "deletion of all resources")
 	})
 
 	cmdutils.AddCommonFlagsForAWS(group, p, true)
@@ -56,31 +64,17 @@ func deleteNodeGroupCmd(g *cmdutils.Grouping) *cobra.Command {
 	return cmd
 }
 
-func doDeleteNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.NodeGroup, nameArg string) error {
-	ctl := eks.New(p, cfg)
+func doDeleteNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.NodeGroup, nameArg string, cmd *cobra.Command) error {
+	ngFilter := cmdutils.NewNodeGroupFilter()
 
-	if err := api.Register(); err != nil {
+	if err := cmdutils.NewDeleteNodeGroupLoader(p, cfg, ng, clusterConfigFile, nameArg, cmd, ngFilter, includeNodeGroups, excludeNodeGroups, &plan).Load(); err != nil {
 		return err
 	}
+
+	ctl := eks.New(p, cfg)
 
 	if err := ctl.CheckAuth(); err != nil {
 		return err
-	}
-
-	if cfg.Metadata.Name == "" {
-		return cmdutils.ErrMustBeSet("--cluster")
-	}
-
-	if ng.Name != "" && nameArg != "" {
-		return cmdutils.ErrNameFlagAndArg(ng.Name, nameArg)
-	}
-
-	if nameArg != "" {
-		ng.Name = nameArg
-	}
-
-	if ng.Name == "" {
-		return cmdutils.ErrMustBeSet("--name")
 	}
 
 	if err := ctl.GetCredentials(cfg); err != nil {
@@ -92,40 +86,74 @@ func doDeleteNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.No
 		return err
 	}
 
+	stackManager := ctl.NewStackManager(cfg)
+
+	if clusterConfigFile != "" {
+		logger.Info("comparing %d nodegroups defined in the given config (%q) against remote state", len(cfg.NodeGroups), clusterConfigFile)
+		if err := ngFilter.SetIncludeOrExcludeMissingFilter(stackManager, deleteOnlyMissingNodeGroups, &cfg.NodeGroups); err != nil {
+			return err
+		}
+	}
+
+	ngSubset, _ := ngFilter.MatchAll(cfg.NodeGroups)
+	ngCount := ngSubset.Len()
+
+	ngFilter.LogInfo(cfg.NodeGroups)
+
 	if updateAuthConfigMap {
-		// remove node group from config map
-		if err := authconfigmap.RemoveNodeGroup(clientSet, ng); err != nil {
-			logger.Warning(err.Error())
+		cmdutils.LogIntendedAction(plan, "delete %d nodegroups from auth ConfigMap in cluster %q", ngCount, cfg.Metadata.Name)
+		err := ngFilter.ForEach(cfg.NodeGroups, func(_ int, ng *api.NodeGroup) error {
+			if plan {
+				return nil
+			}
+			if ng.IAM == nil || ng.IAM.InstanceRoleARN == "" {
+				if err := ctl.GetNodeGroupIAM(stackManager, cfg, ng); err != nil {
+					logger.Warning("error getting instance role ARN for nodegroup %q", ng.Name)
+					return nil
+				}
+			}
+			if err := authconfigmap.RemoveNodeGroup(clientSet, ng); err != nil {
+				logger.Warning(err.Error())
+			}
+			return nil
+		})
+		if err != nil {
+			return err
 		}
 	}
 
 	if deleteNodeGroupDrain {
-		if err := drain.NodeGroup(clientSet, ng, ctl.Provider.WaitTimeout(), false); err != nil {
-			return err
-		}
-	}
-
-	stackManager := ctl.NewStackManager(cfg)
-
-	if ng.IAM.InstanceRoleARN == "" {
-		if err := ctl.GetNodeGroupIAM(cfg, ng); err != nil {
-			logger.Warning("%s getting instance role ARN for node group %q", err.Error(), ng.Name)
-		}
-	}
-
-	logger.Info("deleting nodegroup %q in cluster %q", ng.Name, cfg.Metadata.Name)
-
-	{
-		tasks, err := stackManager.NewTasksToDeleteNodeGroups(sets.NewString(ng.Name), wait, nil)
+		cmdutils.LogIntendedAction(plan, "drain %d nodegroups in cluster %q", ngCount, cfg.Metadata.Name)
+		err := ngFilter.ForEach(cfg.NodeGroups, func(_ int, ng *api.NodeGroup) error {
+			if plan {
+				return nil
+			}
+			if err := drain.NodeGroup(clientSet, ng, ctl.Provider.WaitTimeout(), false); err != nil {
+				return err
+			}
+			return nil
+		})
 		if err != nil {
 			return err
 		}
+	}
+
+	cmdutils.LogIntendedAction(plan, "delete %d nodegroups from cluster %q", ngCount, cfg.Metadata.Name)
+
+	{
+		tasks, err := stackManager.NewTasksToDeleteNodeGroups(ngSubset, wait, nil)
+		if err != nil {
+			return err
+		}
+		tasks.PlanMode = plan
 		logger.Info(tasks.Describe())
 		if errs := tasks.DoAllSync(); len(errs) > 0 {
 			return handleErrors(errs, "nodegroup(s)")
 		}
-		logger.Success("all nodes in nodegroup %q will be deleted", ng.Name)
+		cmdutils.LogCompletedAction(plan, "deleted %d nodegroups from cluster %q", ngCount, cfg.Metadata.Name)
 	}
+
+	cmdutils.LogPlanModeWarning(plan && ngCount > 0)
 
 	return nil
 }


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->


Enhance `eksctl delete nodegroup`:

- add functionality to delete multiple nodegroups with `--config-file`
- and `--include`/`--exclude` filters
- add `--only-missing` (inverted fitering)
- add `--approve` (only with `--config-file`)

Fixes #664.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
