### PR TITLE
Rename GitOps to gitops

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,7 +218,7 @@ This allows the message to be easier to read on GitHub as well as in various git
 It's recommended to run containerised tests with `make integration-test-container TEST_V=1 AWS_PROFILE="<AWS profile name>"`. The tests require:
 
 - Access to an AWS account. If there is an issue with access (e.g. expired MFA token), you will see all tests failing (albeit the error message may be slightly unclear).
-- Access to the private SSH key for the Git repository to use for testing GitOps-related operations. It is recommended to extract the private SSH key available [here](https://weaveworks.1password.com/vaults/all/allitems/kuxa5ujn7424jzkqqk7qtngovi) into `~/.ssh/eksctl-bot_id_rsa`, and then let the integration tests mount this path and use this key.
+- Access to the private SSH key for the Git repository to use for testing gitops-related operations. It is recommended to extract the private SSH key available [here](https://weaveworks.1password.com/vaults/all/allitems/kuxa5ujn7424jzkqqk7qtngovi) into `~/.ssh/eksctl-bot_id_rsa`, and then let the integration tests mount this path and use this key.
 
 At present we ignore flaky tests, so if you see output like show below, you don't need to worry about this for the purpose of the release. However, you might consider reviewing the issues in question after you made the release.
 

--- a/integration/creategetdelete_test.go
+++ b/integration/creategetdelete_test.go
@@ -125,7 +125,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 			})
 		})
 
