### PR TITLE
WIP: Separate autoscaler IAM permissions and autoscaling group autoscaler tagging

### DIFF
--- a/examples/05-advanced-nodegroups.yaml
+++ b/examples/05-advanced-nodegroups.yaml
@@ -12,13 +12,14 @@ nodeGroups:
     instanceType: m5.xlarge
     minSize: 2
     maxSize: 8
+    autoScalerEnabled: true # This configures the nodegroup so that it can be managed by the cluster autoscaler
     volumeSize: 100
     volumeType: gp2
     labels:
       nodegroup-type: frontend-workloads
     iam:
       withAddonPolicies:
-        autoScaler: true
+        autoScaler: true # This sets the required IAM permissions for the cluster autoscaler to run
 
   - name: ng2-private-a
     instanceType: m5.large

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -335,6 +335,7 @@ func (c *ClusterConfig) NewNodeGroup() *NodeGroup {
 
 	ng := &NodeGroup{
 		PrivateNetworking: false,
+		AutoScalerEnabled: Disabled(),
 		SecurityGroups: &NodeGroupSGs{
 			AttachIDs:  []string{},
 			WithLocal:  Enabled(),
@@ -383,6 +384,9 @@ type NodeGroup struct {
 	Tags map[string]string `json:"tags,omitempty"`
 	// +optional
 	PrivateNetworking bool `json:"privateNetworking"`
+
+	// +optional
+	AutoScalerEnabled *bool `json:"autoScalerEnabled,omitempty"`
 
 	// +optional
 	SecurityGroups *NodeGroupSGs `json:"securityGroups,omitempty"`

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -252,6 +252,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 		*ng.VolumeType = api.NodeVolumeTypeIO1
 		ng.VolumeName = new(string)
 		*ng.VolumeName = "/dev/xvda"
+		ng.AutoScalerEnabled = api.Disabled()
 
 		if withFullVPC {
 			cfg.VPC = testVPC()
@@ -349,6 +350,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 					InstanceType:      "t2.medium",
 					Name:              "ng-abcd1234",
 					PrivateNetworking: false,
+					AutoScalerEnabled: api.Disabled(),
 					SecurityGroups: &api.NodeGroupSGs{
 						WithLocal:  api.Enabled(),
 						WithShared: api.Enabled(),
@@ -679,6 +681,8 @@ var _ = Describe("CloudFormation template builder API", func() {
 
 		ng.IAM.InstanceRoleName = "a-named-role"
 		ng.IAM.WithAddonPolicies.AutoScaler = api.Enabled()
+
+		ng.AutoScalerEnabled = api.Enabled()
 
 		build(cfg, "eksctl-test-123-cluster", ng)
 

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -182,7 +182,7 @@ func (n *NodeGroupResourceSet) addResourcesForNodeGroup() error {
 			"PropagateAtLaunch": "true",
 		},
 	}
-	if api.IsEnabled(n.spec.IAM.WithAddonPolicies.AutoScaler) {
+	if api.IsEnabled(n.spec.AutoScalerEnabled) {
 		tags = append(tags,
 			map[string]interface{}{
 				"Key":               "k8s.io/cluster-autoscaler/enabled",

--- a/pkg/ctl/cmdutils/nodegroup_filter_test.go
+++ b/pkg/ctl/cmdutils/nodegroup_filter_test.go
@@ -318,6 +318,7 @@ const expected = `
 			  "amiFamily": "AmazonLinux2",
 			  "instanceType": "m5.large",
 			  "privateNetworking": false,
+			  "autoScalerEnabled": false,
 			  "securityGroups": {
 			    "withShared": true,
 			    "withLocal": true
@@ -353,6 +354,7 @@ const expected = `
 			  "amiFamily": "AmazonLinux2",
 			  "instanceType": "m5.large",
 			  "privateNetworking": false,
+			  "autoScalerEnabled": false,
 			  "securityGroups": {
 			    "withShared": true,
 			    "withLocal": true
@@ -388,6 +390,7 @@ const expected = `
 			  "amiFamily": "AmazonLinux2",
 			  "instanceType": "m3.large",
 			  "privateNetworking": false,
+			  "autoScalerEnabled": false,
 			  "securityGroups": {
 			    "withShared": true,
 			    "withLocal": true
@@ -422,6 +425,7 @@ const expected = `
 			  "amiFamily": "AmazonLinux2",
 			  "instanceType": "m5.large",
 			  "privateNetworking": false,
+			  "autoScalerEnabled": false,
 			  "securityGroups": {
 			    "withShared": true,
 			    "withLocal": true
@@ -455,6 +459,7 @@ const expected = `
 			  "amiFamily": "AmazonLinux2",
 			  "instanceType": "m5.xlarge",
 			  "privateNetworking": false,
+			  "autoScalerEnabled": false,
 			  "securityGroups": {
 			    "attachIDs": [
 			  	"sg-1",
@@ -492,6 +497,7 @@ const expected = `
 			  "amiFamily": "AmazonLinux2",
 			  "instanceType": "m5.large",
 			  "privateNetworking": false,
+			  "autoScalerEnabled": false,
 			  "securityGroups": {
 			    "attachIDs": [
 			  	"sg-1",


### PR DESCRIPTION
### Description

I have added a new config option called autoScalerEnabled which will be responsible for enabling the nodegroup autoscaling group for cluster autoscaling. This was previously managed by iam.withAddonPolicies.autoScaler but it meant that unnecessary permissions were being given to nodegroups and it made it impossible to use existing IAM roles and enable autoscaling at the same time.

Issue #791 

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
