### PR TITLE
Fixed createdeletebeforeactive tests

### DIFF
--- a/integration/createdeletebeforeactive_test.go
+++ b/integration/createdeletebeforeactive_test.go
@@ -42,13 +42,10 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 				"--without-nodegroup",
 				"--version", version,
 			)
-			gexecSession := cmd.Start()
-
+			cmd.Start()
 			awsSession := NewSession(region)
 			Eventually(awsSession, timeOut, pollInterval).Should(
 				HaveExistingCluster(delBeforeActiveName, awseks.ClusterStatusCreating, version))
-
-			gexecSession.Interrupt() // interrupt as soon as cluster is in creating stage
 		})
 	})
 
@@ -78,7 +75,7 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 			cmd := eksctlDeleteClusterCmd.WithArgs(
 				"--name", delBeforeActiveName,
 			)
-			Expect(cmd).To(RunSuccessfully())
+			Expect(cmd).ToNot(RunSuccessfully())
 		})
 	})
 })


### PR DESCRIPTION
- Interrupting the "create" caused process to terminate, FIXED
- Second delete of already deleted cluster should NOT be successful, FIXED

### Description

<!-- Please explain the changes you made here. -->

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
