### PR TITLE
Add various build improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,7 @@ jobs:
     steps:
       - checkout
       - run: mkdir -p ./test-results/ginkgo
-      - run:
-            command: make eksctl-image
-            environment:
-                TEST_OUTPUT: "true"
+      - run: make eksctl-image
       - store_test_results:
           path: ./test-results
       - store_artifacts:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN curl --silent --location "https://dl.k8s.io/${KUBECTL_VERSION}/bin/linux/amd
     && chmod +x /out/usr/local/bin/kubectl
 
 ENV EKSCTL $GOPATH/src/github.com/weaveworks/eksctl
-RUN mkdir -p "$(dirname ${EKSCTL})"
 COPY . $EKSCTL
 
 ARG COVERALLS_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,7 @@ GOBIN ?= $(shell echo `go env GOPATH`/bin)
 
 .PHONY: install-build-deps
 install-build-deps: ## Install dependencies (packages and tools)
-	@go get -u github.com/golang/dep/cmd/dep
-	@cd build && dep ensure && ./install.sh "$(GOBIN)"
+	@cd build && ./install.sh
 
 ##@ Build
 

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ endif
 .PHONY: eksctl-image
 eksctl-image: eksctl-build-image ## Create the eksctl image
 	@docker build --tag=$(EKSCTL_IMAGE) $(EKSCTL_IMAGE_BUILD_ARGS) .
-	./get-testresults.sh
+	@[ -z "${CI}" ] || ./get-testresults.sh # only get test results in Continious Integration
 
 ##@ Release
 

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,16 @@ EKSCTL_IMAGE ?= weaveworks/eksctl:latest
 
 GO_BUILD_TAGS ?= netgo
 
+GOBIN ?= $(shell echo `go env GOPATH`/bin)
+
 .DEFAULT_GOAL := help
 
 ##@ Dependencies
 
 .PHONY: install-build-deps
 install-build-deps: ## Install dependencies (packages and tools)
-	@cd build && dep ensure && ./install.sh
+	@go get -u github.com/golang/dep/cmd/dep
+	@cd build && dep ensure && ./install.sh "$(GOBIN)"
 
 ##@ Build
 
@@ -36,7 +39,7 @@ endif
 LINTER ?= gometalinter ./pkg/... ./cmd/... ./integration/...
 .PHONY: lint
 lint: ## Run linter over the codebase
-	@$(GOPATH)/bin/$(LINTER)
+	@"$(GOBIN)/$(LINTER)"
 
 .PHONY: test
 test: generate ## Run unit test (and re-generate code under test)
@@ -45,7 +48,7 @@ test: generate ## Run unit test (and re-generate code under test)
 	@git diff --exit-code ./pkg/eks/mocks > /dev/null || (git --no-pager diff ./pkg/eks/mocks; exit 1)
 	@git diff --exit-code ./pkg/addons/default > /dev/null || (git --no-pager diff ./pkg/addons/default; exit 1)
 	@$(MAKE) unit-test
-	@test -z $(COVERALLS_TOKEN) || $(GOPATH)/bin/goveralls -coverprofile=coverage.out -service=circle-ci
+	@test -z $(COVERALLS_TOKEN) || "$(GOBIN)/goveralls" -coverprofile=coverage.out -service=circle-ci
 	@$(MAKE) build-integration-test
 
 .PHONY: unit-test

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,9 @@ ifneq ($(INTEGRATION_TEST_FOCUS),)
 INTEGRATION_TEST_ARGS ?= -test.v -ginkgo.v -ginkgo.focus "$(INTEGRATION_TEST_FOCUS)"
 endif
 
-LINTER ?= gometalinter ./pkg/... ./cmd/... ./integration/...
 .PHONY: lint
 lint: ## Run linter over the codebase
-	@"$(GOBIN)/$(LINTER)"
+	@"$(GOBIN)/gometalinter" ./pkg/... ./cmd/... ./integration/...
 
 .PHONY: test
 test: generate ## Run unit test (and re-generate code under test)
@@ -148,7 +147,7 @@ endif
 
 .PHONY: eksctl-image
 eksctl-image: eksctl-build-image ## Create the eksctl image
-	@docker build --tag=$(EKSCTL_IMAGE) $(EKSCTL_IMAGE_BUILD_ARGS) ./
+	@docker build --tag=$(EKSCTL_IMAGE) $(EKSCTL_IMAGE_BUILD_ARGS) .
 	./get-testresults.sh
 
 ##@ Release

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ endif
 .PHONY: eksctl-image
 eksctl-image: eksctl-build-image ## Create the eksctl image
 	@docker build --tag=$(EKSCTL_IMAGE) $(EKSCTL_IMAGE_BUILD_ARGS) .
-	@[ -z "${CI}" ] || ./get-testresults.sh # only get test results in Continious Integration
+	@[ -z "${CI}" ] || ./get-testresults.sh # only get test results in Continuous Integration
 
 ##@ Release
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@ ENV EKSCTL_BUILD $GOPATH/src/github.com/weaveworks/eksctl/build
 COPY . $EKSCTL_BUILD
 
 WORKDIR $EKSCTL_BUILD
