### PR TITLE
Add more details on kubectl version parsing errors

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -45,6 +45,7 @@ Martina Iglesias        @martina-if
 Alfonso Acosta          @2opremio
 Yannig Perré            @Yannig
 Chetan                  @cPu1
+Marc Carré              @marccarre
 
 /* Thanks */
 


### PR DESCRIPTION
### Description

#245 refers to an obscure `kubectl version` parsing error which is currently hard to reproduce.
I had a look at the libraries involved but couldn't find anything obviously wrong. However, `eksctl` currently swallows potential upstream errors, and doesn't mention the version initially read from `kubectl.GetVersionInfo`. Therefore this PR adds such details to hope to be able to get to the bottom of this issue at some point in the future.
Closes #245 -- for now at least, until we're able to gather more information on it.

### Checklist

- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
