### PR TITLE
Fix IT for eksctl enable profile. --outputpath is not needed anymore

### DIFF
--- a/integration/creategetdelete_test.go
+++ b/integration/creategetdelete_test.go
@@ -151,7 +151,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 			})
 		})
 
-		Context("gitops enable", func() {
+		Context("enable profile", func() {
 			It("should add quickstart to the repo and the cluster", func() {
 				// Use a random branch to ensure test runs don't step on each others.
 				branch := namer.RandomName()
@@ -159,7 +159,6 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				defer deleteBranch(branch, cloneDir)
 
-				tempOutputDir, err := ioutil.TempDir(os.TempDir(), "gitops-repo-")
 				assertFluxManifestsAbsentInGit(branch)
 
 				deleteFluxInstallation(kubeconfigPath)
@@ -171,7 +170,6 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					"--git-email", Email,
 					"--git-branch", branch,
 					"--git-private-ssh-key-path", privateSSHKeyPath,
-					"--output-path", tempOutputDir,
 					"--cluster", clusterName,
 					"app-dev",
 				)


### PR DESCRIPTION
Remove `--output-path` from integration test of `eksctl enable profile`.

- [x] All unit tests passing (i.e. `make test`)
- [x] Manually tested

## Before

```
------------------------------
(Integration) Create, Get, Scale & Delete when creating a cluster with 1 node gitops enable 
  should add quickstart to the repo and the cluster
  /home/martina/weaveworks/eksctl/integration/creategetdelete_test.go:155
Cloning into '/tmp/eksctl-install-flux-test-clone-004394416'...
Switched to a new branch 'floral-rainbow'
remote: 
remote: Create a pull request for 'floral-rainbow' on GitHub by visiting:        
remote:      https://github.com/eksctl-bot/my-gitops-repo/pull/new/floral-rainbow        
remote: 
To github.com:eksctl-bot/my-gitops-repo.git
 * [new branch]      floral-rainbow -> floral-rainbow
Cloning into '/tmp/eksctl-install-flux-test-branch-928551522'...
starting '../eksctl "--region" "eu-north-1" "enable" "profile" "--git-url" "git@github.com:eksctl-bot/my-gitops-repo.git" "--git-email" "eksctl-bot@weave.works" "--git-branch" "floral-rainbow" "--git-private-ssh-key-path" "~/.ssh/eksctl-bot_id_rsa" "--output-path" "/tmp/gitops-repo-673925455" "--cluster" "martina-test-4" "app-dev"'
Error: unknown flag: --output-path
unknown flag: --output-path
Usage: eksctl enable profile [flags]

General flags:
      --name string                       name or URL of the Quick Start profile. For example, app-dev.
      --git-url string                    SSH URL of the Git repository that will contain the cluster components, e.g. git@github.com:<github_org>/<repo_name>
      --git-branch string                 Git branch (default "master")
      --git-user string                   Username to use as Git committer (default "Flux")
      --git-email string                  Email to use as Git committer
      --git-private-ssh-key-path string   Optional path to the private SSH key to use with Git, e.g. ~/.ssh/id_rsa
      --cluster string                    name of the EKS cluster to add the nodegroup to
  -r, --region string                     AWS region
  -f, --config-file string                load configuration from a file (or stdin if set to '-')
      --timeout duration                  Maximum waiting time for any long-running operation (default 20s)

AWS client flags:
  -p, --profile string   AWS credentials profile to use (overrides the AWS_PROFILE environment variable)

Common flags:
  -C, --color string   toggle colorized logs (valid options: true, false, fabulous) (default "true")
  -h, --help           help for this command
  -v, --verbose int    set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging (default 3)

Use 'eksctl enable profile [command] --help' for more information about a command.


To github.com:eksctl-bot/my-gitops-repo.git
 - [deleted]         floral-rainbow

• Failure [33.841 seconds]
(Integration) Create, Get, Scale & Delete
/home/martina/weaveworks/eksctl/integration/creategetdelete_test.go:35
  when creating a cluster with 1 node
  /home/martina/weaveworks/eksctl/integration/creategetdelete_test.go:62
    gitops enable
    /home/martina/weaveworks/eksctl/integration/creategetdelete_test.go:154
      should add quickstart to the repo and the cluster [It]
      /home/martina/weaveworks/eksctl/integration/creategetdelete_test.go:155

      Expected '../eksctl "--region" "eu-north-1" "enable" "profile" "--git-url" "git@github.com:eksctl-bot/my-gitops-repo.git" "--git-email" "eksctl-bot@weave.works" "--git-branch" "floral-rainbow" "--git-private-ssh-key-path" "~/.ssh/eksctl-bot_id_rsa" "--output-path" "/tmp/gitops-repo-673925455" "--cluster" "martina-test-4" "app-dev"' to succeed, got return code 255

      /home/martina/weaveworks/eksctl/integration/creategetdelete_test.go:178
```
## After

Only 2 failures in the IT from Flaky tests:

```
Summarizing 2 Failures:

[Fail] (Integration) Create, Get, Scale & Delete when creating a cluster with 1 node and add the second nodegroup and delete the second nodegroup [It] {FLAKY: https://github.com/weaveworks/eksctl/issues/717} should make it 4 nodes total 
/home/martina/weaveworks/eksctl/integration/creategetdelete_test.go:824

[Fail] (Integration) Create, Get, Scale & Delete when creating a cluster with 1 node and scale the initial nodegroup back to 1 node [It] {FLAKY: https://github.com/weaveworks/eksctl/issues/717} should make it 1 nodes total 
/home/martina/weaveworks/eksctl/integration/creategetdelete_test.go:850

Ran 39 of 39 Specs in 3054.604 seconds
FAIL! -- 37 Passed | 2 Failed | 0 Pending | 0 Skipped
--- FAIL: TestSuite (3054.61s)
FAIL
Makefile:92: recipe for target 'integration-test' failed
make: *** [integration-test] Error 1
```
