### PR TITLE
Get rid of eksctl.cluster.k8s.io/v1alpha1/ tags

### DIFF
--- a/integration/creategetdelete_test.go
+++ b/integration/creategetdelete_test.go
@@ -66,7 +66,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 			eksctl("create", "cluster",
 				"--verbose", "4",
 				"--name", clusterName,
-				"--tags", "eksctl.cluster.k8s.io/v1alpha1/description=eksctl integration test",
+				"--tags", "alpha.eksctl.io/description=eksctl integration test",
 				"--nodegroup-name", initNG,
 				"--node-labels", "ng-name="+initNG,
 				"--node-type", "t2.medium",

--- a/pkg/apis/eksctl.io/v1alpha4/types.go
+++ b/pkg/apis/eksctl.io/v1alpha4/types.go
@@ -100,15 +100,22 @@ const (
 	// NodeImageResolverAuto represents auto AMI resolver (see ami package)
 	NodeImageResolverAuto = "auto"
 
-	// ClusterNameTag defines the tag of the clsuter name
-	ClusterNameTag = "eksctl.cluster.k8s.io/v1alpha1/cluster-name"
+	// ClusterNameTag defines the tag of the cluster name
+	ClusterNameTag = "alpha.eksctl.io/cluster-name"
+
+	// OldClusterNameTag defines the tag of the cluster name
+	OldClusterNameTag = "eksctl.cluster.k8s.io/v1alpha1/cluster-name"
 
 	// NodeGroupNameTag defines the tag of the node group name
-	NodeGroupNameTag = "eksctl.io/v1alpha2/nodegroup-name"
+	NodeGroupNameTag = "alpha.eksctl.io/nodegroup-name"
+
+	// OldNodeGroupNameTag defines the tag of the node group name
+	OldNodeGroupNameTag = "eksctl.io/v1alpha2/nodegroup-name"
+
 	// OldNodeGroupIDTag defines the old version of tag of the node group name
 	OldNodeGroupIDTag = "eksctl.cluster.k8s.io/v1alpha1/nodegroup-id"
 
-	// ClusterNameLabel defines the tag of the clsuter name
+	// ClusterNameLabel defines the tag of the cluster name
 	ClusterNameLabel = "alpha.eksctl.io/cluster-name"
 
 	// NodeGroupNameLabel defines the label of the node group name

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -291,7 +291,7 @@ func (c *StackCollection) DeleteStackByNameSync(name string, errs chan error) er
 // DeleteStackBySpec sends a request to delete the stack
 func (c *StackCollection) DeleteStackBySpec(s *Stack) (*Stack, error) {
 	for _, tag := range s.Tags {
-		if *tag.Key == api.ClusterNameTag && *tag.Value == c.spec.Metadata.Name {
+		if matchesClusterName(*tag.Key, *tag.Value, c.spec.Metadata.Name) {
 			input := &cloudformation.DeleteStackInput{
 				StackName: s.StackId,
 			}
@@ -308,8 +308,20 @@ func (c *StackCollection) DeleteStackBySpec(s *Stack) (*Stack, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("cannot delete stack %q as it doesn't bare our %q tag", *s.StackName,
+	return nil, fmt.Errorf("cannot delete stack %q as it doesn't bare our %q, %q tags", *s.StackName,
+		fmt.Sprintf("%s:%s", api.OldClusterNameTag, c.spec.Metadata.Name),
 		fmt.Sprintf("%s:%s", api.ClusterNameTag, c.spec.Metadata.Name))
+}
+
+func matchesClusterName(key, value, name string) bool {
+	if key == api.ClusterNameTag && value == name {
+		return true
+	}
+
+	if key == api.OldClusterNameTag && value == name {
+		return true
+	}
+	return false
 }
 
 // DeleteStackBySpecSync sends a request to delete the stack, and waits until status is DELETE_COMPLETE;

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -155,7 +155,7 @@ func getClusterName(s *Stack) string {
 
 func getClusterNameTag(s *Stack) string {
 	for _, tag := range s.Tags {
-		if *tag.Key == api.ClusterNameTag {
+		if *tag.Key == api.ClusterNameTag || *tag.Key == api.OldClusterNameTag {
 			return *tag.Value
 		}
 	}

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -245,6 +245,9 @@ func getNodeGroupName(s *Stack) string {
 		if *tag.Key == api.NodeGroupNameTag {
 			return *tag.Value
 		}
+		if *tag.Key == api.OldNodeGroupNameTag {
+			return *tag.Value
+		}
 		if *tag.Key == api.OldNodeGroupIDTag {
 			return *tag.Value
 		}


### PR DESCRIPTION
closes https://github.com/weaveworks/eksctl/issues/535
Rename tags from eksctl.cluster.k8s.io/v1alpha1/ to alpha.eksctl.io/ keeping backwards compatibility

<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [x] test manually