### PR TITLE
Increase space between command and description

### DIFF
--- a/pkg/ctl/cmdutils/group.go
+++ b/pkg/ctl/cmdutils/group.go
@@ -75,7 +75,7 @@ func (g *FlagGrouping) Usage(cmd *cobra.Command) error {
 	if cmd.HasAvailableSubCommands() {
 		usage = append(usage, "\nCommands:")
 		for _, subCommand := range cmd.Commands() {
-			usage = append(usage, fmt.Sprintf("  %s %-15s  %s", cmd.CommandPath(), subCommand.Name(), subCommand.Short))
+			usage = append(usage, fmt.Sprintf("  %s %-22s  %s", cmd.CommandPath(), subCommand.Name(), subCommand.Short))
 		}
 	}
 


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

We did this recently, but turns out there wasn't enough room under `eksctl create`.

***Before:***
```
$ eksctl create -h
Create resource(s)

Usage: eksctl create [flags]

Commands:
  eksctl create cluster          Create a cluster
  eksctl create nodegroup        Create a nodegroup
  eksctl create iamidentitymapping  Create an IAM identity mapping

Common flags:
  -C, --color string   toggle colorized logs (valid options: true, false, fabulous) (default "true")
  -h, --help           help for this command
  -v, --verbose int    set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging (default 3)

Use 'eksctl create [command] --help' for more information about a command.
```

***After:***
```
$  ./eksctl create -h
Create resource(s)

Usage: eksctl create [flags]

Commands:
  eksctl create cluster                 Create a cluster
  eksctl create nodegroup               Create a nodegroup
  eksctl create iamidentitymapping      Create an IAM identity mapping

Common flags:
  -C, --color string   toggle colorized logs (valid options: true, false, fabulous) (default "true")
  -h, --help           help for this command
  -v, --verbose int    set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging (default 3)

Use 'eksctl create [command] --help' for more information about a command.
```

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
