### PR TITLE
eksctl install flux now handles re-installation

### DIFF
--- a/pkg/kubernetes/namespace.go
+++ b/pkg/kubernetes/namespace.go
@@ -2,7 +2,9 @@ package kubernetes
 
 import (
 	"fmt"
+	"math"
 	"strings"
+	"time"
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
@@ -51,6 +53,225 @@ func CheckNamespaceExists(clientSet Interface, name string) (bool, error) {
 		return false, errors.Wrapf(err, "checking whether namespace %q exists", name)
 	}
 	return false, nil
+}
+
+// DeleteNamespace deletes the provided namespace and all resources namespaced
+// under it. It waits until all "common" (pods, deployments, services, etc.)
+// resources are deleted before returning.
+// N.B.: this method does NOT delete non-namespaced resources, e.g.:
+//       ClusterRoles or ClusterRoleBindings.
+func DeleteNamespace(clientSet Interface, namespace string) error {
+	if err := clientSet.CoreV1().Namespaces().Delete(namespace, &metav1.DeleteOptions{}); err != nil {
+		return errors.Wrapf(err, "failed to delete namespace %s", namespace)
+	}
+	logger.Info("deleting namespace %s", namespace)
+	// There may be race conditions if we return right after asynchronously
+	// deleting the namespace, hence we wait for commonly used resources.
+	// This isn't perfect in any way, but given there is no way to directly
+	// list all namespaced resources without using kubectl [1] this will
+	// hopefully do in most cases.
+	// [1]: kubectl api-resources --verbs=list --namespaced -o name \
+	//      | xargs -n 1 kubectl get --show-kind --ignore-not-found -n <namespace>
+	return waitForCommonNamespacedResourcesDeletion(clientSet, namespace)
+}
+
+func waitForCommonNamespacedResourcesDeletion(clientSet Interface, namespace string) error {
+	if err := waitForPodsDeletion(clientSet, namespace); err != nil {
+		return err
+	}
+	if err := waitForDaemonSetsDeletion(clientSet, namespace); err != nil {
+		return err
+	}
+	if err := waitForDeploymentsDeletion(clientSet, namespace); err != nil {
+		return err
+	}
+	if err := waitForExtensionDeploymentsDeletion(clientSet, namespace); err != nil {
+		return err
+	}
+	if err := waitForServicesDeletion(clientSet, namespace); err != nil {
+		return err
+	}
+	if err := waitForConfigMapsDeletion(clientSet, namespace); err != nil {
+		return err
+	}
+	if err := waitForSecretsDeletion(clientSet, namespace); err != nil {
+		return err
+	}
+	if err := waitForServiceAccountsDeletion(clientSet, namespace); err != nil {
+		return err
+	}
+	if err := waitForRolesDeletion(clientSet, namespace); err != nil {
+		return err
+	}
+	if err := waitForNamespaceDeletion(clientSet, namespace); err != nil {
+		return err
+	}
+	logger.Info("deleted namespace %s", namespace)
+	return nil
+}
+
+func waitForPodsDeletion(clientSet Interface, namespace string) error {
+	attempt := 0
+	for {
+		list, err := clientSet.CoreV1().Pods(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "failed to list pods under namespace %s", namespace)
+		}
+		if len(list.Items) == 0 {
+			return nil
+		}
+		time.Sleep(exponentialBackOff(attempt) * time.Second)
+		attempt++
+		logger.Info("waiting for pods under namespace %s to be deleted", namespace)
+	}
+}
+
+func waitForDaemonSetsDeletion(clientSet Interface, namespace string) error {
+	attempt := 0
+	for {
+		list, err := clientSet.AppsV1().DaemonSets(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "failed to list daemonsets under namespace %s", namespace)
+		}
+		if len(list.Items) == 0 {
+			return nil
+		}
+		time.Sleep(exponentialBackOff(attempt) * time.Second)
+		attempt++
+		logger.Info("waiting for daemonsets under namespace %s to be deleted", namespace)
+	}
+}
+
+func waitForDeploymentsDeletion(clientSet Interface, namespace string) error {
+	attempt := 0
+	for {
+		list, err := clientSet.AppsV1().Deployments(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "failed to list corev1/deployments under namespace %s", namespace)
+		}
+		if len(list.Items) == 0 {
+			return nil
+		}
+		time.Sleep(exponentialBackOff(attempt) * time.Second)
+		attempt++
+		logger.Info("waiting for corev1/deployments under namespace %s to be deleted", namespace)
+	}
+}
+
+func waitForExtensionDeploymentsDeletion(clientSet Interface, namespace string) error {
+	attempt := 0
+	for {
+		list, err := clientSet.ExtensionsV1beta1().Deployments(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "failed to list extensionsv1beta1/deployments under namespace %s", namespace)
+		}
+		if len(list.Items) == 0 {
+			return nil
+		}
+		time.Sleep(exponentialBackOff(attempt) * time.Second)
+		attempt++
+		logger.Info("waiting for extensionsv1beta1/deployments under namespace %s to be deleted", namespace)
+	}
+}
+
+func waitForServicesDeletion(clientSet Interface, namespace string) error {
+	attempt := 0
+	for {
+		list, err := clientSet.CoreV1().Services(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "failed to list services under namespace %s", namespace)
+		}
+		if len(list.Items) == 0 {
+			return nil
+		}
+		time.Sleep(exponentialBackOff(attempt) * time.Second)
+		attempt++
+		logger.Info("waiting for services under namespace %s to be deleted", namespace)
+	}
+}
+
+func waitForConfigMapsDeletion(clientSet Interface, namespace string) error {
+	attempt := 0
+	for {
+		list, err := clientSet.CoreV1().ConfigMaps(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "failed to list config maps under namespace %s", namespace)
+		}
+		if len(list.Items) == 0 {
+			return nil
+		}
+		time.Sleep(exponentialBackOff(attempt) * time.Second)
+		attempt++
+		logger.Info("waiting for config maps under namespace %s to be deleted", namespace)
+	}
+}
+
+func waitForSecretsDeletion(clientSet Interface, namespace string) error {
+	attempt := 0
+	for {
+		list, err := clientSet.CoreV1().Secrets(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "failed to list secrets under namespace %s", namespace)
+		}
+		if len(list.Items) == 0 {
+			return nil
+		}
+		time.Sleep(exponentialBackOff(attempt) * time.Second)
+		attempt++
+		logger.Info("waiting for secrets under namespace %s to be deleted", namespace)
+	}
+}
+
+func waitForServiceAccountsDeletion(clientSet Interface, namespace string) error {
+	attempt := 0
+	for {
+		list, err := clientSet.CoreV1().ServiceAccounts(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "failed to list service accounts under namespace %s", namespace)
+		}
+		if len(list.Items) == 0 {
+			return nil
+		}
+		time.Sleep(exponentialBackOff(attempt) * time.Second)
+		attempt++
+		logger.Info("waiting for service accounts under namespace %s to be deleted", namespace)
+	}
+}
+
+func waitForRolesDeletion(clientSet Interface, namespace string) error {
+	attempt := 0
+	for {
+		list, err := clientSet.RbacV1beta1().Roles(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "failed to list roles under namespace %s", namespace)
+		}
+		if len(list.Items) == 0 {
+			return nil
+		}
+		time.Sleep(exponentialBackOff(attempt) * time.Second)
+		attempt++
+		logger.Info("waiting for roles under namespace %s to be deleted", namespace)
+	}
+}
+
+func waitForNamespaceDeletion(clientSet Interface, namespace string) error {
+	attempt := 0
+	for {
+		exists, err := CheckNamespaceExists(clientSet, namespace)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return nil
+		}
+		time.Sleep(exponentialBackOff(attempt) * time.Second)
+		attempt++
+		logger.Info("waiting for namespace %s to be deleted", namespace)
+	}
+}
+
+func exponentialBackOff(attempt int) time.Duration {
+	return time.Duration(math.Pow(2, float64(attempt)))
 }
 
 // MaybeCreateNamespace will only create namespace with the given name if it doesn't


