### PR TITLE
 Fix --cluster parameter validation for gitops and install commands

### DIFF
--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -126,8 +126,13 @@ func NewGitopsMetadataLoader(cmd *Cmd) ClusterConfigLoader {
 	l := newCommonClusterConfigLoader(cmd)
 
 	l.validateWithoutConfigFile = func() error {
+		meta := l.ClusterConfig.Metadata
+		if meta.Name == "" {
+			return ErrMustBeSet("--cluster")
+		}
 		return nil
 	}
+
 	return l
 }
 

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -121,8 +121,8 @@ func NewMetadataLoader(cmd *Cmd) ClusterConfigLoader {
 	return l
 }
 
-// NewGitopsMetadataLoader handles loading of clusterConfigFile vs using flags for gitops commands
-func NewGitopsMetadataLoader(cmd *Cmd) ClusterConfigLoader {
+// NewGitopsApplyLoader handles loading of clusterConfigFile vs using flags for gitops commands
+func NewGitopsApplyLoader(cmd *Cmd) ClusterConfigLoader {
 	l := newCommonClusterConfigLoader(cmd)
 
 	l.validateWithoutConfigFile = func() error {
@@ -136,8 +136,8 @@ func NewGitopsMetadataLoader(cmd *Cmd) ClusterConfigLoader {
 	return l
 }
 
-// NewInstallMetadataLoader handles loading of clusterConfigFile vs using flags for install commands
-func NewInstallMetadataLoader(cmd *Cmd) ClusterConfigLoader {
+// NewInstallFluxLoader handles loading of clusterConfigFile vs using flags for install commands
+func NewInstallFluxLoader(cmd *Cmd) ClusterConfigLoader {
 	l := newCommonClusterConfigLoader(cmd)
 
 	l.validateWithoutConfigFile = func() error {

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -136,6 +136,21 @@ func NewGitopsMetadataLoader(cmd *Cmd) ClusterConfigLoader {
 	return l
 }
 
+// NewInstallMetadataLoader handles loading of clusterConfigFile vs using flags for install commands
+func NewInstallMetadataLoader(cmd *Cmd) ClusterConfigLoader {
+	l := newCommonClusterConfigLoader(cmd)
+
+	l.validateWithoutConfigFile = func() error {
+		meta := l.ClusterConfig.Metadata
+		if meta.Name == "" {
+			return ErrMustBeSet("--cluster")
+		}
+		return nil
+	}
+
+	return l
+}
+
 // NewCreateClusterLoader will load config or use flags for 'eksctl create cluster'
 func NewCreateClusterLoader(cmd *Cmd, ngFilter *NodeGroupFilter, ng *api.NodeGroup, withoutNodeGroup bool) ClusterConfigLoader {
 	l := newCommonClusterConfigLoader(cmd)

--- a/pkg/ctl/gitops/apply.go
+++ b/pkg/ctl/gitops/apply.go
@@ -85,7 +85,7 @@ func doApplyGitops(cmd *cmdutils.Cmd, opts options) error {
 		return errors.Wrap(err, "please supply a valid Quick Start name or URL")
 	}
 
-	if err := cmdutils.NewGitopsMetadataLoader(cmd).Load(); err != nil {
+	if err := cmdutils.NewGitopsApplyLoader(cmd).Load(); err != nil {
 		return err
 	}
 	cfg := cmd.ClusterConfig

--- a/pkg/ctl/gitops/apply.go
+++ b/pkg/ctl/gitops/apply.go
@@ -53,7 +53,7 @@ func applyGitops(cmd *cmdutils.Cmd) {
 			"Optional path to the private SSH key to use with Git, e.g. ~/.ssh/id_rsa")
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "name of the EKS cluster to add the nodegroup to")
 
-		requiredFlags := []string{"quickstart-profile", "git-url", "cluster", "git-email"}
+		requiredFlags := []string{"quickstart-profile", "git-url", "git-email"}
 		for _, f := range requiredFlags {
 			if err := cobra.MarkFlagRequired(fs, f); err != nil {
 				logger.Critical("unexpected error: %v", err)

--- a/pkg/ctl/install/flux.go
+++ b/pkg/ctl/install/flux.go
@@ -33,7 +33,7 @@ func installFluxCmd(cmd *cmdutils.Cmd) {
 			return errors.New("please supply a valid --git-private-ssh-key-path argument")
 		}
 
-		if err := cmdutils.NewInstallMetadataLoader(cmd).Load(); err != nil {
+		if err := cmdutils.NewInstallFluxLoader(cmd).Load(); err != nil {
 			return err
 		}
 		cfg := cmd.ClusterConfig

--- a/pkg/ctl/install/flux.go
+++ b/pkg/ctl/install/flux.go
@@ -33,7 +33,7 @@ func installFluxCmd(cmd *cmdutils.Cmd) {
 			return errors.New("please supply a valid --git-private-ssh-key-path argument")
 		}
 
-		if err := cmdutils.NewMetadataLoader(cmd).Load(); err != nil {
+		if err := cmdutils.NewInstallMetadataLoader(cmd).Load(); err != nil {
 			return err
 		}
 		cfg := cmd.ClusterConfig


### PR DESCRIPTION
We were not validating the flags properly in the `gitops apply` and `install flux` commands:

1. `gitops apply` enforced `--cluster` (which shouldn't since the user can provide a config file)
2. `install flux` declared a `--cluster` parameter, but validated whether `--name` was present.

This PR doesn't take any measures towards preventing this from happening in the future. I have created https://github.com/weaveworks/eksctl/issues/1240 for that purpose.

Fixes #1223 