### PR TITLE
Avoid using unreliable `t2.medium` instace type in integration tests

### DIFF
--- a/integration/creategetdelete_test.go
+++ b/integration/creategetdelete_test.go
@@ -87,7 +87,6 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				"--tags", "alpha.eksctl.io/description=eksctl integration test",
 				"--nodegroup-name", initNG,
 				"--node-labels", "ng-name="+initNG,
-				"--node-type", "t2.medium",
 				"--nodes", "1",
 				"--version", version,
 				"--kubeconfig", kubeconfigPath,


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

Solve #1257 for the integration tests only.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] All unit tests passing (i.e. `make test`)
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
