### PR TITLE
correct the default eksctlPath for integration tests

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -27,7 +27,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&eksctlPath, "eksctl.path", "../eksctl", "Path to eksctl")
+	flag.StringVar(&eksctlPath, "eksctl.path", "./eksctl", "Path to eksctl")
 
 	// Flags to help with the development of the integration tests
 	flag.StringVar(&clusterName, "eksctl.cluster", "", "Cluster name (default: generate one)")


### PR DESCRIPTION
### Description

Corrected a small typo in the default eksctlPath variable. Fixes #846  

<!-- Please explain the changes you made here. -->

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [ ] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [ ] All unit tests passing (i.e. `make test`)
- [ ] All integration tests passing (i.e. `make integration-test`)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [ ] Added yourself to the `humans.txt` file
