### PR TITLE
Eagerly validates eksctl gitops apply's --output-path

### DIFF
--- a/pkg/ctl/gitops/apply.go
+++ b/pkg/ctl/gitops/apply.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/gitops"
 	"github.com/weaveworks/eksctl/pkg/gitops/fileprocessor"
 	"github.com/weaveworks/eksctl/pkg/gitops/flux"
+	"github.com/weaveworks/eksctl/pkg/utils/dir"
 	"github.com/weaveworks/eksctl/pkg/utils/file"
 )
 
@@ -40,6 +41,16 @@ func (opts options) validate() error {
 	}
 	if opts.gitPrivateSSHKeyPath != "" && !file.Exists(opts.gitPrivateSSHKeyPath) {
 		return errors.New("please supply a valid --git-private-ssh-key-path argument")
+	}
+	if !file.Exists(opts.outputPath) {
+		return errors.New("directory does not exists: please supply a valid --output-path argument")
+	}
+	isEmpty, err := dir.IsEmpty(opts.outputPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to validate directory provided via the --output-path argument")
+	}
+	if !isEmpty {
+		return errors.New("directory is not empty: please supply a valid --output-path argument")
 	}
 	return nil
 }

--- a/pkg/ctl/gitops/apply.go
+++ b/pkg/ctl/gitops/apply.go
@@ -31,6 +31,19 @@ type options struct {
 	gitPrivateSSHKeyPath string
 }
 
+func (opts options) validate() error {
+	if opts.quickstartNameArg == "" {
+		return errors.New("please supply a valid gitops Quick Start URL or name in --quickstart-profile")
+	}
+	if err := opts.gitOptions.ValidateURL(); err != nil {
+		return errors.Wrap(err, "please supply a valid --git-url argument")
+	}
+	if opts.gitPrivateSSHKeyPath != "" && !file.Exists(opts.gitPrivateSSHKeyPath) {
+		return errors.New("please supply a valid --git-private-ssh-key-path argument")
+	}
+	return nil
+}
+
 func applyGitops(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
@@ -71,15 +84,8 @@ func applyGitops(cmd *cmdutils.Cmd) {
 }
 
 func doApplyGitops(cmd *cmdutils.Cmd, opts options) error {
-	if opts.quickstartNameArg == "" {
-		return errors.New("please supply a valid gitops Quick Start URL or name in --quickstart-profile")
-	}
-
-	if err := opts.gitOptions.ValidateURL(); err != nil {
-		return errors.Wrap(err, "please supply a valid --git-url argument")
-	}
-	if opts.gitPrivateSSHKeyPath != "" && !file.Exists(opts.gitPrivateSSHKeyPath) {
-		return errors.New("please supply a valid --git-private-ssh-key-path argument")
+	if err := opts.validate(); err != nil {
+		return err
 	}
 
 	quickstartRepoURL, err := repoURLForQuickstart(opts.quickstartNameArg)

--- a/pkg/ctl/gitops/apply.go
+++ b/pkg/ctl/gitops/apply.go
@@ -43,7 +43,7 @@ func (opts options) validate() error {
 		return errors.New("please supply a valid --git-private-ssh-key-path argument")
 	}
 	if !file.Exists(opts.outputPath) {
-		return errors.New("directory does not exists: please supply a valid --output-path argument")
+		return errors.New("directory does not exist: please supply a valid --output-path argument")
 	}
 	isEmpty, err := dir.IsEmpty(opts.outputPath)
 	if err != nil {

--- a/pkg/utils/dir/dir.go
+++ b/pkg/utils/dir/dir.go
@@ -1,0 +1,24 @@
+package dir
+
+import (
+	"io"
+	"os"
+
+	"github.com/weaveworks/eksctl/pkg/utils/file"
+)
+
+// IsEmpty checks if the provided directory is empty or not.
+func IsEmpty(path string) (bool, error) {
+	path = file.ExpandPath(path)
+	d, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer d.Close()
+	// Check ONLY the next file's metadata, as no need to check more to know whether the directory is empty or not.
+	_, err = d.Readdir(1)
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, err
+}

--- a/pkg/utils/dir/dir_test.go
+++ b/pkg/utils/dir/dir_test.go
@@ -1,0 +1,54 @@
+package dir_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/testutils"
+	"github.com/weaveworks/eksctl/pkg/utils/dir"
+)
+
+func TestSuite(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}
+
+var _ = Describe("dir.IsEmpty", func() {
+	It("should return true when passed an empty directory", func() {
+		d, err := ioutil.TempDir("", "test_dir_isempty")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(d) // clean up.
+
+		isEmpty, err := dir.IsEmpty(d)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isEmpty).To(BeTrue())
+	})
+
+	It("should return false when passed a directory containing another directory", func() {
+		d, err := ioutil.TempDir("", "test_dir_isempty")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(d) // clean up.
+		err = os.Mkdir(filepath.Join(d, "subdir"), 0755)
+		Expect(err).NotTo(HaveOccurred())
+
+		isEmpty, err := dir.IsEmpty(d)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isEmpty).To(BeFalse())
+	})
+
+	It("should return false when passed a directory containing a file", func() {
+		d, err := ioutil.TempDir("", "test_dir_isempty")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(d) // clean up.
+		f, err := os.OpenFile(filepath.Join(d, "file.tmp"), os.O_CREATE, 0755)
+		Expect(err).NotTo(HaveOccurred())
+		defer os.Remove(f.Name()) // clean up.
+
+		isEmpty, err := dir.IsEmpty(d)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isEmpty).To(BeFalse())
+	})
+})

