### PR TITLE
Print Flux instructions at the end of gitops apply

### DIFF
--- a/pkg/ctl/install/flux.go
+++ b/pkg/ctl/install/flux.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -64,7 +65,9 @@ func installFluxCmd(cmd *cmdutils.Cmd) {
 		}
 
 		installer := flux.NewInstaller(k8sRestConfig, k8sClientSet, &opts)
-		return installer.Run(context.Background())
+		userInstructions, err := installer.Run(context.Background())
+		logger.Info(userInstructions)
+		return err
 	})
 
 	cmd.FlagSetGroup.InFlagSet("Flux installation", func(fs *pflag.FlagSet) {

--- a/pkg/gitops/apply.go
+++ b/pkg/gitops/apply.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -26,7 +27,7 @@ type Applier struct {
 func (g *Applier) Run(ctx context.Context) error {
 
 	// Install Flux, Helm and Tiller. Clones the user's repo
-	err := g.FluxInstaller.Run(context.Background())
+	userInstructions, err := g.FluxInstaller.Run(context.Background())
 	if err != nil {
 		return err
 	}
@@ -62,5 +63,6 @@ func (g *Applier) Run(ctx context.Context) error {
 		return err
 	}
 
+	logger.Info(userInstructions)
 	return nil
 }


### PR DESCRIPTION
### Description

... as otherwise, these instructions appear in the middle of the logs, after installing Flux, and can easily be missed by the end-user.

Fixes #1233.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] ~Added tests that cover your change (if possible)~ Irrelevant.
- [x] All unit tests passing (i.e. `make test`)
- [x] ~Added/modified documentation as required (such as the `README.md`, and `examples` directory)~ Irrelevant.
- [x] Manually tested

### Manual test

```console
$ EKSCTL_EXPERIMENTAL=true ./eksctl -f examples/eks-quickstart-app-dev.yaml \
    gitops apply \
    --quickstart-profile app-dev \
    --git-url git@github.com:marccarre/my-gitops-repo.git \
    --cluster marc --git-email ********@gmail.com

[ℹ]  Generating public key infrastructure for the Helm Operator and Tiller
[ℹ]    this may take up to a minute, please be patient
[!]  Public key infrastructure files were written into directory "/var/folders/24/d3mml6bn20nftpt91cfldq1h0000gn/T/eksctl-helm-pki395014688"
[!]  please move the files into a safe place or delete them
[ℹ]  Generating manifests
[ℹ]  Cloning git@github.com:marccarre/my-gitops-repo.git
Cloning into '/var/folders/24/d3mml6bn20nftpt91cfldq1h0000gn/T/eksctl-install-flux-clone-589070079'...
remote: Enumerating objects: 102, done.
remote: Counting objects: 100% (102/102), done.
remote: Compressing objects: 100% (83/83), done.
remote: Total 244 (delta 27), reused 89 (delta 19), pack-reused 142
Receiving objects: 100% (244/244), 108.11 KiB | 315.00 KiB/s, done.
Resolving deltas: 100% (67/67), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
[ℹ]  Writing Flux manifests
[ℹ]  Applying Helm TLS Secret(s)
[ℹ]  deleted "flux:Secret/flux-helm-tls-cert"
[ℹ]  deleted "flux:Secret/tiller-secret"
[ℹ]  created "flux:Secret/flux-helm-tls-cert"
[ℹ]  created "flux:Secret/tiller-secret"
[!]  Note: certificate secrets aren't added to the Git repository for security reasons
[ℹ]  Applying manifests
[ℹ]  deleted "flux:Deployment.apps/memcached"
[ℹ]  deleted "flux:Service/memcached"
[ℹ]  deleted "CustomResourceDefinition.apiextensions.k8s.io/helmreleases.helm.fluxcd.io"
[ℹ]  deleted "flux:ServiceAccount/flux-helm-operator"
[ℹ]  deleted "ClusterRole.rbac.authorization.k8s.io/flux-helm-operator"
[ℹ]  deleted "ClusterRoleBinding.rbac.authorization.k8s.io/flux-helm-operator"
[ℹ]  deleted "flux:Deployment.apps/flux-helm-operator"
[ℹ]  deleted "flux:Deployment.apps/flux"
[ℹ]  deleted "flux:ConfigMap/flux-helm-tls-ca-config"
[ℹ]  deleted "flux:Deployment.extensions/tiller-deploy"
[ℹ]  deleted "flux:Service/tiller-deploy"
[ℹ]  deleted "flux:ServiceAccount/tiller"
[ℹ]  deleted "ClusterRoleBinding.rbac.authorization.k8s.io/tiller"
[ℹ]  deleted "flux:ServiceAccount/helm"
[ℹ]  deleted "flux:Role.rbac.authorization.k8s.io/tiller-user"
[ℹ]  deleted "kube-system:RoleBinding.rbac.authorization.k8s.io/tiller-user-binding"
[ℹ]  deleted "flux:ServiceAccount/flux"
[ℹ]  deleted "ClusterRole.rbac.authorization.k8s.io/flux"
[ℹ]  deleted "ClusterRoleBinding.rbac.authorization.k8s.io/flux"
[ℹ]  created "flux:Deployment.apps/memcached"
[ℹ]  created "flux:Service/memcached"
[ℹ]  created "CustomResourceDefinition.apiextensions.k8s.io/helmreleases.helm.fluxcd.io"
[ℹ]  created "flux:ServiceAccount/flux-helm-operator"
[ℹ]  created "ClusterRole.rbac.authorization.k8s.io/flux-helm-operator"
[ℹ]  created "ClusterRoleBinding.rbac.authorization.k8s.io/flux-helm-operator"
[ℹ]  created "flux:Deployment.apps/flux-helm-operator"
[ℹ]  created "flux:Deployment.apps/flux"
[ℹ]  created "flux:ConfigMap/flux-helm-tls-ca-config"
[ℹ]  created "flux:Deployment.extensions/tiller-deploy"
[ℹ]  created "flux:Service/tiller-deploy"
[ℹ]  created "flux:ServiceAccount/tiller"
[ℹ]  created "ClusterRoleBinding.rbac.authorization.k8s.io/tiller"
[ℹ]  created "flux:ServiceAccount/helm"
[ℹ]  created "flux:Role.rbac.authorization.k8s.io/tiller-user"
[ℹ]  created "kube-system:RoleBinding.rbac.authorization.k8s.io/tiller-user-binding"
[ℹ]  created "flux:ServiceAccount/flux"
[ℹ]  created "ClusterRole.rbac.authorization.k8s.io/flux"
[ℹ]  created "ClusterRoleBinding.rbac.authorization.k8s.io/flux"
[ℹ]  Waiting for Helm Operator to start
ERROR: logging before flag.Parse: E0903 17:49:20.462731   42115 portforward.go:331] an error occurred forwarding 56785 -> 3030: error forwarding port 3030 to pod 50430b43e2bff703827f4b460966ed4dc8d37e2995caa5175415dfd8d33c616c, uid : exit status 1: 2019/09/03 08:49:20 socat[16025] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:56785/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0903 17:49:22.491233   42115 portforward.go:331] an error occurred forwarding 56785 -> 3030: error forwarding port 3030 to pod 50430b43e2bff703827f4b460966ed4dc8d37e2995caa5175415dfd8d33c616c, uid : exit status 1: 2019/09/03 08:49:22 socat[16036] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:56785/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0903 17:49:24.520647   42115 portforward.go:331] an error occurred forwarding 56785 -> 3030: error forwarding port 3030 to pod 50430b43e2bff703827f4b460966ed4dc8d37e2995caa5175415dfd8d33c616c, uid : exit status 1: 2019/09/03 08:49:24 socat[16044] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:56785/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0903 17:49:26.556913   42115 portforward.go:331] an error occurred forwarding 56785 -> 3030: error forwarding port 3030 to pod 50430b43e2bff703827f4b460966ed4dc8d37e2995caa5175415dfd8d33c616c, uid : exit status 1: 2019/09/03 08:49:26 socat[16067] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:56785/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0903 17:49:28.591199   42115 portforward.go:331] an error occurred forwarding 56785 -> 3030: error forwarding port 3030 to pod 50430b43e2bff703827f4b460966ed4dc8d37e2995caa5175415dfd8d33c616c, uid : exit status 1: 2019/09/03 08:49:28 socat[16069] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:56785/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0903 17:49:30.621486   42115 portforward.go:331] an error occurred forwarding 56785 -> 3030: error forwarding port 3030 to pod 50430b43e2bff703827f4b460966ed4dc8d37e2995caa5175415dfd8d33c616c, uid : exit status 1: 2019/09/03 08:49:30 socat[16120] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:56785/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0903 17:49:32.652487   42115 portforward.go:331] an error occurred forwarding 56785 -> 3030: error forwarding port 3030 to pod 50430b43e2bff703827f4b460966ed4dc8d37e2995caa5175415dfd8d33c616c, uid : exit status 1: 2019/09/03 08:49:32 socat[16175] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:56785/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0903 17:49:34.680380   42115 portforward.go:331] an error occurred forwarding 56785 -> 3030: error forwarding port 3030 to pod 50430b43e2bff703827f4b460966ed4dc8d37e2995caa5175415dfd8d33c616c, uid : exit status 1: 2019/09/03 08:49:34 socat[16176] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:56785/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0903 17:49:36.707054   42115 portforward.go:331] an error occurred forwarding 56785 -> 3030: error forwarding port 3030 to pod 50430b43e2bff703827f4b460966ed4dc8d37e2995caa5175415dfd8d33c616c, uid : exit status 1: 2019/09/03 08:49:36 socat[16188] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:56785/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0903 17:49:38.743559   42115 portforward.go:331] an error occurred forwarding 56785 -> 3030: error forwarding port 3030 to pod 50430b43e2bff703827f4b460966ed4dc8d37e2995caa5175415dfd8d33c616c, uid : exit status 1: 2019/09/03 08:49:38 socat[16190] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:56785/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0903 17:49:40.775110   42115 portforward.go:331] an error occurred forwarding 56785 -> 3030: error forwarding port 3030 to pod 50430b43e2bff703827f4b460966ed4dc8d37e2995caa5175415dfd8d33c616c, uid : exit status 1: 2019/09/03 08:49:40 socat[16191] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:56785/healthz: EOF), retrying ...
[ℹ]  Helm Operator started successfully
[ℹ]  see https://docs.fluxcd.io/projects/helm-operator for details on how to use the Helm Operator
[ℹ]  Waiting for Flux to start
[ℹ]  Flux started successfully
[ℹ]  see https://docs.fluxcd.io/projects/flux for details on how to use Flux
[ℹ]  Committing and pushing manifests to git@github.com:marccarre/my-gitops-repo.git
[master f3d47f6] Add Initial Flux configuration
 1 file changed, 38 insertions(+), 38 deletions(-)
 rewrite flux/tiller-ca-cert-configmap.yaml (87%)
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 8 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 2.13 KiB | 2.13 MiB/s, done.
Total 4 (delta 2), reused 0 (delta 0)
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
To github.com:marccarre/my-gitops-repo.git
   0b321d6..f3d47f6  master -> master
[ℹ]  Flux will only operate properly once it has write-access to the Git repository
Cloning into 'my-gitops-repo'...
remote: Enumerating objects: 106, done.
remote: Counting objects: 100% (106/106), done.
remote: Compressing objects: 100% (86/86), done.
remote: Total 248 (delta 29), reused 92 (delta 20), pack-reused 142
Receiving objects: 100% (248/248), 110.18 KiB | 311.00 KiB/s, done.
Resolving deltas: 100% (69/69), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
[ℹ]  cloning repository "git@github.com:weaveworks/eks-quickstart-app-dev.git":master
Cloning into '/var/folders/24/d3mml6bn20nftpt91cfldq1h0000gn/T/quickstart-328311378'...
remote: Enumerating objects: 25, done.
remote: Counting objects: 100% (25/25), done.
remote: Compressing objects: 100% (20/20), done.
remote: Total 175 (delta 12), reused 12 (delta 5), pack-reused 150
Receiving objects: 100% (175/175), 44.63 KiB | 267.00 KiB/s, done.
Resolving deltas: 100% (78/78), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
[ℹ]  processing template files in repository
[ℹ]  writing new manifests to "my-gitops-repo/base"
[ℹ]  Nothing to commit (the repository contained identical files), moving on
Everything up-to-date
[ℹ]  please configure git@github.com:marccarre/my-gitops-repo.git so that the following Flux SSH public key has write access to it
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQAhF2iCGR7LoTwSAFRB2lQFxT0eF3VyYweS6J2OSzgHUtIRbxWAfOObaeE2w+ZvWvi2u+p1jfygFytAf0Bg38nkQGKz/yp4lJUydU6qe4crBe5E6HJtfw2rLX1uZqHLM5forpx9Mw2urNEHdc7U52dYFfBzxfMgoV9JwfTrQaupaUSHx17A55ormsh64KYSOOBbgsbxiun8UCRx/wlogUOGBVPuNpF78Dxpn6XO1vLhmXNGqrjd3PQEUmhUoM+ZIAAHKKlf+XUNSNmBttr/tN3qz+DfogtlEUyRkjEJsufRmwIa3W4CMu5XYo+SJcuB0XGMmmosVZminaaGVc+F8z
```