### PR TITLE
Fix typo "buildings" -> building...

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $ eksctl create cluster
 [ℹ]  2 sequential tasks: { create cluster control plane "floral-unicorn-1540567338", create nodegroup "ng-98b3b83a" }
 [ℹ]  building cluster stack "eksctl-floral-unicorn-1540567338-cluster"
 [ℹ]  deploying stack "eksctl-floral-unicorn-1540567338-cluster"
-[ℹ]  buildings nodegroup stack "eksctl-floral-unicorn-1540567338-nodegroup-ng-98b3b83a"
+[ℹ]  building nodegroup stack "eksctl-floral-unicorn-1540567338-nodegroup-ng-98b3b83a"
 [ℹ]  --nodes-min=2 was set automatically for nodegroup ng-98b3b83a
 [ℹ]  --nodes-max=2 was set automatically for nodegroup ng-98b3b83a
 [ℹ]  deploying stack "eksctl-floral-unicorn-1540567338-nodegroup-ng-98b3b83a"

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -46,7 +46,7 @@ func (c *StackCollection) makeNodeGroupStackName(name string) string {
 // createNodeGroupTask creates the nodegroup
 func (c *StackCollection) createNodeGroupTask(errs chan error, ng *api.NodeGroup) error {
 	name := c.makeNodeGroupStackName(ng.Name)
-	logger.Info("buildings nodegroup stack %q", name)
+	logger.Info("building nodegroup stack %q", name)
 	stack := builder.NewNodeGroupResourceSet(c.provider, c.spec, c.makeClusterStackName(), ng)
 	if err := stack.AddAllResources(); err != nil {
 		return err


### PR DESCRIPTION
- [x] Code compiles correctly (i.e `make build`) 
- [x] All unit tests passing (i.e. `make test`)