--- a/pkg/utils/file/file.go
+++ b/pkg/utils/file/file.go
@@ -1,15 +1,15 @@
 package file
 
 import (
-	kopsutils "k8s.io/kops/upup/pkg/fi/utils"
 	"os"
+
+	kopsutils "k8s.io/kops/upup/pkg/fi/utils"
 )
 
 // Exists checks to see if a file exists.
 func Exists(path string) bool {
 	extendedPath := ExpandPath(path)
 	_, err := os.Stat(extendedPath)
-
 	return err == nil
 }
 


### PR DESCRIPTION
### Description

Eagerly validates `eksctl gitops apply`'s `--output-path`, in order to "fail fast" with more useful feedback for the end-user, hence hopefully improving the overall user experience.

Addresses part of #1274. (Note that we may want to change the UX completely and maybe not use this argument at all, but a temporary directory instead, but for now I'd rather at least have this validation in place.)

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] ~Added/modified documentation as required (such as the `README.md`, and `examples` directory)~
- [x] Manually tested

### Manual tests

```console
$ cd $GOPATH/src/github.com/weaveworks/eksctl
$ make build
```

Using the default (current directory) fails, as it is a non-empty directory:
```console
$ EKSCTL_EXPERIMENTAL=true ./eksctl \
    -f examples/eks-quickstart-app-dev.yaml \
    gitops apply \
    --quickstart-profile git@github.com:marccarre/eks-quickstart-app-dev.git \
    --git-url git@github.com:marccarre/my-gitops-repo.git \
    --git-email carre.marc+eksctl@gmail.com

[✖]  directory is not empty: please supply a valid --output-path argument
```

