### PR TITLE
fix typo in update-coredns description

### DIFF
--- a/pkg/ctl/utils/update_coredns.go
+++ b/pkg/ctl/utils/update_coredns.go
@@ -15,7 +15,7 @@ func updateCoreDNSCmd(rc *cmdutils.ResourceCmd) {
 	cfg := api.NewClusterConfig()
 	rc.ClusterConfig = cfg
 
-	rc.SetDescription("update-coredns", "Update coredns add-on to ensure image the standard Amazon EKS version", "")
+	rc.SetDescription("update-coredns", "Update coredns add-on to ensure image matches the standard Amazon EKS version", "")
 
 	rc.SetRunFuncWithNameArg(func() error {
 		return doUpdateCoreDNS(rc)


### PR DESCRIPTION
### Description

Super minor fix here. There's a word missing in the `update-coredns` command description.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [x] Manually tested