### PR DESCRIPTION
### Description

`eksctl install flux` now handles re-installation by deleting all resources and creating them again.

Other approaches were considered, like simply using `kubectl apply`
but given this would add an external dependency, this solution was
chosen for now.

Also note that we prompt the user before going ahead and deleting all-the-things. See also "_Manual test_" below.

Fixes #1084.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] ~Added tests that cover your change (if possible)~ I didn't add any E2E test for this given the cost associated to them, and given this is an edge case. Also note that there could be a need to mock `stdin` to simulate the user's input, which is feasible with some additional boilerplate, if we nevertheless want to proceed with an E2E test in the future.
- [x] All unit tests passing (i.e. `make test`)
- [x] ~Added/modified documentation as required (such as the `README.md`, and `examples` directory)~
- [x] Manually tested

### Manual test

```console
$ EKSCTL_EXPERIMENTAL=true AWS_PROFILE=default-mfa ./eksctl \
    -f examples/01-simple-cluster.yaml \
    install flux \
    --git-url=git@github.com:marccarre/my-gitops-repo.git \
    --git-email=carre.marc@gmail.com

[ℹ]  Namespace "flux" already exists. eksctl will now delete all its content before proceeding to install Flux.
Continue? [y/n]:
Invalid choice.
Continue? [y/n]: meh
Invalid choice.
Continue? [y/n]: n
[ℹ]  Installation of Flux was aborted.
```

