### PR TITLE
Kubernetes client improvements

### DIFF
--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/testutils"
 )
 
-var _ = Describe("kubernets client wrappers", func() {
+var _ = Describe("Kubernetes client wrappers", func() {
 	Describe("can create or replace missing objects", func() {
 		It("can update objects that already exist", func() {
 			sampleAddons := testutils.LoadSamples("../addons/default/testdata/sample-1.12.json")

--- a/pkg/kubernetes/namespace.go
+++ b/pkg/kubernetes/namespace.go
@@ -2,39 +2,70 @@ package kubernetes
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/kris-nova/logger"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Namespace creates a corev1.Namespace object with the standard labels set
-// using the provided name.
-func Namespace(name string) *corev1.Namespace {
+// NewNamespace creates a corev1.Namespace object using the provided name.
+func NewNamespace(name string) *corev1.Namespace {
 	return &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Namespace",
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: map[string]string{"name": name},
+			Name: name,
 		},
 	}
 }
 
-const namespaceTemplate = `---
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    name: %s
-  name: %s
-`
-
-// NamespaceYAML returns a YAML string for a Kubernetes Namespace object with
-// the standard labels set using the provided name.
+// NewNamespaceYAML returns a YAML string for a Kubernetes Namespace object.
 // N.B.: Kubernetes' serializers are not used as unnecessary fields are being
 // generated, e.g.: spec, status, creatimeTimestamp.
-func NamespaceYAML(name string) []byte {
-	return []byte(fmt.Sprintf(namespaceTemplate, name, name))
+func NewNamespaceYAML(name string) []byte {
+	nsFmt := strings.Join(
+		[]string{
+			"---",
+			"apiVersion: v1",
+			"kind: Namespace",
+			"metadata: {name: %s}",
+		},
+		"\n")
+
+	return []byte(fmt.Sprintf(nsFmt, name))
+}
+
+// CheckNamespaceExists check if a namespace with a given name already exists, and
+// returns boolean or an error
+func CheckNamespaceExists(clientSet Interface, name string) (bool, error) {
+	_, err := clientSet.CoreV1().Namespaces().Get(name, metav1.GetOptions{})
+	if err == nil {
+		return true, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return false, errors.Wrapf(err, "checking whether namespace %q exists", name)
+	}
+	return false, nil
+}
+
+// MaybeCreateNamespace will only create namespace with the given name if it doesn't
+// already exist
+func MaybeCreateNamespace(clientSet Interface, name string) error {
+	exists, err := CheckNamespaceExists(clientSet, name)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		_, err = clientSet.CoreV1().Namespaces().Create(NewNamespace(name))
+		if err != nil {
+			return err
+		}
+		logger.Info("created namespace %q", name)
+	}
+	return nil
 }

--- a/pkg/kubernetes/serviceaccount.go
+++ b/pkg/kubernetes/serviceaccount.go
@@ -1,0 +1,92 @@
+package kubernetes
+
+import (
+	"github.com/kris-nova/logger"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewServiceAccount creates a corev1.ServiceAccount object using the provided meta.
+func NewServiceAccount(meta metav1.ObjectMeta) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: meta,
+	}
+}
+
+// CheckServiceAccountExists check if a serviceaccount with a given name already exists, and
+// returns boolean or an error
+func CheckServiceAccountExists(clientSet Interface, meta metav1.ObjectMeta) (bool, error) {
+	name := meta.Namespace + "/" + meta.Name
+	_, err := clientSet.CoreV1().ServiceAccounts(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
+	if err == nil {
+		return true, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return false, errors.Wrapf(err, "checking whether serviceaccount %q exists", name)
+	}
+	return false, nil
+}
+
+// MaybeCreateServiceAccountOrUpdateMetadata will only create serviceaccount with the given name if
+// it doesn't already exist, it will also create namespace if needed; if serviceaccount exist - new
+// labels and annotations will get added, all user-set label and annotation keys that are not set in
+// meta will be retained
+func MaybeCreateServiceAccountOrUpdateMetadata(clientSet Interface, meta metav1.ObjectMeta) error {
+	name := meta.Namespace + "/" + meta.Name
+	if err := MaybeCreateNamespace(clientSet, meta.Namespace); err != nil {
+		return err
+	}
+	exists, err := CheckServiceAccountExists(clientSet, meta)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		_, err = clientSet.CoreV1().ServiceAccounts(meta.Namespace).Create(NewServiceAccount(meta))
+		if err != nil {
+			return err
+		}
+		logger.Info("created serviceaccount %q", name)
+		return nil
+	}
+	current, err := clientSet.CoreV1().ServiceAccounts(meta.Namespace).Get(meta.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	updateRequired := false
+
+	mergeMetadata := func(src, dst map[string]string) {
+		for key, value := range src {
+			currentValue, ok := dst[key]
+			updateRequired = !ok || ok && currentValue != value
+			dst[key] = value
+		}
+	}
+
+	if current.Annotations == nil {
+		current.Annotations = make(map[string]string)
+	}
+	mergeMetadata(meta.Annotations, current.Annotations)
+
+	if current.Labels == nil {
+		current.Labels = make(map[string]string)
+	}
+	mergeMetadata(meta.Labels, current.Labels)
+
+	if !updateRequired {
+		logger.Info("serviceaccount %q is already up-to-date", name)
+		return nil
+	}
+	_, err = clientSet.CoreV1().ServiceAccounts(meta.Namespace).Update(current)
+	if err != nil {
+		return err
+	}
+	logger.Info("updated serviceaccount %q", name)
+	return nil
+}

--- a/pkg/kubernetes/serviceaccount_test.go
+++ b/pkg/kubernetes/serviceaccount_test.go
@@ -1,0 +1,104 @@
+package kubernetes_test
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	. "github.com/weaveworks/eksctl/pkg/kubernetes"
+)
+
+var _ = Describe("Kubernetes serviceaccount object helpers", func() {
+	var (
+		clientSet *fake.Clientset
+		err       error
+	)
+
+	BeforeEach(func() {
+		clientSet = fake.NewSimpleClientset()
+	})
+
+	It("can create a serviceaccount object", func() {
+		sa := NewServiceAccount(metav1.ObjectMeta{Name: "sa-1", Namespace: "ns-1"})
+
+		Expect(sa.APIVersion).To(Equal("v1"))
+		Expect(sa.Kind).To(Equal("ServiceAccount"))
+		Expect(sa.Name).To(Equal("sa-1"))
+		Expect(sa.Namespace).To(Equal("ns-1"))
+
+		Expect(sa.Labels).To(BeEmpty())
+
+		js, err := json.Marshal(sa)
+		Expect(err).ToNot(HaveOccurred())
+
+		expected := `{
+				"apiVersion": "v1",
+				"kind": "ServiceAccount",
+				"metadata": {
+		  			"creationTimestamp": null,
+					"name": "sa-1",
+					"namespace": "ns-1"
+				}
+			}`
+		Expect(js).To(MatchJSON([]byte(expected)))
+	})
+
+	It("can create serviceaccount using fake client, and update it in incremental manner with overrides", func() {
+		sa := metav1.ObjectMeta{Name: "sa-1", Namespace: "ns-1"}
+
+		err = MaybeCreateServiceAccountOrUpdateMetadata(clientSet, sa)
+		Expect(err).ToNot(HaveOccurred())
+
+		ok, err := CheckNamespaceExists(clientSet, sa.Namespace)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeTrue())
+
+		ok, err = CheckServiceAccountExists(clientSet, sa)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeTrue())
+
+		{
+			resp, err := clientSet.CoreV1().ServiceAccounts(sa.Namespace).Get(sa.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(resp.Labels).To(BeEmpty())
+			Expect(resp.Annotations).To(BeEmpty())
+		}
+
+		sa.Labels = map[string]string{
+			"foo": "bar",
+		}
+		sa.Annotations = map[string]string{
+			"test": "1",
+		}
+
+		err = MaybeCreateServiceAccountOrUpdateMetadata(clientSet, sa)
+		Expect(err).ToNot(HaveOccurred())
+
+		{
+			resp, err := clientSet.CoreV1().ServiceAccounts(sa.Namespace).Get(sa.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(resp.Labels).To(HaveKey("foo"))
+			Expect(resp.Annotations).To(HaveKeyWithValue("test", "1"))
+		}
+
+		delete(sa.Labels, "foo")
+		sa.Annotations["test"] = "2"
+
+		err = MaybeCreateServiceAccountOrUpdateMetadata(clientSet, sa)
+		Expect(err).ToNot(HaveOccurred())
+
+		{
+			resp, err := clientSet.CoreV1().ServiceAccounts(sa.Namespace).Get(sa.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(resp.Labels).To(HaveKey("foo"))
+			Expect(resp.Annotations).To(HaveKeyWithValue("test", "2"))
+		}
+	})
+})


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

- Improve Kubernetes client wrapper interface
  - add an alias for `"k8s.io/client-go/kubernetes".Interface`
  - define clientset getter interface
- Improve namespace object helpers
  - add client helpers
  - remove `name` label (close #1118)
  - add tests
- Add serviceaccount object helpers

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
