### PR TITLE
 Fix CloneRepoInPath() for relative directories

### DIFF
--- a/pkg/ctl/gitops/apply.go
+++ b/pkg/ctl/gitops/apply.go
@@ -151,7 +151,6 @@ func doApplyGitops(cmd *cmdutils.Cmd, opts options) error {
 	gitClient := git.NewGitClient(context.Background(), git.ClientParams{
 		PrivateSSHKeyPath: opts.gitPrivateSSHKeyPath,
 		Timeout:           git.DefaultGitTimeout,
-		Dir:               usersRepoDir,
 	})
 
 	gitOps := gitops.Applier{

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -84,7 +84,7 @@ func (git *Client) CloneRepoInPath(clonePath string, branch string, gitURL strin
 	if err := os.MkdirAll(git.dir, 0700); err != nil {
 		return errors.Wrapf(err, "unable to create directory for cloning")
 	}
-	args := []string{"clone", "-b", branch, gitURL, git.dir}
+	args := []string{"clone", "-b", branch, gitURL, "."}
 	return git.runGitCmd(args...)
 }
 

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -80,12 +80,17 @@ func (git *Client) CloneRepo(cloneDirPrefix string, branch string, gitURL string
 
 // CloneRepoInPath clones a repo to the specified directory
 func (git *Client) CloneRepoInPath(clonePath string, branch string, gitURL string) error {
-	git.dir = clonePath
-	if err := os.MkdirAll(git.dir, 0700); err != nil {
+	if err := os.MkdirAll(clonePath, 0700); err != nil {
 		return errors.Wrapf(err, "unable to create directory for cloning")
 	}
-	args := []string{"clone", "-b", branch, gitURL, "."}
-	return git.runGitCmd(args...)
+	args := []string{"clone", "-b", branch, gitURL, clonePath}
+	if err := git.runGitCmd(args...); err != nil {
+		return err
+	}
+	// Set the working directory only after the clone so that
+	// it doesn't create an undesirable nested directory
+	git.dir = clonePath
+	return nil
 }
 
 // Add performs can perform a `git add` operation on the given file paths

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -36,7 +36,6 @@ type Client struct {
 type ClientParams struct {
 	Timeout           time.Duration
 	PrivateSSHKeyPath string
-	Dir               string
 }
 
 // Options holds options for cloning a git repository

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -37,7 +37,7 @@ var _ = Describe("GitClient", func() {
 
 		// It called clone
 		Expect(err).To(Not(HaveOccurred()))
-		Expect(fakeExecutor.Dir).To(Equal(tempCloneDir))
+		Expect(fakeExecutor.Dir).To(Equal(""))
 		Expect(fakeExecutor.Args).To(
 			Equal([]string{"clone", "-b", "my-branch", "git@example.com:test/example-repo.git", tempCloneDir}))
 


### PR DESCRIPTION
CloneRepoInPath() did the equivalent of

```
( mkdir $DIR; cd $DIR; git clone url $DIR )
```

There is no need to specify the directory where to clone once
you are in it.

This happened to work with absolute directories:

```
cd /tmp/foo; git clone url /tmp/foo
```

But broke with relative directories, causing the clone to happen
in a nested directory (foo/foo) in the example below:

```
cd foo; git clone url foo
```

This went unnoticed:
1. For `eksctl install flux` and `eksctl generate profile`: because
   they use absolute directories.
2. For `eksctl gitops apply` because the integration test uses
   an absolute `--output-path` parameter.

The problem was introduced at https://github.com/weaveworks/eksctl/pull/1095/files#diff-4de8c4734d5ffab0d7fd8835bf8b3421R47-R48

Fixes #1219