### PR TITLE
Enhance cluster status checks

### DIFF
--- a/integration/createdeletebeforeactive_test.go
+++ b/integration/createdeletebeforeactive_test.go
@@ -36,22 +36,19 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 		It("should not return an error", func() {
 			cmd := eksctlCreateCmd.WithArgs(
 				"cluster",
-				"--verbose", "4",
+				"--verbose", "2",
 				"--name", delBeforeActiveName,
 				"--tags", "alpha.eksctl.io/description=eksctl delete before active test",
-				"--nodegroup-name", initNG,
-				"--node-labels", "ng-name="+initNG,
-				"--node-type", "t2.medium",
-				"--nodes", "1",
+				"--without-nodegroup",
 				"--version", version,
 			)
-			cmd.Start()
-		})
+			gexecSession := cmd.Start()
 
-		It("should eventually show up as creating", func() {
 			awsSession := NewSession(region)
 			Eventually(awsSession, timeOut, pollInterval).Should(
 				HaveExistingCluster(delBeforeActiveName, awseks.ClusterStatusCreating, version))
+
+			gexecSession.Interrupt() // interrupt as soon as cluster is in creating stage
 		})
 	})
 

--- a/integration/creategetdelete_test.go
+++ b/integration/creategetdelete_test.go
@@ -346,7 +346,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				})
 
 				It("should have all types disabled by default", func() {
-					enabled, disable, err := ctl.GetCurrentClusterConfigForLogging(cfg.Metadata)
+					enabled, disable, err := ctl.GetCurrentClusterConfigForLogging(cfg)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(enabled.List()).To(HaveLen(0))
 					Expect(disable.List()).To(HaveLen(5))
@@ -360,7 +360,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					)
 					Expect(cmd).To(RunSuccessfully())
 
-					enabled, disable, err := ctl.GetCurrentClusterConfigForLogging(cfg.Metadata)
+					enabled, disable, err := ctl.GetCurrentClusterConfigForLogging(cfg)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(enabled.List()).To(HaveLen(0))
 					Expect(disable.List()).To(HaveLen(5))
@@ -375,7 +375,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					)
 					Expect(cmd).To(RunSuccessfully())
 
-					enabled, disable, err := ctl.GetCurrentClusterConfigForLogging(cfg.Metadata)
+					enabled, disable, err := ctl.GetCurrentClusterConfigForLogging(cfg)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(enabled.List()).To(HaveLen(2))
 					Expect(disable.List()).To(HaveLen(3))
@@ -392,7 +392,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					)
 					Expect(cmd).To(RunSuccessfully())
 
-					enabled, disable, err := ctl.GetCurrentClusterConfigForLogging(cfg.Metadata)
+					enabled, disable, err := ctl.GetCurrentClusterConfigForLogging(cfg)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(enabled.List()).To(HaveLen(5))
 					Expect(disable.List()).To(HaveLen(0))
@@ -408,7 +408,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					)
 					Expect(cmd).To(RunSuccessfully())
 
-					enabled, disable, err := ctl.GetCurrentClusterConfigForLogging(cfg.Metadata)
+					enabled, disable, err := ctl.GetCurrentClusterConfigForLogging(cfg)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(enabled.List()).To(HaveLen(4))
 					Expect(disable.List()).To(HaveLen(1))
@@ -426,7 +426,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					)
 					Expect(cmd).To(RunSuccessfully())
 
-					enabled, disable, err := ctl.GetCurrentClusterConfigForLogging(cfg.Metadata)
+					enabled, disable, err := ctl.GetCurrentClusterConfigForLogging(cfg)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(disable.List()).To(HaveLen(4))
 					Expect(enabled.List()).To(HaveLen(1))
@@ -443,7 +443,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					)
 					Expect(cmd).To(RunSuccessfully())
 
-					enabled, disable, err := ctl.GetCurrentClusterConfigForLogging(cfg.Metadata)
+					enabled, disable, err := ctl.GetCurrentClusterConfigForLogging(cfg)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(enabled.List()).To(HaveLen(0))
 					Expect(disable.List()).To(HaveLen(5))

