### PR TITLE
Fix flag parsing in integration tests

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -54,6 +54,8 @@ func init() {
 	flag.StringVar(&kubeconfigPath, "eksctl.kubeconfig", "", "Path to kubeconfig (default: create it a temporary file)")
 	flag.StringVar(&privateSSHKeyPath, "eksctl.git.sshkeypath", defaultPrivateSSHKeyPath, fmt.Sprintf("Path to the SSH key to use for Git operations (default: %s)", defaultPrivateSSHKeyPath))
 
+	flag.Parse()
+
 	eksctlCmd = runner.NewCmd(eksctlPath).
 		WithArgs("--region", region).
 		WithTimeout(30 * time.Minute)


### PR DESCRIPTION
The INTEGRATION_TEST_REGION variable didn't work because the flag
`-eksctl.region` was never parsed.

```
------------------------------
(Integration) Create, Get, Scale & Delete when creating a cluster with 1 node and add the second nodegroup and manipulating iam identity mappings
  fails getting unknown mapping
  /home/martina/weaveworks/eksctl/integration/creategetdelete_test.go:684
starting '../eksctl "--region" "us-west-2" "get" "iamidentitymapping" "--name" "martina-test-1" "--region" "eu-north-1" "--role" "idontexist" "-o" "yaml"'
Flag --role has been deprecated, see --arn
[✖]  no iamidentitymapping with arn "idontexist" found
•
```

That meant that the tests were also run in the default flag value "us-west-2"
except when they were overriden like in the example above.


```
------------------------------
(Integration) Create, Get, Scale & Delete when creating a cluster with 1 node and add the second nodegroup and manipulating iam identity mappings 
  fails getting unknown mapping
  /home/martina/weaveworks/eksctl/integration/creategetdelete_test.go:684
starting '../eksctl "--region" "eu-north-1" "get" "iamidentitymapping" "--name" "martina-test-1" "--region" "eu-north-1" "--role" "idontexist" "-o" "yaml"'
Flag --role has been deprecated, see --arn
[✖]  no iamidentitymapping with arn "idontexist" found
•
```

(I also removed the overwrite of the region in the individual tests in a
different PR so that the `--region eu-north-1` only appears once.

<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [ ] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [ ] All unit tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [ ] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->