### PR TITLE
Replace `--dry-run=false` with `--approve`

### DIFF
--- a/pkg/addons/default/aws_node.go
+++ b/pkg/addons/default/aws_node.go
@@ -23,33 +23,33 @@ const (
 )
 
 // UpdateAWSNode will update the `aws-node` add-on
-func UpdateAWSNode(rawClient kubernetes.RawClientInterface, region string) error {
+func UpdateAWSNode(rawClient kubernetes.RawClientInterface, region string, plan bool) (bool, error) {
 	_, err := rawClient.ClientSet().AppsV1().DaemonSets(metav1.NamespaceSystem).Get(AWSNode, metav1.GetOptions{})
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			logger.Warning("%q was not found", AWSNode)
-			return nil
+			return false, nil
 		}
-		return errors.Wrapf(err, "getting %q", AWSNode)
+		return false, errors.Wrapf(err, "getting %q", AWSNode)
 	}
 
 	// if DaemonSets is present, go through our list of assets
 	list, err := LoadAsset(AWSNode, "yaml")
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	for _, rawObj := range list.Items {
 		resource, err := rawClient.NewRawResource(rawObj)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if resource.GVK.Kind == "DaemonSet" {
 			image := &resource.Info.Object.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[0].Image
 			imageParts := strings.Split(*image, ":")
 
 			if len(imageParts) != 2 {
-				return fmt.Errorf("unexpected image format %q for %q", *image, KubeProxy)
+				return false, fmt.Errorf("unexpected image format %q for %q", *image, KubeProxy)
 			}
 
 			if strings.HasPrefix(imageParts[0], awsNodeImagePrefix) &&
@@ -58,13 +58,25 @@ func UpdateAWSNode(rawClient kubernetes.RawClientInterface, region string) error
 			}
 		}
 
-		status, err := resource.CreateOrReplace()
+		if resource.GVK.Kind == "CustomResourceDefinition" && plan {
+			// eniconfigs.crd.k8s.amazonaws.com CRD is only partially defined in the
+			// manifest, and causes a range of issue in plan mode, we can skip it
+			logger.Info(resource.LogAction(plan, "replaced"))
+			continue
+		}
+
+		status, err := resource.CreateOrReplace(plan)
 		if err != nil {
-			return err
+			return false, err
 		}
 		logger.Info(status)
 	}
 
+	if plan {
+		logger.Critical("(plan) %q is not up-to-date", AWSNode)
+		return true, nil
+	}
+
 	logger.Info("%q is now up-to-date", AWSNode)
-	return nil
+	return false, nil
 }

