### PR TITLE
WIP: New nodegroup type: Spotinst Ocean

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.3.2
-	github.com/spotinst/spotinst-sdk-go v0.0.0-20181012192533-fed4677dbf8f // indirect
+	github.com/spotinst/spotinst-sdk-go v0.0.0-20181012192533-fed4677dbf8f
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/tidwall/gjson v1.1.3

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -358,7 +358,6 @@ func (c *ClusterConfig) AppendAvailabilityZone(newAZ string) {
 // NewNodeGroup creates new nodegroup inside cluster config,
 // it returns pointer to the nodegroup for convenience
 func (c *ClusterConfig) NewNodeGroup() *NodeGroup {
-
 	ng := &NodeGroup{
 		PrivateNetworking: false,
 		SecurityGroups: &NodeGroupSGs{
@@ -464,6 +463,9 @@ type NodeGroup struct {
 
 	// +optional
 	KubeletExtraConfig *NodeGroupKubeletConfig `json:"kubeletExtraConfig,omitempty"`
+
+	// +optional
+	Spotinst *NodeGroupSpotinst `json:"spotinst,omitempty"`
 }
 
 // ListOptions returns metav1.ListOptions with label selector for the nodegroup
@@ -546,6 +548,58 @@ type (
 		OnDemandPercentageAboveBaseCapacity *int `json:"onDemandPercentageAboveBaseCapacity,omitEmpty"`
 		//+optional
 		SpotInstancePools *int `json:"spotInstancePools,omitEmpty"`
+	}
+
+	// NodeGroupSpotinst holds the configuration used by Spotinst
+	NodeGroupSpotinst struct {
+		// +optional
+		Ocean *NodeGroupSpotinstOcean `json:"ocean,omitEmpty"`
+		// +optional
+		Strategy *NodeGroupSpotinstStrategy `json:"strategy,omitEmpty"`
+		// +optional
+		AutoScaler *NodeGroupSpotinstAutoScaler `json:"autoScaler,omitEmpty"`
+	}
+
+	// NodeGroupSpotinstOcean holds the Ocean configuration used by Spotinst
+	NodeGroupSpotinstOcean struct {
+		// +optional
+		ID *string `json:"id,omitEmpty"`
+		// +optional
+		DefaultLaunchSpec *bool `json:"defaultLaunchSpec,omitEmpty"`
+	}
+
+	// NodeGroupSpotinstStrategy holds the strategy configuration used by Spotinst
+	NodeGroupSpotinstStrategy struct {
+		// +optional
+		SpotPercentage *int `json:"spotPercentage,omitEmpty"`
+		// +optional
+		FallbackToOnDemand *bool `json:"fallbackToOnDemand,omitEmpty"`
+		// +optional
+		UtilizeReservedInstances *bool `json:"utilizeReservedInstances,omitEmpty"`
+	}
+
+	// NodeGroupSpotinstAutoScaler holds the auto scaler configuration used by Spotinst
+	NodeGroupSpotinstAutoScaler struct {
+		// +optional
+		Enabled *bool `json:"enabled,omitEmpty"`
+		// +optional
+		AutoConfig *bool `json:"autoConfig,omitEmpty"`
+		// +optional
+		Cooldown *int `json:"cooldown,omitEmpty"`
+		// +optional
+		Headroom *NodeGroupSpotinstAutoScalerHeadroom `json:"headroom,omitEmpty"`
+	}
+
+	// NodeGroupSpotinstAutoScalerHeadroom holds the headroom configuration used by Spotinst
+	NodeGroupSpotinstAutoScalerHeadroom struct {
+		// +optional
+		CPUPerUnit *int `json:"cpuPerUnit,omitEmpty"`
+		// +optional
+		GPUPerUnit *int `json:"gpuPerUnit,omitEmpty"`
+		// +optional
+		MemPerUnit *int `json:"memPerUnit,omitEmpty"`
+		// +optional
+		NumOfUnits *int `json:"numOfUnits,omitEmpty"`
 	}
 )
 

--- a/pkg/cfn/manager/create_tasks.go
+++ b/pkg/cfn/manager/create_tasks.go
@@ -3,47 +3,119 @@ package manager
 import (
 	"fmt"
 
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // NewTasksToCreateClusterWithNodeGroups defines all tasks required to create a cluster along
 // with some nodegroups; see CreateAllNodeGroups for how onlyNodeGroupSubset works
-func (c *StackCollection) NewTasksToCreateClusterWithNodeGroups(onlyNodeGroupSubset sets.String) *TaskTree {
+func (c *StackCollection) NewTasksToCreateClusterWithNodeGroups(onlyNodeGroupSubset sets.String) (*TaskTree, error) {
 	tasks := &TaskTree{Parallel: false}
 
-	tasks.Append(
-		&taskWithoutParams{
-			info: fmt.Sprintf("create cluster control plane %q", c.spec.Metadata.Name),
-			call: c.createClusterTask,
-		},
-	)
-
-	nodeGroupTasks := c.NewTasksToCreateNodeGroups(onlyNodeGroupSubset)
-	if nodeGroupTasks.Len() > 0 {
-		nodeGroupTasks.IsSubTask = true
-		tasks.Append(nodeGroupTasks)
+	// Control plane.
+	{
+		tasks.Append(
+			&taskWithoutParams{
+				info: fmt.Sprintf("create cluster control plane %q", c.spec.Metadata.Name),
+				call: c.createClusterTask,
+			},
+		)
 	}
 
-	return tasks
+	// Nodegroups.
+	{
+		nodeGroupTasks, err := c.NewTasksToCreateNodeGroups(onlyNodeGroupSubset)
+		if err != nil {
+			return nil, err
+		}
+
+		if nodeGroupTasks.Len() > 0 {
+			nodeGroupTasks.IsSubTask = true
+			tasks.Append(nodeGroupTasks)
+		}
+	}
+
+	return tasks, nil
 }
 
 // NewTasksToCreateNodeGroups defines tasks required to create all of the nodegroups if
 // onlySubset is nil, otherwise just the tasks for nodegroups that are in onlySubset
 // will be defined
-func (c *StackCollection) NewTasksToCreateNodeGroups(onlySubset sets.String) *TaskTree {
+func (c *StackCollection) NewTasksToCreateNodeGroups(onlySubset sets.String) (*TaskTree, error) {
 	tasks := &TaskTree{Parallel: true}
 
-	for i := range c.spec.NodeGroups {
-		ng := c.spec.NodeGroups[i]
-		if onlySubset != nil && !onlySubset.Has(ng.Name) {
-			continue
+	// Spotinst.
+	{
+		oceanTasks, err := c.newTasksToCreateNodeGroupSpotinstOcean()
+		if err != nil {
+			return nil, err
 		}
+
+		if oceanTasks.Len() > 0 {
+			oceanTasks.IsSubTask = true
+			tasks.Append(oceanTasks)
+		}
+	}
+
+	// Nodegroups.
+	{
+		for i := range c.spec.NodeGroups {
+			ng := c.spec.NodeGroups[i]
+			if onlySubset != nil && !onlySubset.Has(ng.Name) {
+				continue
+			}
+			tasks.Append(&taskWithNodeGroupSpec{
+				info:      fmt.Sprintf("create nodegroup %q", ng.Name),
+				nodeGroup: ng,
+				call:      c.createNodeGroupTask,
+			})
+		}
+	}
+
+	return tasks, nil
+}
+
+func (c *StackCollection) newTasksToCreateNodeGroupSpotinstOcean() (*TaskTree, error) {
+	tasks := &TaskTree{Parallel: true}
+	var ng *api.NodeGroup
+
+	// Single node group.
+	if len(c.spec.NodeGroups) == 1 && c.spec.NodeGroups[0].Spotinst != nil {
+		ng = c.spec.NodeGroups[0]
+	}
+
+	// Multiple node groups.
+	if len(c.spec.NodeGroups) > 1 {
+		for _, g := range c.spec.NodeGroups {
+			if g.Spotinst.Ocean == nil || g.Spotinst.Ocean.DefaultLaunchSpec == nil {
+				continue
+			}
+			if *g.Spotinst.Ocean.DefaultLaunchSpec {
+				if ng != nil {
+					return nil, fmt.Errorf("unable to detect default ocean launch spec: " +
+						"multiple nodegroups configured with `ocean.defaultLaunchSpec: \"true\"`")
+				}
+
+				ng = g
+			}
+		}
+
+		if ng == nil {
+			return nil, fmt.Errorf("unable to detect default ocean launch spec: " +
+				"please configure the desired default nodegroup with `ocean.defaultLaunchSpec: \"true\"`")
+		}
+	}
+
+	// Configure all tasks.
+	if ng != nil {
+		ng.Name = "ocean"
+
 		tasks.Append(&taskWithNodeGroupSpec{
-			info:      fmt.Sprintf("create nodegroup %q", ng.Name),
+			info:      fmt.Sprintf("create spotinst ocean %q", c.spec.Metadata.Name),
 			nodeGroup: ng,
 			call:      c.createNodeGroupTask,
 		})
 	}
 
-	return tasks
+	return tasks, nil
 }

--- a/pkg/cfn/outputs/api.go
+++ b/pkg/cfn/outputs/api.go
@@ -25,7 +25,7 @@ const (
 	ClusterStackName                = "ClusterStackName"
 	ClusterSharedNodeSecurityGroup  = "SharedNodeSecurityGroup"
 	ClusterServiceRoleARN           = "ServiceRoleARN"
-	ClusterFeatureNATMode 			= "FeatureNATMode"
+	ClusterFeatureNATMode           = "FeatureNATMode"
 
 	// outputs from nodegroup stack
 	NodeGroupInstanceRoleARN    = "InstanceRoleARN"
@@ -37,6 +37,9 @@ const (
 	NodeGroupFeaturePrivateNetworking   = "FeaturePrivateNetworking"
 	NodeGroupFeatureSharedSecurityGroup = "FeatureSharedSecurityGroup"
 	NodeGroupFeatureLocalSecurityGroup  = "FeatureLocalSecurityGroup"
+
+	// outputs from spotinst
+	NodeGroupSpotinstOceanID = "SpotinstOceanID"
 )
 
 type (

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -284,7 +284,12 @@ func doCreateCluster(rc *cmdutils.ResourceCmd, params *createClusterCmdParams) e
 			logger.Info("will create a CloudFormation stack for cluster itself and %d nodegroup stack(s)", ngCount)
 		}
 		logger.Info("if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=%s --name=%s'", meta.Region, meta.Name)
-		tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(ngSubset)
+
+		tasks, err := stackManager.NewTasksToCreateClusterWithNodeGroups(ngSubset)
+		if err != nil {
+			return fmt.Errorf("failed to create cluster tasks: %v", err)
+		}
+
 		logger.Info(tasks.Describe())
 		if errs := tasks.DoAllSync(); len(errs) > 0 {
 			logger.Info("%d error(s) occurred and cluster hasn't been created properly, you may wish to check CloudFormation console", len(errs))

--- a/pkg/spotinst/nodegroup.go
+++ b/pkg/spotinst/nodegroup.go
@@ -1,0 +1,25 @@
+package spotinst
+
+import (
+	cfn "github.com/aws/aws-sdk-go/service/cloudformation"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/cfn/outputs"
+)
+
+// UseNodeGroupSpotinstOceanId retrieves the Spotinst Ocean cluster identifier
+// from an existing node group based on stack outputs.
+func UseNodeGroupSpotinstOceanId(provider api.ClusterProvider, stack *cfn.Stack, ng *api.NodeGroup) error {
+	if ng.Spotinst.Ocean == nil {
+		ng.Spotinst.Ocean = &api.NodeGroupSpotinstOcean{}
+	}
+
+	requiredCollectors := map[string]outputs.Collector{
+		outputs.NodeGroupSpotinstOceanID: func(v string) error {
+			ng.Spotinst.Ocean.ID = &v
+			return nil
+		},
+	}
+
+	return outputs.Collect(*stack, requiredCollectors, nil)
+}


### PR DESCRIPTION
### Description

This PR adds [Spotinst](https://spotinst.com) as a nodegroup provider. As part of this implementation, AWS Auto Scaling Groups have been replaced with [Spotinst Ocean](https://spotinst.com/products/ocean).

### Example

```yaml
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: demo
  region: us-west-2

nodeGroups:
  - name: ng-1
    ...
    spotinst:

      strategy:
        spotPercentage: 100
        fallbackToOndemand: true
        utilizeReservedInstances: true

      autoScaler:
        enabled: true
        autoConfig: true
      
```

### Todo
- [x] Replace AWS Auto Scaling Groups with Spotinst Ocean.
- [ ] Add support in multiple nodegroups (=multiple Spotinst Ocean Launch Specs).
- [ ] Configure auto-scaler node labels.
- [ ] Configure auto-scaler headroom.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [ ] All unit tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested