### PR TITLE
Remove redundant `--region` flag

### DIFF
--- a/integration/createdeletebeforeactive_test.go
+++ b/integration/createdeletebeforeactive_test.go
@@ -43,7 +43,6 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 				"--node-labels", "ng-name="+initNG,
 				"--node-type", "t2.medium",
 				"--nodes", "1",
-				"--region", region,
 				"--version", version,
 			)
 			cmd.Start()
@@ -60,7 +59,6 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 		It("deleting cluster should have a zero exitcode", func() {
 			cmd := eksctlDeleteClusterCmd.WithArgs(
 				"--name", delBeforeActiveName,
-				"--region", region,
 			)
 			Expect(cmd).To(RunSuccessfully())
 		})
@@ -82,7 +80,6 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 		It("should return an a non-zero exit code", func() {
 			cmd := eksctlDeleteClusterCmd.WithArgs(
 				"--name", delBeforeActiveName,
-				"--region", region,
 			)
 			Expect(cmd).To(RunSuccessfully())
 		})

--- a/integration/creategetdelete_test.go
+++ b/integration/creategetdelete_test.go
@@ -172,7 +172,6 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					"--output-path", tempOutputDir,
 					"--quickstart-profile", "app-dev",
 					"--cluster", clusterName,
-					"--region", region,
 				)
 				Expect(cmd).To(RunSuccessfully())
 
@@ -224,7 +223,6 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					cmd := eksctlGetCmd.WithArgs(
 						"nodegroup",
 						"--cluster", clusterName,
-						"--region", region,
 						initNG,
 					)
 					Expect(cmd).To(RunSuccessfullyWithOutputStringLines(
@@ -236,7 +234,6 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					cmd := eksctlGetCmd.WithArgs(
 						"nodegroup",
 						"--cluster", clusterName,
-						"--region", region,
 						testNG,
 					)
 					Expect(cmd).To(RunSuccessfullyWithOutputStringLines(
@@ -248,7 +245,6 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					cmd := eksctlGetCmd.WithArgs(
 						"nodegroup",
 						"--cluster", clusterName,
-						"--region", region,
 					)
 					Expect(cmd).To(RunSuccessfullyWithOutputStringLines(
 						ContainElement(ContainSubstring(testNG)),


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

The `--region` flag is set globally, we don't need to set in each command.

```Go
	eksctlCmd = runner.NewCmd(eksctlPath).
		WithArgs("--region", region).
		WithTimeout(30 * time.Minute)
```

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
