### PR TITLE
build: Change git repository for Apache Thrift

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,8 @@ require (
 )
 
 replace (
+	// Override since git.apache.org is down.  The docs say to fetch from github.
+	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v10.14.0+incompatible
 	// Needed due to to Sirupsen/sirupsen case clash
 	github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,7 @@ github.com/aokoli/goutils v1.0.1 h1:7fpzNGoJ3VA8qcrm++XEE1QUe0mIwNeLa02Nwq7RDkg=
 github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
 github.com/apache/arrow/go/arrow v0.0.0-20181031164735-a56c009257a7/go.mod h1:GjvccvtI06FGFvRU1In/maF7tKp3h7GBV9Sexo5rNPM=
 github.com/apache/arrow/go/arrow v0.0.0-20181217213538-e9ed591db9cb/go.mod h1:GjvccvtI06FGFvRU1In/maF7tKp3h7GBV9Sexo5rNPM=
+github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apex/log v1.1.0 h1:J5rld6WVFi6NxA6m8GJ1LJqu3+GiTFIt3mYv27gdQWI=
 github.com/apex/log v1.1.0/go.mod h1:yA770aXIDQrhVOIGurT/pVdfCpSq1GQV/auzMN5fzvY=


### PR DESCRIPTION
git.apache.org doesn't answer anymore:

```
go: git.apache.org/thrift.git@v0.12.0: unknown revision v0.12.0
go: git.apache.org/thrift.git@v0.0.0-20180902110319-2566ecd5d999: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /home/damien/go/pkg/mod/cache/vcs/83dba939f95a790e497d565fc4418400145a1a514f955fa052f662d56e920c3e: exit status 128:
	fatal: unable to access 'https://git.apache.org/thrift.git/': Failed to connect to git.apache.org port 443: Connection timed out
go: error loading module requirements
go: finding git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999
go: finding git.apache.org/thrift.git v0.12.0
go: git.apache.org/thrift.git@v0.12.0: unknown revision v0.12.0
```

The official documentation points at github:

https://thrift.apache.org/lib/go

```
$ go get github.com/apache/thrift/lib/go/thrift/...
```