### PR TITLE
Release scripts now release from branch instead of master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,10 +162,10 @@ This allows the message to be easier to read on GitHub as well as in various git
 
 ## Release Process
 
-1. Ensure integration tests pass (see below)
-2. Determine next release tag (e.g. `0.1.35`)
-3. Create release notes file for the given tag – `docs/release_notes/<tag>.md` (e.g. `docs/release_notes/0.1.35.md`)
-4. Run `./tag-release-candidate.sh <tag>-rc.<N>` or `./tag-release.sh <tag>` (e.g. `./tag-release-candidate.sh 0.1.35-rc.0` or `./tag-release.sh 0.1.35`)
+1. Ensure integration tests pass (see below).
+2. Determine next release tag (e.g. `0.1.35`).
+3. Create release notes file for the given tag – `docs/release_notes/<tag>.md` (e.g. `docs/release_notes/0.1.35.md`).
+4. Run `./tag-release-candidate.sh <tag>-rc.<N>` or `./tag-release.sh <tag>` (e.g. `./tag-release-candidate.sh 0.1.35-rc.0` or `./tag-release.sh 0.1.35`).
 5. Ensure release jobs succeeded in [CircleCI](https://circleci.com/gh/weaveworks/eksctl).
 6. Ensure the release was successfully [published in Github](https://github.com/weaveworks/eksctl/releases).
 7. Download the binary just released, verify its checksum, and perform any relevant manual testing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,7 @@ At present we ignore flaky tests, so if you see output like show below, you don'
 
 ```console
 $ make integration-test-container TEST_V=1
+[...]
 Summarizing 2 Failures:
 
 [Fail] (Integration) Create, Get, Scale & Delete when creating a cluster with 1 node and add the second nodegroup and delete the second nodegroup [It] {FLAKY: https://github.com/weaveworks/eksctl/issues/717} should make it 4 nodes total

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,11 +162,13 @@ This allows the message to be easier to read on GitHub as well as in various git
 
 ## Release Process
 
-1. Checkout master branch
-2. Ensure integration tests pass (see below)
-3. Determine next release tag (e.g. `0.1.35`)
-4. Create release notes file for the given tag – `docs/release_notes/<tag>.md` (e.g. `docs/release_notes/0.1.35.md`)
-5. Run `./tag-release-candidatate.sh <tag>-rc.<N>` or `./tag-release.sh <tag>` (e.g. `./tag-release.sh 0.1.35-rc.2` or `./tag-release.sh 0.1.35`)
+1. Ensure integration tests pass (see below)
+2. Determine next release tag (e.g. `0.1.35`)
+3. Create release notes file for the given tag – `docs/release_notes/<tag>.md` (e.g. `docs/release_notes/0.1.35.md`)
+4. Run `./tag-release-candidatate.sh <tag>-rc.<N>` or `./tag-release.sh <tag>` (e.g. `./tag-release.sh 0.1.35-rc.2` or `./tag-release.sh 0.1.35`)
+5. Ensure release jobs succeeded in [CircleCI](https://circleci.com/gh/weaveworks/eksctl).
+6. Ensure the release was successfully [published in Github](https://github.com/weaveworks/eksctl/releases).
+7. Download the binary just released, verify its checksum, and perform any relevant manual testing.
 
 ### Notes on Integration Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,7 +172,7 @@ This allows the message to be easier to read on GitHub as well as in various git
 
 ### Notes on Integration Tests
 
-It's recommened to run containerised tests with `make integration-test-container TEST_V=1`. The tests require access to an AWS account. If there is an issue with access (e.g. expired MFA token), you will see all tests failing (albeit the error message may be slightly unclear).
+It's recommended to run containerised tests with `make integration-test-container TEST_V=1`. The tests require access to an AWS account. If there is an issue with access (e.g. expired MFA token), you will see all tests failing (albeit the error message may be slightly unclear).
 
 At present we ignore flaky tests, so if you see output like show below, you don't need to worry about this for the purpose of the release. However, you might consider reviewing the issues in question after you made the release.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,7 @@ This allows the message to be easier to read on GitHub as well as in various git
 1. Ensure integration tests pass (see below)
 2. Determine next release tag (e.g. `0.1.35`)
 3. Create release notes file for the given tag – `docs/release_notes/<tag>.md` (e.g. `docs/release_notes/0.1.35.md`)
-4. Run `./tag-release-candidatate.sh <tag>-rc.<N>` or `./tag-release.sh <tag>` (e.g. `./tag-release.sh 0.1.35-rc.2` or `./tag-release.sh 0.1.35`)
+4. Run `./tag-release-candidate.sh <tag>-rc.<N>` or `./tag-release.sh <tag>` (e.g. `./tag-release-candidate.sh 0.1.35-rc.0` or `./tag-release.sh 0.1.35`)
 5. Ensure release jobs succeeded in [CircleCI](https://circleci.com/gh/weaveworks/eksctl).
 6. Ensure the release was successfully [published in Github](https://github.com/weaveworks/eksctl/releases).
 7. Download the binary just released, verify its checksum, and perform any relevant manual testing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ it easier to get your contribution accepted.
 
 We gratefully welcome improvements to documentation as well as to code.
 
-# Certificate of Origin
+## Certificate of Origin
 
 By contributing to this project you agree to the Developer Certificate of
 Origin (DCO). This document was created by the Linux Kernel community and is a
@@ -15,24 +15,23 @@ simple statement that you, as a contributor, have the legal right to make the
 contribution. No action from you is required, but it's a good idea to see the
 [DCO](DCO) file for details before you start contributing code to eksctl.
 
-# Chat
+## Chat
 
-The project uses Slack. If you get stuck or just have a question then you are encouraged to join the 
-[Weave Community](https://weaveworks.github.io/community-slack/) Slack workspace and use the 
+The project uses Slack. If you get stuck or just have a question then you are encouraged to join the
+[Weave Community](https://weaveworks.github.io/community-slack/) Slack workspace and use the
 [#eksctl](https://weave-community.slack.com/messages/eksctl/) channel.
 
-Regular contributor meetings are held on Slack, see [`docs/contributor-meetings.md`](docs/contributor-meetings.md) for 
+Regular contributor meetings are held on Slack, see [`docs/contributor-meetings.md`](docs/contributor-meetings.md) for
 the latest information.
 
-# Getting Started
+## Getting Started
 
 - Fork the repository on GitHub
 - Read the [README](README.md) for getting started as a user and learn how/where to ask for help
 - If you want to contribute as a developer, continue reading this document for further instructions
 - Play with the project, submit bugs, submit pull requests!
 
-## Contribution workflow
-
+### Contribution workflow
 
 #### 1. Set up your Go environment
 
@@ -44,7 +43,6 @@ This project is written in Go. To be able to contribute you will need:
 2. Make sure that `$(go env GOPATH)/bin` is in your shell's `PATH`. You can do so by
    running `export PATH="$(go env GOPATH)/bin:$PATH"`
 
-
 #### 2. Fork and clone the repo
 
 Make a fork of this repository and clone it by running:
@@ -53,15 +51,14 @@ Make a fork of this repository and clone it by running:
 git clone git@github.com:<yourusername>/eksctl.git
 ```
 
-It is not recommended to clone under your `GOPATH` (if you define one). Otherwise, you will need to set 
+It is not recommended to clone under your `GOPATH` (if you define one). Otherwise, you will need to set
 `GO111MODULE=on` explicitly.
-
 
 #### 3. Run the tests and build eksctl
 
 Make sure you can run the tests and build the binary.
 
-```bash 
+```bash
 make install-build-deps
 make test
 make build
@@ -71,15 +68,14 @@ make build
 
 > TODO: Improve Windows instructions, ensure `go build` works.
 
-
-There are integration tests for *eksctl* being developed and more details of how to run them will be included here. You 
-can follow the progress [here](https://github.com/weaveworks/eksctl/issues/151).
+There are integration tests for *eksctl* being developed and more details of
+how to run them will be included here. You can follow the progress [here](https://github.com/weaveworks/eksctl/issues/151).
 
 #### 4. Write your feature
 
-- Find an [issue](https://github.com/weaveworks/eksctl/issues) to work on or create your own. If you are a new 
-contributor take a look at issues marked with 
-[good first issue](https://github.com/weaveworks/eksctl/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+- Find an [issue](https://github.com/weaveworks/eksctl/issues) to work on or
+  create your own. If you are a new contributor take a look at issues marked
+  with [good first issue](https://github.com/weaveworks/eksctl/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 - Then create a topic branch from where you want to base your work (usually branched from master):
 
@@ -87,11 +83,11 @@ contributor take a look at issues marked with
     git checkout -b <feature-name>
     ```
 
-- Write your feature. Make commits of logical units and make sure your commit messages are in the 
-[proper format](#format-of-the-commit-message).
+- Write your feature. Make commits of logical units and make sure your
+  commit messages are in the [proper format](#format-of-the-commit-message).
 
-- Add automated tests to cover your changes. See the [az](https://github.com/weaveworks/eksctl/tree/master/pkg/az) 
-package for a good example of tests.
+- Add automated tests to cover your changes. See the [az](https://github.com/weaveworks/eksctl/tree/master/pkg/az)
+  package for a good example of tests.
 
 - If needed, update the documentation, either in the [README](README.md) or in the [docs](docs/) folder.
 
@@ -99,30 +95,30 @@ package for a good example of tests.
 
 #### 5. Submit a pull request
 
-Push your changes to your fork and submit a pull request to the original repository. If your PR is a work in progress 
-then make sure you prefix the title with `WIP: `. This lets everyone know that this is still being worked on. Once its 
+Push your changes to your fork and submit a pull request to the original repository. If your PR is a work in progress
+then make sure you prefix the title with `WIP: `. This lets everyone know that this is still being worked on. Once its
 ready remove the `WIP: ` title prefix and where possible squash your commits.
 
 ```bash
 git push <username> <feature-name>
 ```
 
-Our CircleCI integration will run the automated tests and give you feedback in the review section. We will review your 
+Our CircleCI integration will run the automated tests and give you feedback in the review section. We will review your
 changes and give you feedback as soon as possible.
 
-# Acceptance policy
+## Acceptance policy
 
 These things will make a PR more likely to be accepted:
 
- * a well-described requirement
- * tests for new code
- * tests for old code!
- * new code and tests follow the conventions in old code and tests
- * a good commit message (see below)
+- a well-described requirement
+- tests for new code
+- tests for old code!
+- new code and tests follow the conventions in old code and tests
+- a good commit message (see below)
 
 In general, we will merge a PR once a maintainer has reviewed and approved it.
 Trivial changes (e.g., corrections to spelling) may get waved through.
-For substantial changes, more people may become involved, and you might get asked to resubmit the PR or divide the 
+For substantial changes, more people may become involved, and you might get asked to resubmit the PR or divide the
 changes into more than one PR.
 
 ### Format of the Commit Message
@@ -131,7 +127,7 @@ We follow a rough convention for commit messages that is designed to answer two
 questions: what changed and why. The subject line should feature the what and
 the body of the commit should describe the why.
 
-```
+```text
 Added AWS Profile Support
 
 Changes to ensure that AWS profiles are supported. This involved making
@@ -152,7 +148,7 @@ Issue #57
 
 The format can be described more formally as follows:
 
-```
+```text
 <short title for what changed>
 <BLANK LINE>
 <why this change was made and what changed>
@@ -164,7 +160,7 @@ The first line is the subject and should be no longer than 70 characters, the
 second line is always blank, and other lines should be wrapped at 80 characters.
 This allows the message to be easier to read on GitHub as well as in various git tools.
 
-# Release Process
+## Release Process
 
 1. Checkout master branch
 2. Ensure integration tests pass (see below)
@@ -172,19 +168,20 @@ This allows the message to be easier to read on GitHub as well as in various git
 4. Create release notes file for the given tag – `docs/release_notes/<tag>.md` (e.g. `docs/release_notes/0.1.35.md`)
 5. Run `./tag-release-candidatate.sh <tag>-rc.<N>` or `./tag-release.sh <tag>` (e.g. `./tag-release.sh 0.1.35-rc.2` or `./tag-release.sh 0.1.35`)
 
-## Notes on Integration Tests
+### Notes on Integration Tests
 
 It's recommened to run containerised tests with `make integration-test-container TEST_V=1`. The tests require access to an AWS account. If there is an issue with access (e.g. expired MFA token), you will see all tests failing (albeit the error message may be slightly unclear).
 
 At present we ignore flaky tests, so if you see output like show below, you don't need to worry about this for the purpose of the release. However, you might consider reviewing the issues in question after you made the release.
 
-```
+```console
+$ make integration-test-container TEST_V=1
 Summarizing 2 Failures:
 
-[Fail] (Integration) Create, Get, Scale & Delete when creating a cluster with 1 node and add the second nodegroup and delete the second nodegroup [It] {FLAKY: https://github.com/weaveworks/eksctl/issues/717} should make it 4 nodes total 
+[Fail] (Integration) Create, Get, Scale & Delete when creating a cluster with 1 node and add the second nodegroup and delete the second nodegroup [It] {FLAKY: https://github.com/weaveworks/eksctl/issues/717} should make it 4 nodes total
 /go/src/github.com/weaveworks/eksctl/integration/creategetdelete_test.go:376
 
-[Fail] (Integration) Create, Get, Scale & Delete when creating a cluster with 1 node and scale the initial nodegroup back to 1 node [It] {FLAKY: https://github.com/weaveworks/eksctl/issues/717} should make it 1 nodes total 
+[Fail] (Integration) Create, Get, Scale & Delete when creating a cluster with 1 node and scale the initial nodegroup back to 1 node [It] {FLAKY: https://github.com/weaveworks/eksctl/issues/717} should make it 1 nodes total
 /go/src/github.com/weaveworks/eksctl/integration/creategetdelete_test.go:403
 
 Ran 26 of 26 Specs in 2556.238 seconds
@@ -192,13 +189,13 @@ FAIL! -- 24 Passed | 2 Failed | 0 Pending | 0 Skipped
 --- FAIL: TestSuite (2556.25s)
 ```
 
-## Notes on Automation
+### Notes on Automation
 
 When you run `./tag-release.sh <tag>` it will push a commit to master and a tag, which will trigger [release workflow](https://github.com/weaveworks/eksctl/blob/38364943776230bcc9ad57a9f8a423c7ec3fb7fe/.circleci/config.yml#L28-L42) in Circle CI. This runs `make eksctl-image` followed by `make release`. Most of the logic is defined in [`do-release.sh`](https://github.com/weaveworks/eksctl/blob/master/do-release.sh).
 
 You want to keep an eye on Circle CI for the progress of the release ([0.1.35 example logs](https://circleci.com/workflow-run/3553542c-88ad-4a77-bd42-441da4c87fa1)). It normally takes 15-20 minutes.
 
-## Notes on Artefacts
+### Notes on Artefacts
 
 We use `latest_release` floating tag, in order to enable static URLs for release artefacts, i.e. `latest_release` gets shifted on every release.
 

--- a/tag-release-candidate.sh
+++ b/tag-release-candidate.sh
@@ -9,24 +9,53 @@ if [ "$#" -ne 1 ] ; then
   exit 1
 fi
 
-if [ ! "$(git rev-parse --abbrev-ref @)" = master ] ; then
-  echo "Must be on master branch"
-  exit 2
-fi
-
 v="${1}"
 candidate_for="${v/-rc.*}"
+release_branch="release-${candidate_for%.*}"  # e.g.: 0.2.0-rc.0 -> release-0.2
 
 if [ "${v}" = "${candidate_for}" ] ; then
   echo "Must provide release candidate tag, use './tag-release.sh ${v}' instead"
+  exit 2
+fi
+
+if ! [[ "${release_branch}" =~ ^release-[0-9]+\.[0-9]+$ ]] ; then
+  echo "Invalid release branch: ${release_branch}"
   exit 3
 fi
+
+function branch_exists() {
+  git ls-remote --heads git@github.com:weaveworks/eksctl.git "${1}" | grep "${1}" >/dev/null
+}
+
+if ! branch_exists "${release_branch}" ; then
+  git checkout master
+  if [ ! "$(git rev-parse --abbrev-ref @)" = master ] ; then
+    echo "Must be on master branch"
+    exit 4
+  fi
+  # Ensure local master is up-to-date by pulling its latest version from origin
+  # and fast-forwarding local master:
+  git fetch origin master
+  git merge --ff-only origin/master
+  # Create the release branch:
+  git push origin master:"${release_branch}"
+fi
+
+# Ensure local release branch is up-to-date by pulling its latest version from
+# origin and fast-forwarding the local branch:
+git fetch origin "${release_branch}"
+git checkout "${release_branch}"
+if [ ! "$(git rev-parse --abbrev-ref @)" = "${release_branch}" ] ; then
+  echo "Must be on ${release_branch} branch"
+  exit 5
+fi
+git merge --ff-only origin/"${release_branch}"
 
 RELEASE_NOTES_FILE="docs/release_notes/${candidate_for}.md"
 
 if [[ ! -f "${RELEASE_NOTES_FILE}" ]]; then
   echo "Must have release notes ${RELEASE_NOTES_FILE}"
-  exit 3
+  exit 6
 fi
 
 export RELEASE_GIT_TAG="${v}"

--- a/tag-release.sh
+++ b/tag-release.sh
@@ -9,23 +9,52 @@ if [ "$#" -ne 1 ] ; then
   exit 1
 fi
 
-if [ ! "$(git rev-parse --abbrev-ref @)" = master ] ; then
-  echo "Must be on master branch"
-  exit 2
-fi
-
 v="${1}"
+release_branch="release-${v%.*}"  # e.g.: 0.2.0 -> release-0.2
 
 if [ ! "${v}" = "${v/-rc.*}" ] ; then
   echo "Must provide release tag, use './tag-release-candidate.sh ${v}' instead"
+  exit 2
+fi
+
+if ! [[ "${release_branch}" =~ ^release-[0-9]+\.[0-9]+$ ]] ; then
+  echo "Invalid release branch: ${release_branch}"
   exit 3
 fi
+
+function branch_exists() {
+  git ls-remote --heads git@github.com:weaveworks/eksctl.git "${1}" | grep "${1}" >/dev/null
+}
+
+if ! branch_exists "${release_branch}" ; then
+  git checkout master
+  if [ ! "$(git rev-parse --abbrev-ref @)" = master ] ; then
+    echo "Must be on master branch"
+    exit 4
+  fi
+  # Ensure local master is up-to-date by pulling its latest version from origin
+  # and fast-forwarding local master:
+  git fetch origin master
+  git merge --ff-only origin/master
+  # Create the release branch:
+  git push origin master:"${release_branch}"
+fi
+
+# Ensure local release branch is up-to-date by pulling its latest version from
+# origin and fast-forwarding the local branch:
+git fetch origin "${release_branch}"
+git checkout "${release_branch}"
+if [ ! "$(git rev-parse --abbrev-ref @)" = "${release_branch}" ] ; then
+  echo "Must be on ${release_branch} branch"
+  exit 5
+fi
+git merge --ff-only origin/"${release_branch}"
 
 RELEASE_NOTES_FILE="docs/release_notes/${v}.md"
 
 if [[ ! -f "${RELEASE_NOTES_FILE}" ]]; then
   echo "Must have release notes ${RELEASE_NOTES_FILE}"
-  exit 4
+  exit 6
 fi
 
 export RELEASE_GIT_TAG="${v}"


### PR DESCRIPTION
Fixes #1041.

**Changelog**:
1. Updated `tag-release-candidate.sh` to release from branch instead of `master`.
2. Updated `tag-release.sh` to release from branch instead of `master`.
3. Updated `CONTRIBUTING.md` to reflect the latest release process.
4. Fixed various `markdownlint` errors and typos in `CONTRIBUTING.md`.

**N.B.**:
Based on `release-0.2` since we'll want to use these scripts for the release.
I will merge/cherry-pick this PR into `master` as well afterwards.

**Preview**:
https://github.com/weaveworks/eksctl/blob/issues/1041-release-branch/CONTRIBUTING.md

**Testing**:
```console
(issues/1041-release-branch)$ ./tag-release-candidate.sh 0.2.0-rc.1
From github.com:weaveworks/eksctl
 * branch              release-0.2 -> FETCH_HEAD
Switched to branch 'release-0.2'
Your branch is up to date with 'origin/release-0.2'.
Already up to date.
[release-0.2 8fe5287d] Tag 0.2.0-rc.1 release candidate
 1 file changed, 1 insertion(+), 1 deletion(-)
From github.com:weaveworks/eksctl
 * branch              HEAD       -> FETCH_HEAD
Everything up-to-date
Enumerating objects: 10, done.
Counting objects: 100% (10/10), done.
Delta compression using up to 8 threads
Compressing objects: 100% (6/6), done.
Writing objects: 100% (6/6), 1001 bytes | 500.00 KiB/s, done.
Total 6 (delta 4), reused 0 (delta 0)
remote: Resolving deltas: 100% (4/4), completed with 4 local objects.
To github.com:weaveworks/eksctl
 * [new tag]           0.2.0-rc.1 -> 0.2.0-rc.1

(release-0.2)$
```
Then cancelled the [CircleCI job](https://circleci.com/gh/weaveworks/eksctl/3736).
Then deleted the tag to clean after myself:
```console
$ git ls-remote --tags git@github.com:weaveworks/eksctl.git | grep 0.2.0-rc.1
8b64165698ef227a092a167d91deb70a708f2851	refs/tags/0.2.0-rc.1
8fe5287d043ebb1b4b721310fc7290dde471b131	refs/tags/0.2.0-rc.1^{}
$ git push --delete origin 0.2.0-rc.1
To github.com:weaveworks/eksctl.git
 - [deleted]           0.2.0-rc.1
$ git ls-remote --tags git@github.com:weaveworks/eksctl.git | grep 0.2.0-rc.1
### No output.
```