### PR TITLE
Override the launchTemplateData DeviceName for custom AMIs

### DIFF
--- a/examples/08-custom-ami.yaml
+++ b/examples/08-custom-ami.yaml
@@ -1,0 +1,17 @@
+# An example of ClusterConfig showing how to use a custom ami that is not Amazon Linux or Ubuntu that has had its volume size increased.
+---
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: cluster-8
+  region: eu-west-1
+
+nodeGroups:
+  - name: ng-1
+    instanceType: m5.large
+    desiredCapacity: 1
+    ami: ami-0259e19aeg5cdf121
+    volumeSize: 100
+    volumeType: gp2
+    deviceName: /dev/sda1 # Override the root volume device name, default is /dev/xvda

--- a/humans.txt
+++ b/humans.txt
@@ -38,6 +38,7 @@ Dann Church             @D3nn
 Roli Schilter           @rndstr
 Mitchel Humpherys       @mgalgs
 Fred Cox                @mcfedr
+Adam Johnson            @adamjohnson01
 
 /* Thanks */
 

--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -49,6 +49,9 @@ func SetNodeGroupDefaults(_ int, ng *NodeGroup) error {
 		if ng.VolumeType == "" {
 			ng.VolumeType = DefaultNodeVolumeType
 		}
+		if ng.DeviceName == "" {
+			ng.DeviceName = DefaultNodeVolumeDevice
+		}
 	}
 
 	if ng.IAM == nil {

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -88,6 +88,8 @@ const (
 	NodeVolumeTypeSC1 = "sc1"
 	// NodeVolumeTypeST1 is Cold HDD
 	NodeVolumeTypeST1 = "st1"
+	// DefaultNodeVolumeDevice defines the default root volume device name to use
+	DefaultNodeVolumeDevice = "/dev/xvda"
 
 	// DefaultNodeImageFamily defines the default image family for the worker nodes
 	DefaultNodeImageFamily = NodeImageFamilyAmazonLinux2
@@ -340,6 +342,7 @@ func (c *ClusterConfig) NewNodeGroup() *NodeGroup {
 		InstanceType:    DefaultNodeType,
 		VolumeSize:      0,
 		VolumeType:      DefaultNodeVolumeType,
+		DeviceName:      DefaultNodeVolumeDevice,
 		IAM: &NodeGroupIAM{
 			WithAddonPolicies: NodeGroupIAMAddonPolicies{
 				ImageBuilder: Disabled(),
@@ -394,6 +397,8 @@ type NodeGroup struct {
 	VolumeSize int `json:"volumeSize"`
 	// +optional
 	VolumeType string `json:"volumeType"`
+	// +optional
+	DeviceName string `json:"deviceName"`
 	// +optional
 	MaxPodsPerNode int `json:"maxPodsPerNode,omitempty"`
 

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -398,7 +398,7 @@ type NodeGroup struct {
 	// +optional
 	VolumeType string `json:"volumeType"`
 	// +optional
-	DeviceName string `json:"deviceName"`
+	DeviceName string `json:"deviceName,omitempty"`
 	// +optional
 	MaxPodsPerNode int `json:"maxPodsPerNode,omitempty"`
 

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -248,7 +248,6 @@ var _ = Describe("CloudFormation template builder API", func() {
 		ng.AMIFamily = "AmazonLinux2"
 		ng.VolumeSize = 2
 		ng.VolumeType = api.NodeVolumeTypeIO1
-		ng.DeviceName = api.DefaultNodeVolumeDevice
 
 		if withFullVPC {
 			cfg.VPC = testVPC()
@@ -355,6 +354,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 					DesiredCapacity: nil,
 					VolumeSize:      2,
 					VolumeType:      api.NodeVolumeTypeIO1,
+					DeviceName:      api.DefaultNodeVolumeDevice,
 					IAM: &api.NodeGroupIAM{
 						WithAddonPolicies: api.NodeGroupIAMAddonPolicies{
 							ImageBuilder: api.Disabled(),

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -248,6 +248,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 		ng.AMIFamily = "AmazonLinux2"
 		ng.VolumeSize = 2
 		ng.VolumeType = api.NodeVolumeTypeIO1
+		ng.DeviceName = api.DefaultNodeVolumeDevice
 
 		if withFullVPC {
 			cfg.VPC = testVPC()

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -128,7 +128,7 @@ func (n *NodeGroupResourceSet) addResourcesForNodeGroup() error {
 
 	if n.spec.VolumeSize > 0 {
 		launchTemplateData.BlockDeviceMappings = []gfn.AWSEC2LaunchTemplate_BlockDeviceMapping{{
-			DeviceName: gfn.NewString("/dev/xvda"),
+			DeviceName: gfn.NewString(n.spec.DeviceName),
 			Ebs: &gfn.AWSEC2LaunchTemplate_Ebs{
 				VolumeSize: gfn.NewInteger(n.spec.VolumeSize),
 				VolumeType: gfn.NewString(n.spec.VolumeType),

--- a/pkg/ctl/cmdutils/configfile_test.go
+++ b/pkg/ctl/cmdutils/configfile_test.go
@@ -57,7 +57,7 @@ var _ = Describe("cmdutils configfile", func() {
 			examples, err := filepath.Glob(examplesDir + "*.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(examples).To(HaveLen(7))
+			Expect(examples).To(HaveLen(8))
 			for _, example := range examples {
 				cfg := api.NewClusterConfig()
 

--- a/pkg/ctl/cmdutils/nodegroup_filter_test.go
+++ b/pkg/ctl/cmdutils/nodegroup_filter_test.go
@@ -319,6 +319,7 @@ const expected = `
 			  },
 			  "volumeSize": 768,
 			  "volumeType": "io1",
+			  "deviceName": "/dev/xvda",
 			  "labels": {
 			    "group": "a",
 			    "seq": "1"
@@ -354,6 +355,7 @@ const expected = `
 			  },
 			  "volumeSize": 0,
 			  "volumeType": "gp2",
+			  "deviceName": "/dev/xvda",
 			  "labels": {
 			    "group": "a",
 			    "seq": "2"
@@ -389,6 +391,7 @@ const expected = `
 			  },
 			  "volumeSize": 0,
 			  "volumeType": "gp2",
+			  "deviceName": "/dev/xvda",
 			  "labels": {
 			    "group": "a",
 			    "seq": "3"
@@ -423,6 +426,7 @@ const expected = `
 			  },
 			  "volumeSize": 0,
 			  "volumeType": "gp2",
+			  "deviceName": "/dev/xvda",
 			  "labels": {
 			    "group": "b",
 			    "seq": "1"
@@ -460,6 +464,7 @@ const expected = `
 			  },
 			  "volumeSize": 0,
 			  "volumeType": "gp2",
+			  "deviceName": "/dev/xvda",
 			  "labels": {
 			    "group": "b",
 			    "seq": "1"
@@ -497,6 +502,7 @@ const expected = `
 			  },
 			  "volumeSize": 192,
 			  "volumeType": "gp2",
+			  "deviceName": "/dev/xvda",
 			  "labels": {
 			    "group": "b",
 			    "seq": "1"


### PR DESCRIPTION

### Description
Added a config option to allow overriding of the launchTemplateData DeviceName. This will allow custom amis that do not have a root device of /dev/xvda to have the root volume extended.

Issue #774

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [ ] All integration tests passing (i.e. `make integration-test`)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Added yourself to the `humans.txt` file
