### PR TITLE
Remove timeout on Git commands

### DIFF
--- a/pkg/ctl/generate/profile.go
+++ b/pkg/ctl/generate/profile.go
@@ -63,8 +63,7 @@ func doGenerateProfile(cmd *cmdutils.Cmd, o options) error {
 		Processor: processor,
 		Path:      o.ProfilePath,
 		GitOpts:   o.GitOptions,
-		GitCloner: git.NewGitClient(context.Background(), git.ClientParams{
-			Timeout:           git.DefaultGitTimeout,
+		GitCloner: git.NewGitClient(git.ClientParams{
 			PrivateSSHKeyPath: o.PrivateSSHKeyPath,
 		}),
 		FS: afero.NewOsFs(),

--- a/pkg/ctl/gitops/apply.go
+++ b/pkg/ctl/gitops/apply.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
@@ -63,6 +64,7 @@ func applyGitops(cmd *cmdutils.Cmd) {
 
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
+		cmdutils.AddTimeoutFlagWithValue(fs, &cmd.ProviderConfig.WaitTimeout, 20*time.Second)
 	})
 
 	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)
@@ -121,9 +123,9 @@ func doApplyGitops(cmd *cmdutils.Cmd, opts options) error {
 		Namespace:   "flux",
 		GitFluxPath: "flux/",
 		WithHelm:    true,
-		Timeout:     git.DefaultGitTimeout,
+		Timeout:     cmd.ProviderConfig.WaitTimeout,
 	}
-	fluxInstaller := flux.NewInstaller(context.Background(), k8sRestConfig, k8sClientSet, &fluxOpts)
+	fluxInstaller := flux.NewInstaller(k8sRestConfig, k8sClientSet, &fluxOpts)
 
 	processor := &fileprocessor.GoTemplateProcessor{
 		Params: fileprocessor.NewTemplateParameters(cmd.ClusterConfig),
@@ -144,17 +146,14 @@ func doApplyGitops(cmd *cmdutils.Cmd, opts options) error {
 			URL:    quickstartRepoURL,
 			Branch: "master",
 		},
-		GitCloner: git.NewGitClient(context.Background(), git.ClientParams{
-			Timeout: git.DefaultGitTimeout,
-		}),
-		FS: afero.NewOsFs(),
-		IO: afero.Afero{Fs: afero.NewOsFs()},
+		GitCloner: git.NewGitClient(git.ClientParams{}),
+		FS:        afero.NewOsFs(),
+		IO:        afero.Afero{Fs: afero.NewOsFs()},
 	}
 
 	// A git client that operates in the user's repo
-	gitClient := git.NewGitClient(context.Background(), git.ClientParams{
+	gitClient := git.NewGitClient(git.ClientParams{
 		PrivateSSHKeyPath: opts.gitPrivateSSHKeyPath,
-		Timeout:           git.DefaultGitTimeout,
 	})
 
 	gitOps := gitops.Applier{

--- a/pkg/ctl/install/flux.go
+++ b/pkg/ctl/install/flux.go
@@ -63,7 +63,7 @@ func installFluxCmd(cmd *cmdutils.Cmd) {
 			return errors.Errorf("cannot create Kubernetes client set: %s", err)
 		}
 
-		installer := flux.NewInstaller(context.Background(), k8sRestConfig, k8sClientSet, &opts)
+		installer := flux.NewInstaller(k8sRestConfig, k8sClientSet, &opts)
 		return installer.Run(context.Background())
 	})
 

--- a/pkg/git/executor/executor.go
+++ b/pkg/git/executor/executor.go
@@ -1,10 +1,8 @@
 package executor
 
 import (
-	"context"
 	"os"
 	"os/exec"
-	"time"
 )
 
 // Executor executes commands shelling out and binding the stdout and stderr to the os ones
@@ -14,25 +12,19 @@ type Executor interface {
 
 // ShellExecutor an executor that shells out to run commands
 type ShellExecutor struct {
-	parentCtx context.Context
-	timeout   time.Duration
-	envVars   []string
+	envVars []string
 }
 
 // NewShellExecutor creates a new executor that runs commands
-func NewShellExecutor(ctx context.Context, timeout time.Duration, envVars []string) Executor {
+func NewShellExecutor(envVars []string) Executor {
 	return ShellExecutor{
-		parentCtx: ctx,
-		timeout:   timeout,
-		envVars:   envVars,
+		envVars: envVars,
 	}
 }
 
 // Exec execute the command inside the directory with the specified args
 func (e ShellExecutor) Exec(command string, dir string, args ...string) error {
-	ctx, ctxCancel := context.WithTimeout(e.parentCtx, e.timeout)
-	defer ctxCancel()
-	cmd := exec.CommandContext(ctx, command, args...)
+	cmd := exec.Command(command, args...)
 	if len(e.envVars) > 0 {
 		cmd.Env = e.envVars
 	}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -1,25 +1,18 @@
 package git
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
 	giturls "github.com/whilp/git-urls"
 
 	"github.com/weaveworks/eksctl/pkg/git/executor"
-)
-
-const (
-	// DefaultGitTimeout timeout for Git operations 20 seconds
-	DefaultGitTimeout = 20 * time.Second
 )
 
 // TmpCloner can clone git repositories in temporary directories
@@ -35,7 +28,6 @@ type Client struct {
 
 // ClientParams groups the arguments to provide to create a new Git client.
 type ClientParams struct {
-	Timeout           time.Duration
 	PrivateSSHKeyPath string
 }
 
@@ -68,9 +60,9 @@ func (o Options) isSSHURL() bool {
 }
 
 // NewGitClient returns a client that can perform git operations
-func NewGitClient(ctx context.Context, params ClientParams) *Client {
+func NewGitClient(params ClientParams) *Client {
 	return &Client{
-		executor: executor.NewShellExecutor(ctx, params.Timeout, envVars(params)),
+		executor: executor.NewShellExecutor(envVars(params)),
 	}
 }
 

--- a/pkg/gitops/flux/installer.go
+++ b/pkg/gitops/flux/installer.go
@@ -116,9 +116,8 @@ type Installer struct {
 }
 
 // NewInstaller creates a new Flux installer
-func NewInstaller(ctx context.Context, k8sRestConfig *rest.Config, k8sClientSet kubeclient.Interface, opts *InstallOpts) *Installer {
-	gitClient := git.NewGitClient(ctx, git.ClientParams{
-		Timeout:           opts.Timeout,
+func NewInstaller(k8sRestConfig *rest.Config, k8sClientSet kubeclient.Interface, opts *InstallOpts) *Installer {
+	gitClient := git.NewGitClient(git.ClientParams{
 		PrivateSSHKeyPath: opts.GitPrivateSSHKeyPath,
 	})
 	fi := &Installer{


### PR DESCRIPTION
### Description

Prior to this commit, if an user was required to enter their SSH key's
credentials (e.g. if identities got removed from the SSH agent), but
wouldn't enter these within 20 seconds, then eksctl would fail and
the command would have to be re-run from scratch, which can be rather
frustrating, especially as credentials would have to be entered several
times during a gitops apply command, for example.

After this change, we no longer enforce a timeout on Git commands, so
eksctl will wait indefinitely for the end-user to enter their
credentials, and will then resume work from there once entered.

Fixes #1236.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] ~Added tests that cover your change (if possible)~ Not relevant.
- [x] All unit tests passing (i.e. `make test`)
- [x] ~Added/modified documentation as required (such as the `README.md`, and `examples` directory)~ Not relevant.
- [x] Manually tested (incl. waiting more than 20 seconds, given that was the previous timeout before failure.)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->

### Manual testing

```console
$ EKSCTL_EXPERIMENTAL=true ./eksctl \
    -f examples/01-simple-cluster.yaml \
    gitops apply \
    --quickstart-profile app-dev \
    --git-url git@github.com:marccarre/my-gitops-repo.git \
    --cluster marcgitops \
    --git-email *********@gmail.com

[ℹ]  Generating public key infrastructure for the Helm Operator and Tiller
[ℹ]    this may take up to a minute, please be patient
[!]  Public key infrastructure files were written into directory "/var/folders/24/d3mml6bn20nftpt91cfldq1h0000gn/T/eksctl-helm-pki195751053"
[!]  please move the files into a safe place or delete them
[ℹ]  Generating manifests
[ℹ]  Cloning git@github.com:marccarre/my-gitops-repo.git
Cloning into '/var/folders/24/d3mml6bn20nftpt91cfldq1h0000gn/T/eksctl-install-flux-clone-805456520'...
Enter passphrase for key '/Users/marc/.ssh/id_rsa': 

remote: Enumerating objects: 84, done.
remote: Counting objects: 100% (84/84), done.
remote: Compressing objects: 100% (66/66), done.
remote: Total 226 (delta 21), reused 81 (delta 18), pack-reused 142
Receiving objects: 100% (226/226), 100.09 KiB | 329.00 KiB/s, done.
Resolving deltas: 100% (61/61), done.
[ℹ]  Writing Flux manifests
[...]
[ℹ]  Committing and pushing manifests to git@github.com:marccarre/my-gitops-repo.git
[master c8e2a17] Add Initial Flux configuration
 1 file changed, 38 insertions(+), 38 deletions(-)
 rewrite flux/tiller-ca-cert-configmap.yaml (87%)
Enter passphrase for key '/Users/marc/.ssh/id_rsa': 

Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 8 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 2.13 KiB | 2.13 MiB/s, done.
Total 4 (delta 2), reused 0 (delta 0)
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
To github.com:marccarre/my-gitops-repo.git
   94b8a6d..c8e2a17  master -> master
[...]
Cloning into 'my-gitops-repo'...
Enter passphrase for key '/Users/marc/.ssh/id_rsa': 

remote: Enumerating objects: 88, done.
remote: Counting objects: 100% (88/88), done.
remote: Compressing objects: 100% (70/70), done.
remote: Total 230 (delta 23), reused 83 (delta 18), pack-reused 142
Receiving objects: 100% (230/230), 102.15 KiB | 326.00 KiB/s, done.
Resolving deltas: 100% (63/63), done.
[ℹ]  cloning repository "git@github.com:weaveworks/eks-quickstart-app-dev.git":master
Cloning into '/var/folders/24/d3mml6bn20nftpt91cfldq1h0000gn/T/quickstart-630174279'...
Enter passphrase for key '/Users/marc/.ssh/id_rsa': 

remote: Enumerating objects: 9, done.
remote: Counting objects: 100% (9/9), done.
remote: Compressing objects: 100% (9/9), done.
remote: Total 159 (delta 2), reused 1 (delta 0), pack-reused 150
Receiving objects: 100% (159/159), 39.55 KiB | 675.00 KiB/s, done.
Resolving deltas: 100% (68/68), done.
[ℹ]  processing template files in repository
[ℹ]  writing new manifests to "my-gitops-repo/base"
[ℹ]  Nothing to commit (the repository contained identical files), moving on
Enter passphrase for key '/Users/marc/.ssh/id_rsa': 

Everything up-to-date
```