### PR TITLE
Rename preBootstrapCommand to preBootstrapCommands

### DIFF
--- a/examples/05-advanced-nodegroups.yaml
+++ b/examples/05-advanced-nodegroups.yaml
@@ -26,7 +26,7 @@ nodeGroups:
     labels:
       nodegroup-type: backend-cluster-addons
     privateNetworking: true
-    preBootstrapCommand:
+    preBootstrapCommands:
       # allow docker registries to be deployed as cluster service 
       - 'echo {\"insecure-registries\": [\"172.20.0.0/16\",\"10.100.0.0/16\"]} > /etc/docker/daemon.json'
       - "systemctl restart docker"
@@ -40,7 +40,7 @@ nodeGroups:
       special: "true:NoSchedule"
     privateNetworking: true
     availabilityZones: ["eu-west-2a"] # use single AZ to optimise data transfer between isntances
-    preBootstrapCommand:
+    preBootstrapCommands:
       # disable hyperthreading
       - "for n in $(cat /sys/devices/system/cpu/cpu*/topology/thread_siblings_list | cut -s -d, -f2- | tr ',' '\n' | sort -un); do echo 0 > /sys/devices/system/cpu/cpu${n}/online; done"
 

--- a/pkg/apis/eksctl.io/v1alpha4/types.go
+++ b/pkg/apis/eksctl.io/v1alpha4/types.go
@@ -402,7 +402,8 @@ type NodeGroup struct {
 	IAM *NodeGroupIAM `json:"iam"`
 
 	// +optional
-	PreBootstrapCommands []string `json:"preBootstrapCommand,omitempty"`
+	PreBootstrapCommands []string `json:"preBootstrapCommands,omitempty"`
+
 	// +optional
 	OverrideBootstrapCommand *string `json:"overrideBootstrapCommand,omitempty"`
 


### PR DESCRIPTION
closes #591

- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)