### PR TITLE
adding EKS Account ID for security measures when using  for AMIs

### DIFF
--- a/pkg/ami/api.go
+++ b/pkg/ami/api.go
@@ -39,6 +39,12 @@ var ImageClasses = []string{
 	"ImageClassGPU",
 }
 
+// ImageFamilyToAccountID is a map of image families to account Ids
+var ImageFamilyToAccountID = map[string]string {
+	ImageFamilyAmazonLinux2: "602401143452",
+	ImageFamilyUbuntu1804: "099720109477",
+}
+
 // IsAvailable checks if a given AMI ID is available in AWS EC2
 func IsAvailable(api ec2iface.EC2API, id string) (bool, error) {
 	input := &ec2.DescribeImagesInput{
@@ -60,8 +66,9 @@ func IsAvailable(api ec2iface.EC2API, id string) (bool, error) {
 // FindImage will get the AMI to use for the EKS nodes by querying AWS EC2 API.
 // It will only look for images with a status of available and it will pick the
 // image with the newest creation date.
-func FindImage(api ec2iface.EC2API, namePattern string) (string, error) {
+func FindImage(api ec2iface.EC2API, namePattern string, imageFamily string) (string, error) {
 	input := &ec2.DescribeImagesInput{
+		Owners: []*string{aws.String(ImageFamilyToAccountID[imageFamily])},
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("name"),

--- a/pkg/ami/api.go
+++ b/pkg/ami/api.go
@@ -39,16 +39,10 @@ var ImageClasses = []string{
 	"ImageClassGPU",
 }
 
-// ImageFamilyToAccountID is a map of image families to account Ids
-var ImageFamilyToAccountID = map[string]string {
-	ImageFamilyAmazonLinux2: "602401143452",
-	ImageFamilyUbuntu1804: "099720109477",
-}
-
 // IsAvailable checks if a given AMI ID is available in AWS EC2
 func IsAvailable(api ec2iface.EC2API, id string) (bool, error) {
 	input := &ec2.DescribeImagesInput{
-		ImageIds: []*string{aws.String(id)},
+		ImageIds: []*string{&id},
 	}
 
 	output, err := api.DescribeImages(input)
@@ -66,13 +60,13 @@ func IsAvailable(api ec2iface.EC2API, id string) (bool, error) {
 // FindImage will get the AMI to use for the EKS nodes by querying AWS EC2 API.
 // It will only look for images with a status of available and it will pick the
 // image with the newest creation date.
-func FindImage(api ec2iface.EC2API, namePattern string, imageFamily string) (string, error) {
+func FindImage(api ec2iface.EC2API, ownerAccount, namePattern string) (string, error) {
 	input := &ec2.DescribeImagesInput{
-		Owners: []*string{aws.String(ImageFamilyToAccountID[imageFamily])},
+		Owners: []*string{&ownerAccount},
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("name"),
-				Values: []*string{aws.String(namePattern)},
+				Values: []*string{&namePattern},
 			},
 			{
 				Name:   aws.String("virtualization-type"),

--- a/pkg/ami/auto_resolver.go
+++ b/pkg/ami/auto_resolver.go
@@ -60,7 +60,7 @@ func (r *AutoResolver) Resolve(region, version, instanceType, imageFamily string
 		}
 	}
 
-	id, err := FindImage(r.api, p)
+	id, err := FindImage(r.api, p, imageFamily)
 	if err != nil {
 		return "", errors.Wrap(err, "error getting AMI")
 	}

--- a/pkg/ami/error.go
+++ b/pkg/ami/error.go
@@ -26,7 +26,7 @@ func NewErrFailedResolution(region, version, instanceType, imageFamily string) *
 
 // Error return the error message
 func (e *ErrFailedResolution) Error() string {
-	return fmt.Sprintf("Unable to determine AMI for region %s, version %s, instance type %s and image family %s", e.region, e.version, e.instanceType, e.imageFamily)
+	return fmt.Sprintf("unable to determine AMI for region %s, version %s, instance type %s and image family %s", e.region, e.version, e.instanceType, e.imageFamily)
 }
 
 // ErrNotFound is an error type that represents
@@ -45,5 +45,5 @@ func NewErrNotFound(ami string) *ErrNotFound {
 
 // Error return the error message
 func (e *ErrNotFound) Error() string {
-	return fmt.Sprintf("Unable to find AMI %s", e.ami)
+	return fmt.Sprintf("unable to find AMI %s", e.ami)
 }

--- a/pkg/ami/static_resolver_ami_generate.go
+++ b/pkg/ami/static_resolver_ami_generate.go
@@ -39,7 +39,7 @@ func main() {
 				for _, region := range api.SupportedRegions() {
 					p := ami.ImageSearchPatterns[version][family][class]
 					log.Printf("looking up images matching %q in %q", p, region)
-					image, err := ami.FindImage(client[region], p)
+					image, err := ami.FindImage(client[region], p, family)
 					if err != nil {
 						log.Fatal(err)
 					}

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -239,7 +239,7 @@ func (c *ClusterProvider) EnsureAMI(version string, ng *api.NodeGroup) error {
 	if ng.AMI == ami.ResolverStatic || ng.AMI == ami.ResolverAuto {
 		id, err := ami.Resolve(c.Provider.Region(), version, ng.InstanceType, ng.AMIFamily)
 		if err != nil {
-			return errors.Wrap(err, "Unable to determine AMI to use")
+			return errors.Wrap(err, "unable to determine AMI to use")
 		}
 		if id == "" {
 			return ami.NewErrFailedResolution(c.Provider.Region(), version, ng.InstanceType, ng.AMIFamily)


### PR DESCRIPTION
Signed-off-by: Christopher Hein <me@chrishein.com>

### Description
closes #732 

This checks the right Account ID for AL2 AMIs so that they always come from the EKS team.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
