### PR TITLE
Mark cluster delete test as flaky

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -44,6 +44,7 @@ Patrick Spek            @tyil
 Martina Iglesias        @martina-if
 Alfonso Acosta          @2opremio
 Yannig Perré            @Yannig
+Chetan                  @cPu1
 
 /* Thanks */
 

--- a/integration/creategetdelete_test.go
+++ b/integration/creategetdelete_test.go
@@ -406,7 +406,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 
 		Context("and deleting the cluster", func() {
 
-			It("should not return an error", func() {
+			It("{FLAKY: https://github.com/weaveworks/eksctl/issues/536} should not return an error", func() {
 				if !doDelete {
 					Skip("will not delete cluster " + clusterName)
 				}


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

Along with the other two tests, the cluster deletion test is also flaky and times out.

```Failure [900.002 seconds]
(Integration) Create, Get, Scale & Delete
/go/src/github.com/weaveworks/eksctl/integration/creategetdelete_test.go:28
  when creating a cluster with 1 node
  /go/src/github.com/weaveworks/eksctl/integration/creategetdelete_test.go:54
    and deleting the cluster
    /go/src/github.com/weaveworks/eksctl/integration/creategetdelete_test.go:407
      should not return an error [It]
      /go/src/github.com/weaveworks/eksctl/integration/creategetdelete_test.go:409

      Timed out after 900.000s.
      Expected process to exit.  It did not.

      /go/src/github.com/weaveworks/eksctl/integration/common_test.go:59
```

```Summarizing 3 Failures:

[Fail] (Integration) Create, Get, Scale & Delete when creating a cluster with 1 node and add the second nodegroup and delete the second nodegroup [It] {FLAKY: https://github.com/weaveworks/eksctl/issues/717} should make it 4 nodes total 
/go/src/github.com/weaveworks/eksctl/integration/creategetdelete_test.go:376

[Fail] (Integration) Create, Get, Scale & Delete when creating a cluster with 1 node and deleting the cluster [It] should not return an error 
/go/src/github.com/weaveworks/eksctl/integration/common_test.go:59

[Fail] (Integration) Create, Get, Scale & Delete when creating a cluster with 1 node and deleting the cluster [It] {FLAKY: https://github.com/weaveworks/eksctl/issues/536} should have deleted the EKS cluster and both CloudFormation stacks 
/go/src/github.com/weaveworks/eksctl/integration/creategetdelete_test.go:431

Ran 24 of 24 Specs in 2598.782 seconds
FAIL! -- 21 Passed | 3 Failed | 0 Pending | 0 Skipped
```

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
