### PR TITLE
Log internal kubernetes errors uniformly

### DIFF
--- a/cmd/eksctl/main.go
+++ b/cmd/eksctl/main.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
-	k8sruntime "k8s.io/apimachinery/pkg/util/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/ctl/completion"
@@ -43,14 +43,14 @@ func addCommands(rootCmd *cobra.Command, flagGrouping *cmdutils.FlagGrouping) {
 func main() {
 
 	// Log internally-logged kubernetes errors uniformly
-	logK8sError := func(err error) {
+	logKubeError := func(err error) {
 		// we need to go one level deeper than k8sruntime.HandleError
 		_, file, line, _ := runtime.Caller(1)
 		idx := strings.Index(file, "/k8s.io/")
 		finalFileLine := file[idx+1:] + ":" + strconv.Itoa(line)
-		logger.Warning("Internal Kubernetes error at %s: %s", finalFileLine, err)
+		logger.Warning("Internal Kubernetes client error at %s: %s", finalFileLine, err)
 	}
-	k8sruntime.ErrorHandlers = []func(error){logK8sError}
+	utilruntime.ErrorHandlers = []func(error){logKubeError}
 
 	cobra.EnableCommandSorting = false
 


### PR DESCRIPTION
### Description

Kubernetes has a way to log errors without exposing them (sigh): `k8s.io/apimachinery/pkg/util/runtime.HandleError`. This results in inconsistently-formatted logs. For instance, see the `ERROR: logging before flag.Parse` line below:

```
[ℹ]  Waiting for Flux to start
ERROR: logging before flag.Parse: E0726 19:56:16.160725    1598 portforward.go:331] an error occurred forwarding 49999 -> 3030: error forwarding port 3030 to pod f5bb5827e0fc76ffa136007d94300bab4da5d1ee87dc577a80444a4d3cdc9780, uid : exit status 1: 2019/07/26 17:56:16 socat[5745] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Flux is not ready yet (executing HTTP request: executing HTTP request: Post http://127.0.0.1:49999/api/flux/v9/git-repo-config: EOF), retrying ...
[ℹ]  Flux started successfully
[ℹ]  Commiting and pushing Flux manifests to git@github.com:2opremio/my-gitops-repo
```

To fix this, we override `k8s.io/apimachinery/pkg/util/runtime.ErrorHandlers`.

Found while testing #1064 . _Inspired_ by https://github.com/fluxcd/flux/commit/6bc1e8931074c819e0b9ef8a7c0c34dcfd7d247d#diff-350e484490d6241fa81c13942d160480 

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
