### PR TITLE
Fix setup instructions to include dep dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ export GOPATH="$(pwd)"
 export GOBIN="${GOPATH}/bin"
 ```
 
+You also need the Go dependency management tool [dep](https://github.com/golang/dep) installed.  You can follow their installation instructions [here](https://github.com/golang/dep#installation)
+
 > NOTE: Windows users should install Docker for Windows and run `make eksctl-image` to build their code.
 
 > TODO: Improve Windows instructions, ensure `go build` works.


### PR DESCRIPTION
### Description
Was trying to do a build of the project to test out a currently open PR, and didn't have a preexisting Go setup on my machine.  Looks like you need dep installed to do the `make install-build-deps` step?  

Adding a bit to the documentation to save someone else time in the future

### Checklist
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
