### PR TITLE
Add examples/eks-quickstart-app-dev.yaml

### DIFF
--- a/examples/eks-quickstart-app-dev.yaml
+++ b/examples/eks-quickstart-app-dev.yaml
@@ -1,0 +1,20 @@
+# An example of ClusterConfig object compatible with the "app-dev" quickstart
+# profile. See also: https://github.com/weaveworks/eks-quickstart-app-dev
+---
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: cluster-12
+  region: eu-north-1
+
+nodeGroups:
+  - name: ng-1
+    instanceType: m5.large
+    minSize: 1
+    maxSize: 2
+    iam:
+      withAddonPolicies:
+        albIngress: true
+        autoScaler: true
+        cloudWatch: true

--- a/pkg/ctl/cmdutils/configfile_test.go
+++ b/pkg/ctl/cmdutils/configfile_test.go
@@ -80,7 +80,7 @@ var _ = Describe("cmdutils configfile", func() {
 			examples, err := filepath.Glob(examplesDir + "*.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(examples).To(HaveLen(11))
+			Expect(examples).To(HaveLen(12))
 			for _, example := range examples {
 				cmd := &Cmd{
 					CobraCommand:      newCmd(),


### PR DESCRIPTION
### Description

Adding an example of ClusterConfig which is compatible with
https://github.com/weaveworks/eks-quickstart-app-dev out-of-the-box
should hopefully help users not face any IAM issue when trying the
quickstart profile.

Fixes bits of #1237.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] ~Code compiles correctly (i.e `make build`)~ Irrelevant.
- [x] ~Added tests that cover your change (if possible)~ Irrelevant.
- [x] ~All unit tests passing (i.e. `make test`)~ Irrelevant.
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory) -- "Coming soon" in the PR for https://github.com/weaveworks/eks-quickstart-app-dev/issues/19
- [x] Manually tested -- I ran all my `eksctl gitops apply` tests with this configuration (name & region aside).

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
