### PR TITLE
Added a check for AMI encryption

### DIFF
--- a/pkg/ami/api.go
+++ b/pkg/ami/api.go
@@ -62,8 +62,13 @@ func Use(ec2api ec2iface.EC2API, ng *api.NodeGroup) error {
 		return fmt.Errorf("%q is an instance-store AMI and EBS block device mappings not supported for instance-store AMIs", ng.AMI)
 	}
 
-	if *output.Images[0].RootDeviceType == "ebs" && !api.IsSetAndNonEmptyString(ng.VolumeName) {
-		ng.VolumeName = output.Images[0].RootDeviceName
+	if *output.Images[0].RootDeviceType == "ebs" {
+		if !api.IsSetAndNonEmptyString(ng.VolumeName) {
+			ng.VolumeName = output.Images[0].RootDeviceName
+		}
+		if ng.VolumeEncrypted == nil {
+			ng.VolumeEncrypted = output.Images[0].BlockDeviceMappings[0].Ebs.Encrypted
+		}
 	}
 
 	return nil

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -406,6 +406,9 @@ type NodeGroup struct {
 	// +optional
 	VolumeName *string `json:"volumeName,omitempty"`
 	// +optional
+	VolumeEncrypted *bool `json:"volumeEncrypted,omitempty"`
+	//
+	// +optional
 	MaxPodsPerNode int `json:"maxPodsPerNode,omitempty"`
 
 	// +optional

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -407,7 +407,6 @@ type NodeGroup struct {
 	VolumeName *string `json:"volumeName,omitempty"`
 	// +optional
 	VolumeEncrypted *bool `json:"volumeEncrypted,omitempty"`
-	//
 	// +optional
 	MaxPodsPerNode int `json:"maxPodsPerNode,omitempty"`
 

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -297,7 +297,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 		*ng.VolumeType = api.NodeVolumeTypeIO1
 		ng.VolumeName = new(string)
 		*ng.VolumeName = "/dev/xvda"
-		ng.VolumeEncrypted = new(bool)
+		ng.VolumeEncrypted = api.Disabled()
 		*ng.VolumeEncrypted = false
 
 		if withFullVPC {
@@ -405,7 +405,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 					VolumeSize:      aws.Int(2),
 					VolumeType:      aws.String(api.NodeVolumeTypeIO1),
 					VolumeName:      aws.String("/dev/xvda"),
-					VolumeEncrypted: aws.Bool(false),
+					VolumeEncrypted: api.Disabled(),
 					IAM: &api.NodeGroupIAM{
 						WithAddonPolicies: api.NodeGroupIAMAddonPolicies{
 							ImageBuilder: api.Disabled(),

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -297,6 +297,8 @@ var _ = Describe("CloudFormation template builder API", func() {
 		*ng.VolumeType = api.NodeVolumeTypeIO1
 		ng.VolumeName = new(string)
 		*ng.VolumeName = "/dev/xvda"
+		ng.VolumeEncrypted = new(bool)
+		*ng.VolumeEncrypted = false
 
 		if withFullVPC {
 			cfg.VPC = testVPC()
@@ -403,6 +405,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 					VolumeSize:      aws.Int(2),
 					VolumeType:      aws.String(api.NodeVolumeTypeIO1),
 					VolumeName:      aws.String("/dev/xvda"),
+					VolumeEncrypted: aws.Bool(false),
 					IAM: &api.NodeGroupIAM{
 						WithAddonPolicies: api.NodeGroupIAMAddonPolicies{
 							ImageBuilder: api.Disabled(),

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -119,6 +119,7 @@ func (n *NodeGroupResourceSet) addResourcesForNodeGroup() error {
 			Ebs: &gfn.AWSEC2LaunchTemplate_Ebs{
 				VolumeSize: gfn.NewInteger(*volumeSize),
 				VolumeType: gfn.NewString(*n.spec.VolumeType),
+				Encrypted: gfn.NewBoolean(*n.spec.VolumeEncrypted),
 			},
 		}}
 	}

--- a/pkg/eks/api_test.go
+++ b/pkg/eks/api_test.go
@@ -167,6 +167,13 @@ func mockDescribeImages(p *mockprovider.MockProvider, expectedNamePattern string
 					State:          aws.String("available"),
 					OwnerId:        aws.String("123"),
 					RootDeviceType: aws.String("ebs"),
+					BlockDeviceMappings: []*ec2.BlockDeviceMapping{
+						{
+							Ebs: &ec2.EbsBlockDevice{
+								Encrypted: aws.Bool(false),
+							},
+						},
+					},
 				},
 			},
 		}, nil)


### PR DESCRIPTION
Fix for #858

I have added a check to see if the ami being used is encrypted and updated the cloudformation template to include the value of that check. This is required to enable the use of encrypted amis

- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] Manually tested