Creating an empty sub-directory and using that instead succeeds:
```console
$ mkdir _test
$ EKSCTL_EXPERIMENTAL=true ./eksctl \
    -f examples/eks-quickstart-app-dev.yaml \
    gitops apply \
    --quickstart-profile git@github.com:marccarre/eks-quickstart-app-dev.git \
    --git-url git@github.com:marccarre/my-gitops-repo.git \
    --git-email carre.marc+eksctl@gmail.com \
    --output-path "$(pwd)/_test"

[ℹ]  Generating public key infrastructure for the Helm Operator and Tiller
[ℹ]    this may take up to a minute, please be patient
[!]  Public key infrastructure files were written into directory "/var/folders/24/d3mml6bn20nftpt91cfldq1h0000gn/T/eksctl-helm-pki798811186"
[!]  please move the files into a safe place or delete them
[ℹ]  Generating manifests
[ℹ]  Cloning git@github.com:marccarre/my-gitops-repo.git
Cloning into '/var/folders/24/d3mml6bn20nftpt91cfldq1h0000gn/T/eksctl-install-flux-clone-306851817'...
remote: Enumerating objects: 53, done.
remote: Counting objects: 100% (53/53), done.
remote: Compressing objects: 100% (40/40), done.
remote: Total 359 (delta 20), reused 40 (delta 9), pack-reused 306
Receiving objects: 100% (359/359), 142.78 KiB | 435.00 KiB/s, done.
Resolving deltas: 100% (127/127), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
[ℹ]  Writing Flux manifests
[ℹ]  created "Namespace/flux"
[ℹ]  Applying Helm TLS Secret(s)
[ℹ]  created "flux:Secret/flux-helm-tls-cert"
[ℹ]  created "flux:Secret/tiller-secret"
[!]  Note: certificate secrets aren't added to the Git repository for security reasons
[ℹ]  Applying manifests
[ℹ]  created "flux:ServiceAccount/flux-helm-operator"
[ℹ]  created "ClusterRole.rbac.authorization.k8s.io/flux-helm-operator"
[ℹ]  created "ClusterRoleBinding.rbac.authorization.k8s.io/flux-helm-operator"
[ℹ]  created "flux:Deployment.apps/flux-helm-operator"
[ℹ]  created "flux:ConfigMap/flux-helm-tls-ca-config"
[ℹ]  created "CustomResourceDefinition.apiextensions.k8s.io/helmreleases.helm.fluxcd.io"
[ℹ]  created "flux:Deployment.extensions/tiller-deploy"
[ℹ]  created "flux:Service/tiller-deploy"
[ℹ]  created "flux:Secret/flux-git-deploy"
[ℹ]  created "flux:ServiceAccount/tiller"
[ℹ]  created "ClusterRoleBinding.rbac.authorization.k8s.io/tiller"
[ℹ]  created "flux:ServiceAccount/helm"
[ℹ]  created "flux:Role.rbac.authorization.k8s.io/tiller-user"
[ℹ]  created "kube-system:RoleBinding.rbac.authorization.k8s.io/tiller-user-binding"
[ℹ]  created "flux:Deployment.apps/flux"
[ℹ]  created "flux:Service/memcached"
[ℹ]  created "flux:Deployment.apps/memcached"
[ℹ]  created "flux:ServiceAccount/flux"
[ℹ]  created "ClusterRole.rbac.authorization.k8s.io/flux"
[ℹ]  created "ClusterRoleBinding.rbac.authorization.k8s.io/flux"
[ℹ]  Waiting for Helm Operator to start
ERROR: logging before flag.Parse: E0917 18:11:54.359238   51013 portforward.go:331] an error occurred forwarding 60173 -> 3030: error forwarding port 3030 to pod fe5119638a70138f4bde9dc7d41690e345acc10a398ecb935ef06cbb45a68db6, uid : exit status 1: 2019/09/17 09:11:54 socat[6399] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:60173/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0917 18:11:56.387871   51013 portforward.go:331] an error occurred forwarding 60173 -> 3030: error forwarding port 3030 to pod fe5119638a70138f4bde9dc7d41690e345acc10a398ecb935ef06cbb45a68db6, uid : exit status 1: 2019/09/17 09:11:56 socat[6444] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:60173/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0917 18:11:58.410358   51013 portforward.go:331] an error occurred forwarding 60173 -> 3030: error forwarding port 3030 to pod fe5119638a70138f4bde9dc7d41690e345acc10a398ecb935ef06cbb45a68db6, uid : exit status 1: 2019/09/17 09:11:58 socat[6522] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:60173/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0917 18:12:00.443544   51013 portforward.go:331] an error occurred forwarding 60173 -> 3030: error forwarding port 3030 to pod fe5119638a70138f4bde9dc7d41690e345acc10a398ecb935ef06cbb45a68db6, uid : exit status 1: 2019/09/17 09:12:00 socat[6523] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:60173/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0917 18:12:02.465606   51013 portforward.go:331] an error occurred forwarding 60173 -> 3030: error forwarding port 3030 to pod fe5119638a70138f4bde9dc7d41690e345acc10a398ecb935ef06cbb45a68db6, uid : exit status 1: 2019/09/17 09:12:02 socat[6530] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:60173/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0917 18:12:04.492025   51013 portforward.go:331] an error occurred forwarding 60173 -> 3030: error forwarding port 3030 to pod fe5119638a70138f4bde9dc7d41690e345acc10a398ecb935ef06cbb45a68db6, uid : exit status 1: 2019/09/17 09:12:04 socat[6607] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:60173/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0917 18:12:06.556698   51013 portforward.go:331] an error occurred forwarding 60173 -> 3030: error forwarding port 3030 to pod fe5119638a70138f4bde9dc7d41690e345acc10a398ecb935ef06cbb45a68db6, uid : exit status 1: 2019/09/17 09:12:06 socat[6716] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:60173/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0917 18:12:08.586786   51013 portforward.go:331] an error occurred forwarding 60173 -> 3030: error forwarding port 3030 to pod fe5119638a70138f4bde9dc7d41690e345acc10a398ecb935ef06cbb45a68db6, uid : exit status 1: 2019/09/17 09:12:08 socat[6728] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:60173/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0917 18:12:10.614703   51013 portforward.go:331] an error occurred forwarding 60173 -> 3030: error forwarding port 3030 to pod fe5119638a70138f4bde9dc7d41690e345acc10a398ecb935ef06cbb45a68db6, uid : exit status 1: 2019/09/17 09:12:10 socat[6740] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:60173/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0917 18:12:12.642803   51013 portforward.go:331] an error occurred forwarding 60173 -> 3030: error forwarding port 3030 to pod fe5119638a70138f4bde9dc7d41690e345acc10a398ecb935ef06cbb45a68db6, uid : exit status 1: 2019/09/17 09:12:12 socat[6823] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:60173/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0917 18:12:14.670660   51013 portforward.go:331] an error occurred forwarding 60173 -> 3030: error forwarding port 3030 to pod fe5119638a70138f4bde9dc7d41690e345acc10a398ecb935ef06cbb45a68db6, uid : exit status 1: 2019/09/17 09:12:14 socat[6948] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:60173/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0917 18:12:16.698780   51013 portforward.go:331] an error occurred forwarding 60173 -> 3030: error forwarding port 3030 to pod fe5119638a70138f4bde9dc7d41690e345acc10a398ecb935ef06cbb45a68db6, uid : exit status 1: 2019/09/17 09:12:16 socat[6951] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:60173/healthz: EOF), retrying ...
ERROR: logging before flag.Parse: E0917 18:12:18.731963   51013 portforward.go:331] an error occurred forwarding 60173 -> 3030: error forwarding port 3030 to pod fe5119638a70138f4bde9dc7d41690e345acc10a398ecb935ef06cbb45a68db6, uid : exit status 1: 2019/09/17 09:12:18 socat[6952] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused
[!]  Helm Operator is not ready yet (Get http://127.0.0.1:60173/healthz: EOF), retrying ...
[ℹ]  Helm Operator started successfully
[ℹ]  see https://docs.fluxcd.io/projects/helm-operator for details on how to use the Helm Operator
[ℹ]  Waiting for Flux to start
[ℹ]  Flux started successfully
[ℹ]  see https://docs.fluxcd.io/projects/flux for details on how to use Flux
[ℹ]  Committing and pushing manifests to git@github.com:marccarre/my-gitops-repo.git
[master 4972572] Add Initial Flux configuration
 2 files changed, 39 insertions(+), 39 deletions(-)
 rewrite flux/tiller-ca-cert-configmap.yaml (87%)
Enumerating objects: 9, done.
Counting objects: 100% (9/9), done.
Delta compression using up to 8 threads
Compressing objects: 100% (5/5), done.
Writing objects: 100% (5/5), 2.21 KiB | 2.21 MiB/s, done.
Total 5 (delta 3), reused 0 (delta 0)
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.
To github.com:marccarre/my-gitops-repo.git
   b8a0592..4972572  master -> master
[ℹ]  Flux will only operate properly once it has write-access to the Git repository
Cloning into '/Users/marc/dev/src/github.com/weaveworks/eksctl/_test/my-gitops-repo'...
remote: Enumerating objects: 58, done.
remote: Counting objects: 100% (58/58), done.
remote: Compressing objects: 100% (45/45), done.
remote: Total 364 (delta 22), reused 42 (delta 9), pack-reused 306
Receiving objects: 100% (364/364), 146.92 KiB | 439.00 KiB/s, done.
Resolving deltas: 100% (129/129), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
[ℹ]  cloning repository "git@github.com:marccarre/eks-quickstart-app-dev.git":master
Cloning into '/var/folders/24/d3mml6bn20nftpt91cfldq1h0000gn/T/quickstart-563289140'...
remote: Enumerating objects: 190, done.
remote: Total 190 (delta 0), reused 0 (delta 0), pack-reused 190
Receiving objects: 100% (190/190), 48.32 KiB | 294.00 KiB/s, done.
Resolving deltas: 100% (84/84), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
[ℹ]  processing template files in repository
[ℹ]  writing new manifests to "/Users/marc/dev/src/github.com/weaveworks/eksctl/_test/my-gitops-repo/base"
[master 0dda406] Add git@github.com:marccarre/eks-quickstart-app-dev.git quickstart components
 4 files changed, 5 insertions(+), 5 deletions(-)
Enumerating objects: 16, done.
Counting objects: 100% (16/16), done.
Delta compression using up to 8 threads
Compressing objects: 100% (9/9), done.
Writing objects: 100% (9/9), 1.59 KiB | 1.59 MiB/s, done.
Total 9 (delta 6), reused 0 (delta 0)
remote: Resolving deltas: 100% (6/6), completed with 6 local objects.
To github.com:marccarre/my-gitops-repo.git
   4972572..0dda406  master -> master
[ℹ]  please configure git@github.com:marccarre/my-gitops-repo.git so that the following Flux SSH public key has write access to it
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCdAKNLuV3hZ2exe0Ku/l6zEFolzGz5OIwxmRmtnvsfHiiSc0BBBVaZvWOuhyodRAMoGms1VyNKbjZvg1MM7IqzdIfx0lgg9EwXPaz/JIx8WsNTUXRUGoO3sn/VYf0WqECJjKd4q+jcN/RSHC6Sv/YhFMMxcBGHPlefsTBKNrTEE6XtgxSlT8hHBh0c+DXKo/2h6TImsoOj0PnMsJRGY5oMhj8J62pwhdCP1z6hCFdkuJbWoS2Ys7xQQnUXoQF+nJHZybrCq7vm4E62H4lANq7eb6g1426ZwVJLCcjPyt1dVhs8/t/a8TE0X9qB7yo5E2OcZmGIZ2/5HrbsY/WS2sLN
```

A sub-sequent call to the same command fails, which is to be expected, as the directory is now no longer empty:
```console
$ EKSCTL_EXPERIMENTAL=true ./eksctl \
    -f examples/eks-quickstart-app-dev.yaml \
    gitops apply \
    --quickstart-profile git@github.com:marccarre/eks-quickstart-app-dev.git \
    --git-url git@github.com:marccarre/my-gitops-repo.git \
    --git-email carre.marc+eksctl@gmail.com \
    --output-path "$(pwd)/_test"

[✖]  directory is not empty: please supply a valid --output-path argument
```
