### PR TITLE
Update _index.md

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -80,8 +80,8 @@ apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 
 metadata:
-name: basic-cluster
-region: eu-north-1
+  name: basic-cluster
+  region: eu-north-1
 
 nodeGroups:
   - name: ng-1


### PR DESCRIPTION
### Description

The current example on the first page of the eksctl website (https://eksctl.io/) relating to creating a cluster from a yaml file does not work as the indentation for name and region is incorrect. This adds two spaces to both the name and region lines to fix this. 

Fixes #1023 


