### PR TITLE
Add generation of cluster autoscaler addon's manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ integration/kubeconfig-*
 
 # Generated header file
 .license-header
+
+# Generated Go file
+*_vfsdata.go

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,15 @@ GOBIN ?= $(shell echo `go env GOPATH`/bin)
 
 AWS_SDK_MOCKS := $(wildcard pkg/eks/mocks/*API.go)
 
+ADDON_CLUSTER_AUTOSCALER_MANIFESTS=$(shell find pkg/addons/clusterautoscaler/templates -name '*.tmpl' -print)
+pkg/addons/clusterautoscaler/templates_vfsdata.go: $(ADDON_CLUSTER_AUTOSCALER_MANIFESTS)
+	go generate ./pkg/addons/clusterautoscaler/
+
 DEEP_COPY_HELPER := pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
 GENERATED_GO_FILES := pkg/addons/default/assets.go \
 pkg/nodebootstrap/assets.go \
 pkg/addons/default/assets/aws-node.yaml \
+pkg/addons/clusterautoscaler/templates_vfsdata.go \
 $(DEEP_COPY_HELPER) \
 pkg/ami/static_resolver_ami.go \
 $(AWS_SDK_MOCKS)

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/prometheus/client_golang v1.0.0 // indirect
 	github.com/riywo/loginshell v0.0.0-20190610082906-2ed199a032f6
 	github.com/sanathkr/yaml v1.0.0 // indirect
+	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
 	github.com/sirupsen/logrus v1.4.2 // indirect
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -760,6 +760,7 @@ github.com/shurcooL/reactions v0.0.0-20181006231557-f2e0b4ca5b82/go.mod h1:TCR1l
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 h1:/vdW8Cb7EXrkqWGufVMES1OH2sU9gKVb2n9/1y5NMBY=
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/users v0.0.0-20180125191416-49c67e49c537/go.mod h1:QJTqeLYEDaXHZDBsXlPCDqdhQuJkuw4NOtaxYe3xii4=
+github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd h1:ug7PpSOB5RBPK1Kg6qskGBoP3Vnj/aNYFTznWvlkGo0=
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5kWdCj2z2KEozexVbfEZIWiTjhE0+UjmZgPqehw=
 github.com/sirupsen/logrus v0.0.0-20170620144510-3d4380f53a34/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=

--- a/pkg/addons/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/addons/clusterautoscaler/cluster_autoscaler.go
@@ -1,0 +1,82 @@
+package clusterautoscaler
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"html/template"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/shurcooL/httpfs/vfsutil"
+	"github.com/weaveworks/eksctl/pkg/kubernetes"
+)
+
+const (
+	defaultNamespace    = "kube-system"
+	defaultImageVersion = "v1.12.3"
+)
+
+// TemplateParameters groups the parameters required to configure cluster
+// autoscaling.
+// N.B.: these parameters are injected into the cluster autoscaler's YAML
+// template, hence their names need to be consistent both here and in the
+// template.
+type TemplateParameters struct {
+	Namespace    string // Namespace under which cluster autoscaler resources will be created.
+	ClusterName  string // Name of the EKS cluster, as configured in eksctl's manifest or via CLI flags.
+	ImageVersion string // Version of the k8s.gcr.io/cluster-autoscaler image.
+}
+
+// Validate validates the values currently set and defaults the ones missing.
+func (p *TemplateParameters) Validate() error {
+	if p.ClusterName == "" {
+		return errors.New("blank cluster name")
+	}
+	if p.Namespace == "" {
+		p.Namespace = defaultNamespace
+	}
+	if p.ImageVersion == "" {
+		p.ImageVersion = defaultImageVersion
+	}
+	return nil
+}
+
+// GenerateManifests fills the cluster autoscaler's YAML templates with the
+// provided template parameters to generate actionable YAML manifests.
+func GenerateManifests(params TemplateParameters) ([]byte, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+	manifests := [][]byte{}
+	err := vfsutil.WalkFiles(Templates, "/", func(path string, info os.FileInfo, rs io.ReadSeeker, err error) error {
+		if err != nil {
+			return fmt.Errorf("cannot walk embedded files: %s", err)
+		}
+		if info.IsDir() {
+			return nil
+		}
+		manifestTemplateBytes, err := ioutil.ReadAll(rs)
+		if err != nil {
+			return fmt.Errorf("cannot read embedded file %q: %s", info.Name(), err)
+		}
+		manifestTemplate, err := template.New(info.Name()).
+			Funcs(template.FuncMap{"StringsJoin": strings.Join}).
+			Parse(string(manifestTemplateBytes))
+		if err != nil {
+			return fmt.Errorf("cannot parse embedded file %q: %s", info.Name(), err)
+		}
+		out := bytes.NewBuffer(nil)
+		if err := manifestTemplate.Execute(out, params); err != nil {
+			return fmt.Errorf("cannot execute template for embedded file %q: %s", info.Name(), err)
+		}
+		manifests = append(manifests, out.Bytes())
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("internal error filling embedded installation templates: %s", err)
+	}
+	return kubernetes.ConcatManifests(manifests...), nil
+}

--- a/pkg/addons/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/addons/clusterautoscaler/cluster_autoscaler_test.go
@@ -1,0 +1,49 @@
+package clusterautoscaler_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	. "github.com/weaveworks/eksctl/pkg/addons/clusterautoscaler"
+)
+
+func TestValidate(t *testing.T) {
+	invalidParams := TemplateParameters{}
+	assert.EqualError(t, invalidParams.Validate(), "blank cluster name")
+	assert.Equal(t, "", invalidParams.ClusterName)
+	assert.Equal(t, "", invalidParams.Namespace)
+	assert.Equal(t, "", invalidParams.ImageVersion)
+
+	params := TemplateParameters{ClusterName: "cluster-name-test"}
+	assert.NoError(t, params.Validate())
+	assert.Equal(t, "cluster-name-test", params.ClusterName)
+	assert.Equal(t, "kube-system", params.Namespace)
+	assert.Equal(t, "v1.12.3", params.ImageVersion)
+}
+
+func TestGenerateManifests(t *testing.T) {
+	invalidManifest, err := GenerateManifests(TemplateParameters{})
+	assert.EqualError(t, err, "blank cluster name")
+	assert.Len(t, invalidManifest, 0)
+
+	defaultManifest, err := GenerateManifests(TemplateParameters{ClusterName: "cluster-name-test"})
+	assert.NoError(t, err)
+	manifest := string(defaultManifest)
+	assert.Contains(t, manifest, "  namespace: kube-system")
+	assert.Contains(t, manifest, "        - image: k8s.gcr.io/cluster-autoscaler:v1.12.3")
+	assert.Contains(t, manifest, "            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/cluster-name-test")
+
+	manifestBytes, err := GenerateManifests(TemplateParameters{
+		ClusterName:  "cluster-name2-test",
+		ImageVersion: "v2.0.0",
+		Namespace:    "custom-ns",
+	})
+	assert.NoError(t, err)
+	manifest = string(manifestBytes)
+	assert.NotContains(t, manifest, "  namespace: kube-system")
+	assert.Contains(t, manifest, "  namespace: custom-ns")
+	assert.NotContains(t, manifest, "        - image: k8s.gcr.io/cluster-autoscaler:v1.12.3")
+	assert.Contains(t, manifest, "        - image: k8s.gcr.io/cluster-autoscaler:v2.0.0")
+	assert.NotContains(t, manifest, "            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/cluster-name-test")
+	assert.Contains(t, manifest, "            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/cluster-name2-test")
+}

--- a/pkg/addons/clusterautoscaler/doc.go
+++ b/pkg/addons/clusterautoscaler/doc.go
@@ -1,0 +1,8 @@
+//go:generate go run -tags=dev templates_generate.go
+
+// Package clusterautoscaler contains:
+// - the logic related to the cluster autoscaler under cluster_autoscaler.go,
+// - the cluster autoscaler's YAML templates under the templates/ directory,
+// - logic to embed these YAML templates inside the eksctl binary via vfsgen in
+//   templates_dev.go and templates_generate.go.
+package clusterautoscaler

--- a/pkg/addons/clusterautoscaler/templates/cluster_autoscaler_autodiscover.yaml.tmpl
+++ b/pkg/addons/clusterautoscaler/templates/cluster_autoscaler_autodiscover.yaml.tmpl
@@ -1,0 +1,157 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: {{ .Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["events", "endpoints"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["watch", "list", "get", "update"]
+  - apiGroups: [""]
+    resources:
+      - "pods"
+      - "services"
+      - "replicationcontrollers"
+      - "persistentvolumeclaims"
+      - "persistentvolumes"
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["batch", "extensions"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "patch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-autoscaler
+  namespace: {{ .Namespace }}
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create","list","watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
+    verbs: ["delete", "get", "update", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: {{ .Namespace }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-autoscaler
+  namespace: {{ .Namespace }}
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: {{ .Namespace }}
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: {{ .Namespace }}
+  labels:
+    app: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+    spec:
+      serviceAccountName: cluster-autoscaler
+      containers:
+        - image: k8s.gcr.io/cluster-autoscaler:{{ .ImageVersion }}
+          name: cluster-autoscaler
+          resources:
+            limits:
+              cpu: 100m
+              memory: 300Mi
+            requests:
+              cpu: 100m
+              memory: 300Mi
+          command:
+            - ./cluster-autoscaler
+            - --v=4
+            - --stderrthreshold=info
+            - --cloud-provider=aws
+            - --skip-nodes-with-local-storage=false
+            - --expander=least-waste
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ .ClusterName }}
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              readOnly: true
+          imagePullPolicy: "Always"
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: "/etc/ssl/certs/ca-bundle.crt"

--- a/pkg/addons/clusterautoscaler/templates_dev.go
+++ b/pkg/addons/clusterautoscaler/templates_dev.go
@@ -1,0 +1,8 @@
+// +build dev
+
+package clusterautoscaler
+
+import "net/http"
+
+// Templates contains the cluster autoscaler's YAML templates.
+var Templates http.FileSystem = http.Dir("templates")

--- a/pkg/addons/clusterautoscaler/templates_generate.go
+++ b/pkg/addons/clusterautoscaler/templates_generate.go
@@ -1,0 +1,21 @@
+// +build ignore
+
+package main
+
+import (
+	"log"
+
+	"github.com/shurcooL/vfsgen"
+	"github.com/weaveworks/eksctl/pkg/addons/clusterautoscaler"
+)
+
+func main() {
+	err := vfsgen.Generate(clusterautoscaler.Templates, vfsgen.Options{
+		PackageName:  "clusterautoscaler",
+		VariableName: "Templates",
+		BuildTags:    "!dev",
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+}


### PR DESCRIPTION
### Description

This PR essentially adds:
```go
func GenerateManifests(params TemplateParameters) ([]byte, error)
```
under `pkg/addons/clusterautoscaler`, which can be used to generate the manifests required to easily [install the cluster autoscaler on EKS](https://aws.amazon.com/premiumsupport/knowledge-center/eks-cluster-autoscaler-setup/).

Note that, it relies on a YAML Go template which is embedded in the `eksctl` binary using `vfsgen`, added to the dependencies via:
```bash
$ GO111MODULE=on go get -u github.com/shurcooL/vfsgen
$ GO111MODULE=on go mod vendor
```

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] ~Manually tested~

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
