### PR TITLE
 Add g4dn instance type as GPU instance

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -54,6 +54,7 @@ David Hao               @davidhao3300
 Brett Shouse            @bmshouse
 Daniel Holbach          @dholbach
 Tak Noguchi             @tnir
+Theo Salvo              @buzzsurfr
 
 /* Thanks */
 

--- a/pkg/ami/static_resolver_test.go
+++ b/pkg/ami/static_resolver_test.go
@@ -96,6 +96,14 @@ var _ = Describe("AMI Static Resolution", func() {
 			ExpectedAMI:  "ami-04668c090ff8c1f50",
 			ExpectError:  false,
 		}),
+		Entry("with gpu (g4dn) instance and us-east-1", ResolveCase{
+			Region:       "us-east-1",
+			Version:      "1.14",
+			InstanceType: "g4dn.xlarge",
+			ImageFamily:  "AmazonLinux2",
+			ExpectedAMI:  "ami-06191d186b526c958",
+			ExpectError:  false,
+		}),
 		Entry("with gpu (p3) instance and non-existent region", ResolveCase{
 			Region:       "eu-east-1",
 			Version:      "1.12",

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -7,7 +7,7 @@ import (
 // IsGPUInstanceType returns tru of the instance type is GPU
 // optimised.
 func IsGPUInstanceType(instanceType string) bool {
-	return strings.HasPrefix(instanceType, "p2") || strings.HasPrefix(instanceType, "p3") || strings.HasPrefix(instanceType, "g3")
+	return strings.HasPrefix(instanceType, "p2") || strings.HasPrefix(instanceType, "p3") || strings.HasPrefix(instanceType, "g3") || strings.HasPrefix(instanceType, "g4")
 }
 
 // HasGPUInstanceType returns true if it finds a gpu instance among the mixed instances


### PR DESCRIPTION
### Description

Changes to add support for the g4dn instance type to use the GPU AMI. Since [eni-max-pods.txt](https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt) is already updated and [pkg/nodebootstrap/maxpods.go](https://github.com/weaveworks/eksctl/blob/master/pkg/nodebootstrap/maxpods.go) has also been updated, the only change was to look for the instance type prefix `g4` to the `IsGPUInstanceType` function.

### Checklist
- [X] Code compiles correctly (i.e `make build`)
- [X] Added tests that cover your change (if possible)
- [X] All unit tests passing (i.e. `make test`)
- [X] ~Added/modified documentation as required (such as the `README.md`, and `examples` directory)~
- [X] Manually tested

