### PR TITLE
Make git shell executor more generic by accepting arbitrary env vars

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -32,8 +32,16 @@ type ClientParams struct {
 // NewGitClient returns a client that can perform git operations
 func NewGitClient(ctx context.Context, params ClientParams) *Client {
 	return &Client{
-		executor: executor.NewShellExecutor(ctx, params.Timeout, params.PrivateSSHKeyPath),
+		executor: executor.NewShellExecutor(ctx, params.Timeout, envVars(params)),
 	}
+}
+
+func envVars(params ClientParams) []string {
+	envVars := []string{}
+	if params.PrivateSSHKeyPath != "" {
+		envVars = append(envVars, fmt.Sprintf("GIT_SSH_COMMAND=ssh -i %s", params.PrivateSSHKeyPath))
+	}
+	return envVars
 }
 
 // NewGitClientFromExecutor returns a client that can have an executor injected. Useful for testing


### PR DESCRIPTION
### Description

After discussion with @martina-if, we decided it would be more flexible to have the git `ShellExecutor` accept an array of environment variables.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] ~Added tests that cover your change (if possible)~
- [x] All unit tests passing (i.e. `make test`)
- [x] ~Added/modified documentation as required (such as the `README.md`, and `examples` directory)~
- [x] ~Manually tested~

Follows up on #1148.