### PR TITLE
Fix panic in ssh when providing key name by cli argument

### DIFF
--- a/pkg/ctl/create/utils.go
+++ b/pkg/ctl/create/utils.go
@@ -88,14 +88,14 @@ func loadSSHKey(ng *api.NodeGroup, clusterName string, provider api.ClusterProvi
 		}
 		sshConfig.PublicKeyName = &keyName
 
-	// A keyPath, when specified as a flag, can mean a local key or a key name in EC2
+	// A keyPath, when specified as a flag, can mean a local key (checked above) or a key name in EC2
 	default:
 		err := ssh.CheckKeyExistsInEC2(*sshConfig.PublicKeyPath, provider)
 		if err != nil {
-			ng.SSH.PublicKeyName = sshConfig.PublicKeyPath
-			ng.SSH.PublicKeyPath = nil
 			return err
 		}
+		sshConfig.PublicKeyName = sshConfig.PublicKeyPath
+		sshConfig.PublicKeyPath = nil
 		logger.Info("using EC2 key pair %q", *ng.SSH.PublicKeyName)
 	}
 


### PR DESCRIPTION
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)