### PR TITLE
Build binaries again through PHONY Makefile targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Make sure you can run the tests and build the binary.
 ```bash 
 make install-build-deps
 make test
-make eksctl
+make build
 ```
 
 > NOTE: Windows users should install Docker for Windows and run `make eksctl-image` to build their code.

--- a/eksctl-image-builder.sh
+++ b/eksctl-image-builder.sh
@@ -4,9 +4,9 @@ export JUNIT_REPORT_DIR=/src/test-results/ginkgo
 mkdir -p "${JUNIT_REPORT_DIR}"
 
 make $TEST_TARGET
-make eksctl \
+make build \
     && cp ./eksctl /out/usr/local/bin/eksctl
-make eksctl-integration-test \
+make build-integration-test \
     && mkdir -p /out/usr/local/share/eksctl \
     && cp integration/*.yaml /out/usr/local/share/eksctl \
     && cp ./eksctl-integration-test /out/usr/local/bin/eksctl-integration-test


### PR DESCRIPTION
Golang is good at computing explicit dependencies, there wasn't really
a reason to re-invent the wheel (computing the dependencies took as long
as invoking the compiler).

However, we continue to compute and use the non-explicit dependencies (generated
code) as Make recipe prerequisites.

This gives us the best of both worlds, while also reducing the time for `make`
to read the Makefile (speeding up things like autocompletion) and adding fresh
compile-time provided symbols (e.g. git commit hash) in every build.

Fixes #989 (which was introduced in #944 )