### PR TITLE
Add old cluster and ng name tags back for forward comp.

### DIFF
--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -51,6 +51,7 @@ func newTag(key, value string) *cloudformation.Tag {
 func NewStackCollection(provider api.ClusterProvider, spec *api.ClusterConfig) *StackCollection {
 	tags := []*cloudformation.Tag{
 		newTag(api.ClusterNameTag, spec.Metadata.Name),
+		newTag(api.OldClusterNameTag, spec.Metadata.Name),
 	}
 	for key, value := range spec.Metadata.Tags {
 		tags = append(tags, newTag(key, value))

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -371,6 +371,10 @@ func fmtStacksRegexForCluster(name string) string {
 	return fmt.Sprintf(ourStackRegexFmt, name)
 }
 
+func (c *StackCollection) errStackNotFound() error {
+	return fmt.Errorf("no eksctl-managed CloudFormation stacks found for %q", c.spec.Metadata.Name)
+}
+
 // DescribeStacks describes the existing stacks
 func (c *StackCollection) DescribeStacks() ([]*Stack, error) {
 	stacks, err := c.ListStacks(fmtStacksRegexForCluster(c.spec.Metadata.Name))
@@ -378,7 +382,7 @@ func (c *StackCollection) DescribeStacks() ([]*Stack, error) {
 		return nil, errors.Wrapf(err, "describing CloudFormation stacks for %q", c.spec.Metadata.Name)
 	}
 	if len(stacks) == 0 {
-		return nil, fmt.Errorf("no eksctl-managed CloudFormation stacks found for %q", c.spec.Metadata.Name)
+		return nil, c.errStackNotFound()
 	}
 	return stacks, nil
 }

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -53,7 +53,7 @@ func (c *StackCollection) DescribeClusterStack() (*Stack, error) {
 			return s, nil
 		}
 	}
-	return nil, nil
+	return nil, c.errStackNotFound()
 }
 
 // AppendNewClusterStackResource will update cluster

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -56,6 +56,7 @@ func (c *StackCollection) createNodeGroupTask(errs chan error, ng *api.NodeGroup
 		ng.Tags = make(map[string]string)
 	}
 	ng.Tags[api.NodeGroupNameTag] = ng.Name
+	ng.Tags[api.OldNodeGroupNameTag] = ng.Name
 
 	return c.CreateStack(name, stack, ng.Tags, nil, errs)
 }


### PR DESCRIPTION
related to https://github.com/weaveworks/eksctl/issues/756


In https://github.com/weaveworks/eksctl/pull/728 the tags used for the cluster
and nodegroup names where renamed.  This PR makes sure both new and old tags
are added to new clusters. We will keep this behavior for a while until we
deprecate the old tags.

- [x] Code compiles correctly (i.e `make build`)
- [ ] All unit tests passing (i.e. `make test`)