### PR TITLE
Rename `cmdutils.ResourceCmd` to `cmdutils.Cmd`

### DIFF
--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -68,11 +68,11 @@ func LogPlanModeWarning(plan bool) {
 }
 
 // AddApproveFlag adds common `--approve` flag
-func AddApproveFlag(fs *pflag.FlagSet, rc *ResourceCmd) {
-	approve := fs.Bool("approve", !rc.Plan, "Apply the changes")
-	AddPreRun(rc.Command, func(cmd *cobra.Command, args []string) {
-		if cmd.Flag("approve").Changed {
-			rc.Plan = !*approve
+func AddApproveFlag(fs *pflag.FlagSet, cmd *Cmd) {
+	approve := fs.Bool("approve", !cmd.Plan, "Apply the changes")
+	AddPreRun(cmd.CobraCommand, func(cobraCmd *cobra.Command, args []string) {
+		if cobraCmd.Flag("approve").Changed {
+			cmd.Plan = !*approve
 		}
 	})
 }

--- a/pkg/ctl/cmdutils/nodegroup_flags.go
+++ b/pkg/ctl/cmdutils/nodegroup_flags.go
@@ -12,21 +12,21 @@ import (
 )
 
 // AddCommonCreateNodeGroupFlags adds common flags for creating a node group
-func AddCommonCreateNodeGroupFlags(fs *pflag.FlagSet, rc *ResourceCmd, ng *api.NodeGroup) {
+func AddCommonCreateNodeGroupFlags(fs *pflag.FlagSet, cmd *Cmd, ng *api.NodeGroup) {
 	fs.StringVarP(&ng.InstanceType, "node-type", "t", api.DefaultNodeType, "node instance type")
 
 	desiredCapacity := fs.IntP("nodes", "N", api.DefaultNodeCount, "total number of nodes (for a static ASG)")
 	minSize := fs.IntP("nodes-min", "m", api.DefaultNodeCount, "minimum nodes in ASG")
 	maxSize := fs.IntP("nodes-max", "M", api.DefaultNodeCount, "maximum nodes in ASG")
 
-	AddPreRun(rc.Command, func(cmd *cobra.Command, args []string) {
-		if f := cmd.Flag("nodes"); f.Changed {
+	AddPreRun(cmd.CobraCommand, func(cobraCmd *cobra.Command, args []string) {
+		if f := cobraCmd.Flag("nodes"); f.Changed {
 			ng.DesiredCapacity = desiredCapacity
 		}
-		if f := cmd.Flag("nodes-min"); f.Changed {
+		if f := cobraCmd.Flag("nodes-min"); f.Changed {
 			ng.MinSize = minSize
 		}
-		if f := cmd.Flag("nodes-max"); f.Changed {
+		if f := cobraCmd.Flag("nodes-max"); f.Changed {
 			ng.MaxSize = maxSize
 		}
 	})

--- a/pkg/ctl/create/iamidentitymapping.go
+++ b/pkg/ctl/create/iamidentitymapping.go
@@ -10,13 +10,13 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-func createIAMIdentityMappingCmd(rc *cmdutils.ResourceCmd) {
+func createIAMIdentityMappingCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
-	rc.ClusterConfig = cfg
+	cmd.ClusterConfig = cfg
 
 	id := &authconfigmap.MapRole{}
 
-	rc.SetDescription("iamidentitymapping", "Create an IAM identity mapping",
+	cmd.SetDescription("iamidentitymapping", "Create an IAM identity mapping",
 		dedent.Dedent(`Creates a mapping from IAM role to Kubernetes user and groups.
 
 			Note aws-iam-authenticator only considers the last entry for any given
@@ -25,31 +25,31 @@ func createIAMIdentityMappingCmd(rc *cmdutils.ResourceCmd) {
 		`),
 	)
 
-	rc.SetRunFunc(func() error {
-		return doCreateIAMIdentityMapping(rc, id)
+	cmd.SetRunFunc(func() error {
+		return doCreateIAMIdentityMapping(cmd, id)
 	})
 
-	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&id.RoleARN, "role", "", "ARN of the IAM role to create")
 		fs.StringVar(&id.Username, "username", "", "User name within Kubernetes to map to IAM role")
 		fs.StringArrayVar(&id.Groups, "group", []string{}, "Group within Kubernetes to which IAM role is mapped")
 		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
-		cmdutils.AddConfigFileFlag(fs, &rc.ClusterConfigFile)
-		cmdutils.AddTimeoutFlag(fs, &rc.ProviderConfig.WaitTimeout)
+		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
+		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
+		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
+	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)
 }
 
-func doCreateIAMIdentityMapping(rc *cmdutils.ResourceCmd, id *authconfigmap.MapRole) error {
-	if err := cmdutils.NewMetadataLoader(rc).Load(); err != nil {
+func doCreateIAMIdentityMapping(cmd *cmdutils.Cmd, id *authconfigmap.MapRole) error {
+	if err := cmdutils.NewMetadataLoader(cmd).Load(); err != nil {
 		return err
 	}
 
-	cfg := rc.ClusterConfig
+	cfg := cmd.ClusterConfig
 
-	ctl, err := rc.NewCtl()
+	ctl, err := cmd.NewCtl()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/create/utils.go
+++ b/pkg/ctl/create/utils.go
@@ -17,7 +17,7 @@ func checkSubnetsGivenAsFlags(params *createClusterCmdParams) bool {
 	return len(*params.subnets[api.SubnetTopologyPrivate])+len(*params.subnets[api.SubnetTopologyPublic]) != 0
 }
 
-func checkVersion(rc *cmdutils.ResourceCmd, ctl *eks.ClusterProvider, meta *api.ClusterMeta) error {
+func checkVersion(cmd *cmdutils.Cmd, ctl *eks.ClusterProvider, meta *api.ClusterMeta) error {
 	switch meta.Version {
 	case "auto":
 		break
@@ -45,7 +45,7 @@ func checkVersion(rc *cmdutils.ResourceCmd, ctl *eks.ClusterProvider, meta *api.
 		logger.Info("will use version %s for new nodegroup(s) based on control plane version", meta.Version)
 	} else if meta.Version != v {
 		hint := "--version=auto"
-		if rc.ClusterConfigFile != "" {
+		if cmd.ClusterConfigFile != "" {
 			hint = "metadata.version: auto"
 		}
 		logger.Warning("will use version %s for new nodegroup(s), while control plane version is %s; to automatically inherit the version use %q", meta.Version, v, hint)

--- a/pkg/ctl/delete/iamidentitymapping.go
+++ b/pkg/ctl/delete/iamidentitymapping.go
@@ -9,41 +9,41 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-func deleteIAMIdentityMappingCmd(rc *cmdutils.ResourceCmd) {
+func deleteIAMIdentityMappingCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
-	rc.ClusterConfig = cfg
+	cmd.ClusterConfig = cfg
 
 	var (
 		role string
 		all  bool
 	)
 
-	rc.SetDescription("iamidentitymapping", "Delete a IAM identity mapping", "")
+	cmd.SetDescription("iamidentitymapping", "Delete a IAM identity mapping", "")
 
-	rc.SetRunFunc(func() error {
-		return doDeleteIAMIdentityMapping(rc, role, all)
+	cmd.SetRunFunc(func() error {
+		return doDeleteIAMIdentityMapping(cmd, role, all)
 	})
 
-	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&role, "role", "", "ARN of the IAM role to delete")
 		fs.BoolVar(&all, "all", false, "Delete all matching mappings instead of just one")
 		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
-		cmdutils.AddConfigFileFlag(fs, &rc.ClusterConfigFile)
-		cmdutils.AddTimeoutFlag(fs, &rc.ProviderConfig.WaitTimeout)
+		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
+		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
+		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
+	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)
 }
 
-func doDeleteIAMIdentityMapping(rc *cmdutils.ResourceCmd, role string, all bool) error {
-	if err := cmdutils.NewMetadataLoader(rc).Load(); err != nil {
+func doDeleteIAMIdentityMapping(cmd *cmdutils.Cmd, role string, all bool) error {
+	if err := cmdutils.NewMetadataLoader(cmd).Load(); err != nil {
 		return err
 	}
 
-	cfg := rc.ClusterConfig
+	cfg := cmd.ClusterConfig
 
-	ctl, err := rc.NewCtl()
+	ctl, err := cmd.NewCtl()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/get/cluster.go
+++ b/pkg/ctl/get/cluster.go
@@ -9,36 +9,36 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-func getClusterCmd(rc *cmdutils.ResourceCmd) {
+func getClusterCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
-	rc.ClusterConfig = cfg
+	cmd.ClusterConfig = cfg
 
 	var listAllRegions bool
 
 	params := &getCmdParams{}
 
-	rc.SetDescription("cluster", "Get cluster(s)", "", "clusters")
+	cmd.SetDescription("cluster", "Get cluster(s)", "", "clusters")
 
-	rc.SetRunFuncWithNameArg(func() error {
-		return doGetCluster(rc, params, listAllRegions)
+	cmd.SetRunFuncWithNameArg(func() error {
+		return doGetCluster(cmd, params, listAllRegions)
 	})
 
-	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddNameFlag(fs, cfg.Metadata)
 		fs.BoolVarP(&listAllRegions, "all-regions", "A", false, "List clusters across all supported regions")
-		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
+		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddCommonFlagsForGetCmd(fs, &params.chunkSize, &params.output)
-		cmdutils.AddTimeoutFlag(fs, &rc.ProviderConfig.WaitTimeout)
+		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
+	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)
 }
 
-func doGetCluster(rc *cmdutils.ResourceCmd, params *getCmdParams, listAllRegions bool) error {
-	cfg := rc.ClusterConfig
+func doGetCluster(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
+	cfg := cmd.ClusterConfig
 	regionGiven := cfg.Metadata.Region != "" // eks.New resets this field, so we need to check if it was set in the fist place
 
-	ctl, err := rc.NewCtl()
+	ctl, err := cmd.NewCtl()
 	if err != nil {
 		return err
 	}
@@ -47,12 +47,12 @@ func doGetCluster(rc *cmdutils.ResourceCmd, params *getCmdParams, listAllRegions
 		logger.Warning("--region=%s is ignored, as --all-regions is given", cfg.Metadata.Region)
 	}
 
-	if cfg.Metadata.Name != "" && rc.NameArg != "" {
-		return cmdutils.ErrNameFlagAndArg(cfg.Metadata.Name, rc.NameArg)
+	if cfg.Metadata.Name != "" && cmd.NameArg != "" {
+		return cmdutils.ErrNameFlagAndArg(cfg.Metadata.Name, cmd.NameArg)
 	}
 
-	if rc.NameArg != "" {
-		cfg.Metadata.Name = rc.NameArg
+	if cmd.NameArg != "" {
+		cfg.Metadata.Name = cmd.NameArg
 	}
 
 	if cfg.Metadata.Name != "" && listAllRegions {

--- a/pkg/ctl/get/iamidentitymapping.go
+++ b/pkg/ctl/get/iamidentitymapping.go
@@ -13,40 +13,40 @@ import (
 	"github.com/weaveworks/eksctl/pkg/printers"
 )
 
-func getIAMIdentityMappingCmd(rc *cmdutils.ResourceCmd) {
+func getIAMIdentityMappingCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
-	rc.ClusterConfig = cfg
+	cmd.ClusterConfig = cfg
 
 	var role string
 
 	params := &getCmdParams{}
 
-	rc.SetDescription("iamidentitymapping", "Get IAM identity mapping(s)", "")
+	cmd.SetDescription("iamidentitymapping", "Get IAM identity mapping(s)", "")
 
-	rc.SetRunFunc(func() error {
-		return doGetIAMIdentityMapping(rc, params, role)
+	cmd.SetRunFunc(func() error {
+		return doGetIAMIdentityMapping(cmd, params, role)
 	})
 
-	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&role, "role", "", "ARN of the IAM role")
 		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
+		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddCommonFlagsForGetCmd(fs, &params.chunkSize, &params.output)
-		cmdutils.AddConfigFileFlag(fs, &rc.ClusterConfigFile)
-		cmdutils.AddTimeoutFlag(fs, &rc.ProviderConfig.WaitTimeout)
+		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
+		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
+	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)
 }
 
-func doGetIAMIdentityMapping(rc *cmdutils.ResourceCmd, params *getCmdParams, role string) error {
-	if err := cmdutils.NewMetadataLoader(rc).Load(); err != nil {
+func doGetIAMIdentityMapping(cmd *cmdutils.Cmd, params *getCmdParams, role string) error {
+	if err := cmdutils.NewMetadataLoader(cmd).Load(); err != nil {
 		return err
 	}
 
-	cfg := rc.ClusterConfig
+	cfg := cmd.ClusterConfig
 
-	ctl, err := rc.NewCtl()
+	ctl, err := cmd.NewCtl()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/get/nodegroup.go
+++ b/pkg/ctl/get/nodegroup.go
@@ -14,34 +14,34 @@ import (
 	"github.com/weaveworks/eksctl/pkg/printers"
 )
 
-func getNodeGroupCmd(rc *cmdutils.ResourceCmd) {
+func getNodeGroupCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
 	ng := cfg.NewNodeGroup()
-	rc.ClusterConfig = cfg
+	cmd.ClusterConfig = cfg
 
 	params := &getCmdParams{}
 
-	rc.SetDescription("nodegroup", "Get nodegroup(s)", "", "ng", "nodegroups")
+	cmd.SetDescription("nodegroup", "Get nodegroup(s)", "", "ng", "nodegroups")
 
-	rc.SetRunFuncWithNameArg(func() error {
-		return doGetNodeGroup(rc, ng, params)
+	cmd.SetRunFuncWithNameArg(func() error {
+		return doGetNodeGroup(cmd, ng, params)
 	})
 
-	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")
 		fs.StringVarP(&ng.Name, "name", "n", "", "Name of the nodegroup")
-		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
+		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddCommonFlagsForGetCmd(fs, &params.chunkSize, &params.output)
-		cmdutils.AddTimeoutFlag(fs, &rc.ProviderConfig.WaitTimeout)
+		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
+	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)
 }
 
-func doGetNodeGroup(rc *cmdutils.ResourceCmd, ng *api.NodeGroup, params *getCmdParams) error {
-	cfg := rc.ClusterConfig
+func doGetNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *getCmdParams) error {
+	cfg := cmd.ClusterConfig
 
-	ctl, err := rc.NewCtl()
+	ctl, err := cmd.NewCtl()
 	if err != nil {
 		return err
 	}
@@ -54,12 +54,12 @@ func doGetNodeGroup(rc *cmdutils.ResourceCmd, ng *api.NodeGroup, params *getCmdP
 		return cmdutils.ErrMustBeSet("--cluster")
 	}
 
-	if ng.Name != "" && rc.NameArg != "" {
-		return cmdutils.ErrNameFlagAndArg(ng.Name, rc.NameArg)
+	if ng.Name != "" && cmd.NameArg != "" {
+		return cmdutils.ErrNameFlagAndArg(ng.Name, cmd.NameArg)
 	}
 
-	if rc.NameArg != "" {
-		ng.Name = rc.NameArg
+	if cmd.NameArg != "" {
+		ng.Name = cmd.NameArg
 	}
 
 	manager := ctl.NewStackManager(cfg)

--- a/pkg/ctl/scale/nodegroup.go
+++ b/pkg/ctl/scale/nodegroup.go
@@ -10,39 +10,39 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-func scaleNodeGroupCmd(rc *cmdutils.ResourceCmd) {
+func scaleNodeGroupCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
 	ng := cfg.NewNodeGroup()
-	rc.ClusterConfig = cfg
+	cmd.ClusterConfig = cfg
 
-	rc.SetDescription("nodegroup", "Scale a nodegroup", "", "ng")
+	cmd.SetDescription("nodegroup", "Scale a nodegroup", "", "ng")
 
-	rc.SetRunFuncWithNameArg(func() error {
-		return doScaleNodeGroup(rc, ng)
+	cmd.SetRunFuncWithNameArg(func() error {
+		return doScaleNodeGroup(cmd, ng)
 	})
 
-	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")
 		fs.StringVarP(&ng.Name, "name", "n", "", "Name of the nodegroup to scale")
 
 		desiredCapacity := fs.IntP("nodes", "N", -1, "total number of nodes (scale to this number)")
-		cmdutils.AddPreRun(rc.Command, func(cmd *cobra.Command, args []string) {
-			if f := cmd.Flag("nodes"); f.Changed {
+		cmdutils.AddPreRun(cmd.CobraCommand, func(cobraCmd *cobra.Command, args []string) {
+			if f := cobraCmd.Flag("nodes"); f.Changed {
 				ng.DesiredCapacity = desiredCapacity
 			}
 		})
 
-		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
-		cmdutils.AddTimeoutFlag(fs, &rc.ProviderConfig.WaitTimeout)
+		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
+		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, true)
+	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, true)
 }
 
-func doScaleNodeGroup(rc *cmdutils.ResourceCmd, ng *api.NodeGroup) error {
-	cfg := rc.ClusterConfig
+func doScaleNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup) error {
+	cfg := cmd.ClusterConfig
 
-	ctl, err := rc.NewCtl()
+	ctl, err := cmd.NewCtl()
 	if err != nil {
 		return err
 	}
@@ -55,12 +55,12 @@ func doScaleNodeGroup(rc *cmdutils.ResourceCmd, ng *api.NodeGroup) error {
 		return cmdutils.ErrMustBeSet("--cluster")
 	}
 
-	if ng.Name != "" && rc.NameArg != "" {
-		return cmdutils.ErrNameFlagAndArg(ng.Name, rc.NameArg)
+	if ng.Name != "" && cmd.NameArg != "" {
+		return cmdutils.ErrNameFlagAndArg(ng.Name, cmd.NameArg)
 	}
 
-	if rc.NameArg != "" {
-		ng.Name = rc.NameArg
+	if cmd.NameArg != "" {
+		ng.Name = cmd.NameArg
 	}
 
 	if ng.Name == "" {

--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -12,47 +12,47 @@ import (
 	"github.com/weaveworks/eksctl/pkg/printers"
 )
 
-func updateClusterCmd(rc *cmdutils.ResourceCmd) {
+func updateClusterCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
-	rc.ClusterConfig = cfg
+	cmd.ClusterConfig = cfg
 
-	rc.SetDescription("cluster", "Update cluster", "")
+	cmd.SetDescription("cluster", "Update cluster", "")
 
-	rc.SetRunFuncWithNameArg(func() error {
-		return doUpdateClusterCmd(rc)
+	cmd.SetRunFuncWithNameArg(func() error {
+		return doUpdateClusterCmd(cmd)
 	})
 
-	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
-		cmdutils.AddConfigFileFlag(fs, &rc.ClusterConfigFile)
+		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
+		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 
 		// cmdutils.AddVersionFlag(fs, cfg.Metadata, `"next" and "latest" can be used to automatically increment version by one, or force latest`)
 
-		cmdutils.AddApproveFlag(fs, rc)
-		fs.BoolVar(&rc.Plan, "dry-run", rc.Plan, "")
+		cmdutils.AddApproveFlag(fs, cmd)
+		fs.BoolVar(&cmd.Plan, "dry-run", cmd.Plan, "")
 		fs.MarkDeprecated("dry-run", "see --aprove")
 
-		rc.Wait = true
-		cmdutils.AddWaitFlag(fs, &rc.Wait, "all update operations to complete")
-		cmdutils.AddTimeoutFlag(fs, &rc.ProviderConfig.WaitTimeout)
+		cmd.Wait = true
+		cmdutils.AddWaitFlag(fs, &cmd.Wait, "all update operations to complete")
+		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
+	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)
 
 }
 
-func doUpdateClusterCmd(rc *cmdutils.ResourceCmd) error {
-	if err := cmdutils.NewMetadataLoader(rc).Load(); err != nil {
+func doUpdateClusterCmd(cmd *cmdutils.Cmd) error {
+	if err := cmdutils.NewMetadataLoader(cmd).Load(); err != nil {
 		return err
 	}
 
-	cfg := rc.ClusterConfig
-	meta := rc.ClusterConfig.Metadata
+	cfg := cmd.ClusterConfig
+	meta := cmd.ClusterConfig.Metadata
 
 	printer := printers.NewJSONPrinter()
 
-	ctl, err := rc.NewCtl()
+	ctl, err := cmd.NewCtl()
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func doUpdateClusterCmd(rc *cmdutils.ResourceCmd) error {
 		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
 	}
 
-	if rc.ClusterConfigFile != "" {
+	if cmd.ClusterConfigFile != "" {
 		logger.Warning("NOTE: config file is used for finding cluster name and region")
 		logger.Warning("NOTE: cluster VPC (subnets, routing & NAT Gateway) configuration changes are not yet implemented")
 	}
@@ -98,7 +98,7 @@ func doUpdateClusterCmd(rc *cmdutils.ResourceCmd) error {
 
 	stackManager := ctl.NewStackManager(cfg)
 
-	stackUpdateRequired, err := stackManager.AppendNewClusterStackResource(rc.Plan)
+	stackUpdateRequired, err := stackManager.AppendNewClusterStackResource(cmd.Plan)
 	if err != nil {
 		return err
 	}
@@ -109,9 +109,9 @@ func doUpdateClusterCmd(rc *cmdutils.ResourceCmd) error {
 
 	if versionUpdateRequired {
 		msgNodeGroupsAndAddons := "you will need to follow the upgrade procedure for all of nodegroups and add-ons"
-		cmdutils.LogIntendedAction(rc.Plan, "upgrade cluster %q control plane from current version %q to %q", cfg.Metadata.Name, currentVersion, cfg.Metadata.Version)
-		if !rc.Plan {
-			if rc.Wait {
+		cmdutils.LogIntendedAction(cmd.Plan, "upgrade cluster %q control plane from current version %q to %q", cfg.Metadata.Name, currentVersion, cfg.Metadata.Version)
+		if !cmd.Plan {
+			if cmd.Wait {
 				if err := ctl.UpdateClusterVersionBlocking(cfg); err != nil {
 					return err
 				}
@@ -127,7 +127,7 @@ func doUpdateClusterCmd(rc *cmdutils.ResourceCmd) error {
 		}
 	}
 
-	cmdutils.LogPlanModeWarning(rc.Plan && (stackUpdateRequired || versionUpdateRequired))
+	cmdutils.LogPlanModeWarning(cmd.Plan && (stackUpdateRequired || versionUpdateRequired))
 
 	return nil
 }

--- a/pkg/ctl/utils/describe_stacks.go
+++ b/pkg/ctl/utils/describe_stacks.go
@@ -11,34 +11,34 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-func describeStacksCmd(rc *cmdutils.ResourceCmd) {
+func describeStacksCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
-	rc.ClusterConfig = cfg
+	cmd.ClusterConfig = cfg
 
 	var all, events, trail bool
 
-	rc.SetDescription("describe-stacks", "Describe CloudFormation stack for a given cluster", "")
+	cmd.SetDescription("describe-stacks", "Describe CloudFormation stack for a given cluster", "")
 
-	rc.SetRunFuncWithNameArg(func() error {
-		return doDescribeStacksCmd(rc, all, events, trail)
+	cmd.SetRunFuncWithNameArg(func() error {
+		return doDescribeStacksCmd(cmd, all, events, trail)
 	})
 
-	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
+		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		fs.BoolVar(&all, "all", false, "include deleted stacks")
 		fs.BoolVar(&events, "events", false, "include stack events")
 		fs.BoolVar(&trail, "trail", false, "lookup CloudTrail events for the cluster")
-		cmdutils.AddTimeoutFlag(fs, &rc.ProviderConfig.WaitTimeout)
+		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
+	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)
 }
 
-func doDescribeStacksCmd(rc *cmdutils.ResourceCmd, all, events, trail bool) error {
-	cfg := rc.ClusterConfig
+func doDescribeStacksCmd(cmd *cmdutils.Cmd, all, events, trail bool) error {
+	cfg := cmd.ClusterConfig
 
-	ctl, err := rc.NewCtl()
+	ctl, err := cmd.NewCtl()
 	if err != nil {
 		return err
 	}
@@ -48,12 +48,12 @@ func doDescribeStacksCmd(rc *cmdutils.ResourceCmd, all, events, trail bool) erro
 		return err
 	}
 
-	if cfg.Metadata.Name != "" && rc.NameArg != "" {
-		return fmt.Errorf("--name=%s and argument %s cannot be used at the same time", cfg.Metadata.Name, rc.NameArg)
+	if cfg.Metadata.Name != "" && cmd.NameArg != "" {
+		return fmt.Errorf("--name=%s and argument %s cannot be used at the same time", cfg.Metadata.Name, cmd.NameArg)
 	}
 
-	if rc.NameArg != "" {
-		cfg.Metadata.Name = rc.NameArg
+	if cmd.NameArg != "" {
+		cfg.Metadata.Name = cmd.NameArg
 	}
 
 	if cfg.Metadata.Name == "" {

--- a/pkg/ctl/utils/update_aws_node.go
+++ b/pkg/ctl/utils/update_aws_node.go
@@ -10,36 +10,36 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-func updateAWSNodeCmd(rc *cmdutils.ResourceCmd) {
+func updateAWSNodeCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
-	rc.ClusterConfig = cfg
+	cmd.ClusterConfig = cfg
 
-	rc.SetDescription("update-aws-node", "Update aws-node add-on to latest released version", "")
+	cmd.SetDescription("update-aws-node", "Update aws-node add-on to latest released version", "")
 
-	rc.SetRunFuncWithNameArg(func() error {
-		return doUpdateAWSNode(rc)
+	cmd.SetRunFuncWithNameArg(func() error {
+		return doUpdateAWSNode(cmd)
 	})
 
-	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
-		cmdutils.AddConfigFileFlag(fs, &rc.ClusterConfigFile)
-		cmdutils.AddApproveFlag(fs, rc)
-		cmdutils.AddTimeoutFlag(fs, &rc.ProviderConfig.WaitTimeout)
+		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
+		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
+		cmdutils.AddApproveFlag(fs, cmd)
+		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
+	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)
 }
 
-func doUpdateAWSNode(rc *cmdutils.ResourceCmd) error {
-	if err := cmdutils.NewMetadataLoader(rc).Load(); err != nil {
+func doUpdateAWSNode(cmd *cmdutils.Cmd) error {
+	if err := cmdutils.NewMetadataLoader(cmd).Load(); err != nil {
 		return err
 	}
 
-	cfg := rc.ClusterConfig
-	meta := rc.ClusterConfig.Metadata
+	cfg := cmd.ClusterConfig
+	meta := cmd.ClusterConfig.Metadata
 
-	ctl, err := rc.NewCtl()
+	ctl, err := cmd.NewCtl()
 	if err != nil {
 		return err
 	}
@@ -63,12 +63,12 @@ func doUpdateAWSNode(rc *cmdutils.ResourceCmd) error {
 		return err
 	}
 
-	updateRequired, err := defaultaddons.UpdateAWSNode(rawClient, meta.Region, kubernetesVersion, rc.Plan)
+	updateRequired, err := defaultaddons.UpdateAWSNode(rawClient, meta.Region, kubernetesVersion, cmd.Plan)
 	if err != nil {
 		return err
 	}
 
-	cmdutils.LogPlanModeWarning(rc.Plan && updateRequired)
+	cmdutils.LogPlanModeWarning(cmd.Plan && updateRequired)
 
 	return nil
 }

--- a/pkg/ctl/utils/update_cluster_stack.go
+++ b/pkg/ctl/utils/update_cluster_stack.go
@@ -9,11 +9,11 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-func updateClusterStackCmd(rc *cmdutils.ResourceCmd) {
-	rc.SetDescription("update-cluster-stack", "DEPRECATED: Use 'eksctl update cluster' instead", "")
+func updateClusterStackCmd(cmd *cmdutils.Cmd) {
+	cmd.SetDescription("update-cluster-stack", "DEPRECATED: Use 'eksctl update cluster' instead", "")
 
-	rc.Command.Run = func(cmd *cobra.Command, _ []string) {
-		logger.Critical(cmd.Short)
+	cmd.CobraCommand.Run = func(cobraCmd *cobra.Command, _ []string) {
+		logger.Critical(cobraCmd.Short)
 		os.Exit(1)
 	}
 }

--- a/pkg/ctl/utils/update_coredns.go
+++ b/pkg/ctl/utils/update_coredns.go
@@ -10,36 +10,36 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-func updateCoreDNSCmd(rc *cmdutils.ResourceCmd) {
+func updateCoreDNSCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
-	rc.ClusterConfig = cfg
+	cmd.ClusterConfig = cfg
 
-	rc.SetDescription("update-coredns", "Update coredns add-on to ensure image matches the standard Amazon EKS version", "")
+	cmd.SetDescription("update-coredns", "Update coredns add-on to ensure image matches the standard Amazon EKS version", "")
 
-	rc.SetRunFuncWithNameArg(func() error {
-		return doUpdateCoreDNS(rc)
+	cmd.SetRunFuncWithNameArg(func() error {
+		return doUpdateCoreDNS(cmd)
 	})
 
-	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
-		cmdutils.AddConfigFileFlag(fs, &rc.ClusterConfigFile)
-		cmdutils.AddApproveFlag(fs, rc)
-		cmdutils.AddTimeoutFlag(fs, &rc.ProviderConfig.WaitTimeout)
+		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
+		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
+		cmdutils.AddApproveFlag(fs, cmd)
+		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
+	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)
 }
 
-func doUpdateCoreDNS(rc *cmdutils.ResourceCmd) error {
-	if err := cmdutils.NewMetadataLoader(rc).Load(); err != nil {
+func doUpdateCoreDNS(cmd *cmdutils.Cmd) error {
+	if err := cmdutils.NewMetadataLoader(cmd).Load(); err != nil {
 		return err
 	}
 
-	cfg := rc.ClusterConfig
-	meta := rc.ClusterConfig.Metadata
+	cfg := cmd.ClusterConfig
+	meta := cmd.ClusterConfig.Metadata
 
-	ctl, err := rc.NewCtl()
+	ctl, err := cmd.NewCtl()
 	if err != nil {
 		return err
 	}
@@ -63,12 +63,12 @@ func doUpdateCoreDNS(rc *cmdutils.ResourceCmd) error {
 		return err
 	}
 
-	updateRequired, err := defaultaddons.UpdateCoreDNS(rawClient, meta.Region, kubernetesVersion, rc.Plan)
+	updateRequired, err := defaultaddons.UpdateCoreDNS(rawClient, meta.Region, kubernetesVersion, cmd.Plan)
 	if err != nil {
 		return err
 	}
 
-	cmdutils.LogPlanModeWarning(rc.Plan && updateRequired)
+	cmdutils.LogPlanModeWarning(cmd.Plan && updateRequired)
 
 	return nil
 }

--- a/pkg/ctl/utils/update_kube_proxy.go
+++ b/pkg/ctl/utils/update_kube_proxy.go
@@ -10,36 +10,36 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-func updateKubeProxyCmd(rc *cmdutils.ResourceCmd) {
+func updateKubeProxyCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
-	rc.ClusterConfig = cfg
+	cmd.ClusterConfig = cfg
 
-	rc.SetDescription("update-kube-proxy", "Update kube-proxy add-on to ensure image matches Kubernetes control plane version", "")
+	cmd.SetDescription("update-kube-proxy", "Update kube-proxy add-on to ensure image matches Kubernetes control plane version", "")
 
-	rc.SetRunFuncWithNameArg(func() error {
-		return doUpdateKubeProxy(rc)
+	cmd.SetRunFuncWithNameArg(func() error {
+		return doUpdateKubeProxy(cmd)
 	})
 
-	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
-		cmdutils.AddConfigFileFlag(fs, &rc.ClusterConfigFile)
-		cmdutils.AddApproveFlag(fs, rc)
-		cmdutils.AddTimeoutFlag(fs, &rc.ProviderConfig.WaitTimeout)
+		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
+		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
+		cmdutils.AddApproveFlag(fs, cmd)
+		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 	})
 
-	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
+	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)
 }
 
-func doUpdateKubeProxy(rc *cmdutils.ResourceCmd) error {
-	if err := cmdutils.NewMetadataLoader(rc).Load(); err != nil {
+func doUpdateKubeProxy(cmd *cmdutils.Cmd) error {
+	if err := cmdutils.NewMetadataLoader(cmd).Load(); err != nil {
 		return err
 	}
 
-	cfg := rc.ClusterConfig
-	meta := rc.ClusterConfig.Metadata
+	cfg := cmd.ClusterConfig
+	meta := cmd.ClusterConfig.Metadata
 
-	ctl, err := rc.NewCtl()
+	ctl, err := cmd.NewCtl()
 	if err != nil {
 		return err
 	}
@@ -63,12 +63,12 @@ func doUpdateKubeProxy(rc *cmdutils.ResourceCmd) error {
 		return err
 	}
 
-	updateRequired, err := defaultaddons.UpdateKubeProxyImageTag(rawClient.ClientSet(), kubernetesVersion, rc.Plan)
+	updateRequired, err := defaultaddons.UpdateKubeProxyImageTag(rawClient.ClientSet(), kubernetesVersion, cmd.Plan)
 	if err != nil {
 		return err
 	}
 
-	cmdutils.LogPlanModeWarning(rc.Plan && updateRequired)
+	cmdutils.LogPlanModeWarning(cmd.Plan && updateRequired)
 
 	return nil
 }

--- a/pkg/ctl/utils/wait_nodes.go
+++ b/pkg/ctl/utils/wait_nodes.go
@@ -10,35 +10,35 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func waitNodesCmd(rc *cmdutils.ResourceCmd) {
+func waitNodesCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
 	ng := cfg.NewNodeGroup()
-	rc.ClusterConfig = cfg
+	cmd.ClusterConfig = cfg
 
 	var kubeconfigPath string
 
-	rc.SetDescription("wait-nodes", "Wait for nodes", "")
+	cmd.SetDescription("wait-nodes", "Wait for nodes", "")
 
-	rc.SetRunFunc(func() error {
-		return doWaitNodes(rc, ng, kubeconfigPath)
+	cmd.SetRunFunc(func() error {
+		return doWaitNodes(cmd, ng, kubeconfigPath)
 	})
 
-	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&kubeconfigPath, "kubeconfig", "kubeconfig", "path to read kubeconfig")
 		minSize := fs.IntP("nodes-min", "m", api.DefaultNodeCount, "minimum number of nodes to wait for")
-		cmdutils.AddPreRun(rc.Command, func(cmd *cobra.Command, args []string) {
-			if f := cmd.Flag("nodes-min"); f.Changed {
+		cmdutils.AddPreRun(cmd.CobraCommand, func(cobraCmd *cobra.Command, args []string) {
+			if f := cobraCmd.Flag("nodes-min"); f.Changed {
 				ng.MinSize = minSize
 			}
 		})
-		fs.DurationVar(&rc.ProviderConfig.WaitTimeout, "timeout", api.DefaultWaitTimeout, "how long to wait")
+		fs.DurationVar(&cmd.ProviderConfig.WaitTimeout, "timeout", api.DefaultWaitTimeout, "how long to wait")
 	})
 }
 
-func doWaitNodes(rc *cmdutils.ResourceCmd, ng *api.NodeGroup, kubeconfigPath string) error {
-	cfg := rc.ClusterConfig
+func doWaitNodes(cmd *cmdutils.Cmd, ng *api.NodeGroup, kubeconfigPath string) error {
+	cfg := cmd.ClusterConfig
 
-	ctl := eks.New(rc.ProviderConfig, cfg)
+	ctl := eks.New(cmd.ProviderConfig, cfg)
 
 	if kubeconfigPath == "" {
 		return cmdutils.ErrMustBeSet("--kubeconfig")

--- a/pkg/ctl/utils/write_kubeconfig.go
+++ b/pkg/ctl/utils/write_kubeconfig.go
@@ -12,9 +12,9 @@ import (
 	"github.com/weaveworks/eksctl/pkg/utils/kubeconfig"
 )
 
-func writeKubeconfigCmd(rc *cmdutils.ResourceCmd) {
+func writeKubeconfigCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
-	rc.ClusterConfig = cfg
+	cmd.ClusterConfig = cfg
 
 	var (
 		outputPath           string
@@ -22,29 +22,29 @@ func writeKubeconfigCmd(rc *cmdutils.ResourceCmd) {
 		setContext, autoPath bool
 	)
 
-	rc.SetDescription("write-kubeconfig", "Write kubeconfig file for a given cluster", "")
+	cmd.SetDescription("write-kubeconfig", "Write kubeconfig file for a given cluster", "")
 
-	rc.SetRunFuncWithNameArg(func() error {
-		return doWriteKubeconfigCmd(rc, outputPath, authenticatorRoleARN, setContext, autoPath)
+	cmd.SetRunFuncWithNameArg(func() error {
+		return doWriteKubeconfigCmd(cmd, outputPath, authenticatorRoleARN, setContext, autoPath)
 	})
 
-	rc.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddNameFlag(fs, cfg.Metadata)
-		cmdutils.AddRegionFlag(fs, rc.ProviderConfig)
-		cmdutils.AddTimeoutFlag(fs, &rc.ProviderConfig.WaitTimeout)
+		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
+		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 	})
 
-	rc.FlagSetGroup.InFlagSet("Output kubeconfig", func(fs *pflag.FlagSet) {
+	cmd.FlagSetGroup.InFlagSet("Output kubeconfig", func(fs *pflag.FlagSet) {
 		cmdutils.AddCommonFlagsForKubeconfig(fs, &outputPath, &authenticatorRoleARN, &setContext, &autoPath, "<name>")
 	})
 
-	cmdutils.AddCommonFlagsForAWS(rc.FlagSetGroup, rc.ProviderConfig, false)
+	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)
 }
 
-func doWriteKubeconfigCmd(rc *cmdutils.ResourceCmd, outputPath, roleARN string, setContext, autoPath bool) error {
-	cfg := rc.ClusterConfig
+func doWriteKubeconfigCmd(cmd *cmdutils.Cmd, outputPath, roleARN string, setContext, autoPath bool) error {
+	cfg := cmd.ClusterConfig
 
-	ctl, err := rc.NewCtl()
+	ctl, err := cmd.NewCtl()
 	if err != nil {
 		return err
 	}
@@ -54,12 +54,12 @@ func doWriteKubeconfigCmd(rc *cmdutils.ResourceCmd, outputPath, roleARN string, 
 		return err
 	}
 
-	if cfg.Metadata.Name != "" && rc.NameArg != "" {
-		return cmdutils.ErrNameFlagAndArg(cfg.Metadata.Name, rc.NameArg)
+	if cfg.Metadata.Name != "" && cmd.NameArg != "" {
+		return cmdutils.ErrNameFlagAndArg(cfg.Metadata.Name, cmd.NameArg)
 	}
 
-	if rc.NameArg != "" {
-		cfg.Metadata.Name = rc.NameArg
+	if cmd.NameArg != "" {
+		cfg.Metadata.Name = cmd.NameArg
 	}
 
 	if cfg.Metadata.Name == "" {


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

- rename `cmdutils.ResourceCmd` to `cmdutils.Cmd`
- call variable `cmd` instead of `rc` (which was confusing) (as promissed in https://github.com/weaveworks/eksctl/pull/859#issuecomment-500481675)

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
