### PR TITLE
Add reference value helpers for *bool and *string

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha4/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha4/defaults.go
@@ -18,25 +18,25 @@ func SetNodeGroupDefaults(_ int, ng *NodeGroup) error {
 		}
 	}
 	if ng.SecurityGroups.WithLocal == nil {
-		ng.SecurityGroups.WithLocal = NewBoolTrue()
+		ng.SecurityGroups.WithLocal = Enabled()
 	}
 	if ng.SecurityGroups.WithShared == nil {
-		ng.SecurityGroups.WithShared = NewBoolTrue()
+		ng.SecurityGroups.WithShared = Enabled()
 	}
 
 	if ng.SSH == nil {
 		ng.SSH = &NodeGroupSSH{
-			Allow: NewBoolFalse(),
+			Allow: Disabled(),
 		}
 	}
 
 	if ng.SSH.Allow == nil {
-		ng.SSH.Allow = NewBoolFalse()
+		ng.SSH.Allow = Disabled()
 	}
 
 	// Enable SSH when a key is provided
 	if ng.SSH.PublicKeyPath != nil {
-		ng.SSH.Allow = NewBoolTrue()
+		ng.SSH.Allow = Enabled()
 	}
 
 	if *ng.SSH.Allow && ng.SSH.PublicKeyPath == nil {
@@ -53,25 +53,25 @@ func SetNodeGroupDefaults(_ int, ng *NodeGroup) error {
 		ng.IAM = &NodeGroupIAM{}
 	}
 	if ng.IAM.WithAddonPolicies.ImageBuilder == nil {
-		ng.IAM.WithAddonPolicies.ImageBuilder = NewBoolFalse()
+		ng.IAM.WithAddonPolicies.ImageBuilder = Disabled()
 	}
 	if ng.IAM.WithAddonPolicies.AutoScaler == nil {
-		ng.IAM.WithAddonPolicies.AutoScaler = NewBoolFalse()
+		ng.IAM.WithAddonPolicies.AutoScaler = Disabled()
 	}
 	if ng.IAM.WithAddonPolicies.ExternalDNS == nil {
-		ng.IAM.WithAddonPolicies.ExternalDNS = NewBoolFalse()
+		ng.IAM.WithAddonPolicies.ExternalDNS = Disabled()
 	}
 	if ng.IAM.WithAddonPolicies.ALBIngress == nil {
-		ng.IAM.WithAddonPolicies.ALBIngress = NewBoolFalse()
+		ng.IAM.WithAddonPolicies.ALBIngress = Disabled()
 	}
 	if ng.IAM.WithAddonPolicies.EBS == nil {
-		ng.IAM.WithAddonPolicies.EBS = NewBoolFalse()
+		ng.IAM.WithAddonPolicies.EBS = Disabled()
 	}
 	if ng.IAM.WithAddonPolicies.FSX == nil {
-		ng.IAM.WithAddonPolicies.FSX = NewBoolFalse()
+		ng.IAM.WithAddonPolicies.FSX = Disabled()
 	}
 	if ng.IAM.WithAddonPolicies.EFS == nil {
-		ng.IAM.WithAddonPolicies.EFS = NewBoolFalse()
+		ng.IAM.WithAddonPolicies.EFS = Disabled()
 	}
 
 	return nil

--- a/pkg/apis/eksctl.io/v1alpha4/defaults_test.go
+++ b/pkg/apis/eksctl.io/v1alpha4/defaults_test.go
@@ -15,7 +15,7 @@ var _ = Describe("Default settings", func() {
 		It("Providing an SSH key enables SSH", func() {
 			testNodeGroup := NodeGroup{
 				SSH: &NodeGroupSSH{
-					Allow:         NewBoolFalse(),
+					Allow:         Disabled(),
 					PublicKeyPath: &testKeyPath,
 				},
 			}
@@ -28,7 +28,7 @@ var _ = Describe("Default settings", func() {
 		It("Enabling SSH without a key uses default key", func() {
 			testNodeGroup := NodeGroup{
 				SSH: &NodeGroupSSH{
-					Allow: NewBoolTrue(),
+					Allow: Enabled(),
 				},
 			}
 

--- a/pkg/apis/eksctl.io/v1alpha4/types.go
+++ b/pkg/apis/eksctl.io/v1alpha4/types.go
@@ -123,19 +123,28 @@ var (
 	DefaultNodeSSHPublicKeyPath = "~/.ssh/id_rsa.pub"
 )
 
-// NewBoolTrue return pointer to true value
+// Enabled return pointer to true value
 // for use in defaulters of *bool fields
-func NewBoolTrue() *bool {
+func Enabled() *bool {
 	v := true
 	return &v
 }
 
-// NewBoolFalse return pointer to false value
+// Disabled return pointer to false value
 // for use in defaulters of *bool fields
-func NewBoolFalse() *bool {
+func Disabled() *bool {
 	v := false
 	return &v
 }
+
+// IsEnabled will only return true if v is not nil and true
+func IsEnabled(v *bool) bool { return v != nil && *v }
+
+// IsDisabled will only return true if v is not nil and false
+func IsDisabled(v *bool) bool { return v != nil && !*v }
+
+// IsSetAndNonEmptyString will only return true if s is not nil and not empty
+func IsSetAndNonEmptyString(s *string) bool { return s != nil && *s != "" }
 
 // SupportedRegions are the regions where EKS is available
 func SupportedRegions() []string {
@@ -317,8 +326,8 @@ func (c *ClusterConfig) NewNodeGroup() *NodeGroup {
 		PrivateNetworking: false,
 		SecurityGroups: &NodeGroupSGs{
 			AttachIDs:  []string{},
-			WithLocal:  NewBoolTrue(),
-			WithShared: NewBoolTrue(),
+			WithLocal:  Enabled(),
+			WithShared: Enabled(),
 		},
 		DesiredCapacity: nil,
 		InstanceType:    DefaultNodeType,
@@ -326,18 +335,18 @@ func (c *ClusterConfig) NewNodeGroup() *NodeGroup {
 		VolumeType:      DefaultNodeVolumeType,
 		IAM: &NodeGroupIAM{
 			WithAddonPolicies: NodeGroupIAMAddonPolicies{
-				ImageBuilder: NewBoolFalse(),
-				AutoScaler:   NewBoolFalse(),
-				ExternalDNS:  NewBoolFalse(),
-				AppMesh:      NewBoolFalse(),
-				EBS:          NewBoolFalse(),
-				FSX:          NewBoolFalse(),
-				EFS:          NewBoolFalse(),
-				ALBIngress:   NewBoolFalse(),
+				ImageBuilder: Disabled(),
+				AutoScaler:   Disabled(),
+				ExternalDNS:  Disabled(),
+				AppMesh:      Disabled(),
+				EBS:          Disabled(),
+				FSX:          Disabled(),
+				EFS:          Disabled(),
+				ALBIngress:   Disabled(),
 			},
 		},
 		SSH: &NodeGroupSSH{
-			Allow:         NewBoolFalse(),
+			Allow:         Disabled(),
 			PublicKeyPath: &DefaultNodeSSHPublicKeyPath,
 		},
 	}

--- a/pkg/apis/eksctl.io/v1alpha4/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha4/validation.go
@@ -16,28 +16,28 @@ func validateNodeGroupIAM(i int, ng *NodeGroup, value, fieldName, path string) e
 		if len(ng.IAM.AttachPolicyARNs) != 0 {
 			return fmt.Errorf("%s.attachPolicyARNs cannot be set at the same time", p)
 		}
-		if v := ng.IAM.WithAddonPolicies.AutoScaler; v != nil && *v {
+		if IsEnabled(ng.IAM.WithAddonPolicies.AutoScaler) {
 			return fmt.Errorf("%s.withAddonPolicies.autoScaler cannot be set at the same time", p)
 		}
-		if v := ng.IAM.WithAddonPolicies.ExternalDNS; v != nil && *v {
+		if IsEnabled(ng.IAM.WithAddonPolicies.ExternalDNS) {
 			return fmt.Errorf("%s.withAddonPolicies.externalDNS cannot be set at the same time", p)
 		}
-		if v := ng.IAM.WithAddonPolicies.ImageBuilder; v != nil && *v {
+		if IsEnabled(ng.IAM.WithAddonPolicies.ImageBuilder) {
 			return fmt.Errorf("%s.imageBuilder cannot be set at the same time", p)
 		}
-		if v := ng.IAM.WithAddonPolicies.AppMesh; v != nil && *v {
+		if IsEnabled(ng.IAM.WithAddonPolicies.AppMesh) {
 			return fmt.Errorf("%s.AppMesh cannot be set at the same time", p)
 		}
-		if v := ng.IAM.WithAddonPolicies.EBS; v != nil && *v {
+		if IsEnabled(ng.IAM.WithAddonPolicies.EBS) {
 			return fmt.Errorf("%s.ebs cannot be set at the same time", p)
 		}
-		if v := ng.IAM.WithAddonPolicies.FSX; v != nil && *v {
+		if IsEnabled(ng.IAM.WithAddonPolicies.FSX) {
 			return fmt.Errorf("%s.fsx cannot be set at the same time", p)
 		}
-		if v := ng.IAM.WithAddonPolicies.EFS; v != nil && *v {
+		if IsEnabled(ng.IAM.WithAddonPolicies.EFS) {
 			return fmt.Errorf("%s.efs cannot be set at the same time", p)
 		}
-		if v := ng.IAM.WithAddonPolicies.ALBIngress; v != nil && *v {
+		if IsEnabled(ng.IAM.WithAddonPolicies.ALBIngress) {
 			return fmt.Errorf("%s.albIngress cannot be set at the same time", p)
 		}
 	}

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -330,8 +330,8 @@ var _ = Describe("CloudFormation template builder API", func() {
 					Name:              "ng-abcd1234",
 					PrivateNetworking: false,
 					SecurityGroups: &api.NodeGroupSGs{
-						WithLocal:  api.NewBoolTrue(),
-						WithShared: api.NewBoolTrue(),
+						WithLocal:  api.Enabled(),
+						WithShared: api.Enabled(),
 						AttachIDs:  []string{},
 					},
 					DesiredCapacity: nil,
@@ -339,18 +339,18 @@ var _ = Describe("CloudFormation template builder API", func() {
 					VolumeType:      api.NodeVolumeTypeIO1,
 					IAM: &api.NodeGroupIAM{
 						WithAddonPolicies: api.NodeGroupIAMAddonPolicies{
-							ImageBuilder: api.NewBoolFalse(),
-							AutoScaler:   api.NewBoolFalse(),
-							ExternalDNS:  api.NewBoolFalse(),
-							AppMesh:      api.NewBoolFalse(),
-							EBS:          api.NewBoolFalse(),
-							FSX:          api.NewBoolFalse(),
-							EFS:          api.NewBoolFalse(),
-							ALBIngress:   api.NewBoolFalse(),
+							ImageBuilder: api.Disabled(),
+							AutoScaler:   api.Disabled(),
+							ExternalDNS:  api.Disabled(),
+							AppMesh:      api.Disabled(),
+							EBS:          api.Disabled(),
+							FSX:          api.Disabled(),
+							EFS:          api.Disabled(),
+							ALBIngress:   api.Disabled(),
 						},
 					},
 					SSH: &api.NodeGroupSSH{
-						Allow:         api.NewBoolFalse(),
+						Allow:         api.Disabled(),
 						PublicKeyPath: &defaultSSHKeyPath,
 					},
 				},
@@ -475,7 +475,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 	Context("NodeGroupAutoScaling", func() {
 		cfg, ng := newClusterConfigAndNodegroup(true)
 
-		ng.IAM.WithAddonPolicies.AutoScaler = api.NewBoolTrue()
+		ng.IAM.WithAddonPolicies.AutoScaler = api.Enabled()
 
 		build(cfg, "eksctl-test-123-cluster", ng)
 
@@ -533,8 +533,8 @@ var _ = Describe("CloudFormation template builder API", func() {
 	Context("NodeGroupAppMeshExternalDNS", func() {
 		cfg, ng := newClusterConfigAndNodegroup(true)
 
-		ng.IAM.WithAddonPolicies.AppMesh = api.NewBoolTrue()
-		ng.IAM.WithAddonPolicies.ExternalDNS = api.NewBoolTrue()
+		ng.IAM.WithAddonPolicies.AppMesh = api.Enabled()
+		ng.IAM.WithAddonPolicies.ExternalDNS = api.Enabled()
 
 		build(cfg, "eksctl-test-megaapps-cluster", ng)
 
@@ -577,7 +577,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 	Context("NodeGroupALBIngress", func() {
 		cfg, ng := newClusterConfigAndNodegroup(true)
 
-		ng.IAM.WithAddonPolicies.ALBIngress = api.NewBoolTrue()
+		ng.IAM.WithAddonPolicies.ALBIngress = api.Enabled()
 
 		build(cfg, "eksctl-test-megaapps-cluster", ng)
 
@@ -664,7 +664,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 		cfg, ng := newClusterConfigAndNodegroup(true)
 
 		ng.VolumeSize = 0
-		ng.IAM.WithAddonPolicies.EBS = api.NewBoolTrue()
+		ng.IAM.WithAddonPolicies.EBS = api.Enabled()
 
 		build(cfg, "eksctl-test-ebs-cluster", ng)
 
@@ -706,7 +706,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 		cfg, ng := newClusterConfigAndNodegroup(true)
 
 		ng.VolumeSize = 0
-		ng.IAM.WithAddonPolicies.FSX = api.NewBoolTrue()
+		ng.IAM.WithAddonPolicies.FSX = api.Enabled()
 
 		build(cfg, "eksctl-test-fsx-cluster", ng)
 
@@ -732,12 +732,12 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Expect(obj.Resources).ToNot(HaveKey("PolicyAppMesh"))
 		})
 	})
-	
+
 	Context("NodeGroupEFS", func() {
 		cfg, ng := newClusterConfigAndNodegroup(true)
 
 		ng.VolumeSize = 0
-		ng.IAM.WithAddonPolicies.EFS = api.NewBoolTrue()
+		ng.IAM.WithAddonPolicies.EFS = api.Enabled()
 
 		build(cfg, "eksctl-test-efs-cluster", ng)
 
@@ -767,7 +767,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 	Context("NodeGroup{PrivateNetworking=true SSH.Allow=true}", func() {
 		cfg, ng := newClusterConfigAndNodegroup(true)
 
-		ng.SSH.Allow = api.NewBoolTrue()
+		ng.SSH.Allow = api.Enabled()
 		keyName := ""
 		ng.SSH.PublicKeyName = &keyName
 		ng.InstanceType = "t2.medium"
@@ -825,7 +825,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 	Context("NodeGroup{PrivateNetworking=false SSH.Allow=true}", func() {
 		cfg, ng := newClusterConfigAndNodegroup(true)
 
-		ng.SSH.Allow = api.NewBoolTrue()
+		ng.SSH.Allow = api.Enabled()
 		keyName := ""
 		ng.SSH.PublicKeyName = &keyName
 		ng.InstanceType = "t2.medium"
@@ -906,7 +906,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 		}
 
 		ng.AvailabilityZones = []string{testAZs[1]}
-		ng.SSH.Allow = api.NewBoolFalse()
+		ng.SSH.Allow = api.Disabled()
 		ng.InstanceType = "t2.medium"
 		ng.PrivateNetworking = false
 		ng.AMIFamily = "AmazonLinux2"

--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -159,7 +159,7 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 	if len(n.spec.IAM.AttachPolicyARNs) == 0 {
 		n.spec.IAM.AttachPolicyARNs = iamDefaultNodePolicyARNs
 	}
-	if v := n.spec.IAM.WithAddonPolicies.ImageBuilder; v != nil && *v {
+	if api.IsEnabled(n.spec.IAM.WithAddonPolicies.ImageBuilder) {
 		n.spec.IAM.AttachPolicyARNs = append(n.spec.IAM.AttachPolicyARNs, iamPolicyAmazonEC2ContainerRegistryPowerUserARN)
 	} else {
 		n.spec.IAM.AttachPolicyARNs = append(n.spec.IAM.AttachPolicyARNs, iamPolicyAmazonEC2ContainerRegistryReadOnlyARN)
@@ -182,7 +182,7 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 		Roles: makeSlice(refIR),
 	})
 
-	if v := n.spec.IAM.WithAddonPolicies.AutoScaler; v != nil && *v {
+	if api.IsEnabled(n.spec.IAM.WithAddonPolicies.AutoScaler) {
 		n.rs.attachAllowPolicy("PolicyAutoScaling", refIR, "*",
 			[]string{
 				"autoscaling:DescribeAutoScalingGroups",
@@ -195,7 +195,7 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 		)
 	}
 
-	if v := n.spec.IAM.WithAddonPolicies.ExternalDNS; v != nil && *v {
+	if api.IsEnabled(n.spec.IAM.WithAddonPolicies.ExternalDNS) {
 		n.rs.attachAllowPolicy("PolicyExternalDNSChangeSet", refIR, "arn:aws:route53:::hostedzone/*",
 			[]string{
 				"route53:ChangeResourceRecordSets",
@@ -209,7 +209,7 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 		)
 	}
 
-	if v := n.spec.IAM.WithAddonPolicies.AppMesh; v != nil && *v {
+	if api.IsEnabled(n.spec.IAM.WithAddonPolicies.AppMesh) {
 		n.rs.attachAllowPolicy("PolicyAppMesh", refIR, "*",
 			[]string{
 				"appmesh:*",
@@ -217,7 +217,7 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 		)
 	}
 
-	if v := n.spec.IAM.WithAddonPolicies.EBS; v != nil && *v {
+	if api.IsEnabled(n.spec.IAM.WithAddonPolicies.EBS) {
 		n.rs.attachAllowPolicy("PolicyEBS", refIR, "*",
 			[]string{
 				"ec2:AttachVolume",
@@ -236,7 +236,7 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 		)
 	}
 
-	if v := n.spec.IAM.WithAddonPolicies.FSX; v != nil && *v {
+	if api.IsEnabled(n.spec.IAM.WithAddonPolicies.FSX) {
 		n.rs.attachAllowPolicy("PolicyFSX", refIR, "*",
 			[]string{
 				"fsx:*",
@@ -245,13 +245,13 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 		n.rs.attachAllowPolicy("PolicyServiceLinkRole", refIR, "arn:aws:iam::*:role/aws-service-role/*",
 			[]string{
 				"iam:CreateServiceLinkedRole",
-        "iam:AttachRolePolicy",
-        "iam:PutRolePolicy",
+				"iam:AttachRolePolicy",
+				"iam:PutRolePolicy",
 			},
 		)
 	}
 
-		if v := n.spec.IAM.WithAddonPolicies.EFS; v != nil && *v {
+	if api.IsEnabled(n.spec.IAM.WithAddonPolicies.EFS) {
 		n.rs.attachAllowPolicy("PolicyEFS", refIR, "arn:aws:elasticfilesystem:us-west-2:123456789012:file-system/*",
 			[]string{
 				"elasticfilesystem:*",
@@ -260,16 +260,16 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 		n.rs.attachAllowPolicy("PolicyEFSEC2", refIR, "*",
 			[]string{
 				"ec2:DescribeSubnets",
-        "ec2:CreateNetworkInterface",
-        "ec2:DescribeNetworkInterfaces",
-        "ec2:DeleteNetworkInterface",
-        "ec2:ModifyNetworkInterfaceAttribute",
-        "ec2:DescribeNetworkInterfaceAttribute",
+				"ec2:CreateNetworkInterface",
+				"ec2:DescribeNetworkInterfaces",
+				"ec2:DeleteNetworkInterface",
+				"ec2:ModifyNetworkInterfaceAttribute",
+				"ec2:DescribeNetworkInterfaceAttribute",
 			},
 		)
 	}
 
-	if v := n.spec.IAM.WithAddonPolicies.ALBIngress; v != nil && *v {
+	if api.IsEnabled(n.spec.IAM.WithAddonPolicies.ALBIngress) {
 		n.rs.attachAllowPolicy("PolicyALBIngress", refIR, "*",
 			[]string{
 				"acm:DescribeCertificate",

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -44,7 +44,7 @@ func (n *NodeGroupResourceSet) AddAllResources() error {
 	n.rs.template.Description = fmt.Sprintf(
 		"%s (AMI family: %s, SSH access: %v, private networking: %v) %s",
 		nodeGroupTemplateDescription,
-		n.spec.AMIFamily, *n.spec.SSH.Allow, n.spec.PrivateNetworking,
+		n.spec.AMIFamily, api.IsEnabled(n.spec.SSH.Allow), n.spec.PrivateNetworking,
 		templateDescriptionSuffix)
 
 	n.rs.defineOutputWithoutCollector(outputs.NodeGroupFeaturePrivateNetworking, n.spec.PrivateNetworking, false)
@@ -114,7 +114,7 @@ func (n *NodeGroupResourceSet) addResourcesForNodeGroup() error {
 		InstanceType:       gfn.NewString(n.spec.InstanceType),
 		UserData:           n.userData,
 	}
-	if *n.spec.SSH.Allow && *n.spec.SSH.PublicKeyName != "" {
+	if api.IsEnabled(n.spec.SSH.Allow) && api.IsSetAndNonEmptyString(n.spec.SSH.PublicKeyName) {
 		lc.KeyName = gfn.NewString(*n.spec.SSH.PublicKeyName)
 	}
 	if n.spec.PrivateNetworking {
@@ -175,7 +175,7 @@ func (n *NodeGroupResourceSet) addResourcesForNodeGroup() error {
 			"PropagateAtLaunch": "true",
 		},
 	}
-	if v := n.spec.IAM.WithAddonPolicies.AutoScaler; v != nil && *v {
+	if api.IsEnabled(n.spec.IAM.WithAddonPolicies.AutoScaler) {
 		tags = append(tags,
 			map[string]interface{}{
 				"Key":               "k8s.io/cluster-autoscaler/enabled",

--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -185,12 +185,12 @@ func (n *NodeGroupResourceSet) addResourcesForSecurityGroups() {
 		n.securityGroups = append(n.securityGroups, gfn.NewString(id))
 	}
 
-	if v := n.spec.SecurityGroups.WithShared; v != nil && *v {
+	if api.IsEnabled(n.spec.SecurityGroups.WithShared) {
 		refClusterSharedNodeSG := makeImportValue(n.clusterStackName, outputs.ClusterSharedNodeSecurityGroup)
 		n.securityGroups = append(n.securityGroups, refClusterSharedNodeSG)
 	}
 
-	if v := n.spec.SecurityGroups.WithLocal; v != nil && !*v {
+	if api.IsDisabled(n.spec.SecurityGroups.WithLocal) {
 		return
 	}
 

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -155,7 +155,7 @@ func (c *StackCollection) DescribeStack(i *Stack) (*Stack, error) {
 	input := &cloudformation.DescribeStacksInput{
 		StackName: i.StackName,
 	}
-	if i.StackId != nil && *i.StackId != "" {
+	if api.IsSetAndNonEmptyString(i.StackId) {
 		input.StackName = i.StackId
 	}
 	resp, err := c.provider.CloudFormation().DescribeStacks(input)
@@ -327,7 +327,7 @@ func (c *StackCollection) DescribeStackEvents(i *Stack) ([]*cloudformation.Stack
 	input := &cloudformation.DescribeStackEventsInput{
 		StackName: i.StackName,
 	}
-	if i.StackId != nil && *i.StackId != "" {
+	if api.IsSetAndNonEmptyString(i.StackId) {
 		input.StackName = i.StackId
 	}
 
@@ -423,7 +423,7 @@ func (c *StackCollection) DescribeStackChangeSet(i *Stack, changeSetName string)
 		StackName:     i.StackName,
 		ChangeSetName: &changeSetName,
 	}
-	if i.StackId != nil {
+	if api.IsSetAndNonEmptyString(i.StackId) {
 		input.StackName = i.StackId
 	}
 	resp, err := c.provider.CloudFormation().DescribeChangeSet(input)

--- a/pkg/cfn/manager/waiters.go
+++ b/pkg/cfn/manager/waiters.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
 
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha4"
 	"github.com/weaveworks/eksctl/pkg/cfn/builder"
 	"github.com/weaveworks/eksctl/pkg/utils/waiters"
 )
@@ -28,7 +29,7 @@ func (c *StackCollection) waitWithAcceptors(i *Stack, acceptors []request.Waiter
 		input := &cfn.DescribeStacksInput{
 			StackName: i.StackName,
 		}
-		if i.StackId != nil && *i.StackId != "" {
+		if api.IsSetAndNonEmptyString(i.StackId) {
 			input.StackName = i.StackId
 		}
 		req, _ := c.provider.CloudFormation().DescribeStacksRequest(input)

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -184,7 +184,7 @@ func NewCreateClusterLoader(provider *api.ProviderConfig, spec *api.ClusterConfi
 				if *ng.SSH.PublicKeyPath == "" {
 					return fmt.Errorf("--ssh-public-key must be non-empty string")
 				}
-				ng.SSH.Allow = api.NewBoolTrue()
+				ng.SSH.Allow = api.Enabled()
 			} else {
 				ng.SSH.PublicKeyPath = nil
 			}
@@ -249,7 +249,7 @@ func NewCreateNodeGroupLoader(provider *api.ProviderConfig, spec *api.ClusterCon
 				if *ng.SSH.PublicKeyPath == "" {
 					return fmt.Errorf("--ssh-public-key must be non-empty string")
 				}
-				ng.SSH.Allow = api.NewBoolTrue()
+				ng.SSH.Allow = api.Enabled()
 			} else {
 				ng.SSH.PublicKeyPath = nil
 			}

--- a/pkg/ctl/cmdutils/nodegroup_filter_test.go
+++ b/pkg/ctl/cmdutils/nodegroup_filter_test.go
@@ -148,7 +148,7 @@ func addGroupA(cfg *api.ClusterConfig) {
 	ng.Name = "test-ng3a"
 	ng.ClusterDNS = "1.2.3.4"
 	ng.InstanceType = "m3.large"
-	ng.SSH.Allow = api.NewBoolTrue()
+	ng.SSH.Allow = api.Enabled()
 	ng.SSH.PublicKeyPath = nil
 	ng.Labels = map[string]string{"group": "a", "seq": "3"}
 }
@@ -158,7 +158,7 @@ func addGroupB(cfg *api.ClusterConfig) {
 
 	ng = cfg.NewNodeGroup()
 	ng.Name = "test-ng1b"
-	ng.SSH.Allow = api.NewBoolTrue()
+	ng.SSH.Allow = api.Enabled()
 	ng.SSH.PublicKeyPath = nil
 	ng.Labels = map[string]string{"group": "b", "seq": "1"}
 
@@ -167,7 +167,7 @@ func addGroupB(cfg *api.ClusterConfig) {
 	ng.ClusterDNS = "4.2.8.14"
 	ng.InstanceType = "m5.xlarge"
 	ng.SecurityGroups.AttachIDs = []string{"sg-1", "sg-2"}
-	ng.SecurityGroups.WithLocal = api.NewBoolFalse()
+	ng.SecurityGroups.WithLocal = api.Disabled()
 	ng.Labels = map[string]string{"group": "b", "seq": "1"}
 	ng.SSH = nil
 
@@ -175,7 +175,7 @@ func addGroupB(cfg *api.ClusterConfig) {
 	ng.Name = "test-ng3b"
 	ng.VolumeSize = 192
 	ng.SecurityGroups.AttachIDs = []string{"sg-1", "sg-2"}
-	ng.SecurityGroups.WithLocal = api.NewBoolFalse()
+	ng.SecurityGroups.WithLocal = api.Disabled()
 	ng.Labels = map[string]string{"group": "b", "seq": "1"}
 	ng.SSH = nil
 }

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -351,7 +351,7 @@ func (c *ClusterProvider) newSession(spec *api.ProviderConfig) *session.Session 
 	})
 
 	if spec.Region == "" {
-		if *s.Config.Region != "" {
+		if api.IsSetAndNonEmptyString(s.Config.Region) {
 			// set cluster config region, based on session config
 			spec.Region = *s.Config.Region
 		} else {

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -180,7 +180,7 @@ func (c *ClusterProvider) doListClusters(chunkSize int64, printer printers.Outpu
 			})
 		}
 
-		if nextToken != nil && *nextToken != "" {
+		if api.IsSetAndNonEmptyString(nextToken) {
 			token = *nextToken
 		} else {
 			break
@@ -311,7 +311,7 @@ func addSummaryTableColumns(printer *printers.TablePrinter) {
 	printer.AddColumn("SUBNETS", func(c *awseks.Cluster) string {
 		subnets := sets.NewString()
 		for _, subnetid := range c.ResourcesVpcConfig.SubnetIds {
-			if *subnetid != "" {
+			if api.IsSetAndNonEmptyString(subnetid) {
 				subnets.Insert(*subnetid)
 			}
 		}
@@ -320,7 +320,7 @@ func addSummaryTableColumns(printer *printers.TablePrinter) {
 	printer.AddColumn("SECURITYGROUPS", func(c *awseks.Cluster) string {
 		groups := sets.NewString()
 		for _, sg := range c.ResourcesVpcConfig.SecurityGroupIds {
-			if *sg != "" {
+			if api.IsSetAndNonEmptyString(sg) {
 				groups.Insert(*sg)
 			}
 		}

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Kubeconfig", func() {
 					AvailabilityZones: []string{"us-west-2b", "us-west-2a", "us-west-2c"},
 					PrivateNetworking: false,
 					SSH: &eksctlapi.NodeGroupSSH{
-						Allow:         eksctlapi.NewBoolFalse(),
+						Allow:         eksctlapi.Disabled(),
 						PublicKeyPath: &exampleSSHKeyPath,
 						PublicKey:     []uint8(nil),
 						PublicKeyName: nil,


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

This PR adds helper for checking if a `*string` value was set and isn't an empty string, as well as helpers for checking when a `*bool` value was set and is either `true` or `false`.


This is a follow-up to #673.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [ ] ~All integration tests passing (i.e. `make integration-test`)~ - blocked by #720
