### PR TITLE
[create cluster] Output Kubernetes version

### DIFF
--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -263,6 +263,7 @@ func doCreateCluster(rc *cmdutils.ResourceCmd, params *createClusterCmdParams) e
 		return err
 	}
 
+	logger.Info("using Kubernetes version %s", meta.Version)
 	logger.Info("creating %s", meta.LogString())
 
 	// TODO dry-run mode should provide a way to render config with all defaults set


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

Outputs the Kubernetes version for `eksctl create cluster`.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->

Sample run:
```
[ℹ]  using region us-east-1
[ℹ]  setting availability zones to [us-east-1d us-east-1b]
[ℹ]  subnets for us-east-1d - public:192.168.0.0/19 private:192.168.64.0/19
[ℹ]  subnets for us-east-1b - public:192.168.32.0/19 private:192.168.96.0/19
[ℹ]  nodegroup "ng-c1e6851b" will use "ami-08c4955bcc43b124e" [AmazonLinux2/1.13]
[ℹ]  using Kubernetes version 1.13
[ℹ]  creating EKS cluster "wonderful-unicorn-1562244510" in "us-east-1" region
[ℹ]  will create 2 separate CloudFormation stacks for cluster itself and the initial nodegroup
...
```
