### PR TITLE
Readded the ability to delete a cluster before it's finished creating

### DIFF
--- a/integration/common_test.go
+++ b/integration/common_test.go
@@ -42,9 +42,7 @@ func eksctl(args ...string) *gexec.Session {
 	command.Env = append(command.Env, "EKSCTL_EXPERIMENTAL=true")
 	fmt.Fprintf(GinkgoWriter, "calling %q with %s and %v\n", eksctlPath, "EKSCTL_EXPERIMENTAL=true", args)
 	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-	if err != nil {
-		Fail(fmt.Sprintf("error starting process: %v\n", err), 1)
-	}
+	Expect(err).To(BeNil())
 
 	t := time.Minute
 	switch args[0] {
@@ -65,25 +63,23 @@ func eksctl(args ...string) *gexec.Session {
 
 func eksctlSuccess(args ...string) *gexec.Session {
 	session := eksctl(args...)
-	Expect(session.ExitCode()).To(Equal(0))
+	Expect(session.ExitCode()).To(BeZero())
 	return session
 }
 
 func eksctlFail(args ...string) *gexec.Session {
 	session := eksctl(args...)
-	Expect(session.ExitCode()).To(Not(Equal(0)))
+	Expect(session.ExitCode()).ToNot(BeZero())
 	return session
 }
 
-//eksctlStart starts running an eksctl command, waits 45 seconds, but doesn't wait for it to finish the command
-//This is primarily so that we can run eksctl create ... and then subsequently call eksctl delete on the same cluster.
-func eksctlStart(args ...string) error {
-	cmd := exec.Command(eksctlPath, args...)
+//eksctlStart starts running an eksctl command but doesn't wait for it to finish the command
+//This is primarily so that we can run eksctl create and then subsequently call eksctl delete
+//on the same cluster, but might be useful for other test scenarios as well.
+func eksctlStart(args ...string) (err error) {
 	fmt.Fprintf(GinkgoWriter, "calling %q with %v\n", eksctlPath, args)
-	err := cmd.Start()
-	if err != nil {
-		return err
-	}
-	time.Sleep(45 * time.Second)
-	return nil
+	cmd := exec.Command(eksctlPath, args...)
+	err = cmd.Start()
+	Expect(err).To(BeNil())
+	return
 }

--- a/integration/common_test.go
+++ b/integration/common_test.go
@@ -76,10 +76,9 @@ func eksctlFail(args ...string) *gexec.Session {
 //eksctlStart starts running an eksctl command but doesn't wait for it to finish the command
 //This is primarily so that we can run eksctl create and then subsequently call eksctl delete
 //on the same cluster, but might be useful for other test scenarios as well.
-func eksctlStart(args ...string) (err error) {
+func eksctlStart(args ...string) {
 	fmt.Fprintf(GinkgoWriter, "calling %q with %v\n", eksctlPath, args)
 	cmd := exec.Command(eksctlPath, args...)
-	err = cmd.Start()
+	err := cmd.Start()
 	Expect(err).To(BeNil())
-	return
 }

--- a/integration/common_test.go
+++ b/integration/common_test.go
@@ -74,3 +74,16 @@ func eksctlFail(args ...string) *gexec.Session {
 	Expect(session.ExitCode()).To(Not(Equal(0)))
 	return session
 }
+
+//eksctlStart starts running an eksctl command, waits 45 seconds, but doesn't wait for it to finish the command
+//This is primarily so that we can run eksctl create ... and then subsequently call eksctl delete on the same cluster.
+func eksctlStart(args ...string) error {
+	cmd := exec.Command(eksctlPath, args...)
+	fmt.Fprintf(GinkgoWriter, "calling %q with %v\n", eksctlPath, args)
+	err := cmd.Start()
+	if err != nil {
+		return err
+	}
+	time.Sleep(45 * time.Second)
+	return nil
+}

--- a/integration/createdeletebeforeactive_test.go
+++ b/integration/createdeletebeforeactive_test.go
@@ -1,0 +1,83 @@
+// +build integration
+
+package integration_test
+
+import (
+	"fmt"
+
+	awseks "github.com/aws/aws-sdk-go/service/eks"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/testutils/aws"
+	. "github.com/weaveworks/eksctl/pkg/testutils/matchers"
+)
+
+var _ = Describe("(Integration) Create & Delete before Active", func() {
+	const (
+		initNG = "ng-0"
+		testNG = "ng-1"
+	)
+
+	Describe("when creating a cluster with 1 node", func() {
+		var clName string
+		Context("for deleting a creating cluster", func() {
+			It("should run eksctl and not wait for it to finish", func() {
+
+				fmt.Fprintf(GinkgoWriter, "Using kubeconfig: %s\n", kubeconfigPath)
+
+				if clName == "" {
+					clName = cmdutils.ClusterName("", "") + "-delb4active"
+				}
+
+				eksctlStart("create", "cluster",
+					"--verbose", "4",
+					"--name", clName,
+					"--tags", "alpha.eksctl.io/description=eksctl delete before active test",
+					"--nodegroup-name", initNG,
+					"--node-labels", "ng-name="+initNG,
+					"--node-type", "t2.medium",
+					"--nodes", "1",
+					"--region", region,
+					"--version", version,
+				)
+			})
+		})
+
+		Context("when deleting the (creating) cluster", func() {
+
+			It("should not return an error", func() {
+
+				eksctlSuccess("delete", "cluster",
+					"--verbose", "4",
+					"--name", clName,
+					"--region", region,
+					"--wait",
+				)
+			})
+
+			It("and should have deleted the EKS cluster and both CloudFormation stacks", func() {
+
+				awsSession := aws.NewSession(region)
+
+				Expect(awsSession).ToNot(HaveExistingCluster(clName, awseks.ClusterStatusActive, version))
+
+				Expect(awsSession).ToNot(HaveExistingStack(fmt.Sprintf("eksctl-%s-cluster", clName)))
+				Expect(awsSession).ToNot(HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-ng-%d", clName, 0)))
+			})
+		})
+
+		Context("when trying to delete the cluster again", func() {
+
+			It("should return an a non-zero exit code", func() {
+
+				eksctlFail("delete", "cluster",
+					"--verbose", "4",
+					"--name", clName,
+					"--region", region,
+				)
+			})
+		})
+	})
+})

--- a/integration/createdeletebeforeactive_test.go
+++ b/integration/createdeletebeforeactive_test.go
@@ -15,27 +15,27 @@ import (
 )
 
 const (
-	POLLINTERVAL = 15   //seconds
-	TIMEOUT      = 1200 //seconds = 20 minutes
+	pollInterval = 15   //seconds
+	timeOut      = 1200 //seconds = 20 minutes
 )
 
 var _ = Describe("(Integration) Create & Delete before Active", func() {
 	const initNG = "ng-0"
-	var delb4activeName string
+	var delBeforeActiveName string
 
-	// initialize delb4activeName (and possibly clusterName) for this test suite
+	// initialize delBeforeActiveName (and possibly clusterName) for this test suite
 	if clusterName == "" {
 		clusterName = cmdutils.ClusterName("", "")
 	}
-	if delb4activeName == "" {
-		delb4activeName = clusterName + "-delb4active"
+	if delBeforeActiveName == "" {
+		delBeforeActiveName = clusterName + "-delb4active"
 	}
 
 	Context("when creating a new cluster", func() {
 		It("should not return an error", func() {
 			eksctlStart("create", "cluster",
 				"--verbose", "4",
-				"--name", delb4activeName,
+				"--name", delBeforeActiveName,
 				"--tags", "alpha.eksctl.io/description=eksctl delete before active test",
 				"--nodegroup-name", initNG,
 				"--node-labels", "ng-name="+initNG,
@@ -48,8 +48,8 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 
 		It("should eventually show up as creating", func() {
 			awsSession := aws.NewSession(region)
-			Eventually(awsSession, TIMEOUT, POLLINTERVAL).Should(
-				HaveExistingCluster(delb4activeName, awseks.ClusterStatusCreating, version))
+			Eventually(awsSession, timeOut, pollInterval).Should(
+				HaveExistingCluster(delBeforeActiveName, awseks.ClusterStatusCreating, version))
 		})
 	})
 
@@ -57,7 +57,7 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 		It("deleting cluster should have a zero exitcode", func() {
 			eksctlSuccess("delete", "cluster",
 				"--verbose", "4",
-				"--name", delb4activeName,
+				"--name", delBeforeActiveName,
 				"--region", region,
 			)
 		})
@@ -66,12 +66,12 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 	Context("after the delete of the cluster in progress has been initiated", func() {
 		It("should eventually delete the EKS cluster and both CloudFormation stacks", func() {
 			awsSession := aws.NewSession(region)
-			Eventually(awsSession, TIMEOUT, POLLINTERVAL).ShouldNot(
-				HaveExistingCluster(delb4activeName, awseks.ClusterStatusActive, version))
-			Eventually(awsSession, TIMEOUT, POLLINTERVAL).ShouldNot(
-				HaveExistingStack(fmt.Sprintf("eksctl-%s-cluster", delb4activeName)))
-			Eventually(awsSession, TIMEOUT, POLLINTERVAL).ShouldNot(
-				HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", delb4activeName, initNG)))
+			Eventually(awsSession, timeOut, pollInterval).ShouldNot(
+				HaveExistingCluster(delBeforeActiveName, awseks.ClusterStatusActive, version))
+			Eventually(awsSession, timeOut, pollInterval).ShouldNot(
+				HaveExistingStack(fmt.Sprintf("eksctl-%s-cluster", delBeforeActiveName)))
+			Eventually(awsSession, timeOut, pollInterval).ShouldNot(
+				HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", delBeforeActiveName, initNG)))
 		})
 	})
 
@@ -79,7 +79,7 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 		It("should return an a non-zero exit code", func() {
 			eksctlFail("delete", "cluster",
 				"--verbose", "4",
-				"--name", delb4activeName,
+				"--name", delBeforeActiveName,
 				"--region", region,
 			)
 		})

--- a/integration/createdeletebeforeactive_test.go
+++ b/integration/createdeletebeforeactive_test.go
@@ -21,21 +21,21 @@ const (
 
 var _ = Describe("(Integration) Create & Delete before Active", func() {
 	const initNG = "ng-0"
-	var clName string
+	var delb4activeName string
 
-	// initialize clName (and possibly clusterName) for this test suite
+	// initialize delb4activeName (and possibly clusterName) for this test suite
 	if clusterName == "" {
 		clusterName = cmdutils.ClusterName("", "")
 	}
-	if clName == "" {
-		clName = clusterName + "-delb4active"
+	if delb4activeName == "" {
+		delb4activeName = clusterName + "-delb4active"
 	}
 
 	Context("when creating a new cluster", func() {
 		It("should not return an error", func() {
 			eksctlStart("create", "cluster",
 				"--verbose", "4",
-				"--name", clName,
+				"--name", delb4activeName,
 				"--tags", "alpha.eksctl.io/description=eksctl delete before active test",
 				"--nodegroup-name", initNG,
 				"--node-labels", "ng-name="+initNG,
@@ -49,7 +49,7 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 		It("should eventually show up as creating", func() {
 			awsSession := aws.NewSession(region)
 			Eventually(awsSession, TIMEOUT, POLLINTERVAL).Should(
-				HaveExistingCluster(clName, awseks.ClusterStatusCreating, version))
+				HaveExistingCluster(delb4activeName, awseks.ClusterStatusCreating, version))
 		})
 	})
 
@@ -57,7 +57,7 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 		It("deleting cluster should have a zero exitcode", func() {
 			eksctlSuccess("delete", "cluster",
 				"--verbose", "4",
-				"--name", clName,
+				"--name", delb4activeName,
 				"--region", region,
 			)
 		})
@@ -67,11 +67,11 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 		It("should eventually delete the EKS cluster and both CloudFormation stacks", func() {
 			awsSession := aws.NewSession(region)
 			Eventually(awsSession, TIMEOUT, POLLINTERVAL).ShouldNot(
-				HaveExistingCluster(clName, awseks.ClusterStatusActive, version))
+				HaveExistingCluster(delb4activeName, awseks.ClusterStatusActive, version))
 			Eventually(awsSession, TIMEOUT, POLLINTERVAL).ShouldNot(
-				HaveExistingStack(fmt.Sprintf("eksctl-%s-cluster", clName)))
+				HaveExistingStack(fmt.Sprintf("eksctl-%s-cluster", delb4activeName)))
 			Eventually(awsSession, TIMEOUT, POLLINTERVAL).ShouldNot(
-				HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", clName, initNG)))
+				HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", delb4activeName, initNG)))
 		})
 	})
 
@@ -79,7 +79,7 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 		It("should return an a non-zero exit code", func() {
 			eksctlFail("delete", "cluster",
 				"--verbose", "4",
-				"--name", clName,
+				"--name", delb4activeName,
 				"--region", region,
 			)
 		})

--- a/pkg/ctl/cmdutils/cmd.go
+++ b/pkg/ctl/cmdutils/cmd.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Cmd holds attributes that are common between commands;
-// not all commands use each attribute, but but they can if needed
+// not all commands use each attribute, but they can if needed
 type Cmd struct {
 	CobraCommand *cobra.Command
 	FlagSetGroup *NamedFlagSetGroup

--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -107,7 +107,6 @@ func doDeleteCluster(cmd *cmdutils.Cmd) error {
 
 	{
 
-		logger.Info("cleaning up LoadBalancer services")
 		// only need to cleanup ELBs if the cluster has already been created.
 		if err := ctl.RefreshClusterConfig(cfg); err == nil {
 			cs, err := ctl.NewStdClientSet(cfg)
@@ -116,6 +115,8 @@ func doDeleteCluster(cmd *cmdutils.Cmd) error {
 			}
 			ctx, cleanup := context.WithTimeout(context.Background(), 10*time.Minute)
 			defer cleanup()
+
+			logger.Info("cleaning up LoadBalancer services")
 			if err := elb.Cleanup(ctx, ctl.Provider.EC2(), ctl.Provider.ELB(), ctl.Provider.ELBV2(), cs, cfg); err != nil {
 				return err
 			}

--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -108,19 +108,18 @@ func doDeleteCluster(cmd *cmdutils.Cmd) error {
 	{
 
 		logger.Info("cleaning up LoadBalancer services")
-		if err := ctl.RefreshClusterConfig(cfg); err != nil {
-			return err
+		// only need to cleanup ELBs if the cluster has already been created.
+		if err := ctl.RefreshClusterConfig(cfg); err == nil {
+			cs, err := ctl.NewStdClientSet(cfg)
+			if err != nil {
+				return err
+			}
+			ctx, cleanup := context.WithTimeout(context.Background(), 10*time.Minute)
+			defer cleanup()
+			if err := elb.Cleanup(ctx, ctl.Provider.EC2(), ctl.Provider.ELB(), ctl.Provider.ELBV2(), cs, cfg); err != nil {
+				return err
+			}
 		}
-		cs, err := ctl.NewStdClientSet(cfg)
-		if err != nil {
-			return err
-		}
-		ctx, cleanup := context.WithTimeout(context.Background(), 10*time.Minute)
-		defer cleanup()
-		if err := elb.Cleanup(ctx, ctl.Provider.EC2(), ctl.Provider.ELB(), ctl.Provider.ELBV2(), cs, cfg); err != nil {
-			return err
-		}
-
 		tasks, err := stackManager.NewTasksToDeleteClusterWithNodeGroups(cmd.Wait, func(errs chan error, _ string) error {
 			logger.Info("trying to cleanup dangling network interfaces")
 			if err := ctl.LoadClusterVPC(cfg); err != nil {

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -33,6 +33,7 @@ func (c *ClusterProvider) DescribeControlPlane(cl *api.ClusterMeta) (*awseks.Clu
 }
 
 // DescribeControlPlaneMustBeActive describes the cluster control plane and checks if status is active
+// If status isn't active and error will be returned unless strict is set to false.
 func (c *ClusterProvider) DescribeControlPlaneMustBeActive(cl *api.ClusterMeta) (*awseks.Cluster, error) {
 	cluster, err := c.DescribeControlPlane(cl)
 	if err != nil {
@@ -56,6 +57,7 @@ func (c *ClusterProvider) RefreshClusterConfig(spec *api.ClusterConfig) error {
 	if err != nil {
 		return err
 	}
+
 	logger.Debug("cluster = %#v", cluster)
 
 	data, err := base64.StdEncoding.DecodeString(*cluster.CertificateAuthority.Data)

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -33,7 +33,6 @@ func (c *ClusterProvider) DescribeControlPlane(cl *api.ClusterMeta) (*awseks.Clu
 }
 
 // DescribeControlPlaneMustBeActive describes the cluster control plane and checks if status is active
-// If status isn't active an error will be returned unless strict is set to false.
 func (c *ClusterProvider) DescribeControlPlaneMustBeActive(cl *api.ClusterMeta) (*awseks.Cluster, error) {
 	cluster, err := c.DescribeControlPlane(cl)
 	if err != nil {

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -33,7 +33,7 @@ func (c *ClusterProvider) DescribeControlPlane(cl *api.ClusterMeta) (*awseks.Clu
 }
 
 // DescribeControlPlaneMustBeActive describes the cluster control plane and checks if status is active
-// If status isn't active and error will be returned unless strict is set to false.
+// If status isn't active an error will be returned unless strict is set to false.
 func (c *ClusterProvider) DescribeControlPlaneMustBeActive(cl *api.ClusterMeta) (*awseks.Cluster, error) {
 	cluster, err := c.DescribeControlPlane(cl)
 	if err != nil {
@@ -57,7 +57,6 @@ func (c *ClusterProvider) RefreshClusterConfig(spec *api.ClusterConfig) error {
 	if err != nil {
 		return err
 	}
-
 	logger.Debug("cluster = %#v", cluster)
 
 	data, err := base64.StdEncoding.DecodeString(*cluster.CertificateAuthority.Data)


### PR DESCRIPTION
### Description

A previous PR (#1010) made it a prerequisite that an EKS cluster must
be in an ACTIVE state before `eksctl delete cluster` would be able to
delete the cluster.  This was done to find all the ELBs that were
created due to services in the cluster.  However, if a cluster isn't
created, there can be no ELBs created for the cluster, so this
PR removes that restriction and adds some integration tests for
this use case.

Resolves #1069

## Checklist

- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
