### PR TITLE
Changes EFS IAM Policy Resource

### DIFF
--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -1097,7 +1097,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 
 			Expect(policy.PolicyDocument.Statement).To(HaveLen(1))
 			Expect(policy.PolicyDocument.Statement[0].Effect).To(Equal("Allow"))
-			Expect(policy.PolicyDocument.Statement[0].Resource).To(Equal("arn:aws:elasticfilesystem:us-west-2:123456789012:file-system/*"))
+			Expect(policy.PolicyDocument.Statement[0].Resource).To(Equal("*"))
 			Expect(policy.PolicyDocument.Statement[0].Action).To(Equal([]string{
 				"elasticfilesystem:*",
 			}))

--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -255,7 +255,7 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 	}
 
 	if api.IsEnabled(n.spec.IAM.WithAddonPolicies.EFS) {
-		n.rs.attachAllowPolicy("PolicyEFS", refIR, "arn:aws:elasticfilesystem:us-west-2:123456789012:file-system/*",
+		n.rs.attachAllowPolicy("PolicyEFS", refIR, "*",
 			[]string{
 				"elasticfilesystem:*",
 			},
@@ -344,7 +344,7 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 	}
 
 	if api.IsEnabled(n.spec.IAM.WithAddonPolicies.XRay) {
-		n.rs.attachAllowPolicy("PolicyXRay", refIR, "*", 
+		n.rs.attachAllowPolicy("PolicyXRay", refIR, "*",
 			[]string{
 				"xray:PutTraceSegments",
 				"xray:PutTelemetryRecords",


### PR DESCRIPTION
### Description

When IAM AddOn Policy for EFS is set to true the policy is generated
specifying a wrong (fake) resource ARN
`arn:aws:elasticfilesystem:us-west-2:123456789012:file-system/*`.

The resource ARN in the policy statement should be in the format of
`arn:aws:elasticfilesystem:<REGION>:<AWS_ACCOUNT>:file-system/*` or simply
allow all resources `*` as is being done in the other addons like the EBS
one.

Fix #828 

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
