### PR TITLE
Describe bash3 completion workaround for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,6 +692,11 @@ To enable bash completion, run the following, or put it in `~/.bashrc` or `~/.pr
 . <(eksctl completion bash)
 ```
 
+If you are stuck on Bash 3 (macOS) use
+```
+source /dev/stdin <<<"$(eksctl completion bash)"
+```
+
 Or for zsh, run:
 ```
 mkdir -p ~/.zsh/completion/

--- a/pkg/ctl/completion/completion.go
+++ b/pkg/ctl/completion/completion.go
@@ -20,6 +20,10 @@ To configure your bash shell to load completions for each session add to your ba
 
 # ~/.bashrc or ~/.profile
 . <(eksctl completion bash)
+
+If you are stuck on Bash 3 (macOS) use
+
+source /dev/stdin <<<"$(eksctl completion bash)"
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return rootCmd.GenBashCompletion(os.Stdout)


### PR DESCRIPTION
### Description

Expands the help text for `eksctl completion bash --help` to include the workaround for bash3 which is commonly found on macOSes.

Closes #803

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)