-RUN cd $EKSCTL_BUILD && ./install.sh
+RUN ./install.sh
 
 WORKDIR $EKSCTL_BUILD/vendor/github.com/goreleaser/goreleaser
 RUN go build -tags netgo && go install -tags netgo

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,21 +10,11 @@ RUN apk add --no-cache \
 
 ENV CGO_ENABLED=0
 
-ENV DEP_VERSION v0.5.0
-
-# Install dep to avoid vendoring all the things
-RUN curl --silent --location "https://github.com/golang/dep/releases/download/${DEP_VERSION}/dep-linux-amd64" --output /usr/local/bin/dep \
-    && chmod +x /usr/local/bin/dep
-
 ENV EKSCTL_BUILD $GOPATH/src/github.com/weaveworks/eksctl/build
-RUN mkdir -p "$(dirname ${EKSCTL_BUILD})"
 COPY . $EKSCTL_BUILD
 
 WORKDIR $EKSCTL_BUILD
-
-RUN dep ensure
-
-RUN ./install.sh
+RUN cd $EKSCTL_BUILD && ./install.sh
 
 WORKDIR $EKSCTL_BUILD/vendor/github.com/goreleaser/goreleaser
 RUN go build -tags netgo && go install -tags netgo

--- a/build/install.sh
+++ b/build/install.sh
@@ -1,6 +1,12 @@
 #!/bin/sh -eu
 
-BIN="$1"
+if [ -z "${GOBIN+x}" ]; then
+ GOBIN="$(go env GOPATH)/bin"
+fi
+
+curl --silent --location "https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64" --output "${GOBIN}/dep"
+chmod +x "${GOBIN}/dep"
+dep ensure
 
 go install ./vendor/github.com/jteeuwen/go-bindata/go-bindata
 go install ./vendor/github.com/weaveworks/github-release
@@ -20,7 +26,7 @@ install_gometalinter() {
   fi
   basename="gometalinter-${version}-${suffix}"
   url="${prefix}/v${version}/${basename}.tar.gz"
-  cd "${BIN}"
+  cd "${GOBIN}"
   curl --silent --location "${url}" | tar xz
   (cd "./${basename}/" ; mv ./* ../)
   rmdir "./${basename}"
@@ -31,7 +37,7 @@ install_golangci_lint() {
   version="${1}"
   curl --silent --fail --location \
     "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" \
-    | sh -s -- -b "${BIN}" "${version}"
+    | sh -s -- -b "${GOBIN}" "${version}"
   unset version
 }
 

--- a/build/install.sh
+++ b/build/install.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -eu
 
+BIN="$1"
+
 go install ./vendor/github.com/jteeuwen/go-bindata/go-bindata
 go install ./vendor/github.com/weaveworks/github-release
 go install ./vendor/golang.org/x/tools/cmd/stringer
@@ -18,7 +20,7 @@ install_gometalinter() {
   fi
   basename="gometalinter-${version}-${suffix}"
   url="${prefix}/v${version}/${basename}.tar.gz"
-  cd "${GOPATH}/bin/"
+  cd "${BIN}"
   curl --silent --location "${url}" | tar xz
   (cd "./${basename}/" ; mv ./* ../)
   rmdir "./${basename}"
@@ -29,7 +31,7 @@ install_golangci_lint() {
   version="${1}"
   curl --silent --fail --location \
     "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" \
-    | sh -s -- -b $GOPATH/bin "${version}"
+    | sh -s -- -b "${BIN}" "${version}"
   unset version
 }
 

--- a/get-testresults.sh
+++ b/get-testresults.sh
@@ -1,13 +1,8 @@
 #!/bin/sh -ex
 
-if [ -n "${TEST_OUTPUT}" ]; then
-
 BUILDID="$(docker images --filter "label=eksctl.builder=true" --format '{{.ID}}')"
 mkdir -p ${PWD}/test-results/ginkgo
 docker run -i --rm -v ${PWD}/test-results/ginkgo:/mnt/test-results  ${BUILDID}  sh -s <<EOF
 cp /go/src/github.com/weaveworks/eksctl/test-results/ginkgo/*.xml /mnt/test-results
 EOF
 
-else
-    echo "not retrieving test results"
-fi

--- a/humans.txt
+++ b/humans.txt
@@ -42,6 +42,7 @@ Adam Johnson            @adamjohnson01
 Paul Maddox             @paulmaddox
 Patrick Spek            @tyil
 Martina Iglesias        @martina-if
+Alfonso Acosta          @2opremio
 
 /* Thanks */
 


### PR DESCRIPTION
* Install `dep` as part of `make install-build-deps`.
* Honor `$GOBIN` variable.
* Stop assuming `$GOPATH` is defined (since it won't be mandatory with go modules).
* Various minor simplifications and refactorings.