### PR TITLE
Spelling Correction

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -51,6 +51,7 @@ Bianca Cheng Costanzo   @bia
 Mathias Lafeldt         @mlafeldt
 Gema Gomez              @gemagomez
 David Hao               @davidhao3300
+Brett Shouse            @bmshouse
 
 /* Thanks */
 

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -308,7 +308,7 @@ func (c *ClusterProvider) SetNodeLabels(ng *api.NodeGroup, meta *api.ClusterMeta
 }
 
 func errTooFewAvailabilityZones(azs []string) error {
-	return fmt.Errorf("only %d zones specified %v, %d are required (can be non-unque)", len(azs), azs, az.MinRequiredAvailabilityZones)
+	return fmt.Errorf("only %d zones specified %v, %d are required (can be non-unique)", len(azs), azs, az.MinRequiredAvailabilityZones)
 }
 
 // SetAvailabilityZones sets the given (or chooses) the availability zones


### PR DESCRIPTION
### Description

A spelling correction of Unique (previously: unque)

### Checklist

n/a