### PR TITLE
Fix typo 'betwee' to 'between'

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -39,6 +39,7 @@ Roli Schilter           @rndstr
 Mitchel Humpherys       @mgalgs
 Fred Cox                @mcfedr
 Adam Johnson            @adamjohnson01
+Patrick Spek            @tyil
 
 /* Thanks */
 

--- a/pkg/vpc/vpc.go
+++ b/pkg/vpc/vpc.go
@@ -33,7 +33,7 @@ func SetSubnets(spec *api.ClusterConfig) error {
 	}
 	prefix, _ := spec.VPC.CIDR.Mask.Size()
 	if (prefix < 16) || (prefix > 24) {
-		return fmt.Errorf("VPC CIDR prefix must be betwee /16 and /24")
+		return fmt.Errorf("VPC CIDR prefix must be between /16 and /24")
 	}
 	zoneCIDRs, err := subnet.SplitInto8(&spec.VPC.CIDR.IPNet)
 	if err != nil {


### PR DESCRIPTION
### Description

While running the program I discovered a typo on in `vpc.go`, line 36:

    VPC CIDR prefix must be betwee /16 and /24

I've changed this to use the word `between` (with an `n` at the end).

I've tried to run the test suite as well, however, `make integration-test` tries to add changes. If I re-run the test with these changes applied locally, it works as expected, however, then CircleCI starts complaining, so I left them out.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [ ] All unit tests passing (i.e. `make test`)
- [ ] All integration tests passing (i.e. `make integration-test`)
- [x] Added yourself to the `humans.txt` file
