### PR TITLE
eksctl now prints "invalid version, X.Y is now deprecated" on deprecated Kubernetes versions

### DIFF
--- a/docs/release_notes/0.2.1.md
+++ b/docs/release_notes/0.2.1.md
@@ -1,0 +1,167 @@
+# Release 0.2.1
+
+## Bug Fixes Since 0.2.0
+
+- more explicit deprecation message for Kubernetes version 1.10 ([#1049](https://github.com/weaveworks/eksctl/issues/1049))
+
+## Bug Fixes Since 0.1.40
+
+- remove support for Kubernetes version 1.10, as [deprecated by AWS from 22nd July 2019 onwards](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html) ([#1026](https://github.com/weaveworks/eksctl/issues/1026))
+  - remove `eksctl utils install-coredns` command that was only relevant to Kubernetes version 1.10
+  - remove `--strorage-class` flag that was only relevant to Kubernetes version 1.10
+- fix long-standing issue with EBS and security groups blocking VPC deletion ([#103](https://github.com/weaveworks/eksctl/issues/103))
+- add support for `aws eks get-token` as fallback when `aws-iam-authenticator` is missing ([#788](https://github.com/weaveworks/eksctl/issues/788))
+- add `volumeIOPS` field to enable use of EBS root volumes of type `io1` ([#1006](https://github.com/weaveworks/eksctl/issues/1006))
+
+## New Features Since 0.1.0
+
+### General features
+
+- create and manage clusters using configuration files
+- Kubernetes versions: 1.11, 1.12 and 1.13
+- cluster upgrades
+- support for all EKS regions
+
+### VPC
+
+- allow re-using existing VPCs
+- public and private subnet topologies
+- NAT Gateway support (HA, single or disable)
+
+### nodegroup
+
+- nodegroup management (create, get, scale, delete)
+- spot instances and mixed instance types
+- extra kubelet configuration parameters
+- custom EC2 tags and Kubernetes labels
+- custom bootstrap logic
+- single-AZ nodegroups
+- public or private networking options
+- use existing security groups
+- root EBS volume size, type and encryption
+- various options for SSH access
+
+### IAM
+
+- use custom service role for cluster
+- use custom roles or policies for nodegroups
+- canned policies for popular add-ons:
+  - External DNS
+  - Cluster Autoscaler
+  - Cert Manager
+  - ALB Ingress
+  - AppMesh & XRay
+  - EBS, EFS and xFS CSI
+- execute CloudFormation actions using dedicated role
+
+### utilities
+
+- describe and troubleshoot CloudFormation stacks, with CloudTrail support
+- update default add-ons during cluster upgrades (`coredns`, `kube-proxy` and `aws-node`)
+- delete stale entries in `~/.kube/config`
+
+## Acknowledgment
+
+Weaveworks team would like to sencirely thank all of the who have
+contributed to the project, your work is highly appreciated and
+the project would get thus far without you!
+
+We have received many very useful contributions from so many of
+you, some of which came as code, and some as issue or participation
+on Slack, we thank all of you!
+
+<details>
+  <summary><i>List of most active contributors in the last 12 month</i></summary>
+
+  @richardcase
+  @christopherhein
+  @mumoshu
+  @adamjohnson01
+  @archisgore
+  @Lazyshot
+  @kschumy
+  @toricls
+  @cristian-radu
+  @tedmiston
+  @karinnainiguez
+  @Chabane
+  @tiffanyfay
+  @yutachaos
+  @gruebel
+  @jstrachan
+  @PaulMaddox
+  @ozzieba
+  @mukaibot
+  @jmcarp
+  @gotjosh
+  @philoserf
+  @pawelprazak
+  @nckturner
+  @af12066
+  @mgalgs
+  @Jeffwan
+  @paulbsch
+  @arbourd
+  @cbluth
+  @knorby
+  @gchaincl
+  @mcfedr
+  @overdrive3000
+  @prageethw
+  @patstrom
+  @sdarwin
+  @unguiculus
+  @Yannig
+  @IPyandy
+  @bowlesns
+  @derwasp
+  @mikeroyal
+  @superseb
+  @zironycho
+  @dcherman
+  @silviogutierrez
+  @sixth
+  @dresnick-sf
+  @jonk
+  @danielfm
+  @denwwer
+  @thapakazi
+  @lucioveloso
+  @callmeradical
+  @manabusakai
+  @justincormack
+  @austbot
+  @pdavies011010
+  @mreferre
+  @flou
+  @polothy
+  @Tyil
+  @cpaika
+  @arun-gupta
+  @cdenneen
+  @danielchalef
+  @mrichman
+  @whereisaaron
+  @StevenACoffman
+  @procyclinsur
+  @braderhart
+  @aparamon
+  @JasonSwindle
+  @jicowan
+  @olipachi
+  @trondhindenes
+  @milkowski
+  @dingn1
+  @jamesalbert
+  @stevepe-1
+  @ArseniiPetrovich
+  @jvanzyl
+  @redborian
+  @tkang007
+  @elirankon
+  @alexclifford
+  @arielvinas
+  @bnutt
+  @voxxit
+
+</details>

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -65,6 +65,9 @@ const (
 	// DefaultRegion defines the default region, where to deploy the EKS cluster
 	DefaultRegion = RegionUSWest2
 
+	// Version1_10 represents Kubernetes version 1.10.x
+	Version1_10 = "1.10"
+
 	// Version1_11 represents Kubernetes version 1.11.x
 	Version1_11 = "1.11"
 
@@ -191,6 +194,15 @@ func SupportedRegions() []string {
 		RegionAPSouthEast1,
 		RegionAPSouthEast2,
 		RegionAPSouth1,
+	}
+}
+
+// DeprecatedVersions are the versions of Kubernetes that EKS used to support
+// but no longer does. See also:
+// https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
+func DeprecatedVersions() []string {
+	return []string{
+		Version1_10,
 	}
 }
 

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -113,6 +113,9 @@ func doCreateCluster(rc *cmdutils.ResourceCmd, params *createClusterCmdParams) e
 	}
 	if cfg.Metadata.Version != api.DefaultVersion {
 		if !isValidVersion(cfg.Metadata.Version) {
+			if isDeprecatedVersion(cfg.Metadata.Version) {
+				return fmt.Errorf("invalid version, %s is now deprecated, supported values: %s\nsee also: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html", cfg.Metadata.Version, strings.Join(api.SupportedVersions(), ", "))
+			}
 			return fmt.Errorf("invalid version, supported values: %s", strings.Join(api.SupportedVersions(), ", "))
 		}
 	}

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -112,14 +112,7 @@ func doCreateCluster(rc *cmdutils.ResourceCmd, params *createClusterCmdParams) e
 		cfg.Metadata.Version = api.DefaultVersion
 	}
 	if cfg.Metadata.Version != api.DefaultVersion {
-		validVersion := false
-		for _, v := range api.SupportedVersions() {
-			if cfg.Metadata.Version == v {
-				validVersion = true
-				break
-			}
-		}
-		if !validVersion {
+		if !isValidVersion(cfg.Metadata.Version) {
 			return fmt.Errorf("invalid version, supported values: %s", strings.Join(api.SupportedVersions(), ", "))
 		}
 	}

--- a/pkg/ctl/create/utils.go
+++ b/pkg/ctl/create/utils.go
@@ -30,14 +30,7 @@ func checkVersion(rc *cmdutils.ResourceCmd, ctl *eks.ClusterProvider, meta *api.
 		meta.Version = api.LatestVersion
 		logger.Info("will use latest version (%s) for new nodegroup(s)", meta.Version)
 	default:
-		validVersion := false
-		for _, v := range api.SupportedVersions() {
-			if meta.Version == v {
-				validVersion = true
-				break
-			}
-		}
-		if !validVersion {
+		if !isValidVersion(meta.Version) {
 			return fmt.Errorf("invalid version %s, supported values: auto, default, latest, %s", meta.Version, strings.Join(api.SupportedVersions(), ", "))
 		}
 	}
@@ -56,6 +49,15 @@ func checkVersion(rc *cmdutils.ResourceCmd, ctl *eks.ClusterProvider, meta *api.
 	}
 
 	return nil
+}
+
+func isValidVersion(version string) bool {
+	for _, v := range api.SupportedVersions() {
+		if version == v {
+			return true
+		}
+	}
+	return false
 }
 
 // loadSSHKey loads the ssh public key specified in the NodeGroup. The key should be specified

--- a/pkg/ctl/create/utils.go
+++ b/pkg/ctl/create/utils.go
@@ -31,6 +31,9 @@ func checkVersion(rc *cmdutils.ResourceCmd, ctl *eks.ClusterProvider, meta *api.
 		logger.Info("will use latest version (%s) for new nodegroup(s)", meta.Version)
 	default:
 		if !isValidVersion(meta.Version) {
+			if isDeprecatedVersion(meta.Version) {
+				return fmt.Errorf("invalid version, %s is now deprecated, supported values: auto, default, latest, %s\nsee also: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html", meta.Version, strings.Join(api.SupportedVersions(), ", "))
+			}
 			return fmt.Errorf("invalid version %s, supported values: auto, default, latest, %s", meta.Version, strings.Join(api.SupportedVersions(), ", "))
 		}
 	}
@@ -53,6 +56,15 @@ func checkVersion(rc *cmdutils.ResourceCmd, ctl *eks.ClusterProvider, meta *api.
 
 func isValidVersion(version string) bool {
 	for _, v := range api.SupportedVersions() {
+		if version == v {
+			return true
+		}
+	}
+	return false
+}
+
+func isDeprecatedVersion(version string) bool {
+	for _, v := range api.DeprecatedVersions() {
 		if version == v {
 			return true
 		}

--- a/pkg/version/release.go
+++ b/pkg/version/release.go
@@ -7,4 +7,4 @@ package version
 // Values of builtAt and gitCommit will be set by the linker.
 var builtAt = ""
 var gitCommit = ""
-var gitTag = "0.2.0-rc.0"
+var gitTag = "0.2.0"


### PR DESCRIPTION
### Description

Fixes #1049.

When provided with `--version=1.10`, `eksctl` now prints:
```console
(issues/1049-deprecated-msg)$ ./eksctl create cluster --version=1.10
[ℹ]  using region us-east-1
[✖]  invalid version, 1.10 is now deprecated, supported values: 1.11, 1.12, 1.13
see also: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
```

**Changelog**:
- Extracted version validation logic to method in order to remove duplication.
- Added custom error message for deprecated Kubernetes versions.
- Added release notes for 0.2.1 given this is the first PR targeting this version. N.B.: I duplicated the "_Bug Fixes Since 0.1.40_" section from `0.2.0.md` since this may still be relevant as the two versions are only going to be one day apart, and we're still transitioning from older versioning/release process. Let me know if appropriate. I can make it leaner otherwise.

### Checklist

- [x] Code compiles correctly (i.e `make build`).
- [x] ~Added tests that cover your change (if possible).~ (Unit tests for this would not add much value.)
- [x] All unit tests passing (i.e. `make test`).
- [x] Added/modified documentation as required: `docs/release_notes/0.2.1.md`.
- [x] Manually tested (see above).