### PR TITLE
Allow reading configuration from stdin

### DIFF
--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -12,7 +12,7 @@ import (
 
 // AddConfigFileFlag adds common --config-file flag
 func AddConfigFileFlag(fs *pflag.FlagSet, path *string) {
-	fs.StringVarP(path, "config-file", "f", "", "load configuration from a file")
+	fs.StringVarP(path, "config-file", "f", "", "load configuration from a file (or stdin if set to '-')")
 }
 
 // ClusterConfigLoader is an inteface that loaders should implement

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -164,7 +164,7 @@ func New(spec *api.ProviderConfig, clusterSpec *api.ClusterConfig) *ClusterProvi
 
 // LoadConfigFromFile populates cfg based on contents of configFile
 func LoadConfigFromFile(configFile string, cfg *api.ClusterConfig) error {
-	data, err := ioutil.ReadFile(configFile)
+	data, err := readConfig(configFile)
 	if err != nil {
 		return errors.Wrapf(err, "reading config file %q", configFile)
 	}
@@ -191,6 +191,13 @@ func LoadConfigFromFile(configFile string, cfg *api.ClusterConfig) error {
 	*cfg = *cfgLoaded // mutate the content, not the reference
 
 	return nil
+}
+
+func readConfig(configFile string) ([]byte, error) {
+	if configFile == "-" {
+		return ioutil.ReadAll(os.Stdin)
+	}
+	return ioutil.ReadFile(configFile)
 }
 
 // IsSupportedRegion check if given region is supported


### PR DESCRIPTION
## Description

With this change, e.g. `eksctl create nodegroup -f -` works similar to `kubectl apply -f -`.

<!-- Please explain the changes you made here. -->

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [ ] All unit tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
