### PR TITLE
WIP: easy ssh with eksctl utils issue#148

### DIFF
--- a/pkg/ctl/utils/ssh.go
+++ b/pkg/ctl/utils/ssh.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"os"
+
+	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
+	"github.com/thapakazi/easyssh-go/library"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+func listNodesCmd(g *cmdutils.Grouping) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list-nodes",
+		Short: "List the nodes in the cluster in ssh config format",
+		Run: func(_ *cobra.Command, args []string) {
+			logger.Info("listing the worker nodes...")
+			generateSSHConfig()
+		},
+	}
+	return cmd
+}
+
+// generateSSHConfig populates the ssh config based on cluster tags
+func generateSSHConfig() {
+
+	// TODO: discover these base on cluster nodes
+	username := "ec2-user"
+	port := "22"
+	var tags = make(map[string][]string)
+	tags["tag:eksctl.cluster.k8s.io/v1alpha1/cluster-name"] = []string{"myeks"}
+	tags["instance-state-name"] = []string{"running", "pending"}
+
+	response, err := library.FetchIps(tags)
+	if err != nil {
+		logger.Critical("Error fetching ips: %q", err.Error())
+		os.Exit(-1)
+	}
+	err = library.GenerateConfig(username, port, response, os.Stdout)
+	if err != nil {
+		logger.Critical("Error generating ssh config: %q", err.Error())
+		os.Exit(-1)
+	}
+}

--- a/pkg/ctl/utils/utils.go
+++ b/pkg/ctl/utils/utils.go
@@ -32,6 +32,7 @@ func Command(g *cmdutils.Grouping) *cobra.Command {
 	cmd.AddCommand(updateAWSNodeCmd(g))
 	cmd.AddCommand(updateCoreDNSCmd(g))
 	cmd.AddCommand(installCoreDNSCmd(g))
+	cmd.AddCommand(listNodesCmd(g))
 
 	return cmd
 }


### PR DESCRIPTION
_**This PR is work in progress.. I will update it accordingly.**_ 

### Description
This PR is to support easy ssh access to the nodes via eksctl utils.  

Initial thread: https://github.com/weaveworks/eksctl/issues/148
### Design: :speaking_head: : 
I would like to break this into:
  1. generating ssh config into a file `~/.eksctl/cluster/ssh.config` based on the tag used in cluster nodes 
```bash
eksctl utils ssh list nodes                # list the nodes
eksctl utils ssh list nodes --update  # or -U similar to update the ssh inventory
```
Sample:<Details>
<summary>Example WIP</summary>

```
(master)⚡ % go run ./cmd/eksctl/*.go utils list nodes                                             ~/go/src/github.com/thapakazi/eksctl
[ℹ]  listing the worker nodes...


Host myeks-ng-96d7c0d7-Node
        hostname 192.168.103.219
        User ec2-user
        Port 22

Host myeks-ng-96d7c0d7-Node
        hostname 192.168.167.172
        User ec2-user
        Port 22
```
</Details>

  2. use the config from step1 && wrap around ssh binary to enter into nodes for
```bash
eksctl utils ssh node_from_list_above...
```
I have built a [library](https://github.com/thapakazi/easyssh-go/blob/master/library/tags_2_ssh_config.go) (a wrapper around aws, nothing fancy) to fetch instance info based on custom tags. I am thinking of re-using it here. Easy Alternatives...?

Suggestion Please...

### Checklist
- [ ] yet to build... idea validation in progress

### Stakes
@errordeveloper 