### PR TITLE
build: Update code-generator version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ pkg/nodebootstrap/maxpods.go:
 deep_copy_helper_input := $(shell $(call godeps_cmd,./pkg/apis/...) | sed 's|$(generated_code_deep_copy_helper)||' )
 $(generated_code_deep_copy_helper): $(deep_copy_helper_input) .license-header ## Generate Kubernetes API helpers
 	time go mod download k8s.io/code-generator # make sure the code-generator is present
-	time env GOPATH="$$(go env GOPATH)" bash "$$(go env GOPATH)/pkg/mod/k8s.io/code-generator@v0.0.0-20190612205613-18da4a14b22b/generate-groups.sh" \
+	time env GOPATH="$$(go env GOPATH)" bash "$$(go env GOPATH)/pkg/mod/k8s.io/code-generator@v0.0.0-20190808180452-d0071a119380/generate-groups.sh" \
 	  deepcopy,defaulter _ ./pkg/apis eksctl.io:v1alpha5 --go-header-file .license-header --output-base="$(git_toplevel)" \
 	  || (cat codegenheader.txt ; cat $(generated_code_deep_copy_helper); exit 1)
 


### PR DESCRIPTION
The version in the Makefile doesn't match the one in go.sum anymore. It works
because CI and people have it cached on their dev machines, but it doesn't work
for fresh installs.
