### PR TITLE
 Add support for `aws eks get-token` authenticator and IAM role ARN

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ or [environment variables][awsenv]. For more information read [AWS documentation
 [awsenv]: https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html
 [awsconfig]: https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html
 
-You will also need [AWS IAM Authenticator for Kubernetes](https://github.com/kubernetes-sigs/aws-iam-authenticator) command (either `aws-iam-authenticator` or `heptio-authenticator-aws`) in your `PATH`.
+You will also need [AWS IAM Authenticator for Kubernetes](https://github.com/kubernetes-sigs/aws-iam-authenticator) command (either `aws-iam-authenticator` or `aws eks get-token` (available in version 1.16.156 or greater of AWS CLI) in your `PATH`.
 
 ## Basic usage
 

--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -135,8 +135,9 @@ func AddUpdateAuthConfigMap(fs *pflag.FlagSet, updateAuthConfigMap *bool, descri
 }
 
 // AddCommonFlagsForKubeconfig adds common flags for controlling how output kubeconfig is written
-func AddCommonFlagsForKubeconfig(fs *pflag.FlagSet, outputPath *string, setContext, autoPath *bool, exampleName string) {
+func AddCommonFlagsForKubeconfig(fs *pflag.FlagSet, outputPath, authenticatorRoleARN *string, setContext, autoPath *bool, exampleName string) {
 	fs.StringVar(outputPath, "kubeconfig", kubeconfig.DefaultPath, "path to write kubeconfig (incompatible with --auto-kubeconfig)")
+	fs.StringVar(authenticatorRoleARN, "authenticator-role-arn", "", "AWS IAM role to assume for authenticator")
 	fs.BoolVar(setContext, "set-kubeconfig-context", true, "if true then current-context will be set in kubeconfig; if a context is already set then it will be overwritten")
 	fs.BoolVar(autoPath, "auto-kubeconfig", false, fmt.Sprintf("save kubeconfig file by cluster name, e.g. %q", kubeconfig.AutoPath(exampleName)))
 }

--- a/pkg/eks/client.go
+++ b/pkg/eks/client.go
@@ -41,6 +41,7 @@ func (c *ClusterProvider) NewClient(spec *api.ClusterConfig, withEmbeddedToken b
 	return config.new(spec, c.Provider.STS())
 }
 
+// GetUsername extracts the username part from the IAM role ARN
 func (c *ClusterProvider) GetUsername() string {
 	usernameParts := strings.Split(c.Status.iamRoleARN, "/")
 	if len(usernameParts) > 1 {

--- a/pkg/eks/client.go
+++ b/pkg/eks/client.go
@@ -27,10 +27,8 @@ type Client struct {
 	rawConfig *restclient.Config
 }
 
-// NewClient creates a new client config, if withEmbeddedToken is true
-// it will embed the STS token, otherwise it will use authenticator exec plugin
-// and ensures that AWS_PROFILE environment variable gets set also
-func (c *ClusterProvider) NewClient(spec *api.ClusterConfig, withEmbeddedToken bool) (*Client, error) {
+// NewClient creates a new client config by embedding the STS token
+func (c *ClusterProvider) NewClient(spec *api.ClusterConfig) (*Client, error) {
 	clientConfig, _, contextName := kubeconfig.New(spec, c.GetUsername(), "")
 
 	config := &Client{
@@ -99,7 +97,7 @@ func (c *ClusterProvider) NewStdClientSet(spec *api.ClusterConfig) (*kubernetes.
 }
 
 func (c *ClusterProvider) newClientSetWithEmbeddedToken(spec *api.ClusterConfig) (*Client, *kubernetes.Clientset, error) {
-	client, err := c.NewClient(spec, true)
+	client, err := c.NewClient(spec)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating Kubernetes client config with embedded token")
 	}

--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -80,7 +80,7 @@ func makeClientConfigData(spec *api.ClusterConfig, ng *api.NodeGroup) ([]byte, e
 	if ng.AMIFamily == ami.ImageFamilyUbuntu1804 {
 		authenticator = kubeconfig.HeptioAuthenticatorAWS
 	}
-	kubeconfig.AppendAuthenticator(clientConfig, spec, authenticator, "")
+	kubeconfig.AppendAuthenticator(clientConfig, spec, authenticator, "", "")
 	clientConfigData, err := clientcmd.Write(*clientConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "serialising kubeconfig for nodegroup")

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -77,7 +77,7 @@ func NewForKubectl(spec *api.ClusterConfig, username, roleARN, profile string) *
 	config, _, _ := New(spec, username, "")
 	authenticator, found := LookupAuthenticator()
 	if !found {
-		// fallback to aws-iam-authenticator
+		// fall back to aws-iam-authenticator
 		authenticator = AWSIAMAuthenticator
 	}
 	AppendAuthenticator(config, spec, authenticator, roleARN, profile)

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -25,7 +25,7 @@ const (
 	AWSIAMAuthenticator = "aws-iam-authenticator"
 	// HeptioAuthenticatorAWS defines the old name of AWS IAM authenticator
 	HeptioAuthenticatorAWS = "heptio-authenticator-aws"
-	// AWS EKS authenticator defines the recently added `aws eks get-token` command
+	// AWSEKSAuthenticator defines the recently added `aws eks get-token` command
 	AWSEKSAuthenticator = "aws"
 )
 
@@ -287,6 +287,7 @@ func deleteClusterInfo(existing *clientcmdapi.Config, cl *api.ClusterMeta) bool 
 	return isChanged
 }
 
+// LookupAuthenticator looks up an available authenticator
 func LookupAuthenticator() (string, bool) {
 	for _, cmd := range AuthenticatorCommands() {
 		_, err := exec.LookPath(cmd)

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -2,10 +2,13 @@ package kubeconfig
 
 import (
 	"fmt"
-	"github.com/weaveworks/eksctl/pkg/utils/file"
 	"os"
 	"path"
 	"strings"
+
+	"github.com/weaveworks/eksctl/pkg/utils/file"
+
+	"os/exec"
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
@@ -22,6 +25,8 @@ const (
 	AWSIAMAuthenticator = "aws-iam-authenticator"
 	// HeptioAuthenticatorAWS defines the old name of AWS IAM authenticator
 	HeptioAuthenticatorAWS = "heptio-authenticator-aws"
+	// AWS EKS authenticator defines the recently added `aws eks get-token` command
+	AWSEKSAuthenticator = "aws"
 )
 
 // AuthenticatorCommands returns all of authenticator commands
@@ -29,11 +34,12 @@ func AuthenticatorCommands() []string {
 	return []string{
 		AWSIAMAuthenticator,
 		HeptioAuthenticatorAWS,
+		AWSEKSAuthenticator,
 	}
 }
 
 // New creates Kubernetes client configuration for a given username
-// if certificateAuthorityPath is no empty, it is used instead of
+// if certificateAuthorityPath is not empty, it is used instead of
 // embedded certificate-authority-data
 func New(spec *api.ClusterConfig, username, certificateAuthorityPath string) (*clientcmdapi.Config, string, string) {
 	clusterName := spec.Metadata.String()
@@ -66,26 +72,58 @@ func New(spec *api.ClusterConfig, username, certificateAuthorityPath string) (*c
 	return c, clusterName, contextName
 }
 
+// NewForKubectl creates configuration for kubectl using a suitable authenticator
+func NewForKubectl(spec *api.ClusterConfig, username, roleARN, profile string) *clientcmdapi.Config {
+	config, _, _ := New(spec, username, "")
+	authenticator, found := LookupAuthenticator()
+	if !found {
+		// fallback to aws-iam-authenticator
+		authenticator = AWSIAMAuthenticator
+	}
+	AppendAuthenticator(config, spec, authenticator, roleARN, profile)
+	return config
+}
+
 // AppendAuthenticator appends the AWS IAM  authenticator, and
 // if profile is non-empty string it sets AWS_PROFILE environment
 // variable also
-func AppendAuthenticator(c *clientcmdapi.Config, spec *api.ClusterConfig, command, profile string) {
+func AppendAuthenticator(config *clientcmdapi.Config, spec *api.ClusterConfig, authenticatorCMD, roleARN, profile string) {
+	var (
+		args        []string
+		roleARNFlag string
+	)
+
+	switch authenticatorCMD {
+	case AWSIAMAuthenticator, HeptioAuthenticatorAWS:
+		args = []string{"token", "-i", spec.Metadata.Name}
+		roleARNFlag = "-r"
+	case AWSEKSAuthenticator:
+		args = []string{"eks", "get-token", "--cluster-name", spec.Metadata.Name}
+		roleARNFlag = "--role-arn"
+		if spec.Metadata.Region != "" {
+			args = append(args, "--region", spec.Metadata.Region)
+		}
+	}
+	if roleARN != "" {
+		args = append(args, roleARNFlag, roleARN)
+	}
+
 	execConfig := &clientcmdapi.ExecConfig{
 		APIVersion: "client.authentication.k8s.io/v1alpha1",
-		Command:    command,
-		Args:       []string{"token", "-i", spec.Metadata.Name},
+		Command:    authenticatorCMD,
+		Args:       args,
 	}
 
 	if profile != "" {
 		execConfig.Env = []clientcmdapi.ExecEnvVar{
-			clientcmdapi.ExecEnvVar{
+			{
 				Name:  "AWS_PROFILE",
 				Value: profile,
 			},
 		}
 	}
 
-	c.AuthInfos[c.CurrentContext] = &clientcmdapi.AuthInfo{
+	config.AuthInfos[config.CurrentContext] = &clientcmdapi.AuthInfo{
 		Exec: execConfig,
 	}
 }
@@ -247,4 +285,14 @@ func deleteClusterInfo(existing *clientcmdapi.Config, cl *api.ClusterMeta) bool 
 	}
 
 	return isChanged
+}
+
+func LookupAuthenticator() (string, bool) {
+	for _, cmd := range AuthenticatorCommands() {
+		_, err := exec.LookPath(cmd)
+		if err == nil {
+			return cmd, true
+		}
+	}
+	return "", false
 }

--- a/pkg/utils/kubectl.go
+++ b/pkg/utils/kubectl.go
@@ -58,9 +58,11 @@ func CheckAllCommands(kubeconfigPath string, isContextSet bool, contextName stri
 		return err
 	}
 
-	if authenticator, found := kubeconfig.LookupAuthenticator(); !found {
-		return fmt.Errorf("could not find any of the authenticator commands: %s", strings.Join(kubeconfig.AuthenticatorCommands(), ", "))
-	} else {
+	{
+		authenticator, found := kubeconfig.LookupAuthenticator()
+		if !found {
+			return fmt.Errorf("could not find any of the authenticator commands: %s", strings.Join(kubeconfig.AuthenticatorCommands(), ", "))
+		}
 		logger.Debug("found authenticator: %s", authenticator)
 	}
 

--- a/pkg/utils/kubectl.go
+++ b/pkg/utils/kubectl.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/blang/semver"
@@ -59,8 +58,10 @@ func CheckAllCommands(kubeconfigPath string, isContextSet bool, contextName stri
 		return err
 	}
 
-	if err := checkAuthenticator(); err != nil {
-		return err
+	if authenticator, found := kubeconfig.LookupAuthenticator(); !found {
+		return fmt.Errorf("could not find any of the authenticator commands: %s", strings.Join(kubeconfig.AuthenticatorCommands(), ", "))
+	} else {
+		logger.Debug("found authenticator: %s", authenticator)
 	}
 
 	if kubeconfigPath != "" {
@@ -95,30 +96,4 @@ func CheckAllCommands(kubeconfigPath string, isContextSet bool, contextName stri
 	}
 
 	return nil
-}
-
-// checkAuthenticator checks if either of authenticator commands is in the path,
-// it returns an error when neither are found
-func checkAuthenticator() error {
-	for _, cmd := range kubeconfig.AuthenticatorCommands() {
-		path, err := exec.LookPath(cmd)
-		if err == nil {
-			// command was found
-			logger.Debug("%s: %q", cmd, path)
-			return nil
-		}
-	}
-	return fmt.Errorf("neither aws-iam-authenticator nor heptio-authenticator-aws are installed")
-}
-
-// DetectAuthenticator finds the authenticator command, it defaults to legacy
-// command when neither are found
-func DetectAuthenticator() string {
-	for _, bin := range kubeconfig.AuthenticatorCommands() {
-		_, err := exec.LookPath(bin)
-		if err == nil {
-			return bin
-		}
-	}
-	return kubeconfig.AWSIAMAuthenticator
 }

--- a/site/content/introduction/02-installation.md
+++ b/site/content/introduction/02-installation.md
@@ -32,7 +32,7 @@ or [environment variables][awsenv]. For more information read [AWS documentation
 [awsenv]: https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html
 [awsconfig]: https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html
 
-You will also need [AWS IAM Authenticator for Kubernetes](https://github.com/kubernetes-sigs/aws-iam-authenticator) command (either `aws-iam-authenticator` or `heptio-authenticator-aws`) in your `PATH`.
+You will also need [AWS IAM Authenticator for Kubernetes](https://github.com/kubernetes-sigs/aws-iam-authenticator) command (either `aws-iam-authenticator` or `aws eks get-token` (available in version 1.16.156 or greater of AWS CLI) in your `PATH`.
 
 ### Shell Completion
 


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->
This PR adds support for:
1. Using `aws eks get-token` as the authenticator for signing requests if neither `aws-iam-authenticator` nor `heptio-authenticator-aws` is available in `PATH`.
2. Specifying a role ARN to use for `aws-iam-authenticator` and `aws eks get-token`, to `eksctl create cluster` and `eksctl utils write-kubeconfig` via flag `--authenticator-role-arn`.

Support for `aws eks get-token` was added recently, so presence of `aws` in `PATH` does not imply `aws eks get-token` would work. Instead of inspecting the version or checking if it supports `get-token`, we simply use it as a fall back if other authenticators aren't available in `PATH` and `aws` is available (which is also the motivation for using `aws eks get-token` since most users would already have `aws` installed).

- Closes #788
- Closes #749 


### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