--- a/pkg/cfn/manager/delete_tasks.go
+++ b/pkg/cfn/manager/delete_tasks.go
@@ -6,8 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
-// NewTasksToDeleteClusterWithNodeGroups defines tasks required to delete all the nodegroup
-// stacks and the cluster
+// NewTasksToDeleteClusterWithNodeGroups defines tasks required to delete the given cluster along with all of its resources
 func (c *StackCollection) NewTasksToDeleteClusterWithNodeGroups(wait bool, cleanup func(chan error, string) error) (*TaskTree, error) {
 	tasks := &TaskTree{Parallel: false}
 

--- a/pkg/ctl/create/iamidentitymapping.go
+++ b/pkg/ctl/create/iamidentitymapping.go
@@ -68,7 +68,7 @@ func doCreateIAMIdentityMapping(cmd *cmdutils.Cmd, id *authconfigmap.MapRole) er
 		return err
 	}
 
-	if err := ctl.RefreshClusterConfig(cfg); err != nil {
+	if ok, err := ctl.CanOperate(cfg); !ok {
 		return err
 	}
 	clientSet, err := ctl.NewStdClientSet(cfg)

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -75,8 +75,8 @@ func doCreateNodeGroups(cmd *cmdutils.Cmd, updateAuthConfigMap bool) error {
 		return err
 	}
 
-	if err := ctl.RefreshClusterConfig(cfg); err != nil {
-		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
+	if ok, err := ctl.CanOperate(cfg); !ok {
+		return err
 	}
 
 	if err := checkVersion(cmd, ctl, cfg.Metadata); err != nil {

--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -13,6 +13,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/elb"
+	"github.com/weaveworks/eksctl/pkg/kubernetes"
 	"github.com/weaveworks/eksctl/pkg/printers"
 	"github.com/weaveworks/eksctl/pkg/ssh"
 	"github.com/weaveworks/eksctl/pkg/utils/kubeconfig"
@@ -92,6 +93,22 @@ func doDeleteCluster(cmd *cmdutils.Cmd) error {
 		return err
 	}
 
+	if ok, err := ctl.CanDelete(cfg); !ok {
+		return err
+	}
+
+	var (
+		clientSet kubernetes.Interface
+	)
+
+	clusterOperable, _ := ctl.CanOperate(cfg)
+	if clusterOperable {
+		clientSet, err = ctl.NewStdClientSet(cfg)
+		if err != nil {
+			return err
+		}
+	}
+
 	stackManager := ctl.NewStackManager(cfg)
 
 	ssh.DeleteKeys(meta.Name, ctl.Provider)
@@ -106,21 +123,17 @@ func doDeleteCluster(cmd *cmdutils.Cmd) error {
 	}
 
 	{
-
 		// only need to cleanup ELBs if the cluster has already been created.
-		if err := ctl.RefreshClusterConfig(cfg); err == nil {
-			cs, err := ctl.NewStdClientSet(cfg)
-			if err != nil {
-				return err
-			}
+		if clusterOperable {
 			ctx, cleanup := context.WithTimeout(context.Background(), 10*time.Minute)
 			defer cleanup()
 
 			logger.Info("cleaning up LoadBalancer services")
-			if err := elb.Cleanup(ctx, ctl.Provider.EC2(), ctl.Provider.ELB(), ctl.Provider.ELBV2(), cs, cfg); err != nil {
+			if err := elb.Cleanup(ctx, ctl.Provider.EC2(), ctl.Provider.ELB(), ctl.Provider.ELBV2(), clientSet, cfg); err != nil {
 				return err
 			}
 		}
+
 		tasks, err := stackManager.NewTasksToDeleteClusterWithNodeGroups(cmd.Wait, func(errs chan error, _ string) error {
 			logger.Info("trying to cleanup dangling network interfaces")
 			if err := ctl.LoadClusterVPC(cfg); err != nil {

--- a/pkg/ctl/delete/iamidentitymapping.go
+++ b/pkg/ctl/delete/iamidentitymapping.go
@@ -60,7 +60,7 @@ func doDeleteIAMIdentityMapping(cmd *cmdutils.Cmd, role string, all bool) error 
 		return cmdutils.ErrMustBeSet("--name")
 	}
 
-	if err := ctl.RefreshClusterConfig(cfg); err != nil {
+	if ok, err := ctl.CanOperate(cfg); !ok {
 		return err
 	}
 	clientSet, err := ctl.NewStdClientSet(cfg)

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -2,7 +2,6 @@ package delete
 
 import (
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -62,8 +61,8 @@ func doDeleteNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, updateAuthConfigMap
 		return err
 	}
 
-	if err := ctl.RefreshClusterConfig(cfg); err != nil {
-		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
+	if ok, err := ctl.CanOperate(cfg); !ok {
+		return err
 	}
 
 	clientSet, err := ctl.NewStdClientSet(cfg)

--- a/pkg/ctl/drain/nodegroup.go
+++ b/pkg/ctl/drain/nodegroup.go
@@ -2,7 +2,6 @@ package drain
 
 import (
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -58,8 +57,8 @@ func doDrainNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, undo, onlyMissing bo
 		return err
 	}
 
-	if err := ctl.RefreshClusterConfig(cfg); err != nil {
-		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
+	if ok, err := ctl.CanOperate(cfg); !ok {
+		return err
 	}
 
 	clientSet, err := ctl.NewStdClientSet(cfg)

--- a/pkg/ctl/get/iamidentitymapping.go
+++ b/pkg/ctl/get/iamidentitymapping.go
@@ -59,7 +59,7 @@ func doGetIAMIdentityMapping(cmd *cmdutils.Cmd, params *getCmdParams, role strin
 		return cmdutils.ErrMustBeSet("--name")
 	}
 
-	if err := ctl.RefreshClusterConfig(cfg); err != nil {
+	if ok, err := ctl.CanOperate(cfg); !ok {
 		return err
 	}
 	clientSet, err := ctl.NewStdClientSet(cfg)

--- a/pkg/ctl/gitops/apply.go
+++ b/pkg/ctl/gitops/apply.go
@@ -99,7 +99,7 @@ func doApplyGitops(cmd *cmdutils.Cmd, opts options) error {
 	if err := ctl.CheckAuth(); err != nil {
 		return err
 	}
-	if err := ctl.RefreshClusterConfig(cfg); err != nil {
+	if ok, err := ctl.CanOperate(cfg); !ok {
 		return err
 	}
 	kubernetesClientConfigs, err := ctl.NewClient(cfg)

--- a/pkg/ctl/install/flux.go
+++ b/pkg/ctl/install/flux.go
@@ -46,7 +46,7 @@ func installFluxCmd(cmd *cmdutils.Cmd) {
 		if err := ctl.CheckAuth(); err != nil {
 			return err
 		}
-		if err := ctl.RefreshClusterConfig(cfg); err != nil {
+		if ok, err := ctl.CanOperate(cfg); !ok {
 			return err
 		}
 		kubernetesClientConfigs, err := ctl.NewClient(cfg)

--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -62,8 +62,8 @@ func doUpdateClusterCmd(cmd *cmdutils.Cmd) error {
 		return err
 	}
 
-	if err := ctl.RefreshClusterConfig(cfg); err != nil {
-		return errors.Wrapf(err, "getting credentials for cluster %q", cfg.Metadata.Name)
+	if ok, err := ctl.CanUpdate(cfg); !ok {
+		return err
 	}
 
 	if cmd.ClusterConfigFile != "" {

--- a/pkg/ctl/utils/update_aws_node.go
+++ b/pkg/ctl/utils/update_aws_node.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 
 	defaultaddons "github.com/weaveworks/eksctl/pkg/addons/default"
@@ -49,8 +48,8 @@ func doUpdateAWSNode(cmd *cmdutils.Cmd) error {
 		return err
 	}
 
-	if err := ctl.RefreshClusterConfig(cfg); err != nil {
-		return errors.Wrapf(err, "getting credentials for cluster %q", meta.Name)
+	if ok, err := ctl.CanUpdate(cfg); !ok {
+		return err
 	}
 
 	rawClient, err := ctl.NewRawClient(cfg)

--- a/pkg/ctl/utils/update_cluster_logging.go
+++ b/pkg/ctl/utils/update_cluster_logging.go
@@ -71,7 +71,7 @@ func doEnableLogging(cmd *cmdutils.Cmd, logTypesToEnable []string, logTypesToDis
 		return err
 	}
 
-	currentlyEnabled, _, err := ctl.GetCurrentClusterConfigForLogging(meta)
+	currentlyEnabled, _, err := ctl.GetCurrentClusterConfigForLogging(cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/update_coredns.go
+++ b/pkg/ctl/utils/update_coredns.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 
 	defaultaddons "github.com/weaveworks/eksctl/pkg/addons/default"
@@ -49,8 +48,8 @@ func doUpdateCoreDNS(cmd *cmdutils.Cmd) error {
 		return err
 	}
 
-	if err := ctl.RefreshClusterConfig(cfg); err != nil {
-		return errors.Wrapf(err, "getting credentials for cluster %q", meta.Name)
+	if ok, err := ctl.CanUpdate(cfg); !ok {
+		return err
 	}
 
 	rawClient, err := ctl.NewRawClient(cfg)

--- a/pkg/ctl/utils/update_kube_proxy.go
+++ b/pkg/ctl/utils/update_kube_proxy.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 
 	defaultaddons "github.com/weaveworks/eksctl/pkg/addons/default"
@@ -49,8 +48,8 @@ func doUpdateKubeProxy(cmd *cmdutils.Cmd) error {
 		return err
 	}
 
-	if err := ctl.RefreshClusterConfig(cfg); err != nil {
-		return errors.Wrapf(err, "getting credentials for cluster %q", meta.Name)
+	if ok, err := ctl.CanUpdate(cfg); !ok {
+		return err
 	}
 
 	rawClient, err := ctl.NewRawClient(cfg)

--- a/pkg/ctl/utils/write_kubeconfig.go
+++ b/pkg/ctl/utils/write_kubeconfig.go
@@ -74,7 +74,7 @@ func doWriteKubeconfigCmd(cmd *cmdutils.Cmd, outputPath, roleARN string, setCont
 		return err
 	}
 
-	if err := ctl.RefreshClusterConfig(cfg); err != nil {
+	if ok, err := ctl.CanOperate(cfg); !ok {
 		return err
 	}
 

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -102,9 +102,9 @@ func (p ProviderServices) WaitTimeout() time.Duration { return p.spec.WaitTimeou
 
 // ProviderStatus stores information about the used IAM role and the resulting session
 type ProviderStatus struct {
-	iamRoleARN        string
-	sessionCreds      *credentials.Credentials
-	cachedClusterInfo *awseks.Cluster
+	iamRoleARN   string
+	sessionCreds *credentials.Credentials
+	clusterInfo  *clusterInfo
 }
 
 // New creates a new setup of the used AWS APIs

--- a/pkg/eks/cache.go
+++ b/pkg/eks/cache.go
@@ -1,0 +1,31 @@
+package eks
+
+import (
+	"time"
+
+	awseks "github.com/aws/aws-sdk-go/service/eks"
+)
+
+const clusterInfoCacheTTL = 15 * time.Second
+
+type clusterInfo struct {
+	timestamp time.Time
+	cluster   *awseks.Cluster
+}
+
+func (c *ClusterProvider) clusterInfoNeedsUpdate() bool {
+	if c.Status.clusterInfo == nil {
+		return true
+	}
+	if time.Since(c.Status.clusterInfo.timestamp) > clusterInfoCacheTTL {
+		return true
+	}
+	return false
+}
+
+func (c *ClusterProvider) setClusterInfo(cluster *awseks.Cluster) {
+	c.Status.clusterInfo = &clusterInfo{
+		timestamp: time.Now(),
+		cluster:   cluster,
+	}
+}

--- a/pkg/eks/testdata/singlecluster_deleting.golden
+++ b/pkg/eks/testdata/singlecluster_deleting.golden
@@ -1,10 +1,12 @@
 [
   {
-    "Arn": "arn-12345678",
-    "CertificateAuthority": null,
+    "Arn": "arn:aws:eks:us-west-2:12345:cluster/test-12345",
+    "CertificateAuthority": {
+      "Data": "dGVzdAo="
+    },
     "ClientRequestToken": null,
     "CreatedAt": "0001-01-01T00:00:00Z",
-    "Endpoint": null,
+    "Endpoint": "https://localhost/",
     "Logging": null,
     "Name": "test-cluster",
     "PlatformVersion": null,

--- a/pkg/eks/update.go
+++ b/pkg/eks/update.go
@@ -16,16 +16,15 @@ import (
 )
 
 // GetCurrentClusterConfigForLogging fetches current cluster logging configuration as two sets - enabled and disabled types
-func (c *ClusterProvider) GetCurrentClusterConfigForLogging(cl *api.ClusterMeta) (sets.String, sets.String, error) {
+func (c *ClusterProvider) GetCurrentClusterConfigForLogging(spec *api.ClusterConfig) (sets.String, sets.String, error) {
 	enabled := sets.NewString()
 	disabled := sets.NewString()
 
-	cluster, err := c.DescribeControlPlaneMustBeActive(cl)
-	if err != nil {
+	if ok, err := c.CanOperate(spec); !ok {
 		return nil, nil, errors.Wrap(err, "unable to retrieve current cluster logging configuration")
 	}
 
-	for _, logTypeGroup := range cluster.Logging.ClusterLogging {
+	for _, logTypeGroup := range c.Status.clusterInfo.cluster.Logging.ClusterLogging {
 		for _, logType := range logTypeGroup.Types {
 			if logType == nil {
 				return nil, nil, fmt.Errorf("unexpected response from EKS API - nil string")

--- a/pkg/eks/update_config_test.go
+++ b/pkg/eks/update_config_test.go
@@ -29,6 +29,7 @@ var _ = Describe("EKS API wrapper", func() {
 			p := mockprovider.NewMockProvider()
 			ctl = &ClusterProvider{
 				Provider: p,
+				Status:   &ProviderStatus{},
 			}
 
 			cfg = api.NewClusterConfig()
@@ -92,7 +93,7 @@ var _ = Describe("EKS API wrapper", func() {
 		})
 
 		It("should get current config", func() {
-			enabled, disabled, err := ctl.GetCurrentClusterConfigForLogging(cfg.Metadata)
+			enabled, disabled, err := ctl.GetCurrentClusterConfigForLogging(cfg)
 			Expect(err).NotTo(HaveOccurred())
 
 			enabled.HasAll("api", "audit")

--- a/pkg/elb/cleanup.go
+++ b/pkg/elb/cleanup.go
@@ -39,7 +39,7 @@ type loadBalancer struct {
 
 // Cleanup finds and deletes any dangling ELBs associated to a Kubernetes Service
 func Cleanup(ctx context.Context, ec2API ec2iface.EC2API, elbAPI elbiface.ELBAPI, elbv2API elbv2iface.ELBV2API,
-	kubernetesCS *kubernetes.Clientset, clusterConfig *api.ClusterConfig) error {
+	kubernetesCS kubernetes.Interface, clusterConfig *api.ClusterConfig) error {
 
 	deadline, ok := ctx.Deadline()
 	if !ok {

--- a/pkg/testutils/cluster.go
+++ b/pkg/testutils/cluster.go
@@ -14,12 +14,16 @@ func NewFakeCluster(clusterName string, status string) *awseks.Cluster {
 	cluster := &awseks.Cluster{
 		Name:      aws.String(clusterName),
 		Status:    aws.String(status),
-		Arn:       aws.String("arn-12345678"),
+		Arn:       aws.String("arn:aws:eks:us-west-2:12345:cluster/test-12345"),
 		CreatedAt: created,
 		ResourcesVpcConfig: &awseks.VpcConfigResponse{
 			VpcId:     aws.String("vpc-1234"),
 			SubnetIds: []*string{aws.String("sub1"), aws.String("sub2")},
 		},
+		CertificateAuthority: &awseks.Certificate{
+			Data: aws.String("dGVzdAo="),
+		},
+		Endpoint: aws.String("https://localhost/"),
 	}
 
 	return cluster


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This fixes #1254.

- rename `ctl.RefreshClusterConfig` to `ctl.RefreshClusterStatus`, so
  it's clear what it does and doesn't do
- enable simple short-term cache of cluster info
- imporove how `ctl.RefreshClusterStatus` works
- defined concrete methods - `ctl.CanOperate`, `ctl.CanUpdate`, `ctl.CanDelete`,
  for perfomaing high-level status checks and avoid usign
  `ctl.RefreshClusterStatus` directly
- remove `ctl.DescribeControlPlaneMustBeActive`
- ensure Kuberntes API deletion operations are only perfoermed on operable clusters
- improve early deletion test case


### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
