### PR TITLE
Pin base dependencies image

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -1,5 +1,8 @@
-# Make sure to bump the version of EKSCTL_DEPENDENCIES_IMAGEif you make any changes
-FROM golang:1.12-alpine3.9 AS dependencies
+# Make sure to bump the version of EKSCTL_DEPENDENCIES_IMAGE if you make any changes
+# to this file
+
+# This digest corresponds to golang:1.12.6-alpine3.9 (when Alpine was pointing to 3.9.4)
+FROM golang@sha256:39677a9dd517a8e5d514dff8e36fa46ecc3fb14618b970bfaf3100cb8fab9ba6
 
 # Build-time dependencies
 RUN apk add --no-cache \


### PR DESCRIPTION
This is needed to achieve reproducible builds and avoid unexpected build cache misses.

Unfortunately the `golang` dockerhub image doesn't tag minor versions of Alpine
(e.g. it provides golang:1.12.6-alpine3.9 but not golang:1.12.6-alpine3.9.4
making all the images mutable when patches are released).

Thus, we ping the image digest instead of a tag.

As a side note: there is no need to bump the version of the dependencies image
(`EKSCTL_DEPENDENCIES_IMAGE` in the Makefile) since the change doesn't affect
layering.

Followup on #920 