### PR TITLE
Refactor command functions

### DIFF
--- a/cmd/eksctl/main.go
+++ b/cmd/eksctl/main.go
@@ -32,9 +32,9 @@ func init() {
 
 	var colorValue string
 
-	g := cmdutils.NewGrouping()
+	flagGrouping := cmdutils.NewGrouping()
 
-	addCommands(g)
+	addCommands(flagGrouping)
 
 	rootCmd.PersistentFlags().BoolP("help", "h", false, "help for this command")
 	rootCmd.PersistentFlags().StringVarP(&colorValue, "color", "C", "true", "toggle colorized logs (true,false,fabulous)")
@@ -61,7 +61,7 @@ func init() {
 		}
 	})
 
-	rootCmd.SetUsageFunc(g.Usage)
+	rootCmd.SetUsageFunc(flagGrouping.Usage)
 }
 
 func main() {
@@ -71,14 +71,14 @@ func main() {
 	}
 }
 
-func addCommands(g *cmdutils.Grouping) {
-	rootCmd.AddCommand(versionCmd(g))
-	rootCmd.AddCommand(create.Command(g))
-	rootCmd.AddCommand(delete.Command(g))
-	rootCmd.AddCommand(get.Command(g))
-	rootCmd.AddCommand(update.Command(g))
-	rootCmd.AddCommand(scale.Command(g))
-	rootCmd.AddCommand(drain.Command(g))
-	rootCmd.AddCommand(utils.Command(g))
+func addCommands(flagGrouping *cmdutils.FlagGrouping) {
+	rootCmd.AddCommand(versionCmd(flagGrouping))
+	rootCmd.AddCommand(create.Command(flagGrouping))
+	rootCmd.AddCommand(delete.Command(flagGrouping))
+	rootCmd.AddCommand(get.Command(flagGrouping))
+	rootCmd.AddCommand(update.Command(flagGrouping))
+	rootCmd.AddCommand(scale.Command(flagGrouping))
+	rootCmd.AddCommand(drain.Command(flagGrouping))
+	rootCmd.AddCommand(utils.Command(flagGrouping))
 	rootCmd.AddCommand(completion.Command(rootCmd))
 }

--- a/cmd/eksctl/version.go
+++ b/cmd/eksctl/version.go
@@ -8,7 +8,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/version"
 )
 
