### PR TITLE
NodeGroup: Define Subnets per node group

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -63,6 +63,7 @@ Miguel Pereira          @onemorepereira
 Pedro Tôrres            @t0rr3sp3dr0
 Michael Treacher        @treacher
 Ajay Kemparaj           @ajayk
+Dario Nascimento        @dnascimento
 
 /* Thanks */
 

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -552,6 +552,8 @@ type NodeGroup struct {
 	// +optional
 	AvailabilityZones []string `json:"availabilityZones,omitempty"`
 	// +optional
+	Subnets []string `json:"subnets,omitempty"`
+	// +optional
 	Tags map[string]string `json:"tags,omitempty"`
 	// +optional
 	PrivateNetworking bool `json:"privateNetworking"`

--- a/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
@@ -611,6 +611,11 @@ func (in *NodeGroup) DeepCopyInto(out *NodeGroup) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Subnets != nil {
+		in, out := &in.Subnets, &out.Subnets
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make(map[string]string, len(*in))

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -147,9 +147,15 @@ func (n *NodeGroupResourceSet) addResourcesForNodeGroup() error {
 		LaunchTemplateData: launchTemplateData,
 	})
 
-	vpcZoneIdentifier, err := AssignSubnets(n.spec.AvailabilityZones, n.clusterStackName, n.clusterSpec, n.spec.PrivateNetworking)
-	if err != nil {
-		return err
+	var vpcZoneIdentifier interface{}
+	if numSubnets := len(n.spec.Subnets); numSubnets > 0 {
+		vpcZoneIdentifier = n.spec.Subnets
+	} else {
+		var err error
+		vpcZoneIdentifier, err = AssignSubnets(n.spec.AvailabilityZones, n.clusterStackName, n.clusterSpec, n.spec.PrivateNetworking)
+		if err != nil {
+			return err
+		}
 	}
 
 	tags := []map[string]interface{}{

--- a/site/content/usage/20-schema.md
+++ b/site/content/usage/20-schema.md
@@ -385,6 +385,10 @@ NodeGroup:
     ssh:
       $ref: '#/definitions/NodeGroupSSH'
       $schema: http://json-schema.org/draft-04/schema#
+    subnets:
+      items:
+        type: string
+      type: array
     tags:
       patternProperties:
         .*:


### PR DESCRIPTION
### Description

Define multiple subnets per node group. This allows deploying node groups in subnets other than the EKS control plane. It also allows having multiple subnets in the same availability zone, for instance: internet-facing, application and database subnets

1. We need to verify that these subnets exist. `n.clusterSpec.VPC.Subnets.Private` contains a list of subnets that are verified but if we define two subnets in the same AZ, it fails. The code assumes one subnet per AZ [here](https://github.com/weaveworks/eksctl/blob/e9fc98eef14a8bbe86f417ba10b56b9bb438964c/pkg/apis/eksctl.io/v1alpha5/vpc.go#L133). How can we validate these subnets without breaking the code structure?
2. Should I create a test in `api_test.go` or what is the best place to test it?

@errordeveloper could you review this PR?

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [ ] All unit tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
