### PR TITLE
Add command to manipulate IAM identity mappings

### DIFF
--- a/integration/common_test.go
+++ b/integration/common_test.go
@@ -61,8 +61,18 @@ func eksctl(args ...string) *gexec.Session {
 	default:
 		t *= 30
 	}
-
 	session.Wait(t)
+	return session
+}
+
+func eksctlSuccess(args ...string) *gexec.Session {
+	session := eksctl(args...)
 	Expect(session.ExitCode()).To(Equal(0))
+	return session
+}
+
+func eksctlFail(args ...string) *gexec.Session {
+	session := eksctl(args...)
+	Expect(session.ExitCode()).To(Not(Equal(0)))
 	return session
 }

--- a/integration/common_test.go
+++ b/integration/common_test.go
@@ -15,11 +15,6 @@ import (
 	"github.com/onsi/gomega/gexec"
 )
 
-type tInterface interface {
-	GinkgoTInterface
-	Helper()
-}
-
 type tHelper struct{ GinkgoTInterface }
 
 func (t *tHelper) Helper()      { return }

--- a/pkg/authconfigmap/authconfigmap_test.go
+++ b/pkg/authconfigmap/authconfigmap_test.go
@@ -165,7 +165,7 @@ var _ = Describe("AuthConfigMap{}", func() {
 
 		removeAndSave := func(arn string) *corev1.ConfigMap {
 			client.reset()
-			err := acm.RemoveRole(arn)
+			err := acm.RemoveRole(arn, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = acm.Save()
@@ -187,8 +187,19 @@ var _ = Describe("AuthConfigMap{}", func() {
 			Expect(cm.Data["mapRoles"]).To(MatchYAML("[]"))
 		})
 		It("should fail if role not found", func() {
-			err := acm.RemoveRole(roleA)
+			err := acm.RemoveRole(roleA, false)
 			Expect(err).To(HaveOccurred())
+		})
+		It("should remove all if specified", func() {
+			err := acm.AddRole(roleA, RoleNodeGroupUsername, RoleNodeGroupGroups)
+			Expect(err).NotTo(HaveOccurred())
+			err = acm.AddRole(roleA, RoleNodeGroupUsername, RoleNodeGroupGroups)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.updated.Data["mapRoles"]).To(Not(MatchYAML("[]")))
+
+			err = acm.RemoveRole(roleA, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.updated.Data["mapRoles"]).To(MatchYAML("[]"))
 		})
 	})
 	Describe("AddAccount()", func() {

--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -135,7 +135,13 @@ func ErrUnsupportedRegion(p *api.ProviderConfig) error {
 
 // ErrNameFlagAndArg is a common error message
 func ErrNameFlagAndArg(nameFlag, nameArg string) error {
-	return fmt.Errorf("--name=%s and argument %s %s", nameFlag, nameArg, IncompatibleFlags)
+	return ErrFlagAndArg("--name", nameFlag, nameArg)
+}
+
+// ErrFlagAndArg may be used to err for options that can be given
+// as flags /and/ arg but only one is allowed to be used.
+func ErrFlagAndArg(kind, flag, arg string) error {
+	return fmt.Errorf("%s=%s and argument %s %s", kind, flag, arg, IncompatibleFlags)
 }
 
 // ErrMustBeSet is a common error message

--- a/pkg/ctl/create/create.go
+++ b/pkg/ctl/create/create.go
@@ -24,6 +24,7 @@ func Command(g *cmdutils.Grouping) *cobra.Command {
 
 	cmd.AddCommand(createClusterCmd(g))
 	cmd.AddCommand(createNodeGroupCmd(g))
+	cmd.AddCommand(createIAMIdentityMappingCmd(g))
 
 	return cmd
 }

--- a/pkg/ctl/create/iamidentitymapping.go
+++ b/pkg/ctl/create/iamidentitymapping.go
@@ -1,0 +1,95 @@
+package create
+
+import (
+	"os"
+
+	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/authconfigmap"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/eks"
+)
+
+func createIAMIdentityMappingCmd(g *cmdutils.Grouping) *cobra.Command {
+	p := &api.ProviderConfig{}
+	cfg := api.NewClusterConfig()
+	id := &authconfigmap.MapRole{}
+	cmd := &cobra.Command{
+		Use:   "iamidentitymapping",
+		Short: "Create an IAM identity mapping",
+		Long: `Creates a mapping from IAM role to Kubernetes user and groups.
+
+Note aws-iam-authenticator only considers the last entry for any given
+role. If you create a duplicate entry it will shadow all the previous
+username and groups mapping.
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := doCreateIAMIdentityMapping(p, cfg, id); err != nil {
+				logger.Critical("%s\n", err.Error())
+				os.Exit(1)
+			}
+		},
+	}
+	group := g.New(cmd)
+
+	group.InFlagSet("General", func(fs *pflag.FlagSet) {
+		fs.StringVar(&id.RoleARN, "role", "", "ARN of the IAM role to create")
+		fs.StringVar(&id.Username, "username", "", "User name within Kubernetes to map to IAM role")
+		fs.StringArrayVar(&id.Groups, "group", []string{}, "Group within Kubernetes to which IAM role is mapped")
+		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")
+		cmdutils.AddRegionFlag(fs, p)
+	})
+
+	cmdutils.AddCommonFlagsForAWS(group, p, false)
+
+	group.AddTo(cmd)
+
+	return cmd
+}
+
+func doCreateIAMIdentityMapping(p *api.ProviderConfig, cfg *api.ClusterConfig, id *authconfigmap.MapRole) error {
+	ctl := eks.New(p, cfg)
+
+	if err := ctl.CheckAuth(); err != nil {
+		return err
+	}
+	if id.RoleARN == "" {
+		return cmdutils.ErrMustBeSet("--role")
+	}
+	if cfg.Metadata.Name == "" {
+		return cmdutils.ErrMustBeSet("--cluster")
+	}
+	if err := id.Valid(); err != nil {
+		return err
+	}
+
+	if err := ctl.GetCredentials(cfg); err != nil {
+		return err
+	}
+	clientSet, err := ctl.NewStdClientSet(cfg)
+	if err != nil {
+		return err
+	}
+	acm, err := authconfigmap.NewFromClientSet(clientSet)
+	if err != nil {
+		return err
+	}
+
+	// Check whether role already exists.
+	roles, err := acm.Roles()
+	if err != nil {
+		return err
+	}
+	filtered := roles.Get(id.RoleARN)
+	if len(filtered) > 0 {
+		logger.Warning("found %d mappings with same role %q (which will be shadowed by your new mapping)", len(filtered), id.RoleARN)
+	}
+
+	if err := acm.AddRole(id.RoleARN, id.Username, id.Groups); err != nil {
+		return err
+	}
+	return acm.Save()
+}

--- a/pkg/ctl/delete/delete.go
+++ b/pkg/ctl/delete/delete.go
@@ -3,6 +3,7 @@ package delete
 import (
 	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
+
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
@@ -27,6 +28,7 @@ func Command(g *cmdutils.Grouping) *cobra.Command {
 
 	cmd.AddCommand(deleteClusterCmd(g))
 	cmd.AddCommand(deleteNodeGroupCmd(g))
+	cmd.AddCommand(deleteIAMIdentityMappingCmd(g))
 
 	return cmd
 }

--- a/pkg/ctl/delete/iamidentitymapping.go
+++ b/pkg/ctl/delete/iamidentitymapping.go
@@ -1,0 +1,90 @@
+package delete
+
+import (
+	"os"
+
+	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/authconfigmap"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/eks"
+)
+
+func deleteIAMIdentityMappingCmd(g *cmdutils.Grouping) *cobra.Command {
+	p := &api.ProviderConfig{}
+	cfg := api.NewClusterConfig()
+	var roleFlag string
+	var all bool
+	cmd := &cobra.Command{
+		Use:   "iamidentitymapping",
+		Short: "Delete a IAM identity mapping",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := doDeleteIAMIdentityMapping(p, cfg, roleFlag, all); err != nil {
+				logger.Critical("%s\n", err.Error())
+				os.Exit(1)
+			}
+		},
+	}
+	group := g.New(cmd)
+
+	group.InFlagSet("General", func(fs *pflag.FlagSet) {
+		fs.StringVar(&roleFlag, "role", "", "ARN of the IAM role to delete")
+		fs.BoolVar(&all, "all", false, "Delete all matching mappings instead of just one")
+		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")
+		cmdutils.AddRegionFlag(fs, p)
+	})
+
+	cmdutils.AddCommonFlagsForAWS(group, p, false)
+
+	group.AddTo(cmd)
+
+	return cmd
+}
+
+func doDeleteIAMIdentityMapping(p *api.ProviderConfig, cfg *api.ClusterConfig, roleFlag string, all bool) error {
+	ctl := eks.New(p, cfg)
+
+	if err := ctl.CheckAuth(); err != nil {
+		return err
+	}
+
+	if roleFlag == "" {
+		return cmdutils.ErrMustBeSet("--role")
+	}
+	if cfg.Metadata.Name == "" {
+		return cmdutils.ErrMustBeSet("--cluster")
+	}
+
+	if err := ctl.GetCredentials(cfg); err != nil {
+		return err
+	}
+	clientSet, err := ctl.NewStdClientSet(cfg)
+	if err != nil {
+		return err
+	}
+	acm, err := authconfigmap.NewFromClientSet(clientSet)
+	if err != nil {
+		return err
+	}
+
+	if err := acm.RemoveRole(roleFlag, all); err != nil {
+		return err
+	}
+	if err := acm.Save(); err != nil {
+		return err
+	}
+
+	// Check whether we have more roles that match
+	roles, err := acm.Roles()
+	if err != nil {
+		return err
+	}
+	filtered := roles.Get(roleFlag)
+	if len(filtered) > 0 {
+		logger.Warning("there are %d mappings left with same role %q (use --all to delete them at once)", len(filtered), roleFlag)
+	}
+	return nil
+}

--- a/pkg/ctl/get/get.go
+++ b/pkg/ctl/get/get.go
@@ -25,6 +25,7 @@ func Command(g *cmdutils.Grouping) *cobra.Command {
 
 	cmd.AddCommand(getClusterCmd(g))
 	cmd.AddCommand(getNodegroupCmd(g))
+	cmd.AddCommand(getIAMIdentityMappingCmd(g))
 
 	return cmd
 }

--- a/pkg/ctl/get/iamidentitymapping.go
+++ b/pkg/ctl/get/iamidentitymapping.go
@@ -1,0 +1,108 @@
+package get
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/authconfigmap"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/eks"
+	"github.com/weaveworks/eksctl/pkg/printers"
+)
+
+func getIAMIdentityMappingCmd(g *cmdutils.Grouping) *cobra.Command {
+	p := &api.ProviderConfig{}
+	cfg := api.NewClusterConfig()
+	var roleFlag string
+	cmd := &cobra.Command{
+		Use:   "iamidentitymapping",
+		Short: "Get IAM identity mapping(s)",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := doGetIAMIdentityMapping(p, cfg, roleFlag); err != nil {
+				logger.Critical("%s\n", err.Error())
+				os.Exit(1)
+			}
+		},
+	}
+	group := g.New(cmd)
+
+	group.InFlagSet("General", func(fs *pflag.FlagSet) {
+		fs.StringVar(&roleFlag, "role", "", "ARN of the IAM role")
+		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")
+		cmdutils.AddRegionFlag(fs, p)
+		cmdutils.AddCommonFlagsForGetCmd(fs, &chunkSize, &output)
+	})
+
+	cmdutils.AddCommonFlagsForAWS(group, p, false)
+
+	group.AddTo(cmd)
+
+	return cmd
+}
+
+func doGetIAMIdentityMapping(p *api.ProviderConfig, cfg *api.ClusterConfig, roleFlag string) error {
+	ctl := eks.New(p, cfg)
+
+	if err := ctl.CheckAuth(); err != nil {
+		return err
+	}
+
+	if cfg.Metadata.Name == "" {
+		return cmdutils.ErrMustBeSet("--cluster")
+	}
+
+	if err := ctl.GetCredentials(cfg); err != nil {
+		return err
+	}
+	clientSet, err := ctl.NewStdClientSet(cfg)
+	if err != nil {
+		return err
+	}
+	acm, err := authconfigmap.NewFromClientSet(clientSet)
+	if err != nil {
+		return err
+	}
+	roles, err := acm.Roles()
+	if err != nil {
+		return err
+	}
+	if roleFlag != "" {
+		roles = roles.Get(roleFlag)
+		// If a filter was given, we error if none was found
+		if len(roles) == 0 {
+			return fmt.Errorf("no iamidentitymapping with role %q found", roleFlag)
+		}
+	}
+
+	printer, err := printers.NewPrinter(output)
+	if err != nil {
+		return err
+	}
+	if output == "table" {
+		addIAMIdentityMappingTableColumns(printer.(*printers.TablePrinter))
+	}
+
+	if err := printer.PrintObjWithKind("iamidentitymappings", roles, os.Stdout); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func addIAMIdentityMappingTableColumns(printer *printers.TablePrinter) {
+	printer.AddColumn("ROLE", func(r authconfigmap.MapRole) string {
+		return r.RoleARN
+	})
+	printer.AddColumn("USERNAME", func(r authconfigmap.MapRole) string {
+		return r.Username
+	})
+	printer.AddColumn("GROUPS", func(r authconfigmap.MapRole) string {
+		return strings.Join(r.Groups, ",")
+	})
+}

--- a/pkg/iam/mapping.go
+++ b/pkg/iam/mapping.go
@@ -1,0 +1,17 @@
+package iam
+
+import "errors"
+
+// Identity represents an IAM identity.
+type Identity struct {
+	Username string   `json:"username"`
+	Groups   []string `json:"groups"`
+}
+
+// Valid ensures the identity is proper.
+func (i Identity) Valid() error {
+	if len(i.Groups) == 0 {
+		return errors.New("identity mapping needs at least 1 group")
+	}
+	return nil
+}


### PR DESCRIPTION
### Description

Adds the following commands to get/create/delete IAM role mappings to
Kubernetes username and groups.

    eksctl get iamidentitymapping [--role arn]
    eksctl create iamidentitymapping --role <arn> [--username=USER] --group=GROUP0 [--group=GROUP1]
    eksctl delete iamidentitymapping --role <arn> [--all]

`eksctl get iamidentitymapping`
Returns all mappings; if role filter is given it returns all matching
roles (can be more than one).

`eksctl create iamidentitymapping`
Allows creating duplicates. Will warn if duplicates exist.

`eksctl delete iamidentitymapping`
Deletes a single mapping FIFO unless `--all` is given in which case it
removes all matching. Will warn if more mappings matching this role are
found.

Closes #625
Some remarks about implementation at  https://github.com/weaveworks/eksctl/issues/625#issuecomment-492055564

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)


### Example of interaction

```
$ eksctl get iamidentitymapping --cluster=roli-dev                                                                                      
ROLE                                                                                     USERNAME                                GROUPS                                       
arn:aws:iam::376248598259:role/eksctl-roli-dev-nodegroup-ng1-pub-NodeInstanceRole-5SO5IE system:node:{{EC2PrivateDNSName}}       system:bootstrappers,system:nodes            
arn:aws:iam::376248598259:role/eksctl-roli-dev-nodegroup-ng2-pub-NodeInstanceRole-4SVDI  system:node:{{EC2PrivateDNSName}}       system:bootstrappers,system:nodes            
arntest                                                                                  roli                                    foo1,bar2                                    
foo                                                                                                                              bar                                          
foo                                                                                                                              bar


$ eksctl delete iamidentitymapping --cluster=roli-dev --role foo
[ℹ]  removing role "foo" from auth ConfigMap (username = "", groups = ["bar"])
[!]  there are 1 mappings left with same role "foo" (use --all to delete them at once)

$ eksctl create iamidentitymapping --cluster=roli-dev --role foo --group=moo                                                            
[!]  found 1 mappings with same role "foo" (which will be shadowed by your new mapping)
[ℹ]  adding role "foo" to auth ConfigMap

$ eksctl get iamidentitymapping --cluster=roli-dev --role foo                                                                           
ROLE    USERNAME        GROUPS
foo                     bar
foo                     moo

$ eksctl delete iamidentitymapping --cluster=roli-dev --role foo --all                                                                  
[ℹ]  removing role "foo" from auth ConfigMap (username = "", groups = ["bar"])
[ℹ]  removing role "foo" from auth ConfigMap (username = "", groups = ["moo"])
```
