### PR TITLE
Enforce SSH Git URLs in install flux & gitops apply commands

### DIFF
--- a/pkg/ctl/gitops/apply.go
+++ b/pkg/ctl/gitops/apply.go
@@ -44,7 +44,7 @@ func applyGitops(cmd *cmdutils.Cmd) {
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&opts.quickstartNameArg, "quickstart-profile", "", "", "name or URL of the Quick Start profile. For example, app-dev.")
-		fs.StringVarP(&opts.gitOptions.URL, "git-url", "", "", "URL for the git repository that will contain the cluster components")
+		fs.StringVarP(&opts.gitOptions.URL, "git-url", "", "", "SSH URL of the Git repository that will contain the cluster components, e.g.: git@github.com:<github_org>/<repo_name>")
 		fs.StringVarP(&opts.gitOptions.Branch, "git-branch", "", "master", "Git branch")
 		fs.StringVarP(&opts.outputPath, "output-path", "", "./", "Path to directory where the GitOps repo will be cloned")
 		fs.StringVar(&opts.gitOptions.User, "git-user", "Flux", "Username to use as Git committer")

--- a/pkg/ctl/gitops/apply.go
+++ b/pkg/ctl/gitops/apply.go
@@ -73,8 +73,8 @@ func doApplyGitops(cmd *cmdutils.Cmd, opts options) error {
 		return errors.New("please supply a valid gitops Quick Start URL or name in --quickstart-profile")
 	}
 
