### PR TITLE
Rename `ctl.GetCredentials` to `ctl.GetActiveCluster`

### DIFF
--- a/pkg/ctl/create/iamidentitymapping.go
+++ b/pkg/ctl/create/iamidentitymapping.go
@@ -64,7 +64,7 @@ func doCreateIAMIdentityMapping(rc *cmdutils.ResourceCmd, id *authconfigmap.MapR
 		return err
 	}
 
-	if err := ctl.GetCredentials(cfg); err != nil {
+	if err := ctl.GetActiveCluster(cfg); err != nil {
 		return err
 	}
 	clientSet, err := ctl.NewStdClientSet(cfg)

--- a/pkg/ctl/create/iamidentitymapping.go
+++ b/pkg/ctl/create/iamidentitymapping.go
@@ -64,7 +64,7 @@ func doCreateIAMIdentityMapping(rc *cmdutils.ResourceCmd, id *authconfigmap.MapR
 		return err
 	}
 
-	if err := ctl.GetActiveCluster(cfg); err != nil {
+	if err := ctl.RefreshClusterConfig(cfg); err != nil {
 		return err
 	}
 	clientSet, err := ctl.NewStdClientSet(cfg)

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -79,7 +79,7 @@ func doCreateNodeGroups(rc *cmdutils.ResourceCmd, updateAuthConfigMap bool) erro
 		return err
 	}
 
-	if err := ctl.GetCredentials(cfg); err != nil {
+	if err := ctl.GetActiveCluster(cfg); err != nil {
 		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
 	}
 

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -79,7 +79,7 @@ func doCreateNodeGroups(rc *cmdutils.ResourceCmd, updateAuthConfigMap bool) erro
 		return err
 	}
 
-	if err := ctl.GetActiveCluster(cfg); err != nil {
+	if err := ctl.RefreshClusterConfig(cfg); err != nil {
 		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
 	}
 

--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -108,7 +108,7 @@ func doDeleteCluster(rc *cmdutils.ResourceCmd) error {
 	{
 
 		logger.Info("cleaning up LoadBalancer services")
-		if err := ctl.GetActiveCluster(cfg); err != nil {
+		if err := ctl.RefreshClusterConfig(cfg); err != nil {
 			return err
 		}
 		cs, err := ctl.NewStdClientSet(cfg)

--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -108,7 +108,7 @@ func doDeleteCluster(rc *cmdutils.ResourceCmd) error {
 	{
 
 		logger.Info("cleaning up LoadBalancer services")
-		if err := ctl.GetCredentials(cfg); err != nil {
+		if err := ctl.GetActiveCluster(cfg); err != nil {
 			return err
 		}
 		cs, err := ctl.NewStdClientSet(cfg)

--- a/pkg/ctl/delete/iamidentitymapping.go
+++ b/pkg/ctl/delete/iamidentitymapping.go
@@ -56,7 +56,7 @@ func doDeleteIAMIdentityMapping(rc *cmdutils.ResourceCmd, role string, all bool)
 		return cmdutils.ErrMustBeSet("--name")
 	}
 
-	if err := ctl.GetCredentials(cfg); err != nil {
+	if err := ctl.GetActiveCluster(cfg); err != nil {
 		return err
 	}
 	clientSet, err := ctl.NewStdClientSet(cfg)

--- a/pkg/ctl/delete/iamidentitymapping.go
+++ b/pkg/ctl/delete/iamidentitymapping.go
@@ -56,7 +56,7 @@ func doDeleteIAMIdentityMapping(rc *cmdutils.ResourceCmd, role string, all bool)
 		return cmdutils.ErrMustBeSet("--name")
 	}
 
-	if err := ctl.GetActiveCluster(cfg); err != nil {
+	if err := ctl.RefreshClusterConfig(cfg); err != nil {
 		return err
 	}
 	clientSet, err := ctl.NewStdClientSet(cfg)

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -58,7 +58,7 @@ func doDeleteNodeGroup(rc *cmdutils.ResourceCmd, ng *api.NodeGroup, updateAuthCo
 		return err
 	}
 
-	if err := ctl.GetActiveCluster(cfg); err != nil {
+	if err := ctl.RefreshClusterConfig(cfg); err != nil {
 		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
 	}
 

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -58,7 +58,7 @@ func doDeleteNodeGroup(rc *cmdutils.ResourceCmd, ng *api.NodeGroup, updateAuthCo
 		return err
 	}
 
-	if err := ctl.GetCredentials(cfg); err != nil {
+	if err := ctl.GetActiveCluster(cfg); err != nil {
 		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
 	}
 

--- a/pkg/ctl/drain/nodegroup.go
+++ b/pkg/ctl/drain/nodegroup.go
@@ -54,7 +54,7 @@ func doDrainNodeGroup(rc *cmdutils.ResourceCmd, ng *api.NodeGroup, undo, onlyMis
 		return err
 	}
 
-	if err := ctl.GetCredentials(cfg); err != nil {
+	if err := ctl.GetActiveCluster(cfg); err != nil {
 		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
 	}
 

--- a/pkg/ctl/drain/nodegroup.go
+++ b/pkg/ctl/drain/nodegroup.go
@@ -54,7 +54,7 @@ func doDrainNodeGroup(rc *cmdutils.ResourceCmd, ng *api.NodeGroup, undo, onlyMis
 		return err
 	}
 
-	if err := ctl.GetActiveCluster(cfg); err != nil {
+	if err := ctl.RefreshClusterConfig(cfg); err != nil {
 		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
 	}
 

--- a/pkg/ctl/get/iamidentitymapping.go
+++ b/pkg/ctl/get/iamidentitymapping.go
@@ -56,7 +56,7 @@ func doGetIAMIdentityMapping(rc *cmdutils.ResourceCmd, params *getCmdParams, rol
 		return cmdutils.ErrMustBeSet("--name")
 	}
 
-	if err := ctl.GetActiveCluster(cfg); err != nil {
+	if err := ctl.RefreshClusterConfig(cfg); err != nil {
 		return err
 	}
 	clientSet, err := ctl.NewStdClientSet(cfg)

--- a/pkg/ctl/get/iamidentitymapping.go
+++ b/pkg/ctl/get/iamidentitymapping.go
@@ -56,7 +56,7 @@ func doGetIAMIdentityMapping(rc *cmdutils.ResourceCmd, params *getCmdParams, rol
 		return cmdutils.ErrMustBeSet("--name")
 	}
 
-	if err := ctl.GetCredentials(cfg); err != nil {
+	if err := ctl.GetActiveCluster(cfg); err != nil {
 		return err
 	}
 	clientSet, err := ctl.NewStdClientSet(cfg)

--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -62,7 +62,7 @@ func doUpdateClusterCmd(rc *cmdutils.ResourceCmd) error {
 		return err
 	}
 
-	if err := ctl.GetCredentials(cfg); err != nil {
+	if err := ctl.GetActiveCluster(cfg); err != nil {
 		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
 	}
 

--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -62,7 +62,7 @@ func doUpdateClusterCmd(rc *cmdutils.ResourceCmd) error {
 		return err
 	}
 
-	if err := ctl.GetActiveCluster(cfg); err != nil {
+	if err := ctl.RefreshClusterConfig(cfg); err != nil {
 		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
 	}
 

--- a/pkg/ctl/utils/update_aws_node.go
+++ b/pkg/ctl/utils/update_aws_node.go
@@ -50,7 +50,7 @@ func doUpdateAWSNode(rc *cmdutils.ResourceCmd) error {
 		return err
 	}
 
-	if err := ctl.GetActiveCluster(cfg); err != nil {
+	if err := ctl.RefreshClusterConfig(cfg); err != nil {
 		return errors.Wrapf(err, "getting credentials for cluster %q", meta.Name)
 	}
 

--- a/pkg/ctl/utils/update_aws_node.go
+++ b/pkg/ctl/utils/update_aws_node.go
@@ -50,7 +50,7 @@ func doUpdateAWSNode(rc *cmdutils.ResourceCmd) error {
 		return err
 	}
 
-	if err := ctl.GetCredentials(cfg); err != nil {
+	if err := ctl.GetActiveCluster(cfg); err != nil {
 		return errors.Wrapf(err, "getting credentials for cluster %q", meta.Name)
 	}
 

--- a/pkg/ctl/utils/update_coredns.go
+++ b/pkg/ctl/utils/update_coredns.go
@@ -50,7 +50,7 @@ func doUpdateCoreDNS(rc *cmdutils.ResourceCmd) error {
 		return err
 	}
 
-	if err := ctl.GetActiveCluster(cfg); err != nil {
+	if err := ctl.RefreshClusterConfig(cfg); err != nil {
 		return errors.Wrapf(err, "getting credentials for cluster %q", meta.Name)
 	}
 

--- a/pkg/ctl/utils/update_coredns.go
+++ b/pkg/ctl/utils/update_coredns.go
@@ -50,7 +50,7 @@ func doUpdateCoreDNS(rc *cmdutils.ResourceCmd) error {
 		return err
 	}
 
-	if err := ctl.GetCredentials(cfg); err != nil {
+	if err := ctl.GetActiveCluster(cfg); err != nil {
 		return errors.Wrapf(err, "getting credentials for cluster %q", meta.Name)
 	}
 

--- a/pkg/ctl/utils/update_kube_proxy.go
+++ b/pkg/ctl/utils/update_kube_proxy.go
@@ -50,7 +50,7 @@ func doUpdateKubeProxy(rc *cmdutils.ResourceCmd) error {
 		return err
 	}
 
-	if err := ctl.GetActiveCluster(cfg); err != nil {
+	if err := ctl.RefreshClusterConfig(cfg); err != nil {
 		return errors.Wrapf(err, "getting credentials for cluster %q", meta.Name)
 	}
 

--- a/pkg/ctl/utils/update_kube_proxy.go
+++ b/pkg/ctl/utils/update_kube_proxy.go
@@ -50,7 +50,7 @@ func doUpdateKubeProxy(rc *cmdutils.ResourceCmd) error {
 		return err
 	}
 
-	if err := ctl.GetCredentials(cfg); err != nil {
+	if err := ctl.GetActiveCluster(cfg); err != nil {
 		return errors.Wrapf(err, "getting credentials for cluster %q", meta.Name)
 	}
 

--- a/pkg/ctl/utils/write_kubeconfig.go
+++ b/pkg/ctl/utils/write_kubeconfig.go
@@ -69,7 +69,7 @@ func doWriteKubeconfigCmd(rc *cmdutils.ResourceCmd, outputPath, roleARN string, 
 		outputPath = kubeconfig.AutoPath(cfg.Metadata.Name)
 	}
 
-	if err := ctl.GetCredentials(cfg); err != nil {
+	if err := ctl.GetActiveCluster(cfg); err != nil {
 		return err
 	}
 

--- a/pkg/ctl/utils/write_kubeconfig.go
+++ b/pkg/ctl/utils/write_kubeconfig.go
@@ -69,7 +69,7 @@ func doWriteKubeconfigCmd(rc *cmdutils.ResourceCmd, outputPath, roleARN string, 
 		outputPath = kubeconfig.AutoPath(cfg.Metadata.Name)
 	}
 
-	if err := ctl.GetActiveCluster(cfg); err != nil {
+	if err := ctl.RefreshClusterConfig(cfg); err != nil {
 		return err
 	}
 

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -47,12 +47,12 @@ func (c *ClusterProvider) DescribeControlPlaneMustBeActive(cl *api.ClusterMeta) 
 	return cluster, nil
 }
 
-// GetActiveCluster calls c.DescribeControlPlaneMustBeActive and caches the results;
+// RefreshClusterConfig calls c.DescribeControlPlaneMustBeActive and caches the results;
 // it parses the credentials (endpoint, CA certificate) and stores them in spec.Status,
 // so that a Kubernetes client can be constructed; additionally it caches Kubernetes
 // version (use ctl.ControlPlaneVersion to retrieve it) and other properties in
 // c.Status.cachedClusterInfo
-func (c *ClusterProvider) GetActiveCluster(spec *api.ClusterConfig) error {
+func (c *ClusterProvider) RefreshClusterConfig(spec *api.ClusterConfig) error {
 	// Check the cluster exists and is active
 	cluster, err := c.DescribeControlPlaneMustBeActive(spec.Metadata)
 	if err != nil {

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -47,8 +47,12 @@ func (c *ClusterProvider) DescribeControlPlaneMustBeActive(cl *api.ClusterMeta) 
 	return cluster, nil
 }
 
-// GetCredentials retrieves cluster endpoint and the certificate authority data
-func (c *ClusterProvider) GetCredentials(spec *api.ClusterConfig) error {
+// GetActiveCluster calls c.DescribeControlPlaneMustBeActive and caches the results;
+// it parses the credentials (endpoint, CA certificate) and stores them in spec.Status,
+// so that a Kubernetes client can be constructed; additionally it caches Kubernetes
+// version (use ctl.ControlPlaneVersion to retrieve it) and other properties in
+// c.Status.cachedClusterInfo
+func (c *ClusterProvider) GetActiveCluster(spec *api.ClusterConfig) error {
 	// Check the cluster exists and is active
 	cluster, err := c.DescribeControlPlaneMustBeActive(spec.Metadata)
 	if err != nil {


### PR DESCRIPTION
# Description

<!-- Please explain the changes you made here. -->

This function was already doing more then just collecting
credetials and was due to be renamed for a while.


### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
