### PR TITLE
Added CloudWatch Support

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -67,6 +67,9 @@ func SetNodeGroupDefaults(_ int, ng *NodeGroup) error {
 	if ng.IAM.WithAddonPolicies.XRay == nil {
 		ng.IAM.WithAddonPolicies.XRay = Disabled()
 	}
+	if ng.IAM.WithAddonPolicies.CloudWatch == nil {
+		ng.IAM.WithAddonPolicies.CloudWatch = Disabled()
+	}
 	if ng.IAM.WithAddonPolicies.EBS == nil {
 		ng.IAM.WithAddonPolicies.EBS = Disabled()
 	}

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -355,7 +355,8 @@ func (c *ClusterConfig) NewNodeGroup() *NodeGroup {
 				FSX:          Disabled(),
 				EFS:          Disabled(),
 				ALBIngress:   Disabled(),
-				XRay: 		  Disabled(),
+				XRay:         Disabled(),
+				CloudWatch:   Disabled(),
 			},
 		},
 		SSH: &NodeGroupSSH{
@@ -479,6 +480,8 @@ type (
 		ALBIngress *bool `json:"albIngress"`
 		// +optional
 		XRay *bool `json:"xRay"`
+		// +optional
+		CloudWatch *bool `json:"cloudWatch"`
 	}
 
 	// NodeGroupSSH holds all the ssh access configuration to a NodeGroup

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -43,6 +43,9 @@ func validateNodeGroupIAM(i int, ng *NodeGroup, value, fieldName, path string) e
 		if IsEnabled(ng.IAM.WithAddonPolicies.XRay) {
 			return fmt.Errorf("%s.xRay cannot be set at the same time", p)
 		}
+		if IsEnabled(ng.IAM.WithAddonPolicies.CloudWatch) {
+			return fmt.Errorf("%s.cloudWatch cannot be set at the same time", p)
+		}
 	}
 	return nil
 }

--- a/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
@@ -419,6 +419,11 @@ func (in *NodeGroupIAMAddonPolicies) DeepCopyInto(out *NodeGroupIAMAddonPolicies
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CloudWatch != nil {
+		in, out := &in.CloudWatch, &out.CloudWatch
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -16,6 +16,7 @@ const (
 	iamPolicyAmazonEKSCNIPolicyARN                  = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
 	iamPolicyAmazonEC2ContainerRegistryPowerUserARN = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
 	iamPolicyAmazonEC2ContainerRegistryReadOnlyARN  = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+	iamPolicyCloudWatchAgentServerPolicyARN         = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 )
 
 var (
@@ -164,6 +165,10 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 		n.spec.IAM.AttachPolicyARNs = append(n.spec.IAM.AttachPolicyARNs, iamPolicyAmazonEC2ContainerRegistryPowerUserARN)
 	} else {
 		n.spec.IAM.AttachPolicyARNs = append(n.spec.IAM.AttachPolicyARNs, iamPolicyAmazonEC2ContainerRegistryReadOnlyARN)
+	}
+
+	if api.IsEnabled(n.spec.IAM.WithAddonPolicies.CloudWatch) {
+		n.spec.IAM.AttachPolicyARNs = append(n.spec.IAM.AttachPolicyARNs, iamPolicyCloudWatchAgentServerPolicyARN)
 	}
 
 	role := gfn.AWSIAMRole{

--- a/pkg/ctl/cmdutils/nodegroup_filter_test.go
+++ b/pkg/ctl/cmdutils/nodegroup_filter_test.go
@@ -345,7 +345,8 @@ const expected = `
 			  		"fsx": false,
 			  		"efs": false,
 					"albIngress": false,
-					"xRay": false  
+					"xRay": false,
+					"cloudWatch": false
 			    }
 			  }
 		  },
@@ -381,7 +382,8 @@ const expected = `
 			  		"fsx": false,
 			  		"efs": false,
 					"albIngress": false,
-					"xRay": false  
+					"xRay": false,
+					"cloudWatch": false
 			    }
 			  }
 		  },
@@ -415,7 +417,8 @@ const expected = `
 			  	"fsx": false,
 			  	"efs": false,
 				"albIngress": false,
-				"xRay": false  
+				"xRay": false,
+				"cloudWatch": false
 			  }
 			  },
 			  "clusterDNS": "1.2.3.4"
@@ -450,7 +453,8 @@ const expected = `
 			  	  "fsx": false,
 			  	  "efs": false,
 				  "albIngress": false,
-				  "xRay": false	
+				  "xRay": false,
+				  "cloudWatch": false
 			    }
 			  }
 		  },
@@ -487,7 +491,8 @@ const expected = `
 			  	  "fsx": false,
 			  	  "efs": false,
 				  "albIngress": false,
-				  "xRay": false	
+				  "xRay": false,
+				  "cloudWatch": false
 			    }
 			  },
 			  "clusterDNS": "4.2.8.14"
@@ -525,7 +530,8 @@ const expected = `
 			  	  "fsx": false,
 			  	  "efs": false,
 				  "albIngress": false,
-				  "xRay": false	
+				  "xRay": false,
+				  "cloudWatch": false
 			    }
 			  }
 		  }

--- a/pkg/ctl/cmdutils/nodegroup_flags.go
+++ b/pkg/ctl/cmdutils/nodegroup_flags.go
@@ -58,6 +58,7 @@ func AddCommonCreateNodeGroupIAMAddonsFlags(fs *pflag.FlagSet, ng *api.NodeGroup
 	ng.IAM.WithAddonPolicies.AppMesh = new(bool)
 	ng.IAM.WithAddonPolicies.ALBIngress = new(bool)
 	ng.IAM.WithAddonPolicies.XRay = new(bool)
+	ng.IAM.WithAddonPolicies.CloudWatch = new(bool)
 	fs.BoolVar(ng.IAM.WithAddonPolicies.AutoScaler, "asg-access", false, "enable IAM policy for cluster-autoscaler")
 	fs.BoolVar(ng.IAM.WithAddonPolicies.ExternalDNS, "external-dns-access", false, "enable IAM policy for external-dns")
 	fs.BoolVar(ng.IAM.WithAddonPolicies.ImageBuilder, "full-ecr-access", false, "enable full access to ECR")


### PR DESCRIPTION
### Description

This change enables nodegroups to put metrics and logs into CloudWatch via monitoring, log-forwarding agents including the CloudWatch agent (to use the [Container Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html)).

Users can enable this by adding `cloudWatch: true` under `nodeGroups.[x].iam.withAddonPolicies` as other addon policies.

At this time, the `CloudWatchAgentServerPolicy` managed policy has the following actions for any resources:
```
cloudwatch:PutMetricData
ec2:DescribeTags
logs:PutLogEvents
logs:DescribeLogStreams
logs:DescribeLogGroups
logs:CreateLogStream
logs:CreateLogGroup
```
and also has the following action for `arn:aws:ssm:*:*:parameter/AmazonCloudWatch-*`
```
ssm:GetParameter
```

### Checklist

- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] All integration tests passing (i.e. `make integration-test`)
- ~[ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)~
- ~[ ] Added yourself to the `humans.txt` file~