### PR TITLE
Rename reference to eks-gitops-example to eks-quickstart-app-dev

### DIFF
--- a/pkg/ctl/gitops/apply.go
+++ b/pkg/ctl/gitops/apply.go
@@ -175,8 +175,7 @@ func repoURLForQuickstart(quickstartArgument string) (string, error) {
 		return quickstartArgument, nil
 	}
 	if quickstartArgument == "app-dev" {
-		// FIXME rename to eks-quickstart-app-dev once the repo is renamed
-		return "git@github.com:weaveworks/eks-gitops-example.git", nil
+		return "git@github.com:weaveworks/eks-quickstart-app-dev.git", nil
 	}
 	return "", fmt.Errorf("invalid URL or unknown Quick Start %s ", quickstartArgument)
 }


### PR DESCRIPTION
### Description
The eks-gitops-example repo has been renamed to eks-quickstart-app-dev. This change updates the reference.
<!-- Please explain the changes you made here. -->

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)


<!-- If you haven't done so already, you can add your name to the humans.txt file -->