```console
$ EKSCTL_EXPERIMENTAL=true AWS_PROFILE=default-mfa ./eksctl \
    -f examples/01-simple-cluster.yaml \
    install flux \
    --git-url=git@github.com:marccarre/my-gitops-repo.git \
    --git-email=carre.marc@gmail.com

[ℹ]  Namespace "flux" already exists. eksctl will now delete all its content before proceeding to install Flux.
Continue? [y/n]: y
[ℹ]  deleted namespace flux
[ℹ]  waiting for pods under namespace flux to be deleted
[ℹ]  waiting for pods under namespace flux to be deleted
[ℹ]  waiting for pods under namespace flux to be deleted
[ℹ]  waiting for pods under namespace flux to be deleted
[ℹ]  waiting for namespace flux to be deleted
[ℹ]  waiting for namespace flux to be deleted
[ℹ]  waiting for namespace flux to be deleted
[ℹ]  waiting for namespace flux to be deleted
[ℹ]  Generating public key infrastructure for the Helm Operator and Tiller
[ℹ]    this may take up to a minute, please be patient
[!]  Public key infrastructure files were written into directory "/var/folders/24/d3mml6bn20nftpt91cfldq1h0000gn/T/eksctl-helm-pki937905532"
[!]  please move the files into a safe place or delete them
[ℹ]  Generating manifests
[ℹ]  Cloning git@github.com:marccarre/my-gitops-repo.git
Cloning into '/var/folders/24/d3mml6bn20nftpt91cfldq1h0000gn/T/eksctl-install-flux-clone-816069291'...
remote: Enumerating objects: 142, done.
remote: Total 142 (delta 0), reused 0 (delta 0), pack-reused 142
Receiving objects: 100% (142/142), 55.70 KiB | 160.00 KiB/s, done.
Resolving deltas: 100% (40/40), done.
[ℹ]  Writing Flux manifests
[ℹ]  Applying manifests
[ℹ]  created "Namespace/flux"
[ℹ]  created "flux:Deployment.apps/memcached"
[ℹ]  created "flux:Service/memcached"
[ℹ]  created "flux:Deployment.extensions/tiller-deploy"
[ℹ]  replaced "CustomResourceDefinition.apiextensions.k8s.io/helmreleases.helm.fluxcd.io"
[ℹ]  created "flux:Deployment.apps/flux"
[ℹ]  created "flux:Deployment.apps/flux-helm-operator"
[ℹ]  created "flux:ConfigMap/flux-helm-tls-ca-config"
[ℹ]  created "flux:Secret/flux-git-deploy"
[ℹ]  created "flux:Service/tiller-deploy"
[ℹ]  created "flux:ServiceAccount/tiller"
[ℹ]  replaced "ClusterRoleBinding.rbac.authorization.k8s.io/tiller"
[ℹ]  created "flux:ServiceAccount/helm"
[ℹ]  created "flux:Role.rbac.authorization.k8s.io/tiller-user"
[ℹ]  replaced "kube-system:RoleBinding.rbac.authorization.k8s.io/tiller-user-binding"
[ℹ]  created "flux:ServiceAccount/flux"
[ℹ]  replaced "ClusterRole.rbac.authorization.k8s.io/flux"
[ℹ]  replaced "ClusterRoleBinding.rbac.authorization.k8s.io/flux"
[ℹ]  created "flux:ServiceAccount/flux-helm-operator"
[ℹ]  replaced "ClusterRole.rbac.authorization.k8s.io/flux-helm-operator"
[ℹ]  replaced "ClusterRoleBinding.rbac.authorization.k8s.io/flux-helm-operator"
[ℹ]  Applying Helm TLS Secret(s)
[ℹ]  created "flux:Secret/flux-helm-tls-cert"
[ℹ]  created "flux:Secret/tiller-secret"
[!]  Note: certificate secrets aren't added to the Git repository for security reasons
[ℹ]  Waiting for Helm Operator to start
ERROR: logging before flag.Parse: E0827 19:36:51.844610   16191 portforward.go:331] an error occurred forwarding 58983 -> 3030: error forwarding port 3030 to pod beaf29b468ce3d61de1e6d046af8b5445495d1443c7c2dfd9cffb9ac03a5b482, uid : exit status 1: 2019/08/27 10:36:51 socat[12993] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[...]
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:58983/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0827 19:37:10.087267   16191 portforward.go:331] an error occurred forwarding 58983 -> 3030: error forwarding port 3030 to pod beaf29b468ce3d61de1e6d046af8b5445495d1443c7c2dfd9cffb9ac03a5b482, uid : exit status 1: 2019/08/27 10:37:10 socat[13055] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:58983/healthz: EOF), retrying ...
[ℹ]  Helm Operator started successfully
[ℹ]  see https://docs.fluxcd.io/projects/helm-operator for details on how to use the Helm Operator
[ℹ]  Waiting for Flux to start
[ℹ]  Flux started successfully
[ℹ]  see https://docs.fluxcd.io/projects/flux for details on how to use Flux
[ℹ]  Committing and pushing manifests to git@github.com:marccarre/my-gitops-repo.git
[master 23e5094] Add Initial Flux configuration
 1 file changed, 38 insertions(+), 38 deletions(-)
 rewrite flux/tiller-ca-cert-configmap.yaml (87%)
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 8 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 2.15 KiB | 2.15 MiB/s, done.
Total 4 (delta 1), reused 0 (delta 0)
remote: Resolving deltas: 100% (1/1), completed with 1 local object.
To github.com:marccarre/my-gitops-repo.git
   8535eb4..23e5094  master -> master
[ℹ]  Flux will only operate properly once it has write-access to the Git repository
[ℹ]  please configure git@github.com:marccarre/my-gitops-repo.git so that the following Flux SSH public key has write access to it
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDlp4wLL67rDn6EsNq4LOUbmx7SQ3taOoMl0cykQJf+AFqhEGDLHR9CrtNnoAsAkqiuykrEdj3c1k3a1I0p+o2+hp0iimWa/t9Q+woSYXv3TfNhnw9mMfM6HKNE/7m63j3aUg5o1nsM2fm+Rs67orw4mtjxML9PJJ/Zmq8mDsWNH93Q6WKMwdi2JHhyXVZu0CR0IAzqPU3TQ6McPlZ+coiQtlSJzf9gTu8ImkYK+J4nLvo40BNsFgCNbyxVzHUN9zfjoeMUhhRvj6YRVLBkE06nfxzP6t/UdflHTjfatQR137Pex43HQ6+RV/C6gcX0n3rm8vaIwiSaHb1LimZ/Maiv
```