### PR TITLE
Fix regression in hadnling of default SSH key flag

### DIFF
--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -185,6 +185,8 @@ func NewCreateClusterLoader(provider *api.ProviderConfig, spec *api.ClusterConfi
 					return fmt.Errorf("--ssh-public-key must be non-empty string")
 				}
 				ng.SSH.Allow = api.NewBoolTrue()
+			} else {
+				ng.SSH.PublicKeyPath = nil
 			}
 
 			// generate nodegroup name or use flag
@@ -248,6 +250,8 @@ func NewCreateNodeGroupLoader(provider *api.ProviderConfig, spec *api.ClusterCon
 					return fmt.Errorf("--ssh-public-key must be non-empty string")
 				}
 				ng.SSH.Allow = api.NewBoolTrue()
+			} else {
+				ng.SSH.PublicKeyPath = nil
 			}
 
 			// generate nodegroup name or use either flag or argument


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

When using flags, we apply defaults in a way that is specifig to
CLI flags first, and then again in generic way. We need to make
sure that if flag hasn't changed, the field remains unset.

Fix #720.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [ ] All integration tests passing (i.e. `make integration-test`)