-	if opts.gitOptions.URL == "" {
-		return errors.New("please supply a valid --git-url argument")
+	if err := opts.gitOptions.ValidateURL(); err != nil {
+		return errors.Wrapf(err, "please supply a valid --git-url argument")
 	}
 	if opts.gitPrivateSSHKeyPath != "" && !file.Exists(opts.gitPrivateSSHKeyPath) {
 		return errors.New("please supply a valid --git-private-ssh-key-path argument")

--- a/pkg/ctl/gitops/apply.go
+++ b/pkg/ctl/gitops/apply.go
@@ -74,7 +74,7 @@ func doApplyGitops(cmd *cmdutils.Cmd, opts options) error {
 	}
 
 	if err := opts.gitOptions.ValidateURL(); err != nil {
-		return errors.Wrapf(err, "please supply a valid --git-url argument")
+		return errors.Wrap(err, "please supply a valid --git-url argument")
 	}
 	if opts.gitPrivateSSHKeyPath != "" && !file.Exists(opts.gitPrivateSSHKeyPath) {
 		return errors.New("please supply a valid --git-private-ssh-key-path argument")
@@ -82,7 +82,7 @@ func doApplyGitops(cmd *cmdutils.Cmd, opts options) error {
 
 	quickstartRepoURL, err := repoURLForQuickstart(opts.quickstartNameArg)
 	if err != nil {
-		return errors.Wrapf(err, "please supply a valid Quick Start name or URL")
+		return errors.Wrap(err, "please supply a valid Quick Start name or URL")
 	}
 
 	if err := cmdutils.NewGitopsMetadataLoader(cmd).Load(); err != nil {

--- a/pkg/ctl/gitops/apply.go
+++ b/pkg/ctl/gitops/apply.go
@@ -117,10 +117,7 @@ func doApplyGitops(cmd *cmdutils.Cmd, opts options) error {
 
 	// Create the flux installer. It will clone the user's repository in the outputPath
 	fluxOpts := flux.InstallOpts{
-		GitURL:      opts.gitOptions.URL,
-		GitBranch:   opts.gitOptions.Branch,
-		GitEmail:    opts.gitOptions.Email,
-		GitUser:     opts.gitOptions.User,
+		GitOptions:  opts.gitOptions,
 		Namespace:   "flux",
 		GitFluxPath: "flux/",
 		WithHelm:    true,

--- a/pkg/ctl/gitops/apply.go
+++ b/pkg/ctl/gitops/apply.go
@@ -44,13 +44,13 @@ func applyGitops(cmd *cmdutils.Cmd) {
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&opts.quickstartNameArg, "quickstart-profile", "", "", "name or URL of the Quick Start profile. For example, app-dev.")
-		fs.StringVarP(&opts.gitOptions.URL, "git-url", "", "", "SSH URL of the Git repository that will contain the cluster components, e.g.: git@github.com:<github_org>/<repo_name>")
+		fs.StringVarP(&opts.gitOptions.URL, "git-url", "", "", "SSH URL of the Git repository that will contain the cluster components, e.g. git@github.com:<github_org>/<repo_name>")
 		fs.StringVarP(&opts.gitOptions.Branch, "git-branch", "", "master", "Git branch")
 		fs.StringVarP(&opts.outputPath, "output-path", "", "./", "Path to directory where the GitOps repo will be cloned")
 		fs.StringVar(&opts.gitOptions.User, "git-user", "Flux", "Username to use as Git committer")
 		fs.StringVar(&opts.gitOptions.Email, "git-email", "", "Email to use as Git committer")
 		fs.StringVar(&opts.gitPrivateSSHKeyPath, "git-private-ssh-key-path", "",
-			"Optional path to the private SSH key to use with Git, e.g.: ~/.ssh/id_rsa")
+			"Optional path to the private SSH key to use with Git, e.g. ~/.ssh/id_rsa")
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "name of the EKS cluster to add the nodegroup to")
 
 		requiredFlags := []string{"quickstart-profile", "git-url", "cluster", "git-email"}

--- a/pkg/ctl/install/flux.go
+++ b/pkg/ctl/install/flux.go
@@ -23,10 +23,10 @@ func installFluxCmd(cmd *cmdutils.Cmd) {
 	)
 	var opts flux.InstallOpts
 	cmd.SetRunFuncWithNameArg(func() error {
-		if opts.GitURL == "" {
+		if opts.GitOptions.URL == "" {
 			return errors.New("please supply a valid --git-url argument")
 		}
-		if opts.GitEmail == "" {
+		if opts.GitOptions.Email == "" {
 			return errors.New("please supply a valid --git-email argument")
 		}
 		if opts.GitPrivateSSHKeyPath != "" && !file.Exists(opts.GitPrivateSSHKeyPath) {
@@ -68,17 +68,17 @@ func installFluxCmd(cmd *cmdutils.Cmd) {
 	})
 
 	cmd.FlagSetGroup.InFlagSet("Flux installation", func(fs *pflag.FlagSet) {
-		fs.StringVar(&opts.GitURL, "git-url", "",
+		fs.StringVar(&opts.GitOptions.URL, "git-url", "",
 			"URL of the Git repository to be used by Flux, e.g. git@github.com:<github_org>/flux-get-started")
-		fs.StringVar(&opts.GitBranch, "git-branch", "master",
+		fs.StringVar(&opts.GitOptions.Branch, "git-branch", "master",
 			"Git branch to be used by Flux")
 		fs.StringSliceVar(&opts.GitPaths, "git-paths", []string{},
 			"Relative paths within the Git repo for Flux to locate Kubernetes manifests")
 		fs.StringVar(&opts.GitLabel, "git-label", "flux",
 			"Git label to keep track of Flux's sync progress; overrides both --git-sync-tag and --git-notes-ref")
-		fs.StringVar(&opts.GitUser, "git-user", "Flux",
+		fs.StringVar(&opts.GitOptions.User, "git-user", "Flux",
 			"Username to use as Git committer")
-		fs.StringVar(&opts.GitEmail, "git-email", "",
+		fs.StringVar(&opts.GitOptions.Email, "git-email", "",
 			"Email to use as Git committer")
 		fs.StringVar(&opts.GitFluxPath, "git-flux-subdir", "flux/",
 			"Directory within the Git repository where to commit the Flux manifests")

--- a/pkg/ctl/install/flux.go
+++ b/pkg/ctl/install/flux.go
@@ -69,7 +69,7 @@ func installFluxCmd(cmd *cmdutils.Cmd) {
 
 	cmd.FlagSetGroup.InFlagSet("Flux installation", func(fs *pflag.FlagSet) {
 		fs.StringVar(&opts.GitOptions.URL, "git-url", "",
-			"URL of the Git repository to be used by Flux, e.g. git@github.com:<github_org>/flux-get-started")
+			"SSH URL of the Git repository to be used by Flux, e.g.: git@github.com:<github_org>/<repo_name>")
 		fs.StringVar(&opts.GitOptions.Branch, "git-branch", "master",
 			"Git branch to be used by Flux")
 		fs.StringSliceVar(&opts.GitPaths, "git-paths", []string{},

--- a/pkg/ctl/install/flux.go
+++ b/pkg/ctl/install/flux.go
@@ -24,7 +24,7 @@ func installFluxCmd(cmd *cmdutils.Cmd) {
 	var opts flux.InstallOpts
 	cmd.SetRunFuncWithNameArg(func() error {
 		if err := opts.GitOptions.ValidateURL(); err != nil {
-			return errors.Wrapf(err, "please supply a valid --git-url argument")
+			return errors.Wrap(err, "please supply a valid --git-url argument")
 		}
 		if opts.GitOptions.Email == "" {
 			return errors.New("please supply a valid --git-email argument")

--- a/pkg/ctl/install/flux.go
+++ b/pkg/ctl/install/flux.go
@@ -69,7 +69,7 @@ func installFluxCmd(cmd *cmdutils.Cmd) {
 
 	cmd.FlagSetGroup.InFlagSet("Flux installation", func(fs *pflag.FlagSet) {
 		fs.StringVar(&opts.GitOptions.URL, "git-url", "",
-			"SSH URL of the Git repository to be used by Flux, e.g.: git@github.com:<github_org>/<repo_name>")
+			"SSH URL of the Git repository to be used by Flux, e.g. git@github.com:<github_org>/<repo_name>")
 		fs.StringVar(&opts.GitOptions.Branch, "git-branch", "master",
 			"Git branch to be used by Flux")
 		fs.StringSliceVar(&opts.GitPaths, "git-paths", []string{},
@@ -83,7 +83,7 @@ func installFluxCmd(cmd *cmdutils.Cmd) {
 		fs.StringVar(&opts.GitFluxPath, "git-flux-subdir", "flux/",
 			"Directory within the Git repository where to commit the Flux manifests")
 		fs.StringVar(&opts.GitPrivateSSHKeyPath, "git-private-ssh-key-path", "",
-			"Optional path to the private SSH key to use with Git, e.g.: ~/.ssh/id_rsa")
+			"Optional path to the private SSH key to use with Git, e.g. ~/.ssh/id_rsa")
 		fs.StringVar(&opts.Namespace, "namespace", "flux",
 			"Cluster namespace where to install Flux, the Helm Operator and Tiller")
 		fs.BoolVar(&opts.WithHelm, "with-helm", true,

--- a/pkg/ctl/install/flux.go
+++ b/pkg/ctl/install/flux.go
@@ -23,8 +23,8 @@ func installFluxCmd(cmd *cmdutils.Cmd) {
 	)
 	var opts flux.InstallOpts
 	cmd.SetRunFuncWithNameArg(func() error {
-		if opts.GitOptions.URL == "" {
-			return errors.New("please supply a valid --git-url argument")
+		if err := opts.GitOptions.ValidateURL(); err != nil {
+			return errors.Wrapf(err, "please supply a valid --git-url argument")
 		}
 		if opts.GitOptions.Email == "" {
 			return errors.New("please supply a valid --git-email argument")

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -62,7 +62,8 @@ func (o Options) ValidateURL() error {
 }
 
 func (o Options) isSSHURL() bool {
-	return strings.HasPrefix(o.URL, "git@") || strings.HasPrefix(o.URL, "ssh://")
+	url, err := giturls.Parse(o.URL)
+	return err == nil && (url.Scheme == "git" || url.Scheme == "ssh")
 }
 
 // NewGitClient returns a client that can perform git operations

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -46,6 +46,25 @@ type Options struct {
 	Email  string
 }
 
+// ValidateURL validates the URL field of this Options object, returning an
+// error should the current value not be valid.
+func (o Options) ValidateURL() error {
+	if o.URL == "" {
+		return errors.New("empty Git URL")
+	}
+	if !IsGitURL(o.URL) {
+		return errors.New("invalid Git URL")
+	}
+	if !o.isSSHURL() {
+		return errors.New("got a HTTP(S) Git URL, but eksctl currently only supports SSH Git URLs")
+	}
+	return nil
+}
+
+func (o Options) isSSHURL() bool {
+	return strings.HasPrefix(o.URL, "git@") || strings.HasPrefix(o.URL, "ssh://")
+}
+
 // NewGitClient returns a client that can perform git operations
 func NewGitClient(ctx context.Context, params ClientParams) *Client {
 	return &Client{

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -141,6 +141,32 @@ var _ = Describe("git", func() {
 			Expect(git.IsGitURL("app-dev")).To(BeFalse())
 		})
 	})
+
+	Describe("Options", func() {
+		Describe("ValidateURL", func() {
+			It("returns an error on empty Git URL", func() {
+				Expect(git.Options{}.ValidateURL()).To(MatchError("empty Git URL"))
+			})
+
+			It("returns an error on invalid Git URL", func() {
+				Expect(git.Options{
+					URL: "https://",
+				}.ValidateURL()).To(MatchError("invalid Git URL"))
+			})
+
+			It("returns an error on HTTPS Git URL", func() {
+				Expect(git.Options{
+					URL: "https://github.com/eksctl-bot/my-gitops-repo.git",
+				}.ValidateURL()).To(MatchError("got a HTTP(S) Git URL, but eksctl currently only supports SSH Git URLs"))
+			})
+
+			It("succeeds when a SSH Git URL is provided", func() {
+				Expect(git.Options{
+					URL: "git@github.com:eksctl-bot/my-gitops-repo.git",
+				}.ValidateURL()).NotTo(HaveOccurred())
+			})
+		})
+	})
 })
 
 func deleteTempDir(tempDir string) {

--- a/pkg/gitops/flux/installer_test.go
+++ b/pkg/gitops/flux/installer_test.go
@@ -8,18 +8,21 @@ import (
 	"github.com/instrumenta/kubeval/kubeval"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/git"
 	"k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/yaml"
 )
 
 var _ = Describe("Installer", func() {
 	mockOpts := &InstallOpts{
-		GitURL:      "git@github.com/foo/bar.git",
-		GitBranch:   "gitbranch",
+		GitOptions: git.Options{
+			URL:    "git@github.com/foo/bar.git",
+			Branch: "gitbranch",
+			User:   "gituser",
+			Email:  "gitemail@example.com",
+		},
 		GitPaths:    []string{"gitpath/"},
 		GitLabel:    "gitlabel",
-		GitUser:     "gituser",
-		GitEmail:    "gitemail@example.com",
 		GitFluxPath: "fluxpath/",
 		Namespace:   "fluxnamespace",
 		WithHelm:    true,


### PR DESCRIPTION
### Description

Fixes #1212, specifically, implements `2. (d)` mentioned [here](https://github.com/weaveworks/eksctl/issues/1212#issuecomment-526163555) by @2opremio.
Some clean-up and factorisation where possible/easy/relevant in the process.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] ~Added/modified documentation as required (such as the `README.md`, and `examples` directory)~
- [x] Manually tested

### Manual tests

```console
$ EKSCTL_EXPERIMENTAL=true ./eksctl install flux
[✖]  please supply a valid --git-url argument: empty Git URL

$ EKSCTL_EXPERIMENTAL=true ./eksctl install flux --git-url meh
[✖]  please supply a valid --git-url argument: invalid Git URL

$ EKSCTL_EXPERIMENTAL=true ./eksctl install flux --git-url https://github.com/marccarre/my-gitops-repo.git
[✖]  please supply a valid --git-url argument: got a HTTP(S) Git URL, but eksctl currently only supports SSH Git URLs

$ EKSCTL_EXPERIMENTAL=true ./eksctl install flux --git-url git@github.com:marccarre/my-gitops-repo.git
[... No error on the Git URL...]

$ EKSCTL_EXPERIMENTAL=true ./eksctl install flux --help
Bootstrap Flux, installing it in the cluster and initializing its manifests in the specified Git repository

Usage: eksctl install flux [flags]

Flux installation flags:
      --git-url string                    SSH URL of the Git repository to be used by Flux, e.g. git@github.com:<github_org>/<repo_name>
[...]
```

```console
$ EKSCTL_EXPERIMENTAL=true ./eksctl gitops apply --cluster gitops --quickstart-profile app-dev --git-url meh
[✖]  please supply a valid --git-url argument: invalid Git URL

$ EKSCTL_EXPERIMENTAL=true ./eksctl gitops apply --cluster gitops --quickstart-profile app-dev --git-url https://github.com/marccarre/my-gitops-repo.git
[✖]  please supply a valid --git-url argument: got a HTTP(S) Git URL, but eksctl currently only supports SSH Git URLs

$ EKSCTL_EXPERIMENTAL=true ./eksctl gitops apply --cluster gitops --quickstart-profile app-dev --git-url git@github.com:marccarre/my-gitops-repo.git
[... No error on the Git URL...]

$ EKSCTL_EXPERIMENTAL=true ./eksctl gitops apply --help
Setting up GitOps and apply a Quick Start profile

Usage: eksctl gitops apply [flags]

General flags:
      --quickstart-profile string         name or URL of the Quick Start profile. For example, app-dev.
      --git-url string                    SSH URL of the Git repository that will contain the cluster components, e.g. git@github.com:<github_org>/<repo_name>
[...]
```
