### PR TITLE
fixing #1012, cluster autoscaler requres a valid LT intance type

### DIFF
--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -2499,7 +2499,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Expect(ngTemplate.Resources).To(HaveKey("NodeGroupLaunchTemplate"))
 
 			launchTemplateData := getLaunchTemplateData(ngTemplate)
-			Expect(launchTemplateData.InstanceType).To(Equal(""))
+			Expect(launchTemplateData.InstanceType).To(Equal("m5.large"))
 			Expect(launchTemplateData.InstanceMarketOptions).To(BeNil())
 
 			nodeGroupProperties := getNodeGroupProperties(ngTemplate)

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"fmt"
+
 	"github.com/kris-nova/logger"
 
 	cfn "github.com/aws/aws-sdk-go/service/cloudformation"
@@ -119,7 +120,7 @@ func (n *NodeGroupResourceSet) addResourcesForNodeGroup() error {
 			Ebs: &gfn.AWSEC2LaunchTemplate_Ebs{
 				VolumeSize: gfn.NewInteger(*volumeSize),
 				VolumeType: gfn.NewString(*n.spec.VolumeType),
-				Encrypted: gfn.NewBoolean(*n.spec.VolumeEncrypted),
+				Encrypted:  gfn.NewBoolean(*n.spec.VolumeEncrypted),
 			},
 		}}
 		if api.IsSetAndNonEmptyString(n.spec.VolumeKmsKeyID) {
@@ -214,6 +215,8 @@ func newLaunchTemplateData(n *NodeGroupResourceSet) *gfn.AWSEC2LaunchTemplate_La
 	}
 	if !api.HasMixedInstances(n.spec) {
 		launchTemplateData.InstanceType = gfn.NewString(n.spec.InstanceType)
+	} else {
+		launchTemplateData.InstanceType = gfn.NewString(n.spec.InstancesDistribution.InstanceTypes[0])
 	}
 
 	return launchTemplateData


### PR DESCRIPTION
Kubernetes cluster autoscaler (AWS) requres a valid LT intance type to scale up/down ASG. See #1012 

### Description

Adding first instance type from distribution instance types as a default `LaunchTemplate` instance type.

### Checklist
- [x] Code compiles correctly (i.e `make build`)
- [x] Updated tests that cover your change 
- [x] All unit tests passing (i.e. `make test`)
- [x] Manually tested