-		Context("and configuring Flux for GitOps", func() {
+		Context("and configuring Flux for gitops", func() {
 			It("should not return an error", func() {
 				// Use a random branch to ensure test runs don't step on each others.
 				branch := namer.RandomName()

--- a/pkg/ctl/generate/generate.go
+++ b/pkg/ctl/generate/generate.go
@@ -8,7 +8,7 @@ import (
 
 // Command creates `generate` commands
 func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
-	verbCmd := cmdutils.NewVerbCmd("generate", "Generate GitOps manifests", "")
+	verbCmd := cmdutils.NewVerbCmd("generate", "Generate gitops manifests", "")
 	cmdutils.AddResourceCmd(flagGrouping, verbCmd, generateProfileCmd)
 	return verbCmd
 }

--- a/pkg/ctl/generate/profile.go
+++ b/pkg/ctl/generate/profile.go
@@ -25,7 +25,7 @@ func generateProfileCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
 
-	cmd.SetDescription("profile", "Generate a GitOps profile", "")
+	cmd.SetDescription("profile", "Generate a gitops profile", "")
 
 	var o options
 

--- a/pkg/ctl/gitops/apply.go
+++ b/pkg/ctl/gitops/apply.go
@@ -48,7 +48,7 @@ func applyGitops(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
 
-	cmd.SetDescription("apply", "Setting up GitOps and apply a Quick Start profile", "")
+	cmd.SetDescription("apply", "Setting up gitops and apply a Quick Start profile", "")
 
 	var opts options
 

--- a/pkg/ctl/gitops/gitops.go
+++ b/pkg/ctl/gitops/gitops.go
@@ -8,7 +8,7 @@ import (
 
 // Command will create the `gitops` commands
 func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
-	verbCmd := cmdutils.NewVerbCmd("gitops", "Helps setting up GitOps in a cluster", "")
+	verbCmd := cmdutils.NewVerbCmd("gitops", "Helps setting up gitops in a cluster", "")
 
 	cmdutils.AddResourceCmd(flagGrouping, verbCmd, applyGitops)
 

--- a/pkg/gitops/profile.go
+++ b/pkg/gitops/profile.go
@@ -18,7 +18,7 @@ const (
 	cloneDirPrefix = "quickstart-"
 )
 
-// Profile represents a GitOps profile
+// Profile represents a gitops profile
 type Profile struct {
 	Processor fileprocessor.FileProcessor
 	Path      string

--- a/site/content/community/02-roadmap.md
+++ b/site/content/community/02-roadmap.md
@@ -13,7 +13,7 @@ One or more release candidate(s) (RC) builds will be made available prior to eac
 
 ## Project Roadmap Themes
 
-### Cluster Quick Start with gitops
+### Cluster Quick Start with Gitops
 
 It should be easy to create a cluster with various applications pre-installed, e.g. Weave Flux, Helm 2 (Tiller), ALB Ingress controller. It should also be easy to manage these applications in a declarative way using config files in a git repo (with [gitops](https://www.weave.works/blog/what-is-gitops-really)).
 

--- a/site/content/community/02-roadmap.md
+++ b/site/content/community/02-roadmap.md
@@ -13,9 +13,9 @@ One or more release candidate(s) (RC) builds will be made available prior to eac
 
 ## Project Roadmap Themes
 
-### Cluster quickstart with GitOps
+### Cluster Quick Start with gitops
 
-It should be easy to create a cluster with various applications pre-installed, e.g. Weave Flux, Helm 2 (Tiller), ALB Ingress controller. It should also be easy to manage these applications in a declarative way using config files in a git repo (with [GitOps](https://www.weave.works/blog/what-is-gitops-really)).
+It should be easy to create a cluster with various applications pre-installed, e.g. Weave Flux, Helm 2 (Tiller), ALB Ingress controller. It should also be easy to manage these applications in a declarative way using config files in a git repo (with [gitops](https://www.weave.works/blog/what-is-gitops-really)).
 
 ### Declarative configuration management for clusters
 

--- a/site/content/community/02-roadmap.md
+++ b/site/content/community/02-roadmap.md
@@ -13,7 +13,7 @@ One or more release candidate(s) (RC) builds will be made available prior to eac
 
 ## Project Roadmap Themes
 
-### Cluster Quick Start with Gitops
+### Cluster Quick Start with gitops
 
 It should be easy to create a cluster with various applications pre-installed, e.g. Weave Flux, Helm 2 (Tiller), ALB Ingress controller. It should also be easy to manage these applications in a declarative way using config files in a git repo (with [gitops](https://www.weave.works/blog/what-is-gitops-really)).
 

--- a/site/content/gitops-quickstart/01-apply-gitops.md
+++ b/site/content/gitops-quickstart/01-apply-gitops.md
@@ -1,12 +1,12 @@
 ---
-title: Setup your cluster with GitOps
+title: Setup your cluster with gitops
 weight: 10
 url: gitops-quickstart/setup-gitops
 ---
 
-# Setup your cluster with GitOps
+# Setup your cluster with gitops
 
-Welcome to `eksctl` GitOps Quick Starts. In this guide we will show you
+Welcome to `eksctl` gitops Quick Starts. In this guide we will show you
 how to launch fully-configured Kubernetes clusters that are ready to
 run production workloads in minutes: easy for you to get started running
 Kubernetes on EKS and to launch standard clusters in your organisation.
@@ -15,9 +15,9 @@ At the end of this, you will have a Kubernetes cluster including control
 plane, worker nodes, and all of the software needed for code deployment,
 monitoring, and logging.
 
-## Quick Start to GitOps
+## Quick Start to gitops
 
-[GitOps][gitops] is a way to do Kubernetes application delivery. It
+[gitops][gitops] is a way to do Kubernetes application delivery. It
 works by using Git as a single source of truth for Kubernetes resources
 and everything else. With Git at the center of your delivery pipelines,
 you and your team can make pull requests to accelerate and simplify
@@ -25,7 +25,7 @@ application deployments and operations tasks to Kubernetes.
 
 [gitops]: https://www.weave.works/technologies/gitops/
 
-Using GitOps Quick Starts will get you set up in next to no time. You
+Using gitops Quick Starts will get you set up in next to no time. You
 will benefit from a setup that is based on the experience of companies
 who run workloads at scale.
 
@@ -45,9 +45,9 @@ Next, you will have to have the following tools installed:
 [aws-iam-authenticator]: https://github.com/kubernetes-sigs/aws-iam-authenticator
 [aws-kubectl]: https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
 
-### Getting ready for GitOps
+### Getting ready for gitops
 
-The main point of GitOps is to keep everything (config, alerts, dashboards,
+The main point of gitops is to keep everything (config, alerts, dashboards,
 apps, literally everything) in Git and use it as a single source of truth.
 To keep your cluster configuration in Git, please go ahead and create an
 _empty_ repository. On Github, for example, follow [these steps][github-repo].
@@ -89,10 +89,10 @@ kube-system   kube-proxy-qzcmk           1/1     Running   0          45s
 ```
 
 
-## Applying GitOps
+## Applying gitops
 
 The following command will set up your cluster with the `app-dev` profile,
-the first GitOps Quick Start. All of the config files you need for a
+the first gitops Quick Start. All of the config files you need for a
 production-ready cluster will be in the git repo you have provided and
 those components will be deployed to your cluster. When you make changes
 in the configuration they will be reflected on your cluster.
@@ -112,7 +112,7 @@ What will happen during the following command is:
 
 - `eksctl` will add install [Flux](https://fluxcd.io) and Helm in your cluster, and add their
   manifest to Git, so you can configure them through pull requests.
-- It will also add the `app-dev` GitOps Quick Start profile to it,
+- It will also add the `app-dev` gitops Quick Start profile to it,
   which comes with a lot of very useful services and config. It is how
   we feel EKS `app-dev` clusters are best run.
 
@@ -142,10 +142,10 @@ Let us go through the specified arguments one by one:
   to see all clusters in your default region.
 
 There are more arguments and options, please refer to the
-[GitOps reference of eksctl](/usage/experimental/gitops-flux/)
+[gitops reference of eksctl](/usage/experimental/gitops-flux/)
 which details all the flags and resulting directory structure.
 
-This will set up Flux on your cluster and load GitOps
+This will set up Flux on your cluster and load gitops
 Quick Start config files into your repo. It will use templating to add your
 cluster name and region to the configuration so that cluster components
 that need those values can work (e.g. `alb-ingress`).
@@ -202,11 +202,11 @@ monitoring             prometheus-prometheus-operator-prometheus-0              
 ```
 
 All of the cluster configuration can be easily edited in Git now.
-Welcome to a fully GitOpsed world!
+Welcome to a fully gitopsed world!
 
-## Your GitOps cluster
+## Your gitops cluster
 
-Welcome to your fully GitOpsed cluster. By choosing the `app-dev` Quick
+Welcome to your fully gitopsed cluster. By choosing the `app-dev` Quick
 Start profile, you will now also have the following components running
 in your cluster:
 
@@ -240,7 +240,7 @@ If you open `localhost:9898` in your browser, you will see
 
 ![podinfo up and running](../images/podinfo-screenshot.png)
 
-Congratulations to your GitOpsed cluster on EKS!
+Congratulations to your gitopsed cluster on EKS!
 
 ## Advanced setups
 
@@ -252,12 +252,12 @@ Congratulations to your GitOpsed cluster on EKS!
 So for more complex use cases, you will want to run these steps
 separately on your own and adjust flags and options as necessary. The
 first command installs Flux and links it to a Git repo that you provide.
-The second generates the manifest files from the GitOps Quick Start profile
+The second generates the manifest files from the gitops Quick Start profile
 locally, so that you can edit them before pushing to your Git repo.
 
 ### Configuring Flux
 
-Here we will install [Flux](https://fluxcd.io), the Kubernetes GitOps
+Here we will install [Flux](https://fluxcd.io), the Kubernetes gitops
 operator in your cluster. It will take care of deployments for you.
 
 ```console
@@ -342,7 +342,7 @@ organisation has already experience in setting up clusters and use the
 same defaults, it makes sense to use those as a profile. You could
 be entirely starting from scratch here too. What we will do in this part
 of the tutorial is using `weaveworks/eks-quickstart-app-dev`, which is
-the `app-dev` GitOps Quick Start profile. To create your own profile
+the `app-dev` gitops Quick Start profile. To create your own profile
 check out [the documentation](usage/experimental/gitops-flux/#creating-your-own-quick-start-profile).
 
 Now please run:
@@ -402,7 +402,7 @@ kubernetes-dashboard   kubernetes-dashboard-7447f48f55-2pl66       1/1     Runni
 ```
 
 All of the cluster configuration can be easily edited in Git now.
-Welcome to a fully GitOpsed world!
+Welcome to a fully gitopsed world!
 
 ## Conclusion
 

--- a/site/content/usage/experimental/01-gitops.md
+++ b/site/content/usage/experimental/01-gitops.md
@@ -1,12 +1,12 @@
 ---
-title: "GitOps"
+title: "gitops"
 weight: 190
 url: usage/experimental/gitops-flux
 ---
 
-## GitOps
+## gitops
 
-[GitOps][gitops] is a way to do Kubernetes application delivery. It works by using Git as a single source of truth for
+[gitops][gitops] is a way to do Kubernetes application delivery. It works by using Git as a single source of truth for
 Kubernetes resources. With Git at the center of your delivery pipelines, developers can make pull requests to accelerate
 and simplify application deployments and operations tasks to Kubernetes.
 
@@ -119,12 +119,12 @@ memcached-958f745c-qdfgz   1/1     Running   0          29m
 
 #### Adding a workload
 
-To deploy a new workload on the cluster using GitOps just add a kubernetes manifest to the repository. After a few
+To deploy a new workload on the cluster using gitops just add a kubernetes manifest to the repository. After a few
 minutes you should see the resources appearing in the cluster.
 
 #### Further reading
 
-To learn more about GitOps and Flux, check the [Flux documentation][flux]
+To learn more about gitops and Flux, check the [Flux documentation][flux]
 
 
 ### Installing components from a Quick Start profile
@@ -213,11 +213,11 @@ git push origin master
 
 After a few minutes, Flux and Helm should have installed all the components in your cluster.
 
-## Setting up GitOps in a repo from a Quick Start
+## Setting up gitops in a repo from a Quick Start
 
-Configuring GitOps can be done easily with eksctl. The command `eksctl gitops apply` takes an existing EKS cluster and
-an empty repository and sets them up with GitOps and a specified Quick Start profile. This means that with one command
-the cluster will have all the components provided by the Quick Start profile installed in the cluster and you can enjoy the advantages of GitOps moving forward.
+Configuring gitops can be done easily with eksctl. The command `eksctl gitops apply` takes an existing EKS cluster and
+an empty repository and sets them up with gitops and a specified Quick Start profile. This means that with one command
+the cluster will have all the components provided by the Quick Start profile installed in the cluster and you can enjoy the advantages of gitops moving forward.
 
 The basic command usage looks like this:
 
@@ -428,7 +428,7 @@ All CLI arguments:
 ## Creating your own Quick Start profile
 
 A Quick Start profile is a Git repository that contains Kubernetes manifests that can be installed in a cluster using
-GitOps (through [Flux][flux]).
+gitops (through [Flux][flux]).
 
 These manifests, will probably need some information about the cluster they will be installed in, such as the cluster
 name or the AWS region. That's why they are templated using [Go templates][go-templates].
@@ -458,7 +458,7 @@ metadata:
 ```
 
 Write this into a file with the extension `*.yaml.tmpl` and commit it to your Quick Start repository.
-Files with this extension get processed by eksctl before committing them to the user's GitOps repository, while the rest get copied unmodified.
+Files with this extension get processed by eksctl before committing them to the user's gitops repository, while the rest get copied unmodified.
 
 Regarding the folder structure inside the Quick Start repository, we recommend using a folder for each `namespace` and
 one file per Kubernetes resource.
@@ -497,7 +497,7 @@ EKSCTL_EXPERIMENTAL=true eksctl gitops apply --cluster team1 --region eu-west-1 
 ```
 
 In this example we provide `github.com:my-org/production-infra` as the Quick Start profile and 
-`github.com:my-org/team1-cluster` as the GitOps repository that is connected to the Flux instance in the cluster named
+`github.com:my-org/team1-cluster` as the gitops repository that is connected to the Flux instance in the cluster named
 `cluster1`.
 
 


### PR DESCRIPTION
Rename GitOps to gitops in both documentation and logging messages.