--- a/pkg/addons/default/aws_node_test.go
+++ b/pkg/addons/default/aws_node_test.go
@@ -29,7 +29,7 @@ var _ = Describe("default addons - aws-node", func() {
 			for _, item := range sampleAddons {
 				rc, err := rawClient.NewRawResource(runtime.RawExtension{Object: item})
 				Expect(err).ToNot(HaveOccurred())
-				_, err = rc.CreateOrReplace()
+				_, err = rc.CreateOrReplace(false)
 				Expect(err).ToNot(HaveOccurred())
 			}
 
@@ -58,7 +58,7 @@ var _ = Describe("default addons - aws-node", func() {
 		It("can update 1.10 sample to latest", func() {
 			rawClient.AssumeObjectsMissing = false
 
-			err := UpdateAWSNode(rawClient, "eu-west-2")
+			_, err := UpdateAWSNode(rawClient, "eu-west-2", false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(rawClient.Collection.UpdatedItems()).To(HaveLen(4))
 			Expect(rawClient.Collection.CreatedItems()).To(HaveLen(6))
@@ -78,7 +78,7 @@ var _ = Describe("default addons - aws-node", func() {
 		It("can update 1.10 sample for different region", func() {
 			rawClient.ClientSetUseUpdatedObjects = false // must be set for subsequent UpdateAWSNode
 
-			err := UpdateAWSNode(rawClient, "us-east-1")
+			_, err := UpdateAWSNode(rawClient, "us-east-1", false)
 			Expect(err).ToNot(HaveOccurred())
 
 			rawClient.ClientSetUseUpdatedObjects = true // for verification of updated objects

--- a/pkg/addons/default/coredns.go
+++ b/pkg/addons/default/coredns.go
@@ -37,37 +37,39 @@ const (
 )
 
 // InstallCoreDNS will install the `coredns` add-on in place of `kube-dns`
-func InstallCoreDNS(rawClient kubernetes.RawClientInterface, region string, waitTimeout *time.Duration) error {
+func InstallCoreDNS(rawClient kubernetes.RawClientInterface, region string, waitTimeout *time.Duration, plan bool) (bool, error) {
 	kubeDNSSevice, err := rawClient.ClientSet().CoreV1().Services(metav1.NamespaceSystem).Get(KubeDNS, metav1.GetOptions{})
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			logger.Warning("%q service was not found", KubeDNS)
-			return nil
+			return false, nil
 		}
-		return errors.Wrapf(err, "getting %q service", KubeDNS)
+		return false, errors.Wrapf(err, "getting %q service", KubeDNS)
 	}
 
 	kubeDNSDeployment, err := rawClient.ClientSet().AppsV1().Deployments(metav1.NamespaceSystem).Get(KubeDNS, metav1.GetOptions{})
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			logger.Warning("%q deployment was not found", KubeDNS)
-			return nil
+			return false, nil
 		}
-		return errors.Wrapf(err, "getting %q deployment", KubeDNS)
+		return false, errors.Wrapf(err, "getting %q deployment", KubeDNS)
 	}
 
 	if v, ok := kubeDNSDeployment.Spec.Selector.MatchLabels[componentLabel]; !ok || v != KubeDNS {
 		logger.Debug("adding %q label to %q", componentLabel, KubeDNS)
 		kubeDNSDeployment.Spec.Selector.MatchLabels[componentLabel] = KubeDNS
-		if _, err := rawClient.ClientSet().AppsV1().Deployments(metav1.NamespaceSystem).Update(kubeDNSDeployment); err != nil {
-			return errors.Wrapf(err, "patching %q", KubeDNS)
+		if !plan {
+			if _, err := rawClient.ClientSet().AppsV1().Deployments(metav1.NamespaceSystem).Update(kubeDNSDeployment); err != nil {
+				return false, errors.Wrapf(err, "patching %q", KubeDNS)
+			}
 		}
 	}
 
 	// if kube-dns is present, go ahead and try to replace it with coredns
 	list, err := LoadAsset(CoreDNS, "yaml")
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	listPodsOptions := metav1.ListOptions{}
@@ -75,7 +77,7 @@ func InstallCoreDNS(rawClient kubernetes.RawClientInterface, region string, wait
 	for _, rawObj := range list.Items {
 		resource, err := rawClient.NewRawResource(rawObj)
 		if err != nil {
-			return err
+			return false, err
 		}
 		switch resource.GVK.Kind {
 		case "Deployment":
@@ -86,7 +88,7 @@ func InstallCoreDNS(rawClient kubernetes.RawClientInterface, region string, wait
 			imageParts := strings.Split(*image, ":")
 
 			if len(imageParts) != 2 {
-				return fmt.Errorf("unexpected image format %q for %q", *image, KubeProxy)
+				return false, fmt.Errorf("unexpected image format %q for %q", *image, KubeProxy)
 			}
 
 			if strings.HasPrefix(imageParts[0], coreDNSImagePrefix) &&
@@ -94,28 +96,29 @@ func InstallCoreDNS(rawClient kubernetes.RawClientInterface, region string, wait
 				*image = coreDNSImagePrefix + region + coreDNSImageSuffix + ":" + imageParts[1]
 			}
 		case "Service":
+			resource.Info.Object.(*corev1.Service).SetResourceVersion(kubeDNSSevice.GetResourceVersion())
 			resource.Info.Object.(*corev1.Service).Spec.ClusterIP = kubeDNSSevice.Spec.ClusterIP
 		}
 
-		status, err := resource.CreateOrReplace()
+		status, err := resource.CreateOrReplace(plan)
 		if err != nil {
-			return err
+			return false, err
 		}
 		logger.Info(status)
 	}
 
-	if waitTimeout != nil {
+	if waitTimeout != nil && !plan {
 		timer := time.After(*waitTimeout)
 		timeout := false
 		readyPods := sets.NewString()
 		watcher, err := rawClient.ClientSet().CoreV1().Pods(metav1.NamespaceSystem).Watch(listPodsOptions)
 		if err != nil {
-			return errors.Wrapf(err, "creating %q pod watcher", CoreDNS)
+			return false, errors.Wrapf(err, "creating %q pod watcher", CoreDNS)
 		}
 
 		podList, err := rawClient.ClientSet().CoreV1().Pods(metav1.NamespaceSystem).List(listPodsOptions)
 		if err != nil {
-			return errors.Wrapf(err, "listing %q pods", CoreDNS)
+			return false, errors.Wrapf(err, "listing %q pods", CoreDNS)
 		}
 		for _, pod := range podList.Items {
 			if pod.Status.Phase == corev1.PodRunning {
@@ -145,68 +148,73 @@ func InstallCoreDNS(rawClient kubernetes.RawClientInterface, region string, wait
 		}
 		watcher.Stop()
 		if timeout {
-			return fmt.Errorf("timed out (after %s) waiting for %q pods to become ready", waitTimeout, CoreDNS)
+			return false, fmt.Errorf("timed out (after %s) waiting for %q pods to become ready", waitTimeout, CoreDNS)
 		}
 	}
 
+	if plan {
+		logger.Info("(plan) would have waited for %q pods to become ready and then delete %q", CoreDNS, KubeDNS)
+		return true, nil
+	}
+
 	if err := rawClient.ClientSet().AppsV1().Deployments(metav1.NamespaceSystem).Delete(KubeDNS, &metav1.DeleteOptions{}); err != nil {
-		return errors.Wrapf(err, "deleting %q", KubeDNS)
+		return false, errors.Wrapf(err, "deleting %q", KubeDNS)
 	}
 
 	logger.Info("deleted %q", KubeDNS)
 
 	logger.Info("%q is now up-to-date", CoreDNS)
-	return nil
+	return false, nil
 }
 
 // UpdateCoreDNSImageTag updates image tag for kube-system:deployment/coredns based to match the latest release
-func UpdateCoreDNSImageTag(clientSet k8s.Interface, dryRun bool) error {
+func UpdateCoreDNSImageTag(clientSet k8s.Interface, plan bool) (bool, error) {
 	printer := printers.NewJSONPrinter()
 
 	d, err := clientSet.AppsV1().Deployments(metav1.NamespaceSystem).Get(CoreDNS, metav1.GetOptions{})
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			logger.Warning("%q was not found", CoreDNS)
-			return nil
+			return false, nil
 		}
-		return errors.Wrapf(err, "getting %q", CoreDNS)
+		return false, errors.Wrapf(err, "getting %q", CoreDNS)
 	}
 	if numContainers := len(d.Spec.Template.Spec.Containers); !(numContainers >= 1) {
-		return fmt.Errorf("%s has %d containers, expected at least 1", CoreDNS, numContainers)
+		return false, fmt.Errorf("%s has %d containers, expected at least 1", CoreDNS, numContainers)
 	}
 
 	if err := printer.LogObj(logger.Debug, CoreDNS+" [current] = \\\n%s\n", d); err != nil {
-		return err
+		return false, err
 	}
 
 	image := &d.Spec.Template.Spec.Containers[0].Image
 	imageParts := strings.Split(*image, ":")
 
 	if len(imageParts) != 2 {
-		return fmt.Errorf("unexpected image format %q for %q", *image, CoreDNS)
+		return false, fmt.Errorf("unexpected image format %q for %q", *image, CoreDNS)
 	}
 
 	if imageParts[1] == CoreDNSVersion {
 		logger.Debug("imageParts = %v, desiredTag = %s", imageParts, CoreDNSVersion)
 		logger.Info("%q is already up-to-date", CoreDNS)
-		return nil
+		return false, nil
 	}
 
-	if dryRun {
-		logger.Critical("%q is not up-to-date", CoreDNS)
-		return nil
+	if plan {
+		logger.Critical("(plan) %q is not up-to-date", CoreDNS)
+		return true, nil
 	}
 
 	imageParts[1] = CoreDNSVersion
 	*image = strings.Join(imageParts, ":")
 
 	if err := printer.LogObj(logger.Debug, CoreDNS+" [updated] = \\\n%s\n", d); err != nil {
-		return err
+		return false, err
 	}
 	if _, err := clientSet.AppsV1().Deployments(metav1.NamespaceSystem).Update(d); err != nil {
-		return err
+		return false, err
 	}
 
 	logger.Info("%q is now up-to-date", CoreDNS)
-	return nil
+	return false, nil
 }

--- a/pkg/addons/default/coredns_test.go
+++ b/pkg/addons/default/coredns_test.go
@@ -30,7 +30,7 @@ var _ = Describe("default addons - coredns", func() {
 			for _, item := range sampleAddons {
 				rc, err := rawClient.NewRawResource(runtime.RawExtension{Object: item})
 				Expect(err).ToNot(HaveOccurred())
-				_, err = rc.CreateOrReplace()
+				_, err = rc.CreateOrReplace(false)
 				Expect(err).ToNot(HaveOccurred())
 			}
 
@@ -63,7 +63,7 @@ var _ = Describe("default addons - coredns", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// test client doesn't support watching, and we would have to create some pods, so we set nil timeout
-			err = InstallCoreDNS(rawClient, "eu-west-1", nil)
+			_, err = InstallCoreDNS(rawClient, "eu-west-1", nil, false)
 			Expect(err).ToNot(HaveOccurred())
 
 			updateReqs := []string{
@@ -132,13 +132,13 @@ var _ = Describe("default addons - coredns", func() {
 		})
 
 		It("can update based to latest version", func() {
-			err := UpdateCoreDNSImageTag(clientSet, false)
+			_, err := UpdateCoreDNSImageTag(clientSet, false)
 			Expect(err).ToNot(HaveOccurred())
 			check("v1.2.2")
 		})
 
 		It("can dry-run update to latest version", func() {
-			err := UpdateCoreDNSImageTag(clientSet, true)
+			_, err := UpdateCoreDNSImageTag(clientSet, true)
 			Expect(err).ToNot(HaveOccurred())
 			check("v1.1.3")
 		})

--- a/pkg/addons/default/kube_proxy_test.go
+++ b/pkg/addons/default/kube_proxy_test.go
@@ -38,13 +38,13 @@ var _ = Describe("default addons - kube-proxy", func() {
 		})
 
 		It("can update based on control plane version", func() {
-			err := UpdateKubeProxyImageTag(clientSet, "1.11.0", false)
+			_, err := UpdateKubeProxyImageTag(clientSet, "1.11.0", false)
 			Expect(err).ToNot(HaveOccurred())
 			check("v1.11.0")
 		})
 
 		It("can dry-run update based on control plane version", func() {
-			err := UpdateKubeProxyImageTag(clientSet, "1.12.1", true)
+			_, err := UpdateKubeProxyImageTag(clientSet, "1.12.1", true)
 			Expect(err).ToNot(HaveOccurred())
 			check("v1.10.3")
 		})

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -58,7 +58,7 @@ func (c *StackCollection) DescribeClusterStack() (*Stack, error) {
 
 // AppendNewClusterStackResource will update cluster
 // stack with new resources in append-only way
-func (c *StackCollection) AppendNewClusterStackResource(dryRun bool) (bool, error) {
+func (c *StackCollection) AppendNewClusterStackResource(plan bool) (bool, error) {
 	name := c.makeClusterStackName()
 
 	// NOTE: currently we can only append new resources to the stack,
@@ -133,8 +133,8 @@ func (c *StackCollection) AppendNewClusterStackResource(dryRun bool) (bool, erro
 	logger.Debug("currentTemplate = %s", currentTemplate)
 
 	describeUpdate := fmt.Sprintf("updating stack to add new resources %v and ouputs %v", addResources, addOutputs)
-	if dryRun {
-		logger.Info("(dry-run) %s", describeUpdate)
+	if plan {
+		logger.Info("(plan) %s", describeUpdate)
 		return false, nil
 	}
 	return true, c.UpdateStack(name, c.MakeChangeSetName("update-cluster"), describeUpdate, []byte(currentTemplate), nil)

--- a/pkg/cfn/manager/tasks.go
+++ b/pkg/cfn/manager/tasks.go
@@ -20,7 +20,7 @@ type Task interface {
 type TaskTree struct {
 	tasks     []Task
 	Parallel  bool
-	DryRun    bool
+	PlanMode  bool
 	IsSubTask bool
 }
 
@@ -65,8 +65,8 @@ func (t *TaskTree) Describe() string {
 		noun += "s"
 		msg = fmt.Sprintf("%d %s %s: { %s }", count, mode, noun, strings.Join(descriptions, ", "))
 	}
-	if t.DryRun {
-		return "(dry-run) " + msg
+	if t.PlanMode {
+		return "(plan) " + msg
 	}
 	return msg
 }
@@ -75,7 +75,7 @@ func (t *TaskTree) Describe() string {
 // or eventually write to the errs channel; it will close the channel once all tasks
 // are completed
 func (t *TaskTree) Do(allErrs chan error) error {
-	if t.Len() == 0 || t.DryRun {
+	if t.Len() == 0 || t.PlanMode {
 		logger.Debug("no actual tasks")
 		close(allErrs)
 		return nil
@@ -102,7 +102,7 @@ func (t *TaskTree) Do(allErrs chan error) error {
 // DoAllSync will run through the set in the foregounds and return all the errors
 // in a slice
 func (t *TaskTree) DoAllSync() []error {
-	if t.Len() == 0 || t.DryRun {
+	if t.Len() == 0 || t.PlanMode {
 		logger.Debug("no actual tasks")
 		return nil
 	}

--- a/pkg/cfn/manager/tasks_test.go
+++ b/pkg/cfn/manager/tasks_test.go
@@ -57,9 +57,9 @@ var _ = Describe("StackCollection Tasks", func() {
 					tasks.Append(&TaskTree{Parallel: false})
 					Expect(tasks.Describe()).To(Equal("1 task: { no tasks }"))
 					tasks.IsSubTask = true
-					tasks.DryRun = true
+					tasks.PlanMode = true
 					tasks.Append(&TaskTree{Parallel: false, IsSubTask: true})
-					Expect(tasks.Describe()).To(Equal("(dry-run) 2 sequential sub-tasks: { no tasks, no tasks }"))
+					Expect(tasks.Describe()).To(Equal("(plan) 2 sequential sub-tasks: { no tasks, no tasks }"))
 				}
 
 				{
@@ -322,11 +322,11 @@ var _ = Describe("StackCollection Tasks", func() {
 						},
 					})
 
-					tasks.DryRun = true
+					tasks.PlanMode = true
 
 					Expect(tasks.DoAllSync()).To(HaveLen(0))
 
-					tasks.DryRun = false
+					tasks.PlanMode = false
 					errs := tasks.DoAllSync()
 					Expect(errs).To(HaveLen(4))
 					Expect(errs[0].Error()).To(Equal("t1.0 does not even bother and always returns an immediate error"))
@@ -375,11 +375,11 @@ var _ = Describe("StackCollection Tasks", func() {
 						},
 					})
 
-					tasks.DryRun = true
+					tasks.PlanMode = true
 
 					Expect(tasks.DoAllSync()).To(HaveLen(0))
 
-					tasks.DryRun = false
+					tasks.PlanMode = false
 					errs := tasks.DoAllSync()
 					Expect(errs).To(HaveLen(2))
 					Expect(errs[0].Error()).To(Equal("t1.1 always fails"))

--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha4"
 	"github.com/weaveworks/eksctl/pkg/utils/kubeconfig"
@@ -13,6 +14,41 @@ import (
 
 // IncompatibleFlags is a common substring of an error message
 const IncompatibleFlags = "cannot be used at the same time"
+
+// LogIntendedAction calls logger.Info with appropriate prefix
+func LogIntendedAction(plan bool, msgFmt string, args ...interface{}) {
+	prefix := "will "
+	if plan {
+		prefix = "(plan) would "
+	}
+	logger.Info(prefix+msgFmt, args...)
+}
+
+// LogCompletedAction calls logger.Success with appropriate prefix
+func LogCompletedAction(plan bool, msgFmt string, args ...interface{}) {
+	prefix := ""
+	if plan {
+		prefix = "(plan) would have "
+	}
+	logger.Success(prefix+msgFmt, args...)
+}
+
+// LogPlanModeWarning will log a message to inform user that they are in plan-mode
+func LogPlanModeWarning(plan bool) {
+	if plan {
+		logger.Warning("no changes were applied, run again with '--approve' to apply the changes")
+	}
+}
+
+// AddApproveFlag adds common `--approve` flag
+func AddApproveFlag(plan *bool, cmd *cobra.Command, fs *pflag.FlagSet) {
+	approve := fs.Bool("approve", !*plan, "Apply the changes")
+	cmd.PreRun = func(cmd *cobra.Command, args []string) {
+		if cmd.Flag("approve").Changed {
+			*plan = !*approve
+		}
+	}
+}
 
 // GetNameArg tests to ensure there is only 1 name argument
 func GetNameArg(args []string) string {

--- a/pkg/ctl/cmdutils/nodegroup_flags.go
+++ b/pkg/ctl/cmdutils/nodegroup_flags.go
@@ -19,7 +19,7 @@ func AddCommonCreateNodeGroupFlags(cmd *cobra.Command, fs *pflag.FlagSet, p *api
 	minSize := fs.IntP("nodes-min", "m", api.DefaultNodeCount, "minimum nodes in ASG")
 	maxSize := fs.IntP("nodes-max", "M", api.DefaultNodeCount, "maximum nodes in ASG")
 
-	cmd.PreRun = func(cmd *cobra.Command, args []string) {
+	AddPreRun(cmd, func(cmd *cobra.Command, args []string) {
 		if f := cmd.Flag("nodes"); f.Changed {
 			ng.DesiredCapacity = desiredCapacity
 		}
@@ -29,7 +29,7 @@ func AddCommonCreateNodeGroupFlags(cmd *cobra.Command, fs *pflag.FlagSet, p *api
 		if f := cmd.Flag("nodes-max"); f.Changed {
 			ng.MaxSize = maxSize
 		}
-	}
+	})
 
 	fs.IntVar(&ng.VolumeSize, "node-volume-size", ng.VolumeSize, "node volume size in GB")
 	fs.StringVar(&ng.VolumeType, "node-volume-type", ng.VolumeType, fmt.Sprintf("node volume type (valid options: %s)", strings.Join(api.SupportedNodeVolumeTypes(), ", ")))

--- a/pkg/ctl/scale/nodegroup.go
+++ b/pkg/ctl/scale/nodegroup.go
@@ -36,11 +36,11 @@ func scaleNodeGroupCmd(g *cmdutils.Grouping) *cobra.Command {
 		fs.StringVarP(&ng.Name, "name", "n", "", "Name of the nodegroup to scale")
 
 		desiredCapacity := fs.IntP("nodes", "N", -1, "total number of nodes (scale to this number)")
-		cmd.PreRun = func(cmd *cobra.Command, args []string) {
+		cmdutils.AddPreRun(cmd, func(cmd *cobra.Command, args []string) {
 			if f := cmd.Flag("nodes"); f.Changed {
 				ng.DesiredCapacity = desiredCapacity
 			}
-		}
+		})
 
 		cmdutils.AddRegionFlag(fs, p)
 	})

--- a/pkg/ctl/utils/install_corends.go
+++ b/pkg/ctl/utils/install_corends.go
@@ -36,6 +36,7 @@ func installCoreDNSCmd(g *cmdutils.Grouping) *cobra.Command {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name")
 		cmdutils.AddRegionFlag(fs, p)
 		cmdutils.AddConfigFileFlag(&clusterConfigFile, fs)
+		cmdutils.AddApproveFlag(&plan, cmd, fs)
 	})
 
 	cmdutils.AddCommonFlagsForAWS(group, p, false)
@@ -80,5 +81,12 @@ func doInstallCoreDNS(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg str
 
 	waitTimeout := ctl.Provider.WaitTimeout()
 
-	return defaultaddons.InstallCoreDNS(rawClient, meta.Region, &waitTimeout)
+	updateRequired, err := defaultaddons.InstallCoreDNS(rawClient, meta.Region, &waitTimeout, plan)
+	if err != nil {
+		return err
+	}
+
+	cmdutils.LogPlanModeWarning(plan && updateRequired)
+
+	return nil
 }

--- a/pkg/ctl/utils/update_aws_node.go
+++ b/pkg/ctl/utils/update_aws_node.go
@@ -35,6 +35,7 @@ func updateAWSNodeCmd(g *cmdutils.Grouping) *cobra.Command {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name")
 		cmdutils.AddRegionFlag(fs, p)
 		cmdutils.AddConfigFileFlag(&clusterConfigFile, fs)
+		cmdutils.AddApproveFlag(&plan, cmd, fs)
 	})
 
 	cmdutils.AddCommonFlagsForAWS(group, p, false)
@@ -70,5 +71,12 @@ func doUpdateAWSNode(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 		return err
 	}
 
-	return defaultaddons.UpdateAWSNode(rawClient, meta.Region)
+	updateRequired, err := defaultaddons.UpdateAWSNode(rawClient, meta.Region, plan)
+	if err != nil {
+		return err
+	}
+
+	cmdutils.LogPlanModeWarning(plan && updateRequired)
+
+	return nil
 }

--- a/pkg/ctl/utils/update_coredns.go
+++ b/pkg/ctl/utils/update_coredns.go
@@ -35,6 +35,7 @@ func updateCoreDNSCmd(g *cmdutils.Grouping) *cobra.Command {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name")
 		cmdutils.AddRegionFlag(fs, p)
 		cmdutils.AddConfigFileFlag(&clusterConfigFile, fs)
+		cmdutils.AddApproveFlag(&plan, cmd, fs)
 	})
 
 	cmdutils.AddCommonFlagsForAWS(group, p, false)
@@ -70,5 +71,12 @@ func doUpdateCoreDNS(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 		return err
 	}
 
-	return defaultaddons.UpdateCoreDNSImageTag(clientSet, false)
+	updateRequired, err := defaultaddons.UpdateCoreDNSImageTag(clientSet, plan)
+	if err != nil {
+		return err
+	}
+
+	cmdutils.LogPlanModeWarning(plan && updateRequired)
+
+	return nil
 }

--- a/pkg/ctl/utils/update_kube_proxy.go
+++ b/pkg/ctl/utils/update_kube_proxy.go
@@ -35,6 +35,7 @@ func updateKubeProxyCmd(g *cmdutils.Grouping) *cobra.Command {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name")
 		cmdutils.AddRegionFlag(fs, p)
 		cmdutils.AddConfigFileFlag(&clusterConfigFile, fs)
+		cmdutils.AddApproveFlag(&plan, cmd, fs)
 	})
 
 	cmdutils.AddCommonFlagsForAWS(group, p, false)
@@ -75,5 +76,12 @@ func doUpdateKubeProxy(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg st
 		return err
 	}
 
-	return defaultaddons.UpdateKubeProxyImageTag(clientSet, cprv, false)
+	updateRequired, err := defaultaddons.UpdateKubeProxyImageTag(clientSet, cprv, plan)
+	if err != nil {
+		return err
+	}
+
+	cmdutils.LogPlanModeWarning(plan && updateRequired)
+
+	return nil
 }

--- a/pkg/ctl/utils/utils.go
+++ b/pkg/ctl/utils/utils.go
@@ -8,6 +8,8 @@ import (
 
 var (
 	clusterConfigFile = ""
+
+	plan = true
 )
 
 // Command will create the `utils` commands

--- a/pkg/ctl/utils/wait_nodes.go
+++ b/pkg/ctl/utils/wait_nodes.go
@@ -36,11 +36,11 @@ func waitNodesCmd(g *cmdutils.Grouping) *cobra.Command {
 	group.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&waitNodesKubeconfigPath, "kubeconfig", "kubeconfig", "path to read kubeconfig")
 		minSize := fs.IntP("nodes-min", "m", api.DefaultNodeCount, "minimum number of nodes to wait for")
-		cmd.PreRun = func(cmd *cobra.Command, args []string) {
+		cmdutils.AddPreRun(cmd, func(cmd *cobra.Command, args []string) {
 			if f := cmd.Flag("nodes-min"); f.Changed {
 				ng.MinSize = minSize
 			}
-		}
+		})
 		fs.DurationVar(&p.WaitTimeout, "timeout", api.DefaultWaitTimeout, "how long to wait")
 	})
 

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -20,7 +20,7 @@ var _ = Describe("kubernets client wrappers", func() {
 
 			for _, item := range sampleAddons {
 				rc, track := testutils.NewFakeRawResource(item, false, false, ct)
-				_, err := rc.CreateOrReplace()
+				_, err := rc.CreateOrReplace(false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(track).ToNot(BeNil())
 				Expect(track.Methods()).To(Equal([]string{"GET", "GET", "PUT"}))
@@ -38,7 +38,7 @@ var _ = Describe("kubernets client wrappers", func() {
 
 			for _, item := range sampleAddons {
 				rc, track := testutils.NewFakeRawResource(item, true, false, ct)
-				_, err := rc.CreateOrReplace()
+				_, err := rc.CreateOrReplace(false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(track).ToNot(BeNil())
 				Expect(track.Methods()).To(Equal([]string{"GET", "POST"}))
@@ -56,7 +56,7 @@ var _ = Describe("kubernets client wrappers", func() {
 
 			for _, item := range sampleAddons {
 				rc, track := testutils.NewFakeRawResource(item, false, false, ct)
-				_, err := rc.CreateOrReplace()
+				_, err := rc.CreateOrReplace(false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(track).ToNot(BeNil())
 				Expect(track.Methods()).To(Equal([]string{"GET", "GET", "PUT"}))
@@ -78,7 +78,7 @@ var _ = Describe("kubernets client wrappers", func() {
 			for _, item := range sampleAddons {
 				rc, err := rawClient.NewRawResource(runtime.RawExtension{Object: item})
 				Expect(err).ToNot(HaveOccurred())
-				_, err = rc.CreateOrReplace()
+				_, err = rc.CreateOrReplace(false)
 				Expect(err).ToNot(HaveOccurred())
 			}
 
@@ -137,7 +137,7 @@ var _ = Describe("kubernets client wrappers", func() {
 			for _, item := range []runtime.Object{saTest1, saTest2a, saTest2b} {
 				rc, err := rawClient.NewRawResource(runtime.RawExtension{Object: item})
 				Expect(err).ToNot(HaveOccurred())
-				_, err = rc.CreateOrReplace()
+				_, err = rc.CreateOrReplace(false)
 				Expect(err).ToNot(HaveOccurred())
 			}
 


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

Having to set `--dry-run=false` is a little unintuitive.
This change deprecates `--dry-run` flag from `eksctl update cluster`
command with new `--approve` flag. The new flag is also added in the
commands that already had most of the plumbing in place to support it.

This also fixes an issue with `cmd.PreRun`.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
