### PR TITLE
Fixes #772: Adds extraCIDRs to VPC

### DIFF
--- a/examples/02-custom-vpc-cidr-no-nodes.yaml
+++ b/examples/02-custom-vpc-cidr-no-nodes.yaml
@@ -1,5 +1,5 @@
 # An example of ClusterConfig object with custom VPC CIDR,
-# and without any nodegroups:
+# an additional CIDR block, and without any nodegroups:
 --- 
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
@@ -8,6 +8,8 @@ metadata:
   name: cluster-2
   region: eu-north-1
 
-vpc: {cidr: 10.10.0.0/16}
+vpc: 
+  cidr: 10.10.0.0/16
+  extraCIDRs: [ 54.168.0.0/16 ] 
 
 nodeGroups: []

--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"fmt"
 	"strings"
 
 	gfn "github.com/awslabs/goformation/cloudformation"
@@ -48,6 +49,17 @@ func (c *ClusterResourceSet) addResourcesForVPC() {
 		EnableDnsSupport:   gfn.True(),
 		EnableDnsHostnames: gfn.True(),
 	})
+
+	for i, extraCIDR := range c.spec.VPC.ExtraCIDRs {
+		c.newResource(fmt.Sprintf("ExtraCIDR%d", i), &awsCloudFormationResource{
+			Type: "AWS::EC2::VPCCidrBlock",
+			Properties: map[string]interface{}{
+				"CidrBlock": extraCIDR.String(),
+				"VpcId":     c.vpc,
+			},
+			DependsOn: []string{"VPC"},
+		})
+	}
 
 	c.subnets = make(map[api.SubnetTopology][]*gfn.Value)
 


### PR DESCRIPTION
### Description
Fixes #772: uses extraCIDRs in config file and adds the CIDR blocks to the VPC in CloudFormation.

@errordeveloper should I add it to flags too?

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible) @errordeveloper where would it go?
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory) @errordeveloper any particular doc this should go in? Would be cool if we had a blank template of all options that are editable
- [x] Added yourself to the `humans.txt` file
