### PR TITLE
Add ec2:DescribeLaunchTemplateVersions policy for CA

### DIFF
--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -755,6 +755,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 				"autoscaling:DescribeTags",
 				"autoscaling:SetDesiredCapacity",
 				"autoscaling:TerminateInstanceInAutoScalingGroup",
+				"ec2:DescribeLaunchTemplateVersions",
 			}))
 		})
 

--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -193,6 +193,7 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 				"autoscaling:DescribeTags",
 				"autoscaling:SetDesiredCapacity",
 				"autoscaling:TerminateInstanceInAutoScalingGroup",
+				"ec2:DescribeLaunchTemplateVersions",
 			},
 		)
 	}


### PR DESCRIPTION
closes #810 

Attach ec2:DescribeLaunchTemplateVersions policy to the nodegroup to support
CA scaling down to 0.

See https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#scaling-a-node-group-to-0

<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)