-func versionCmd(_ *cmdutils.Grouping) *cobra.Command {
+func versionCmd(_ *cmdutils.FlagGrouping) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Output the version of eksctl",

--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -15,6 +15,20 @@ import (
 // IncompatibleFlags is a common substring of an error message
 const IncompatibleFlags = "cannot be used at the same time"
 
+// NewVerbCmd defines a standard verb command
+func NewVerbCmd(use, short, long string) *cobra.Command {
+	return &cobra.Command{
+		Use:   use,
+		Short: short,
+		Long:  long,
+		Run: func(c *cobra.Command, _ []string) {
+			if err := c.Help(); err != nil {
+				logger.Debug("ignoring error %q", err.Error())
+			}
+		},
+	}
+}
+
 // AddPreRun chains cmd.PreRun handlers, as cobra only allows one, so we don't
 // accidentially override one we registered earlier
 func AddPreRun(cmd *cobra.Command, newFn func(cmd *cobra.Command, args []string)) {
@@ -53,11 +67,11 @@ func LogPlanModeWarning(plan bool) {
 }
 
 // AddApproveFlag adds common `--approve` flag
-func AddApproveFlag(plan *bool, cmd *cobra.Command, fs *pflag.FlagSet) {
-	approve := fs.Bool("approve", !*plan, "Apply the changes")
-	AddPreRun(cmd, func(cmd *cobra.Command, args []string) {
+func AddApproveFlag(fs *pflag.FlagSet, rc *ResourceCmd) {
+	approve := fs.Bool("approve", !rc.Plan, "Apply the changes")
+	AddPreRun(rc.Command, func(cmd *cobra.Command, args []string) {
 		if cmd.Flag("approve").Changed {
-			*plan = !*approve
+			rc.Plan = !*approve
 		}
 	})
 }
@@ -111,12 +125,12 @@ func AddVersionFlag(fs *pflag.FlagSet, meta *api.ClusterMeta, extraUsageInfo str
 }
 
 // AddWaitFlag adds common --wait flag
-func AddWaitFlag(wait *bool, fs *pflag.FlagSet, description string) {
+func AddWaitFlag(fs *pflag.FlagSet, wait *bool, description string) {
 	fs.BoolVarP(wait, "wait", "w", *wait, fmt.Sprintf("wait for %s before exiting", description))
 }
 
 // AddUpdateAuthConfigMap adds common --update-auth-configmap flag
-func AddUpdateAuthConfigMap(updateAuthConfigMap *bool, fs *pflag.FlagSet, description string) {
+func AddUpdateAuthConfigMap(fs *pflag.FlagSet, updateAuthConfigMap *bool, description string) {
 	fs.BoolVar(updateAuthConfigMap, "update-auth-configmap", true, description)
 }
 
@@ -134,8 +148,8 @@ func AddCommonFlagsForGetCmd(fs *pflag.FlagSet, chunkSize *int, outputMode *stri
 }
 
 // ErrUnsupportedRegion is a common error message
-func ErrUnsupportedRegion(p *api.ProviderConfig) error {
-	return fmt.Errorf("--region=%s is not supported - use one of: %s", p.Region, strings.Join(api.SupportedRegions(), ", "))
+func ErrUnsupportedRegion(provider *api.ProviderConfig) error {
+	return fmt.Errorf("--region=%s is not supported - use one of: %s", provider.Region, strings.Join(api.SupportedRegions(), ", "))
 }
 
 // ErrNameFlagAndArg is a common error message

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -3,7 +3,6 @@ package cmdutils
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -12,7 +11,7 @@ import (
 )
 
 // AddConfigFileFlag adds common --config-file flag
-func AddConfigFileFlag(path *string, fs *pflag.FlagSet) {
+func AddConfigFileFlag(fs *pflag.FlagSet, path *string) {
 	fs.StringVarP(path, "config-file", "f", "", "load configuration from a file")
 }
 
@@ -22,25 +21,18 @@ type ClusterConfigLoader interface {
 }
 
 type commonClusterConfigLoader struct {
-	provider *api.ProviderConfig
-	path     string
-	cmd      *cobra.Command
-	spec     *api.ClusterConfig
-	nameArg  string
+	*ResourceCmd
 
 	flagsIncompatibleWithConfigFile, flagsIncompatibleWithoutConfigFile sets.String
 
 	validateWithConfigFile, validateWithoutConfigFile func() error
 }
 
-func newCommonClusterConfigLoader(provider *api.ProviderConfig, spec *api.ClusterConfig, clusterConfigFile string, cmd *cobra.Command) *commonClusterConfigLoader {
+func newCommonClusterConfigLoader(rc *ResourceCmd) *commonClusterConfigLoader {
 	nilValidatorFunc := func() error { return nil }
 
 	return &commonClusterConfigLoader{
-		provider: provider,
-		path:     clusterConfigFile,
-		cmd:      cmd,
-		spec:     spec,
+		ResourceCmd: rc,
 
 		validateWithConfigFile:             nilValidatorFunc,
 		flagsIncompatibleWithConfigFile:    sets.NewString("name", "region", "version"),
@@ -55,28 +47,28 @@ func (l *commonClusterConfigLoader) Load() error {
 		return err
 	}
 
-	if l.path == "" {
+	if l.ClusterConfigFile == "" {
 		for f := range l.flagsIncompatibleWithoutConfigFile {
-			if flag := l.cmd.Flag(f); flag != nil && flag.Changed {
+			if flag := l.Command.Flag(f); flag != nil && flag.Changed {
 				return fmt.Errorf("cannot use --%s unless a config file is specified via --config-file/-f", f)
 			}
 		}
 		return l.validateWithoutConfigFile()
 	}
 
-	if err := eks.LoadConfigFromFile(l.path, l.spec); err != nil {
+	if err := eks.LoadConfigFromFile(l.ClusterConfigFile, l.ClusterConfig); err != nil {
 		return err
 	}
-	meta := l.spec.Metadata
+	meta := l.ClusterConfig.Metadata
 
 	for f := range l.flagsIncompatibleWithConfigFile {
-		if flag := l.cmd.Flag(f); flag != nil && flag.Changed {
+		if flag := l.Command.Flag(f); flag != nil && flag.Changed {
 			return ErrCannotUseWithConfigFile(fmt.Sprintf("--%s", f))
 		}
 	}
 
-	if l.nameArg != "" {
-		return ErrCannotUseWithConfigFile(fmt.Sprintf("name argument %q", l.nameArg))
+	if l.NameArg != "" {
+		return ErrCannotUseWithConfigFile(fmt.Sprintf("name argument %q", l.NameArg))
 	}
 
 	if meta.Name == "" {
@@ -86,7 +78,7 @@ func (l *commonClusterConfigLoader) Load() error {
 	if meta.Region == "" {
 		return ErrMustBeSet("metadata.region")
 	}
-	l.provider.Region = meta.Region
+	l.ProviderConfig.Region = meta.Region
 
 	return l.validateWithConfigFile()
 }
@@ -94,20 +86,18 @@ func (l *commonClusterConfigLoader) Load() error {
 // NewMetadataLoader handles loading of clusterConfigFile vs using flags for all commands that require only
 // metadata fileds, e.g. `eksctl delete cluster` or `eksctl utils update-kube-proxy` and other similar
 // commands that do simple operations against existing clusters
-func NewMetadataLoader(provider *api.ProviderConfig, spec *api.ClusterConfig, clusterConfigFile, nameArg string, cmd *cobra.Command) ClusterConfigLoader {
-	l := newCommonClusterConfigLoader(provider, spec, clusterConfigFile, cmd)
-
-	l.nameArg = nameArg
+func NewMetadataLoader(rc *ResourceCmd) ClusterConfigLoader {
+	l := newCommonClusterConfigLoader(rc)
 
 	l.validateWithoutConfigFile = func() error {
-		meta := l.spec.Metadata
+		meta := l.ClusterConfig.Metadata
 
-		if meta.Name != "" && l.nameArg != "" {
-			return ErrNameFlagAndArg(meta.Name, l.nameArg)
+		if meta.Name != "" && l.NameArg != "" {
+			return ErrNameFlagAndArg(meta.Name, l.NameArg)
 		}
 
-		if l.nameArg != "" {
-			meta.Name = l.nameArg
+		if l.NameArg != "" {
+			meta.Name = l.NameArg
 		}
 
 		if meta.Name == "" {
@@ -121,10 +111,8 @@ func NewMetadataLoader(provider *api.ProviderConfig, spec *api.ClusterConfig, cl
 }
 
 // NewCreateClusterLoader will laod config or use flags for 'eksctl create cluster'
-func NewCreateClusterLoader(provider *api.ProviderConfig, spec *api.ClusterConfig, clusterConfigFile, nameArg string, cmd *cobra.Command, ngFilter *NodeGroupFilter) ClusterConfigLoader {
-	l := newCommonClusterConfigLoader(provider, spec, clusterConfigFile, cmd)
-
-	l.nameArg = nameArg
+func NewCreateClusterLoader(rc *ResourceCmd, ngFilter *NodeGroupFilter) ClusterConfigLoader {
+	l := newCommonClusterConfigLoader(rc)
 
 	l.flagsIncompatibleWithConfigFile.Insert(
 		"tags",
@@ -155,11 +143,11 @@ func NewCreateClusterLoader(provider *api.ProviderConfig, spec *api.ClusterConfi
 	)
 
 	l.validateWithConfigFile = func() error {
-		if l.spec.VPC == nil {
-			l.spec.VPC = api.NewClusterVPC()
+		if l.ClusterConfig.VPC == nil {
+			l.ClusterConfig.VPC = api.NewClusterVPC()
 		}
 
-		if l.spec.HasAnySubnets() && len(l.spec.AvailabilityZones) != 0 {
+		if l.ClusterConfig.HasAnySubnets() && len(l.ClusterConfig.AvailabilityZones) != 0 {
 			return fmt.Errorf("vpc.subnets and availabilityZones cannot be set at the same time")
 		}
 
@@ -167,20 +155,20 @@ func NewCreateClusterLoader(provider *api.ProviderConfig, spec *api.ClusterConfi
 	}
 
 	l.validateWithoutConfigFile = func() error {
-		meta := l.spec.Metadata
+		meta := l.ClusterConfig.Metadata
 
 		// generate cluster name or use either flag or argument
-		if ClusterName(meta.Name, l.nameArg) == "" {
-			return ErrNameFlagAndArg(meta.Name, l.nameArg)
+		if ClusterName(meta.Name, l.NameArg) == "" {
+			return ErrNameFlagAndArg(meta.Name, l.NameArg)
 		}
-		meta.Name = ClusterName(meta.Name, l.nameArg)
+		meta.Name = ClusterName(meta.Name, l.NameArg)
 
-		if l.spec.Status != nil {
+		if l.ClusterConfig.Status != nil {
 			return fmt.Errorf("status fields are read-only")
 		}
 
-		return ngFilter.ForEach(l.spec.NodeGroups, func(i int, ng *api.NodeGroup) error {
-			if cmd.Flag("ssh-public-key").Changed {
+		return ngFilter.ForEach(l.ClusterConfig.NodeGroups, func(i int, ng *api.NodeGroup) error {
+			if l.Command.Flag("ssh-public-key").Changed {
 				if *ng.SSH.PublicKeyPath == "" {
 					return fmt.Errorf("--ssh-public-key must be non-empty string")
 				}
@@ -200,10 +188,8 @@ func NewCreateClusterLoader(provider *api.ProviderConfig, spec *api.ClusterConfi
 }
 
 // NewCreateNodeGroupLoader will laod config or use flags for 'eksctl create nodegroup'
-func NewCreateNodeGroupLoader(provider *api.ProviderConfig, spec *api.ClusterConfig, clusterConfigFile, nameArg string, cmd *cobra.Command, ngFilter *NodeGroupFilter, include, exclude []string) ClusterConfigLoader {
-	l := newCommonClusterConfigLoader(provider, spec, clusterConfigFile, cmd)
-
-	l.nameArg = nameArg
+func NewCreateNodeGroupLoader(rc *ResourceCmd, ngFilter *NodeGroupFilter) ClusterConfigLoader {
+	l := newCommonClusterConfigLoader(rc)
 
 	l.flagsIncompatibleWithConfigFile.Insert(
 		"cluster",
@@ -228,7 +214,7 @@ func NewCreateNodeGroupLoader(provider *api.ProviderConfig, spec *api.ClusterCon
 	)
 
 	l.validateWithConfigFile = func() error {
-		if err := ngFilter.AppendGlobs(include, exclude, spec.NodeGroups); err != nil {
+		if err := ngFilter.AppendGlobs(l.IncludeNodeGroups, l.ExcludeNodeGroups, l.ClusterConfig.NodeGroups); err != nil {
 			return err
 		}
 		return nil
@@ -241,13 +227,13 @@ func NewCreateNodeGroupLoader(provider *api.ProviderConfig, spec *api.ClusterCon
 	)
 
 	l.validateWithoutConfigFile = func() error {
-		if spec.Metadata.Name == "" {
+		if l.ClusterConfig.Metadata.Name == "" {
 			return ErrMustBeSet("--cluster")
 		}
 
-		return ngFilter.ForEach(spec.NodeGroups, func(i int, ng *api.NodeGroup) error {
+		return ngFilter.ForEach(l.ClusterConfig.NodeGroups, func(i int, ng *api.NodeGroup) error {
 
-			if cmd.Flag("ssh-public-key").Changed {
+			if l.Command.Flag("ssh-public-key").Changed {
 				if *ng.SSH.PublicKeyPath == "" {
 					return fmt.Errorf("--ssh-public-key must be non-empty string")
 				}
@@ -257,10 +243,10 @@ func NewCreateNodeGroupLoader(provider *api.ProviderConfig, spec *api.ClusterCon
 			}
 
 			// generate nodegroup name or use either flag or argument
-			if NodeGroupName(ng.Name, l.nameArg) == "" {
-				return ErrNameFlagAndArg(ng.Name, l.nameArg)
+			if NodeGroupName(ng.Name, l.NameArg) == "" {
+				return ErrNameFlagAndArg(ng.Name, l.NameArg)
 			}
-			ng.Name = NodeGroupName(ng.Name, l.nameArg)
+			ng.Name = NodeGroupName(ng.Name, l.NameArg)
 
 			return nil
 		})
@@ -270,17 +256,15 @@ func NewCreateNodeGroupLoader(provider *api.ProviderConfig, spec *api.ClusterCon
 }
 
 // NewDeleteNodeGroupLoader will laod config or use flags for 'eksctl delete nodegroup'
-func NewDeleteNodeGroupLoader(provider *api.ProviderConfig, spec *api.ClusterConfig, ng *api.NodeGroup, clusterConfigFile, nameArg string, cmd *cobra.Command, ngFilter *NodeGroupFilter, include, exclude []string, plan *bool) ClusterConfigLoader {
-	l := newCommonClusterConfigLoader(provider, spec, clusterConfigFile, cmd)
-
-	l.nameArg = nameArg
+func NewDeleteNodeGroupLoader(rc *ResourceCmd, ng *api.NodeGroup, ngFilter *NodeGroupFilter) ClusterConfigLoader {
+	l := newCommonClusterConfigLoader(rc)
 
 	l.flagsIncompatibleWithConfigFile.Insert(
 		"cluster",
 	)
 
 	l.validateWithConfigFile = func() error {
-		return ngFilter.AppendGlobs(include, exclude, spec.NodeGroups)
+		return ngFilter.AppendGlobs(l.IncludeNodeGroups, l.ExcludeNodeGroups, l.ClusterConfig.NodeGroups)
 	}
 
 	l.flagsIncompatibleWithoutConfigFile.Insert(
@@ -292,16 +276,16 @@ func NewDeleteNodeGroupLoader(provider *api.ProviderConfig, spec *api.ClusterCon
 	)
 
 	l.validateWithoutConfigFile = func() error {
-		if l.spec.Metadata.Name == "" {
+		if l.ClusterConfig.Metadata.Name == "" {
 			return ErrMustBeSet("--cluster")
 		}
 
-		if ng.Name != "" && nameArg != "" {
-			return ErrNameFlagAndArg(ng.Name, nameArg)
+		if ng.Name != "" && l.NameArg != "" {
+			return ErrNameFlagAndArg(ng.Name, l.NameArg)
 		}
 
-		if nameArg != "" {
-			ng.Name = nameArg
+		if l.NameArg != "" {
+			ng.Name = l.NameArg
 		}
 
 		if ng.Name == "" {
@@ -310,7 +294,7 @@ func NewDeleteNodeGroupLoader(provider *api.ProviderConfig, spec *api.ClusterCon
 
 		ngFilter.AppendIncludeNames(ng.Name)
 
-		*plan = false
+		l.Plan = false
 
 		return nil
 	}

--- a/pkg/ctl/cmdutils/group.go
+++ b/pkg/ctl/cmdutils/group.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// Grouping holds a superset of all flagsets for all commands
-type Grouping struct {
+// FlagGrouping holds a superset of all flagsets for all commands
+type FlagGrouping struct {
 	groups map[*cobra.Command]*NamedFlagSetGroup
 }
 
@@ -25,14 +25,14 @@ type NamedFlagSetGroup struct {
 }
 
 // NewGrouping creates an instance of Grouping
-func NewGrouping() *Grouping {
-	return &Grouping{
+func NewGrouping() *FlagGrouping {
+	return &FlagGrouping{
 		make(map[*cobra.Command]*NamedFlagSetGroup),
 	}
 }
 
 // New creates a new group of flagsets for use with a subcommand
-func (g *Grouping) New(cmd *cobra.Command) *NamedFlagSetGroup {
+func (g *FlagGrouping) New(cmd *cobra.Command) *NamedFlagSetGroup {
 	n := &NamedFlagSetGroup{}
 	g.groups[cmd] = n
 	return n
@@ -63,7 +63,7 @@ func (n *NamedFlagSetGroup) AddTo(cmd *cobra.Command) {
 }
 
 // Usage is for use with (*cobra.Command).SetUsageFunc
-func (g *Grouping) Usage(cmd *cobra.Command) error {
+func (g *FlagGrouping) Usage(cmd *cobra.Command) error {
 	if cmd == nil {
 		return fmt.Errorf("nil command")
 	}

--- a/pkg/ctl/cmdutils/nodegroup_flags.go
+++ b/pkg/ctl/cmdutils/nodegroup_flags.go
@@ -12,14 +12,14 @@ import (
 )
 
 // AddCommonCreateNodeGroupFlags adds common flags for creating a node group
-func AddCommonCreateNodeGroupFlags(cmd *cobra.Command, fs *pflag.FlagSet, p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.NodeGroup) {
+func AddCommonCreateNodeGroupFlags(fs *pflag.FlagSet, rc *ResourceCmd, ng *api.NodeGroup) {
 	fs.StringVarP(&ng.InstanceType, "node-type", "t", api.DefaultNodeType, "node instance type")
 
 	desiredCapacity := fs.IntP("nodes", "N", api.DefaultNodeCount, "total number of nodes (for a static ASG)")
 	minSize := fs.IntP("nodes-min", "m", api.DefaultNodeCount, "minimum nodes in ASG")
 	maxSize := fs.IntP("nodes-max", "M", api.DefaultNodeCount, "maximum nodes in ASG")
 
-	AddPreRun(cmd, func(cmd *cobra.Command, args []string) {
+	AddPreRun(rc.Command, func(cmd *cobra.Command, args []string) {
 		if f := cmd.Flag("nodes"); f.Changed {
 			ng.DesiredCapacity = desiredCapacity
 		}
@@ -67,7 +67,7 @@ func AddCommonCreateNodeGroupIAMAddonsFlags(fs *pflag.FlagSet, ng *api.NodeGroup
 }
 
 // AddNodeGroupFilterFlags add common `--include` and `--exclude` flags for filtering nodegroups
-func AddNodeGroupFilterFlags(includeGlobs, excludeGlobs *[]string, fs *pflag.FlagSet) {
+func AddNodeGroupFilterFlags(fs *pflag.FlagSet, includeGlobs, excludeGlobs *[]string) {
 	fs.StringSliceVar(includeGlobs, "only", nil, "")
 	fs.MarkDeprecated("only", "use --include")
 

--- a/pkg/ctl/cmdutils/resource.go
+++ b/pkg/ctl/cmdutils/resource.go
@@ -1,0 +1,69 @@
+package cmdutils
+
+import (
+	"os"
+
+	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+)
+
+// ResourceCmd holds attributes that most of the commands use
+type ResourceCmd struct {
+	Command      *cobra.Command
+	FlagSetGroup *NamedFlagSetGroup
+
+	Plan, Wait bool
+
+	NameArg string
+
+	ClusterConfigFile string
+
+	ProviderConfig *api.ProviderConfig
+	ClusterConfig  *api.ClusterConfig
+
+	IncludeNodeGroups, ExcludeNodeGroups []string
+}
+
+// AddResourceCmd create a registers a new command under the given verb command
+func AddResourceCmd(flagGrouping *FlagGrouping, parentVerbCmd *cobra.Command, newResourceCmd func(*ResourceCmd)) {
+	resource := &ResourceCmd{
+		Command:        &cobra.Command{},
+		ProviderConfig: &api.ProviderConfig{},
+	}
+	resource.FlagSetGroup = flagGrouping.New(resource.Command)
+	newResourceCmd(resource)
+	resource.FlagSetGroup.AddTo(resource.Command)
+	parentVerbCmd.AddCommand(resource.Command)
+}
+
+// SetDescription sets usage along with short and long descriptions as well as aliases
+func (rc *ResourceCmd) SetDescription(use, short, long string, aliases ...string) {
+	rc.Command.Use = use
+	rc.Command.Short = short
+	rc.Command.Long = long
+	rc.Command.Aliases = aliases
+}
+
+// SetRunFunc registers a command function
+func (rc *ResourceCmd) SetRunFunc(cmd func() error) {
+	rc.Command.Run = func(_ *cobra.Command, _ []string) {
+		run(cmd)
+	}
+}
+
+// SetRunFuncWithNameArg registers a command function with an optional name argument
+func (rc *ResourceCmd) SetRunFuncWithNameArg(cmd func() error) {
+	rc.Command.Run = func(_ *cobra.Command, args []string) {
+		rc.NameArg = GetNameArg(args)
+		run(cmd)
+	}
+}
+
+func run(cmd func() error) {
+	if err := cmd(); err != nil {
+		logger.Critical("%s\n", err.Error())
+		os.Exit(1)
+	}
+}

--- a/pkg/ctl/create/create.go
+++ b/pkg/ctl/create/create.go
@@ -1,30 +1,18 @@
 package create
 
 import (
-	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
+
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-var (
-	clusterConfigFile = ""
-)
-
 // Command will create the `create` commands
-func Command(g *cmdutils.Grouping) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create resource(s)",
-		Run: func(c *cobra.Command, _ []string) {
-			if err := c.Help(); err != nil {
-				logger.Debug("ignoring error %q", err.Error())
-			}
-		},
-	}
+func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
+	verbCmd := cmdutils.NewVerbCmd("create", "Create resource(s)", "")
 
-	cmd.AddCommand(createClusterCmd(g))
-	cmd.AddCommand(createNodeGroupCmd(g))
-	cmd.AddCommand(createIAMIdentityMappingCmd(g))
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, createClusterCmd)
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, createNodeGroupCmd)
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, createIAMIdentityMappingCmd)
 
-	return cmd
+	return verbCmd
 }

--- a/pkg/ctl/create/iamidentitymapping.go
+++ b/pkg/ctl/create/iamidentitymapping.go
@@ -1,11 +1,8 @@
 package create
 
 import (
-	"os"
-
 	"github.com/kris-nova/logger"
 	"github.com/lithammer/dedent"
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -14,45 +11,40 @@ import (
 	"github.com/weaveworks/eksctl/pkg/eks"
 )
 
-func createIAMIdentityMappingCmd(g *cmdutils.Grouping) *cobra.Command {
-	p := &api.ProviderConfig{}
+func createIAMIdentityMappingCmd(rc *cmdutils.ResourceCmd) {
 	cfg := api.NewClusterConfig()
+	rc.ClusterConfig = cfg
+
 	id := &authconfigmap.MapRole{}
-	cmd := &cobra.Command{
-		Use:   "iamidentitymapping",
-		Short: "Create an IAM identity mapping",
-		Long: dedent.Dedent(`Creates a mapping from IAM role to Kubernetes user and groups.
+
+	rc.SetDescription("iamidentitymapping", "Create an IAM identity mapping",
+		dedent.Dedent(`Creates a mapping from IAM role to Kubernetes user and groups.
 
 			Note aws-iam-authenticator only considers the last entry for any given
 			role. If you create a duplicate entry it will shadow all the previous
 			username and groups mapping.
 		`),
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := doCreateIAMIdentityMapping(p, cfg, id); err != nil {
-				logger.Critical("%s\n", err.Error())
-				os.Exit(1)
-			}
-		},
-	}
-	group := g.New(cmd)
+	)
 
-	group.InFlagSet("General", func(fs *pflag.FlagSet) {
+	rc.SetRunFunc(func() error {
+		return doCreateIAMIdentityMapping(rc, id)
+	})
+
+	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&id.RoleARN, "role", "", "ARN of the IAM role to create")
 		fs.StringVar(&id.Username, "username", "", "User name within Kubernetes to map to IAM role")
 		fs.StringArrayVar(&id.Groups, "group", []string{}, "Group within Kubernetes to which IAM role is mapped")
 		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		cmdutils.AddRegionFlag(fs, p)
+		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(group, p, false)
-
-	group.AddTo(cmd)
-
-	return cmd
+	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
 }
 
-func doCreateIAMIdentityMapping(p *api.ProviderConfig, cfg *api.ClusterConfig, id *authconfigmap.MapRole) error {
-	ctl := eks.New(p, cfg)
+func doCreateIAMIdentityMapping(rc *cmdutils.ResourceCmd, id *authconfigmap.MapRole) error {
+	cfg := rc.ClusterConfig
+
+	ctl := eks.New(rc.ProviderConfig, cfg)
 
 	if err := ctl.CheckAuth(); err != nil {
 		return err

--- a/pkg/ctl/create/utils.go
+++ b/pkg/ctl/create/utils.go
@@ -2,21 +2,22 @@ package create
 
 import (
 	"fmt"
-	"github.com/weaveworks/eksctl/pkg/ssh"
-	"github.com/weaveworks/eksctl/pkg/utils/file"
 	"strings"
 
 	"github.com/kris-nova/logger"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/eks"
+	"github.com/weaveworks/eksctl/pkg/ssh"
+	"github.com/weaveworks/eksctl/pkg/utils/file"
 )
 
-func checkSubnetsGivenAsFlags() bool {
-	return len(*subnets[api.SubnetTopologyPrivate])+len(*subnets[api.SubnetTopologyPublic]) != 0
+func checkSubnetsGivenAsFlags(params *createClusterCmdParams) bool {
+	return len(*params.subnets[api.SubnetTopologyPrivate])+len(*params.subnets[api.SubnetTopologyPublic]) != 0
 }
 
-func checkVersion(ctl *eks.ClusterProvider, meta *api.ClusterMeta) error {
+func checkVersion(rc *cmdutils.ResourceCmd, ctl *eks.ClusterProvider, meta *api.ClusterMeta) error {
 	switch meta.Version {
 	case "auto":
 		break
@@ -44,7 +45,7 @@ func checkVersion(ctl *eks.ClusterProvider, meta *api.ClusterMeta) error {
 		logger.Info("will use version %s for new nodegroup(s) based on control plane version", meta.Version)
 	} else if meta.Version != v {
 		hint := "--version=auto"
-		if clusterConfigFile != "" {
+		if rc.ClusterConfigFile != "" {
 			hint = "metadata.version: auto"
 		}
 		logger.Warning("will use version %s for new nodegroup(s), while control plane version is %s; to automatically inherit the version use %q", meta.Version, v, hint)

--- a/pkg/ctl/delete/delete.go
+++ b/pkg/ctl/delete/delete.go
@@ -1,34 +1,18 @@
 package delete
 
 import (
-	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
 
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-var (
-	wait = false
-	plan = true
-
-	clusterConfigFile = ""
-)
-
 // Command will create the `delete` commands
-func Command(g *cmdutils.Grouping) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "delete",
-		Short: "Delete resource(s)",
-		Run: func(c *cobra.Command, _ []string) {
-			if err := c.Help(); err != nil {
-				logger.Debug("ignoring error %q", err.Error())
-			}
-		},
-	}
+func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
+	verbCmd := cmdutils.NewVerbCmd("delete", "Delete resource(s)", "")
 
-	cmd.AddCommand(deleteClusterCmd(g))
-	cmd.AddCommand(deleteNodeGroupCmd(g))
-	cmd.AddCommand(deleteIAMIdentityMappingCmd(g))
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, deleteClusterCmd)
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, deleteNodeGroupCmd)
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, deleteIAMIdentityMappingCmd)
 
-	return cmd
+	return verbCmd
 }

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -1,11 +1,8 @@
 package delete
 
 import (
-	"os"
-
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -15,63 +12,45 @@ import (
 	"github.com/weaveworks/eksctl/pkg/eks"
 )
 
-var (
-	updateAuthConfigMap  bool
-	deleteNodeGroupDrain bool
-
-	includeNodeGroups []string
-	excludeNodeGroups []string
-
-	deleteOnlyMissingNodeGroups bool
-)
-
-func deleteNodeGroupCmd(g *cmdutils.Grouping) *cobra.Command {
-	p := &api.ProviderConfig{}
+func deleteNodeGroupCmd(rc *cmdutils.ResourceCmd) {
 	cfg := api.NewClusterConfig()
 	ng := cfg.NewNodeGroup()
+	rc.ClusterConfig = cfg
 
-	cmd := &cobra.Command{
-		Use:     "nodegroup",
-		Short:   "Delete a nodegroup",
-		Aliases: []string{"ng"},
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := doDeleteNodeGroup(p, cfg, ng, cmdutils.GetNameArg(args), cmd); err != nil {
-				logger.Critical("%s\n", err.Error())
-				os.Exit(1)
-			}
-		},
-	}
+	var updateAuthConfigMap, deleteNodeGroupDrain, onlyMissing bool
 
-	group := g.New(cmd)
+	rc.SetDescription("nodegroup", "Delete a nodegroup", "", "ng")
 
-	group.InFlagSet("General", func(fs *pflag.FlagSet) {
-		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")
-		cmdutils.AddRegionFlag(fs, p)
-		fs.StringVarP(&ng.Name, "name", "n", "", "Name of the nodegroup to delete")
-		cmdutils.AddConfigFileFlag(&clusterConfigFile, fs)
-		cmdutils.AddApproveFlag(&plan, cmd, fs)
-		cmdutils.AddNodeGroupFilterFlags(&includeNodeGroups, &excludeNodeGroups, fs)
-		fs.BoolVar(&deleteOnlyMissingNodeGroups, "only-missing", false, "Only delete nodegroups that are not defined in the given config file")
-		cmdutils.AddUpdateAuthConfigMap(&updateAuthConfigMap, fs, "Remove nodegroup IAM role from aws-auth configmap")
-		fs.BoolVar(&deleteNodeGroupDrain, "drain", true, "Drain and cordon all nodes in the nodegroup before deletion")
-		cmdutils.AddWaitFlag(&wait, fs, "deletion of all resources")
+	rc.SetRunFuncWithNameArg(func() error {
+		return doDeleteNodeGroup(rc, ng, updateAuthConfigMap, deleteNodeGroupDrain, onlyMissing)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(group, p, true)
+	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")
+		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
+		fs.StringVarP(&ng.Name, "name", "n", "", "Name of the nodegroup to delete")
+		cmdutils.AddConfigFileFlag(fs, &rc.ClusterConfigFile)
+		cmdutils.AddApproveFlag(fs, rc)
+		cmdutils.AddNodeGroupFilterFlags(fs, &rc.IncludeNodeGroups, &rc.ExcludeNodeGroups)
+		fs.BoolVar(&onlyMissing, "only-missing", false, "Only delete nodegroups that are not defined in the given config file")
+		cmdutils.AddUpdateAuthConfigMap(fs, &updateAuthConfigMap, "Remove nodegroup IAM role from aws-auth configmap")
+		fs.BoolVar(&deleteNodeGroupDrain, "drain", true, "Drain and cordon all nodes in the nodegroup before deletion")
+		cmdutils.AddWaitFlag(fs, &rc.Wait, "deletion of all resources")
+	})
 
-	group.AddTo(cmd)
-
-	return cmd
+	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, true)
 }
 
-func doDeleteNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.NodeGroup, nameArg string, cmd *cobra.Command) error {
+func doDeleteNodeGroup(rc *cmdutils.ResourceCmd, ng *api.NodeGroup, updateAuthConfigMap, deleteNodeGroupDrain, onlyMissing bool) error {
 	ngFilter := cmdutils.NewNodeGroupFilter()
 
-	if err := cmdutils.NewDeleteNodeGroupLoader(p, cfg, ng, clusterConfigFile, nameArg, cmd, ngFilter, includeNodeGroups, excludeNodeGroups, &plan).Load(); err != nil {
+	if err := cmdutils.NewDeleteNodeGroupLoader(rc, ng, ngFilter).Load(); err != nil {
 		return err
 	}
 
-	ctl := eks.New(p, cfg)
+	cfg := rc.ClusterConfig
+
+	ctl := eks.New(rc.ProviderConfig, cfg)
 
 	if err := ctl.CheckAuth(); err != nil {
 		return err
@@ -88,9 +67,9 @@ func doDeleteNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.No
 
 	stackManager := ctl.NewStackManager(cfg)
 
-	if clusterConfigFile != "" {
-		logger.Info("comparing %d nodegroups defined in the given config (%q) against remote state", len(cfg.NodeGroups), clusterConfigFile)
-		if err := ngFilter.SetIncludeOrExcludeMissingFilter(stackManager, deleteOnlyMissingNodeGroups, &cfg.NodeGroups); err != nil {
+	if rc.ClusterConfigFile != "" {
+		logger.Info("comparing %d nodegroups defined in the given config (%q) against remote state", len(cfg.NodeGroups), rc.ClusterConfigFile)
+		if err := ngFilter.SetIncludeOrExcludeMissingFilter(stackManager, onlyMissing, &cfg.NodeGroups); err != nil {
 			return err
 		}
 	}
@@ -101,9 +80,9 @@ func doDeleteNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.No
 	ngFilter.LogInfo(cfg.NodeGroups)
 
 	if updateAuthConfigMap {
-		cmdutils.LogIntendedAction(plan, "delete %d nodegroups from auth ConfigMap in cluster %q", ngCount, cfg.Metadata.Name)
+		cmdutils.LogIntendedAction(rc.Plan, "delete %d nodegroups from auth ConfigMap in cluster %q", ngCount, cfg.Metadata.Name)
 		err := ngFilter.ForEach(cfg.NodeGroups, func(_ int, ng *api.NodeGroup) error {
-			if plan {
+			if rc.Plan {
 				return nil
 			}
 			if ng.IAM == nil || ng.IAM.InstanceRoleARN == "" {
@@ -123,9 +102,9 @@ func doDeleteNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.No
 	}
 
 	if deleteNodeGroupDrain {
-		cmdutils.LogIntendedAction(plan, "drain %d nodegroups in cluster %q", ngCount, cfg.Metadata.Name)
+		cmdutils.LogIntendedAction(rc.Plan, "drain %d nodegroups in cluster %q", ngCount, cfg.Metadata.Name)
 		err := ngFilter.ForEach(cfg.NodeGroups, func(_ int, ng *api.NodeGroup) error {
-			if plan {
+			if rc.Plan {
 				return nil
 			}
 			if err := drain.NodeGroup(clientSet, ng, ctl.Provider.WaitTimeout(), false); err != nil {
@@ -138,22 +117,22 @@ func doDeleteNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.No
 		}
 	}
 
-	cmdutils.LogIntendedAction(plan, "delete %d nodegroups from cluster %q", ngCount, cfg.Metadata.Name)
+	cmdutils.LogIntendedAction(rc.Plan, "delete %d nodegroups from cluster %q", ngCount, cfg.Metadata.Name)
 
 	{
-		tasks, err := stackManager.NewTasksToDeleteNodeGroups(ngSubset, wait, nil)
+		tasks, err := stackManager.NewTasksToDeleteNodeGroups(ngSubset, rc.Wait, nil)
 		if err != nil {
 			return err
 		}
-		tasks.PlanMode = plan
+		tasks.PlanMode = rc.Plan
 		logger.Info(tasks.Describe())
 		if errs := tasks.DoAllSync(); len(errs) > 0 {
 			return handleErrors(errs, "nodegroup(s)")
 		}
-		cmdutils.LogCompletedAction(plan, "deleted %d nodegroups from cluster %q", ngCount, cfg.Metadata.Name)
+		cmdutils.LogCompletedAction(rc.Plan, "deleted %d nodegroups from cluster %q", ngCount, cfg.Metadata.Name)
 	}
 
-	cmdutils.LogPlanModeWarning(plan && ngCount > 0)
+	cmdutils.LogPlanModeWarning(rc.Plan && ngCount > 0)
 
 	return nil
 }

--- a/pkg/ctl/drain/drain.go
+++ b/pkg/ctl/drain/drain.go
@@ -1,30 +1,16 @@
 package drain
 
 import (
-	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
+
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-var (
-	plan = true
-
-	clusterConfigFile = ""
-)
-
 // Command will create the `drain` commands
-func Command(g *cmdutils.Grouping) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "drain",
-		Short: "drain resources(s)",
-		Run: func(c *cobra.Command, _ []string) {
-			if err := c.Help(); err != nil {
-				logger.Debug("ignoring error %q", err.Error())
-			}
-		},
-	}
+func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
+	verbCmd := cmdutils.NewVerbCmd("drain", "Drain resource(s)", "")
 
-	cmd.AddCommand(drainNodeGroupCmd(g))
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, drainNodeGroupCmd)
 
-	return cmd
+	return verbCmd
 }

--- a/pkg/ctl/drain/nodegroup.go
+++ b/pkg/ctl/drain/nodegroup.go
@@ -1,11 +1,8 @@
 package drain
 
 import (
-	"os"
-
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -15,60 +12,43 @@ import (
 	"github.com/weaveworks/eksctl/pkg/drain"
 )
 
-var (
-	drainNodeGroupUndo bool
-
-	includeNodeGroups []string
-	excludeNodeGroups []string
-
-	drainOnlyMissingNodeGroups bool
-)
-
-func drainNodeGroupCmd(g *cmdutils.Grouping) *cobra.Command {
-	p := &api.ProviderConfig{}
+func drainNodeGroupCmd(rc *cmdutils.ResourceCmd) {
 	cfg := api.NewClusterConfig()
 	ng := cfg.NewNodeGroup()
+	rc.ClusterConfig = cfg
 
-	cmd := &cobra.Command{
-		Use:     "nodegroup",
-		Short:   "Cordon and drain a nodegroup",
-		Aliases: []string{"ng"},
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := doDrainNodeGroup(p, cfg, ng, cmdutils.GetNameArg(args), cmd); err != nil {
-				logger.Critical("%s\n", err.Error())
-				os.Exit(1)
-			}
-		},
-	}
+	var undo, onlyMissing bool
 
-	group := g.New(cmd)
+	rc.SetDescription("nodegroup", "Cordon and drain a nodegroup", "", "ng")
 
-	group.InFlagSet("General", func(fs *pflag.FlagSet) {
-		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")
-		cmdutils.AddRegionFlag(fs, p)
-		fs.StringVarP(&ng.Name, "name", "n", "", "Name of the nodegroup to delete")
-		cmdutils.AddConfigFileFlag(&clusterConfigFile, fs)
-		cmdutils.AddApproveFlag(&plan, cmd, fs)
-		cmdutils.AddNodeGroupFilterFlags(&includeNodeGroups, &excludeNodeGroups, fs)
-		fs.BoolVar(&drainOnlyMissingNodeGroups, "only-missing", false, "Only drain nodegroups that are not defined in the given config file")
-		fs.BoolVar(&drainNodeGroupUndo, "undo", false, "Uncordone the nodegroup")
+	rc.SetRunFuncWithNameArg(func() error {
+		return doDrainNodeGroup(rc, ng, undo, onlyMissing)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(group, p, true)
+	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")
+		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
+		fs.StringVarP(&ng.Name, "name", "n", "", "Name of the nodegroup to delete")
+		cmdutils.AddConfigFileFlag(fs, &rc.ClusterConfigFile)
+		cmdutils.AddApproveFlag(fs, rc)
+		cmdutils.AddNodeGroupFilterFlags(fs, &rc.IncludeNodeGroups, &rc.ExcludeNodeGroups)
+		fs.BoolVar(&onlyMissing, "only-missing", false, "Only drain nodegroups that are not defined in the given config file")
+		fs.BoolVar(&undo, "undo", false, "Uncordone the nodegroup")
+	})
 
-	group.AddTo(cmd)
-
-	return cmd
+	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, true)
 }
 
-func doDrainNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.NodeGroup, nameArg string, cmd *cobra.Command) error {
+func doDrainNodeGroup(rc *cmdutils.ResourceCmd, ng *api.NodeGroup, undo, onlyMissing bool) error {
 	ngFilter := cmdutils.NewNodeGroupFilter()
 
-	if err := cmdutils.NewDeleteNodeGroupLoader(p, cfg, ng, clusterConfigFile, nameArg, cmd, ngFilter, includeNodeGroups, excludeNodeGroups, &plan).Load(); err != nil {
+	if err := cmdutils.NewDeleteNodeGroupLoader(rc, ng, ngFilter).Load(); err != nil {
 		return err
 	}
 
-	ctl := eks.New(p, cfg)
+	cfg := rc.ClusterConfig
+
+	ctl := eks.New(rc.ProviderConfig, cfg)
 
 	if err := ctl.CheckAuth(); err != nil {
 		return err
@@ -85,9 +65,9 @@ func doDrainNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.Nod
 
 	stackManager := ctl.NewStackManager(cfg)
 
-	if clusterConfigFile != "" {
-		logger.Info("comparing %d nodegroups defined in the given config (%q) against remote state", len(cfg.NodeGroups), clusterConfigFile)
-		if err := ngFilter.SetIncludeOrExcludeMissingFilter(stackManager, drainOnlyMissingNodeGroups, &cfg.NodeGroups); err != nil {
+	if rc.ClusterConfigFile != "" {
+		logger.Info("comparing %d nodegroups defined in the given config (%q) against remote state", len(cfg.NodeGroups), rc.ClusterConfigFile)
+		if err := ngFilter.SetIncludeOrExcludeMissingFilter(stackManager, onlyMissing, &cfg.NodeGroups); err != nil {
 			return err
 		}
 	}
@@ -97,18 +77,18 @@ func doDrainNodeGroup(p *api.ProviderConfig, cfg *api.ClusterConfig, ng *api.Nod
 
 	ngFilter.LogInfo(cfg.NodeGroups)
 	verb := "drain"
-	if drainNodeGroupUndo {
+	if undo {
 		verb = "uncordon"
 	}
-	cmdutils.LogIntendedAction(plan, "%s %d nodegroups in cluster %q", verb, ngCount, cfg.Metadata.Name)
+	cmdutils.LogIntendedAction(rc.Plan, "%s %d nodegroups in cluster %q", verb, ngCount, cfg.Metadata.Name)
 
-	cmdutils.LogPlanModeWarning(plan && ngCount > 0)
+	cmdutils.LogPlanModeWarning(rc.Plan && ngCount > 0)
 
 	return ngFilter.ForEach(cfg.NodeGroups, func(_ int, ng *api.NodeGroup) error {
-		if plan {
+		if rc.Plan {
 			return nil
 		}
-		if err := drain.NodeGroup(clientSet, ng, ctl.Provider.WaitTimeout(), drainNodeGroupUndo); err != nil {
+		if err := drain.NodeGroup(clientSet, ng, ctl.Provider.WaitTimeout(), undo); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/ctl/get/cluster.go
+++ b/pkg/ctl/get/cluster.go
@@ -2,68 +2,58 @@ package get
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/kris-nova/logger"
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/eks"
 )
 
-var listAllRegions bool
-
-func getClusterCmd(g *cmdutils.Grouping) *cobra.Command {
-	p := &api.ProviderConfig{}
+func getClusterCmd(rc *cmdutils.ResourceCmd) {
 	cfg := api.NewClusterConfig()
+	rc.ClusterConfig = cfg
 
-	cmd := &cobra.Command{
-		Use:     "cluster",
-		Short:   "Get cluster(s)",
-		Aliases: []string{"clusters"},
-		Run: func(_ *cobra.Command, args []string) {
-			if err := doGetCluster(p, cfg, cmdutils.GetNameArg(args)); err != nil {
-				logger.Critical("%s\n", err.Error())
-				os.Exit(1)
-			}
-		},
-	}
+	var listAllRegions bool
 
-	group := g.New(cmd)
+	params := &getCmdParams{}
 
-	group.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		fs.BoolVarP(&listAllRegions, "all-regions", "A", false, "List clusters across all supported regions")
-		cmdutils.AddRegionFlag(fs, p)
-		cmdutils.AddCommonFlagsForGetCmd(fs, &chunkSize, &output)
+	rc.SetDescription("cluster", "Get cluster(s)", "", "clusters")
+
+	rc.SetRunFuncWithNameArg(func() error {
+		return doGetCluster(rc, params, listAllRegions)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(group, p, false)
+	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		fs.BoolVarP(&listAllRegions, "all-regions", "A", false, "List clusters across all supported regions")
+		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
+		cmdutils.AddCommonFlagsForGetCmd(fs, &params.chunkSize, &params.output)
+	})
 
-	group.AddTo(cmd)
-
-	return cmd
+	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
 }
 
-func doGetCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg string) error {
+func doGetCluster(rc *cmdutils.ResourceCmd, params *getCmdParams, listAllRegions bool) error {
+	cfg := rc.ClusterConfig
 	regionGiven := cfg.Metadata.Region != "" // eks.New resets this field, so we need to check if it was set in the fist place
-	ctl := eks.New(p, cfg)
+
+	ctl := eks.New(rc.ProviderConfig, cfg)
 
 	if !ctl.IsSupportedRegion() {
-		return cmdutils.ErrUnsupportedRegion(p)
+		return cmdutils.ErrUnsupportedRegion(rc.ProviderConfig)
 	}
 
 	if regionGiven && listAllRegions {
 		logger.Warning("--region=%s is ignored, as --all-regions is given", cfg.Metadata.Region)
 	}
 
-	if cfg.Metadata.Name != "" && nameArg != "" {
-		return cmdutils.ErrNameFlagAndArg(cfg.Metadata.Name, nameArg)
+	if cfg.Metadata.Name != "" && rc.NameArg != "" {
+		return cmdutils.ErrNameFlagAndArg(cfg.Metadata.Name, rc.NameArg)
 	}
 
-	if nameArg != "" {
-		cfg.Metadata.Name = nameArg
+	if rc.NameArg != "" {
+		cfg.Metadata.Name = rc.NameArg
 	}
 
 	if cfg.Metadata.Name != "" && listAllRegions {
@@ -74,5 +64,5 @@ func doGetCluster(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg string)
 		return err
 	}
 
-	return ctl.ListClusters(cfg.Metadata.Name, chunkSize, output, listAllRegions)
+	return ctl.ListClusters(cfg.Metadata.Name, params.chunkSize, params.output, listAllRegions)
 }

--- a/pkg/ctl/get/get.go
+++ b/pkg/ctl/get/get.go
@@ -1,31 +1,23 @@
 package get
 
 import (
-	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
+
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-var (
+type getCmdParams struct {
 	chunkSize int
 	output    string
-)
+}
 
 // Command will create the `get` commands
-func Command(g *cmdutils.Grouping) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "get",
-		Short: "Get resource(s)",
-		Run: func(c *cobra.Command, _ []string) {
-			if err := c.Help(); err != nil {
-				logger.Debug("ignoring error %q", err.Error())
-			}
-		},
-	}
+func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
+	verbCmd := cmdutils.NewVerbCmd("get", "Get resource(s)", "")
 
-	cmd.AddCommand(getClusterCmd(g))
-	cmd.AddCommand(getNodegroupCmd(g))
-	cmd.AddCommand(getIAMIdentityMappingCmd(g))
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, getClusterCmd)
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, getNodeGroupCmd)
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, getIAMIdentityMappingCmd)
 
-	return cmd
+	return verbCmd
 }

--- a/pkg/ctl/get/iamidentitymapping.go
+++ b/pkg/ctl/get/iamidentitymapping.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kris-nova/logger"
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -16,38 +14,34 @@ import (
 	"github.com/weaveworks/eksctl/pkg/printers"
 )
 
-func getIAMIdentityMappingCmd(g *cmdutils.Grouping) *cobra.Command {
-	p := &api.ProviderConfig{}
+func getIAMIdentityMappingCmd(rc *cmdutils.ResourceCmd) {
 	cfg := api.NewClusterConfig()
-	var roleFlag string
-	cmd := &cobra.Command{
-		Use:   "iamidentitymapping",
-		Short: "Get IAM identity mapping(s)",
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := doGetIAMIdentityMapping(p, cfg, roleFlag); err != nil {
-				logger.Critical("%s\n", err.Error())
-				os.Exit(1)
-			}
-		},
-	}
-	group := g.New(cmd)
+	rc.ClusterConfig = cfg
 
-	group.InFlagSet("General", func(fs *pflag.FlagSet) {
-		fs.StringVar(&roleFlag, "role", "", "ARN of the IAM role")
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		cmdutils.AddRegionFlag(fs, p)
-		cmdutils.AddCommonFlagsForGetCmd(fs, &chunkSize, &output)
+	var role string
+
+	params := &getCmdParams{}
+
+	rc.SetDescription("iamidentitymapping", "Get IAM identity mapping(s)", "")
+
+	rc.SetRunFunc(func() error {
+		return doGetIAMIdentityMapping(rc, params, role)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(group, p, false)
+	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+		fs.StringVar(&role, "role", "", "ARN of the IAM role")
+		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
+		cmdutils.AddCommonFlagsForGetCmd(fs, &params.chunkSize, &params.output)
+	})
 
-	group.AddTo(cmd)
-
-	return cmd
+	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
 }
 
-func doGetIAMIdentityMapping(p *api.ProviderConfig, cfg *api.ClusterConfig, roleFlag string) error {
-	ctl := eks.New(p, cfg)
+func doGetIAMIdentityMapping(rc *cmdutils.ResourceCmd, params *getCmdParams, role string) error {
+	cfg := rc.ClusterConfig
+
+	ctl := eks.New(rc.ProviderConfig, cfg)
 
 	if err := ctl.CheckAuth(); err != nil {
 		return err
@@ -72,19 +66,19 @@ func doGetIAMIdentityMapping(p *api.ProviderConfig, cfg *api.ClusterConfig, role
 	if err != nil {
 		return err
 	}
-	if roleFlag != "" {
-		roles = roles.Get(roleFlag)
+	if role != "" {
+		roles = roles.Get(role)
 		// If a filter was given, we error if none was found
 		if len(roles) == 0 {
-			return fmt.Errorf("no iamidentitymapping with role %q found", roleFlag)
+			return fmt.Errorf("no iamidentitymapping with role %q found", role)
 		}
 	}
 
-	printer, err := printers.NewPrinter(output)
+	printer, err := printers.NewPrinter(params.output)
 	if err != nil {
 		return err
 	}
-	if output == "table" {
+	if params.output == "table" {
 		addIAMIdentityMappingTableColumns(printer.(*printers.TablePrinter))
 	}
 

--- a/pkg/ctl/scale/scale.go
+++ b/pkg/ctl/scale/scale.go
@@ -1,24 +1,15 @@
 package scale
 
 import (
-	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
 // Command will create the `scale` commands
-func Command(g *cmdutils.Grouping) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "scale",
-		Short: "Scale resources(s)",
-		Run: func(c *cobra.Command, _ []string) {
-			if err := c.Help(); err != nil {
-				logger.Debug("ignoring error %q", err.Error())
-			}
-		},
-	}
+func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
+	verbCmd := cmdutils.NewVerbCmd("scale", "Scale resources(s)", "")
 
-	cmd.AddCommand(scaleNodeGroupCmd(g))
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, scaleNodeGroupCmd)
 
-	return cmd
+	return verbCmd
 }

--- a/pkg/ctl/update/update.go
+++ b/pkg/ctl/update/update.go
@@ -1,31 +1,16 @@
 package update
 
 import (
-	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
+
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-var (
-	plan = true
-	wait = true
-
-	clusterConfigFile string
-)
-
 // Command will create the `create` commands
-func Command(g *cmdutils.Grouping) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "update",
-		Short: "Update resource(s)",
-		Run: func(c *cobra.Command, _ []string) {
-			if err := c.Help(); err != nil {
-				logger.Debug("ignoring error %q", err.Error())
-			}
-		},
-	}
+func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
+	verbCmd := cmdutils.NewVerbCmd("update", "Update resource(s)", "")
 
-	cmd.AddCommand(updateClusterCmd(g))
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, updateClusterCmd)
 
-	return cmd
+	return verbCmd
 }

--- a/pkg/ctl/utils/describe_stacks.go
+++ b/pkg/ctl/utils/describe_stacks.go
@@ -2,11 +2,9 @@ package utils
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/kris-nova/logger"
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -14,56 +12,44 @@ import (
 	"github.com/weaveworks/eksctl/pkg/eks"
 )
 
-var (
-	describeStacksAll    bool
-	describeStacksEvents bool
-	describeStacksTrail  bool
-)
-
-func describeStacksCmd(g *cmdutils.Grouping) *cobra.Command {
-	p := &api.ProviderConfig{}
+func describeStacksCmd(rc *cmdutils.ResourceCmd) {
 	cfg := api.NewClusterConfig()
+	rc.ClusterConfig = cfg
 
-	cmd := &cobra.Command{
-		Use:   "describe-stacks",
-		Short: "Describe CloudFormation stack for a given cluster",
-		Run: func(_ *cobra.Command, args []string) {
-			if err := doDescribeStacksCmd(p, cfg, cmdutils.GetNameArg(args)); err != nil {
-				logger.Critical("%s\n", err.Error())
-				os.Exit(1)
-			}
-		},
-	}
+	var all, events, trail bool
 
-	group := g.New(cmd)
+	rc.SetDescription("describe-stacks", "Describe CloudFormation stack for a given cluster", "")
 
-	group.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		cmdutils.AddRegionFlag(fs, p)
-		fs.BoolVar(&describeStacksAll, "all", false, "include deleted stacks")
-		fs.BoolVar(&describeStacksEvents, "events", false, "include stack events")
-		fs.BoolVar(&describeStacksTrail, "trail", false, "lookup CloudTrail events for the cluster")
+	rc.SetRunFunc(func() error {
+		return doDescribeStacksCmd(rc, all, events, trail)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(group, p, false)
+	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
+		fs.BoolVar(&all, "all", false, "include deleted stacks")
+		fs.BoolVar(&events, "events", false, "include stack events")
+		fs.BoolVar(&trail, "trail", false, "lookup CloudTrail events for the cluster")
+	})
 
-	group.AddTo(cmd)
-	return cmd
+	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
 }
 
-func doDescribeStacksCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg string) error {
-	ctl := eks.New(p, cfg)
+func doDescribeStacksCmd(rc *cmdutils.ResourceCmd, all, events, trail bool) error {
+	cfg := rc.ClusterConfig
+
+	ctl := eks.New(rc.ProviderConfig, cfg)
 
 	if err := ctl.CheckAuth(); err != nil {
 		return err
 	}
 
-	if cfg.Metadata.Name != "" && nameArg != "" {
-		return fmt.Errorf("--name=%s and argument %s cannot be used at the same time", cfg.Metadata.Name, nameArg)
+	if cfg.Metadata.Name != "" && rc.NameArg != "" {
+		return fmt.Errorf("--name=%s and argument %s cannot be used at the same time", cfg.Metadata.Name, rc.NameArg)
 	}
 
-	if nameArg != "" {
-		cfg.Metadata.Name = nameArg
+	if rc.NameArg != "" {
+		cfg.Metadata.Name = rc.NameArg
 	}
 
 	if cfg.Metadata.Name == "" {
@@ -82,11 +68,11 @@ func doDescribeStacksCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg 
 	}
 
 	for _, s := range stacks {
-		if !describeStacksAll && *s.StackStatus == cloudformation.StackStatusDeleteComplete {
+		if !all && *s.StackStatus == cloudformation.StackStatusDeleteComplete {
 			continue
 		}
 		logger.Info("stack/%s = %#v", *s.StackName, s)
-		if describeStacksEvents {
+		if events {
 			events, err := stackManager.DescribeStackEvents(s)
 			if err != nil {
 				logger.Critical(err.Error())
@@ -95,7 +81,7 @@ func doDescribeStacksCmd(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg 
 				logger.Info("CloudFormation.events/%s[%d] = %#v", *s.StackName, i, e)
 			}
 		}
-		if describeStacksTrail {
+		if trail {
 			events, err := stackManager.LookupCloudTrailEvents(s)
 			if err != nil {
 				logger.Critical(err.Error())

--- a/pkg/ctl/utils/install_corends.go
+++ b/pkg/ctl/utils/install_corends.go
@@ -2,11 +2,9 @@ package utils
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	defaultaddons "github.com/weaveworks/eksctl/pkg/addons/default"
@@ -15,47 +13,39 @@ import (
 	"github.com/weaveworks/eksctl/pkg/eks"
 )
 
-func installCoreDNSCmd(g *cmdutils.Grouping) *cobra.Command {
-	p := &api.ProviderConfig{}
+func installCoreDNSCmd(rc *cmdutils.ResourceCmd) {
 	cfg := api.NewClusterConfig()
+	rc.ClusterConfig = cfg
 
-	cmd := &cobra.Command{
-		Use:   "install-coredns",
-		Short: "Installs latest version of CoreDNS add-on into clusters, replacing kube-dns",
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := doInstallCoreDNS(p, cfg, cmdutils.GetNameArg(args), cmd); err != nil {
-				logger.Critical("%s\n", err.Error())
-				os.Exit(1)
-			}
-		},
-	}
+	rc.SetDescription("install-coredns", "Installs latest version of CoreDNS add-on, replacing kube-dns", "")
 
-	group := g.New(cmd)
-
-	group.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		cmdutils.AddRegionFlag(fs, p)
-		cmdutils.AddConfigFileFlag(&clusterConfigFile, fs)
-		cmdutils.AddApproveFlag(&plan, cmd, fs)
+	rc.SetRunFunc(func() error {
+		return doInstallCoreDNS(rc)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(group, p, false)
+	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
+		cmdutils.AddConfigFileFlag(fs, &rc.ClusterConfigFile)
+		cmdutils.AddApproveFlag(fs, rc)
+	})
 
-	group.AddTo(cmd)
+	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
 
-	return cmd
 }
 
-func doInstallCoreDNS(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg string, cmd *cobra.Command) error {
-	if err := cmdutils.NewMetadataLoader(p, cfg, clusterConfigFile, nameArg, cmd).Load(); err != nil {
+func doInstallCoreDNS(rc *cmdutils.ResourceCmd) error {
+	if err := cmdutils.NewMetadataLoader(rc).Load(); err != nil {
 		return err
 	}
 
-	ctl := eks.New(p, cfg)
-	meta := cfg.Metadata
+	cfg := rc.ClusterConfig
+	meta := rc.ClusterConfig.Metadata
+
+	ctl := eks.New(rc.ProviderConfig, cfg)
 
 	if !ctl.IsSupportedRegion() {
-		return cmdutils.ErrUnsupportedRegion(p)
+		return cmdutils.ErrUnsupportedRegion(rc.ProviderConfig)
 	}
 	logger.Info("using region %s", meta.Region)
 
@@ -81,12 +71,12 @@ func doInstallCoreDNS(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg str
 
 	waitTimeout := ctl.Provider.WaitTimeout()
 
-	updateRequired, err := defaultaddons.InstallCoreDNS(rawClient, meta.Region, &waitTimeout, plan)
+	updateRequired, err := defaultaddons.InstallCoreDNS(rawClient, meta.Region, &waitTimeout, rc.Plan)
 	if err != nil {
 		return err
 	}
 
-	cmdutils.LogPlanModeWarning(plan && updateRequired)
+	cmdutils.LogPlanModeWarning(rc.Plan && updateRequired)
 
 	return nil
 }

--- a/pkg/ctl/utils/update_aws_node.go
+++ b/pkg/ctl/utils/update_aws_node.go
@@ -1,11 +1,8 @@
 package utils
 
 import (
-	"os"
-
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	defaultaddons "github.com/weaveworks/eksctl/pkg/addons/default"
@@ -14,47 +11,38 @@ import (
 	"github.com/weaveworks/eksctl/pkg/eks"
 )
 
-func updateAWSNodeCmd(g *cmdutils.Grouping) *cobra.Command {
-	p := &api.ProviderConfig{}
+func updateAWSNodeCmd(rc *cmdutils.ResourceCmd) {
 	cfg := api.NewClusterConfig()
+	rc.ClusterConfig = cfg
 
-	cmd := &cobra.Command{
-		Use:   "update-aws-node",
-		Short: "Update aws-node add-on to latest released version",
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := doUpdateAWSNode(p, cfg, cmdutils.GetNameArg(args), cmd); err != nil {
-				logger.Critical("%s\n", err.Error())
-				os.Exit(1)
-			}
-		},
-	}
+	rc.SetDescription("update-aws-node", "Update aws-node add-on to latest released version", "")
 
-	group := g.New(cmd)
-
-	group.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		cmdutils.AddRegionFlag(fs, p)
-		cmdutils.AddConfigFileFlag(&clusterConfigFile, fs)
-		cmdutils.AddApproveFlag(&plan, cmd, fs)
+	rc.SetRunFunc(func() error {
+		return doUpdateAWSNode(rc)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(group, p, false)
+	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
+		cmdutils.AddConfigFileFlag(fs, &rc.ClusterConfigFile)
+		cmdutils.AddApproveFlag(fs, rc)
+	})
 
-	group.AddTo(cmd)
-
-	return cmd
+	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
 }
 
-func doUpdateAWSNode(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg string, cmd *cobra.Command) error {
-	if err := cmdutils.NewMetadataLoader(p, cfg, clusterConfigFile, nameArg, cmd).Load(); err != nil {
+func doUpdateAWSNode(rc *cmdutils.ResourceCmd) error {
+	if err := cmdutils.NewMetadataLoader(rc).Load(); err != nil {
 		return err
 	}
 
-	ctl := eks.New(p, cfg)
-	meta := cfg.Metadata
+	cfg := rc.ClusterConfig
+	meta := rc.ClusterConfig.Metadata
+
+	ctl := eks.New(rc.ProviderConfig, cfg)
 
 	if !ctl.IsSupportedRegion() {
-		return cmdutils.ErrUnsupportedRegion(p)
+		return cmdutils.ErrUnsupportedRegion(rc.ProviderConfig)
 	}
 	logger.Info("using region %s", meta.Region)
 
@@ -76,12 +64,12 @@ func doUpdateAWSNode(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 		return err
 	}
 
-	updateRequired, err := defaultaddons.UpdateAWSNode(rawClient, meta.Region, kubernetesVersion, plan)
+	updateRequired, err := defaultaddons.UpdateAWSNode(rawClient, meta.Region, kubernetesVersion, rc.Plan)
 	if err != nil {
 		return err
 	}
 
-	cmdutils.LogPlanModeWarning(plan && updateRequired)
+	cmdutils.LogPlanModeWarning(rc.Plan && updateRequired)
 
 	return nil
 }

--- a/pkg/ctl/utils/update_cluster_stack.go
+++ b/pkg/ctl/utils/update_cluster_stack.go
@@ -9,13 +9,11 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-func updateClusterStackCmd(_ *cmdutils.Grouping) *cobra.Command {
-	return &cobra.Command{
-		Use:   "update-cluster-stack",
-		Short: "DEPRECATED: Use 'eksctl update cluster' instead",
-		Run: func(cmd *cobra.Command, _ []string) {
-			logger.Critical(cmd.Short)
-			os.Exit(1)
-		},
+func updateClusterStackCmd(rc *cmdutils.ResourceCmd) {
+	rc.SetDescription("update-cluster-stack", "DEPRECATED: Use 'eksctl update cluster' instead", "")
+
+	rc.Command.Run = func(cmd *cobra.Command, _ []string) {
+		logger.Critical(cmd.Short)
+		os.Exit(1)
 	}
 }

--- a/pkg/ctl/utils/update_coredns.go
+++ b/pkg/ctl/utils/update_coredns.go
@@ -1,11 +1,8 @@
 package utils
 
 import (
-	"os"
-
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	defaultaddons "github.com/weaveworks/eksctl/pkg/addons/default"
@@ -14,47 +11,38 @@ import (
 	"github.com/weaveworks/eksctl/pkg/eks"
 )
 
-func updateCoreDNSCmd(g *cmdutils.Grouping) *cobra.Command {
-	p := &api.ProviderConfig{}
+func updateCoreDNSCmd(rc *cmdutils.ResourceCmd) {
 	cfg := api.NewClusterConfig()
+	rc.ClusterConfig = cfg
 
-	cmd := &cobra.Command{
-		Use:   "update-coredns",
-		Short: "Update coredns add-on to ensure image the standard Amazon EKS version",
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := doUpdateCoreDNS(p, cfg, cmdutils.GetNameArg(args), cmd); err != nil {
-				logger.Critical("%s\n", err.Error())
-				os.Exit(1)
-			}
-		},
-	}
+	rc.SetDescription("update-coredns", "Update coredns add-on to ensure image the standard Amazon EKS version", "")
 
-	group := g.New(cmd)
-
-	group.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		cmdutils.AddRegionFlag(fs, p)
-		cmdutils.AddConfigFileFlag(&clusterConfigFile, fs)
-		cmdutils.AddApproveFlag(&plan, cmd, fs)
+	rc.SetRunFunc(func() error {
+		return doUpdateCoreDNS(rc)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(group, p, false)
+	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
+		cmdutils.AddConfigFileFlag(fs, &rc.ClusterConfigFile)
+		cmdutils.AddApproveFlag(fs, rc)
+	})
 
-	group.AddTo(cmd)
-
-	return cmd
+	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
 }
 
-func doUpdateCoreDNS(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg string, cmd *cobra.Command) error {
-	if err := cmdutils.NewMetadataLoader(p, cfg, clusterConfigFile, nameArg, cmd).Load(); err != nil {
+func doUpdateCoreDNS(rc *cmdutils.ResourceCmd) error {
+	if err := cmdutils.NewMetadataLoader(rc).Load(); err != nil {
 		return err
 	}
 
-	ctl := eks.New(p, cfg)
-	meta := cfg.Metadata
+	cfg := rc.ClusterConfig
+	meta := rc.ClusterConfig.Metadata
+
+	ctl := eks.New(rc.ProviderConfig, cfg)
 
 	if !ctl.IsSupportedRegion() {
-		return cmdutils.ErrUnsupportedRegion(p)
+		return cmdutils.ErrUnsupportedRegion(rc.ProviderConfig)
 	}
 	logger.Info("using region %s", meta.Region)
 
@@ -71,12 +59,12 @@ func doUpdateCoreDNS(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg stri
 		return err
 	}
 
-	updateRequired, err := defaultaddons.UpdateCoreDNSImageTag(clientSet, plan)
+	updateRequired, err := defaultaddons.UpdateCoreDNSImageTag(clientSet, rc.Plan)
 	if err != nil {
 		return err
 	}
 
-	cmdutils.LogPlanModeWarning(plan && updateRequired)
+	cmdutils.LogPlanModeWarning(rc.Plan && updateRequired)
 
 	return nil
 }

--- a/pkg/ctl/utils/update_kube_proxy.go
+++ b/pkg/ctl/utils/update_kube_proxy.go
@@ -1,11 +1,8 @@
 package utils
 
 import (
-	"os"
-
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	defaultaddons "github.com/weaveworks/eksctl/pkg/addons/default"
@@ -14,47 +11,38 @@ import (
 	"github.com/weaveworks/eksctl/pkg/eks"
 )
 
-func updateKubeProxyCmd(g *cmdutils.Grouping) *cobra.Command {
-	p := &api.ProviderConfig{}
+func updateKubeProxyCmd(rc *cmdutils.ResourceCmd) {
 	cfg := api.NewClusterConfig()
+	rc.ClusterConfig = cfg
 
-	cmd := &cobra.Command{
-		Use:   "update-kube-proxy",
-		Short: "Update kube-proxy add-on to ensure image matches Kubernetes control plane version",
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := doUpdateKubeProxy(p, cfg, cmdutils.GetNameArg(args), cmd); err != nil {
-				logger.Critical("%s\n", err.Error())
-				os.Exit(1)
-			}
-		},
-	}
+	rc.SetDescription("update-kube-proxy", "Update kube-proxy add-on to ensure image matches Kubernetes control plane version", "")
 
-	group := g.New(cmd)
-
-	group.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		cmdutils.AddRegionFlag(fs, p)
-		cmdutils.AddConfigFileFlag(&clusterConfigFile, fs)
-		cmdutils.AddApproveFlag(&plan, cmd, fs)
+	rc.SetRunFunc(func() error {
+		return doUpdateKubeProxy(rc)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(group, p, false)
+	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
+		cmdutils.AddConfigFileFlag(fs, &rc.ClusterConfigFile)
+		cmdutils.AddApproveFlag(fs, rc)
+	})
 
-	group.AddTo(cmd)
-
-	return cmd
+	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
 }
 
-func doUpdateKubeProxy(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg string, cmd *cobra.Command) error {
-	if err := cmdutils.NewMetadataLoader(p, cfg, clusterConfigFile, nameArg, cmd).Load(); err != nil {
+func doUpdateKubeProxy(rc *cmdutils.ResourceCmd) error {
+	if err := cmdutils.NewMetadataLoader(rc).Load(); err != nil {
 		return err
 	}
 
-	ctl := eks.New(p, cfg)
-	meta := cfg.Metadata
+	cfg := rc.ClusterConfig
+	meta := rc.ClusterConfig.Metadata
+
+	ctl := eks.New(rc.ProviderConfig, cfg)
 
 	if !ctl.IsSupportedRegion() {
-		return cmdutils.ErrUnsupportedRegion(p)
+		return cmdutils.ErrUnsupportedRegion(rc.ProviderConfig)
 	}
 	logger.Info("using region %s", meta.Region)
 
@@ -76,12 +64,12 @@ func doUpdateKubeProxy(p *api.ProviderConfig, cfg *api.ClusterConfig, nameArg st
 		return err
 	}
 
-	updateRequired, err := defaultaddons.UpdateKubeProxyImageTag(rawClient.ClientSet(), kubernetesVersion, plan)
+	updateRequired, err := defaultaddons.UpdateKubeProxyImageTag(rawClient.ClientSet(), kubernetesVersion, rc.Plan)
 	if err != nil {
 		return err
 	}
 
-	cmdutils.LogPlanModeWarning(plan && updateRequired)
+	cmdutils.LogPlanModeWarning(rc.Plan && updateRequired)
 
 	return nil
 }

--- a/pkg/ctl/utils/utils.go
+++ b/pkg/ctl/utils/utils.go
@@ -1,37 +1,22 @@
 package utils
 
 import (
-	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-var (
-	clusterConfigFile = ""
-
-	plan = true
-)
-
 // Command will create the `utils` commands
-func Command(g *cmdutils.Grouping) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "utils",
-		Short: "Various utils",
-		Run: func(c *cobra.Command, _ []string) {
-			if err := c.Help(); err != nil {
-				logger.Debug("ignoring error %q", err.Error())
-			}
-		},
-	}
+func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
+	verbCmd := cmdutils.NewVerbCmd("utils", "Various utils", "")
 
-	cmd.AddCommand(waitNodesCmd(g))
-	cmd.AddCommand(writeKubeconfigCmd(g))
-	cmd.AddCommand(describeStacksCmd(g))
-	cmd.AddCommand(updateClusterStackCmd(g))
-	cmd.AddCommand(updateKubeProxyCmd(g))
-	cmd.AddCommand(updateAWSNodeCmd(g))
-	cmd.AddCommand(updateCoreDNSCmd(g))
-	cmd.AddCommand(installCoreDNSCmd(g))
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, waitNodesCmd)
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, writeKubeconfigCmd)
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, describeStacksCmd)
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, updateClusterStackCmd)
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, updateKubeProxyCmd)
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, updateAWSNodeCmd)
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, updateCoreDNSCmd)
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, installCoreDNSCmd)
 
-	return cmd
+	return verbCmd
 }


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

- create short-hand methods for defining standard commands
- move most of common parameters to a struct
- get rid of global state
- improve overall consistency of command functions
- close #740
- also a step towards #813 

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [ ] All integration tests passing (i.e. `make integration-test`)
