### PR TITLE
Fix link typo in cloudWatch documentation

### DIFF
--- a/site/content/usage/12-cloudwatch-cluster-logging.md
+++ b/site/content/usage/12-cloudwatch-cluster-logging.md
@@ -59,7 +59,7 @@ eksctl utils update-cluster-logging --disable-types all
 
 ### `ClusterConfig` Examples
 
-There 5 types of logs that you may wish to enable (see [EKS documentation](eksdocs) for more details):
+There 5 types of logs that you may wish to enable (see [EKS documentation][eksdocs] for more details):
 
 - `api`
 - `audit`


### PR DESCRIPTION
### Description

There was a typo in a link reference in cloudwatch logging documentation, the link wasn't working.

### Checklist
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
