### PR TITLE
Create branch if none existed when cloning gitops repo

### DIFF
--- a/pkg/git/executor/fake_executor.go
+++ b/pkg/git/executor/fake_executor.go
@@ -5,16 +5,10 @@ import "github.com/stretchr/testify/mock"
 // FakeExecutor is a test double that records the arguments used for calling it
 type FakeExecutor struct {
 	mock.Mock
-	Command string
-	Dir     string
-	Args    []string
 }
 
 // Exec records the arguments used to call it
 func (e *FakeExecutor) Exec(command string, dir string, args ...string) error {
-	e.Command = command
-	e.Dir = dir
-	e.Args = args
 	called := e.Called(command, dir, args)
 	return called.Error(0)
 }

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -128,12 +128,11 @@ func (git *Client) cloneRepoInPath(clonePath string, options CloneOptions) error
 		// Switch to target branch
 		args := []string{"checkout", options.Branch}
 		if options.Bootstrap {
-			// create the branch if the repository is empty (no pre-existing branches)
-			files, err := ioutil.ReadDir(filepath.Join(git.dir, ".git", "refs", "heads"))
+			empty, err := git.isRepoEmpty()
 			if err != nil {
 				return err
 			}
-			if len(files) == 0 {
+			if empty {
 				args = []string{"checkout", "-b", options.Branch}
 			}
 		}
@@ -143,6 +142,15 @@ func (git *Client) cloneRepoInPath(clonePath string, options CloneOptions) error
 	}
 
 	return nil
+}
+
+func (git *Client) isRepoEmpty() (bool, error) {
+	// A repository is empty if it doesn't have branches
+	files, err := ioutil.ReadDir(filepath.Join(git.dir, ".git", "refs", "heads"))
+	if err != nil {
+		return false, err
+	}
+	return len(files) == 0, nil
 }
 
 // Add performs can perform a `git add` operation on the given file paths

--- a/pkg/gitops/apply.go
+++ b/pkg/gitops/apply.go
@@ -32,7 +32,12 @@ func (g *Applier) Run(ctx context.Context) error {
 	}
 
 	// Clone user's repo to apply Quick Start profile
-	err = g.GitClient.CloneRepoInPath(g.UserRepoPath, g.UsersRepoOpts.Branch, g.UsersRepoOpts.URL)
+	options := git.CloneOptions{
+		URL:       g.UsersRepoOpts.URL,
+		Branch:    g.UsersRepoOpts.Branch,
+		Bootstrap: true,
+	}
+	err = g.GitClient.CloneRepoInPath(g.UserRepoPath, options)
 	if err != nil {
 		return err
 	}

--- a/pkg/gitops/flux/installer.go
+++ b/pkg/gitops/flux/installer.go
@@ -144,7 +144,12 @@ func (fi *Installer) Run(ctx context.Context) error {
 	}
 
 	logger.Info("Cloning %s", fi.opts.GitOptions.URL)
-	cloneDir, err := fi.gitClient.CloneRepo("eksctl-install-flux-clone-", fi.opts.GitOptions.Branch, fi.opts.GitOptions.URL)
+	options := git.CloneOptions{
+		URL:       fi.opts.GitOptions.URL,
+		Branch:    fi.opts.GitOptions.Branch,
+		Bootstrap: true,
+	}
+	cloneDir, err := fi.gitClient.CloneRepoInTmpDir("eksctl-install-flux-clone-", options)
 	if err != nil {
 		return errors.Wrapf(err, "cannot clone repository %s", fi.opts.GitOptions.URL)
 	}

--- a/pkg/gitops/gitops_test.go
+++ b/pkg/gitops/gitops_test.go
@@ -17,8 +17,8 @@ type mockCloner struct {
 	mock.Mock
 }
 
-func (m *mockCloner) CloneRepo(cloneDirPrefix string, branch string, gitURL string) (string, error) {
-	args := m.Called(cloneDirPrefix, branch, gitURL)
+func (m *mockCloner) CloneRepoInTmpDir(cloneDirPrefix string, options git.CloneOptions) (string, error) {
+	args := m.Called(cloneDirPrefix, options)
 	return args.String(0), args.Error(1)
 }
 
@@ -47,7 +47,7 @@ var _ = Describe("gitops profile", func() {
 
 			// mock git clone
 			gitCloner = new(mockCloner)
-			gitCloner.On("CloneRepo", mock.Anything, mock.Anything, mock.Anything).Return(testDir, nil)
+			gitCloner.On("CloneRepoInTmpDir", mock.Anything, mock.Anything, mock.Anything).Return(testDir, nil)
 
 			// output path
 			outputDir, _ = io.TempDir("", "test-output-dir-")

--- a/pkg/gitops/profile.go
+++ b/pkg/gitops/profile.go
@@ -23,7 +23,7 @@ type Profile struct {
 	Processor fileprocessor.FileProcessor
 	Path      string
 	GitOpts   git.Options
-	GitCloner git.Cloner
+	GitCloner git.TmpCloner
 	FS        afero.Fs
 	IO        afero.Afero
 	clonedDir string
@@ -33,7 +33,11 @@ type Profile struct {
 // points to a profile repo
 func (p *Profile) Generate(ctx context.Context) error {
 	logger.Info("cloning repository %q:%s", p.GitOpts.URL, p.GitOpts.Branch)
-	clonedDir, err := p.GitCloner.CloneRepo(cloneDirPrefix, p.GitOpts.Branch, p.GitOpts.URL)
+	options := git.CloneOptions{
+		URL:    p.GitOpts.URL,
+		Branch: p.GitOpts.Branch,
+	}
+	clonedDir, err := p.GitCloner.CloneRepoInTmpDir(cloneDirPrefix, options)
 	if err != nil {
 		return errors.Wrapf(err, "error cloning repository %s", p.GitOpts.URL)
 	}


### PR DESCRIPTION
If (and only if) the gitops repo provided by `--git-url` is empty (no branches), we create the branch provided by the user.

Fixes #1137 
