### PR TITLE
Docs: add requirement for aws-iam-authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ or [environment variables][awsenv]. For more information read [AWS documentation
 [awsenv]: https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html
 [awsconfig]: https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html
 
+You will also need [AWS IAM Authenticator for Kubernetes](https://github.com/kubernetes-sigs/aws-iam-authenticator) command (either `aws-iam-authenticator` or `heptio-authenticator-aws`) in your `PATH`.
+
 ## Basic usage
 
 To create a basic cluster, run:

--- a/site/content/introduction/02-installation.md
+++ b/site/content/introduction/02-installation.md
@@ -32,6 +32,8 @@ or [environment variables][awsenv]. For more information read [AWS documentation
 [awsenv]: https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html
 [awsconfig]: https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html
 
+You will also need [AWS IAM Authenticator for Kubernetes](https://github.com/kubernetes-sigs/aws-iam-authenticator) command (either `aws-iam-authenticator` or `heptio-authenticator-aws`) in your `PATH`.
+
 ### Shell Completion
 
 To enable bash completion, run the following, or put it in `~/.bashrc` or `~/.profile`:


### PR DESCRIPTION
### Description

Mention that the tool `aws-iam-authenticator` tool is needed, in the basic installation instructions.

I hit the error message described at #209, and since #211 was never finished I couldn't see any hints what to do.

The text in this PR is adapted from #211. 