### PR TITLE
Do not check nodegroups in transient states for compatibility

### DIFF
--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -205,27 +205,50 @@ func (c *StackCollection) ListStacks(nameRegex string, statusFilters ...string) 
 	return stacks, nil
 }
 
+// StackStatusIsNotTransitional will return true when stack statate is non-transitional
+func (*StackCollection) StackStatusIsNotTransitional(s *Stack) bool {
+	for _, state := range nonTransitionalReadyStackStatuses() {
+		if *s.StackStatus == state {
+			return true
+		}
+	}
+	return false
+}
+
+func nonTransitionalReadyStackStatuses() []string {
+	return []string{
+		cloudformation.StackStatusCreateComplete,
+		cloudformation.StackStatusUpdateComplete,
+		cloudformation.StackStatusUpdateCompleteCleanupInProgress,
+		cloudformation.StackStatusRollbackComplete,
+		cloudformation.StackStatusUpdateRollbackCompleteCleanupInProgress,
+		cloudformation.StackStatusUpdateRollbackComplete,
+	}
+}
+
+func allNonDeletedStackStatuses() []string {
+	return []string{
+		cloudformation.StackStatusCreateInProgress,
+		cloudformation.StackStatusCreateFailed,
+		cloudformation.StackStatusCreateComplete,
+		cloudformation.StackStatusRollbackInProgress,
+		cloudformation.StackStatusRollbackFailed,
+		cloudformation.StackStatusRollbackComplete,
+		cloudformation.StackStatusDeleteInProgress,
+		cloudformation.StackStatusDeleteFailed,
+		cloudformation.StackStatusUpdateInProgress,
+		cloudformation.StackStatusUpdateCompleteCleanupInProgress,
+		cloudformation.StackStatusUpdateComplete,
+		cloudformation.StackStatusUpdateRollbackInProgress,
+		cloudformation.StackStatusUpdateRollbackFailed,
+		cloudformation.StackStatusUpdateRollbackCompleteCleanupInProgress,
+		cloudformation.StackStatusUpdateRollbackComplete,
+		cloudformation.StackStatusReviewInProgress,
+	}
+}
+
 func defaultStackStatusFilter() []*string {
-	return aws.StringSlice(
-		[]string{
-			cloudformation.StackStatusCreateInProgress,
-			cloudformation.StackStatusCreateFailed,
-			cloudformation.StackStatusCreateComplete,
-			cloudformation.StackStatusRollbackInProgress,
-			cloudformation.StackStatusRollbackFailed,
-			cloudformation.StackStatusRollbackComplete,
-			cloudformation.StackStatusDeleteInProgress,
-			cloudformation.StackStatusDeleteFailed,
-			cloudformation.StackStatusUpdateInProgress,
-			cloudformation.StackStatusUpdateCompleteCleanupInProgress,
-			cloudformation.StackStatusUpdateComplete,
-			cloudformation.StackStatusUpdateRollbackInProgress,
-			cloudformation.StackStatusUpdateRollbackFailed,
-			cloudformation.StackStatusUpdateRollbackCompleteCleanupInProgress,
-			cloudformation.StackStatusUpdateRollbackComplete,
-			cloudformation.StackStatusReviewInProgress,
-		},
-	)
+	return aws.StringSlice(allNonDeletedStackStatuses())
 }
 
 // DeleteStackByName sends a request to delete the stack

--- a/pkg/eks/compatibility.go
+++ b/pkg/eks/compatibility.go
@@ -101,11 +101,13 @@ func (c *ClusterProvider) ValidateExistingNodeGroupsForCompatibility(cfg *api.Cl
 	logger.Info("checking security group configuration for all nodegroups")
 	incompatibleNodeGroups := []string{}
 	for ng, info := range infoByNodeGroup {
-		if isNodeGroupCompatible(ng, info) {
-			logger.Debug("nodegroup %q is compatible", ng)
-		} else {
-			logger.Debug("nodegroup %q is incompatible", ng)
-			incompatibleNodeGroups = append(incompatibleNodeGroups, ng)
+		if stackManager.StackStatusIsNotTransitional(info.Stack) {
+			if isNodeGroupCompatible(ng, info) {
+				logger.Debug("nodegroup %q is compatible", ng)
+			} else {
+				logger.Debug("nodegroup %q is incompatible", ng)
+				incompatibleNodeGroups = append(incompatibleNodeGroups, ng)
+			}
 		}
 	}
 


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

Just a minor fix to allows creating new nodegroups while some nodegroups are being created.  Compatibility checker trips over nodegroups that don't have stack outputs it expects, and when those are being created, the outputs aren't there yet.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
