### PR TITLE
Add support for EC2 instances of G4 type

### DIFF
--- a/site/content/usage/07-gpu-support.md
+++ b/site/content/usage/07-gpu-support.md
@@ -6,20 +6,32 @@ url: usage/gpu-support
 
 ## GPU Support
 
-If you'd like to use GPU instance types (i.e. [p2](https://aws.amazon.com/ec2/instance-types/p2/) or [p3](https://aws.amazon.com/ec2/instance-types/p3/) ) then the first thing you need to do is subscribe to the [EKS-optimized AMI with GPU Support](https://aws.amazon.com/marketplace/pp/B07GRHFXGM). If you don't do this then node creation will fail.
+If you'd like to use GPU instance types (i.e. [p2](https://aws.amazon.com/ec2/instance-types/p2/),
+[p3](https://aws.amazon.com/ec2/instance-types/p3/),
+[g3](https://aws.amazon.com/ec2/instance-types/g3/) or
+[g4](https://aws.amazon.com/ec2/instance-types/g4/)) then the first thing you
+need to do is subscribe to the [EKS-optimized AMI with GPU Support](https://aws.amazon.com/marketplace/pp/B07GRHFXGM).
+If you don't do this then node creation will fail.
 
-After subscribing to the AMI you can create a cluster specifying the GPU instance type you'd like to use for the nodes. For example:
+After subscribing to the AMI you can create a cluster specifying the GPU
+instance type you'd like to use for the nodes. For example:
 
-```
+```console
 eksctl create cluster --node-type=p2.xlarge
 ```
 
-The AMI resolvers (both static and auto) will see that you want to use a GPU instance type (p2 or p3 only) and they will select the correct AMI.
+The AMI resolvers (both static and auto) will see that you want to use a GPU
+instance type and they will select the correct AMI.
 
-Once the cluster is created you will need to install the [NVIDIA Kubernetes device plugin](https://github.com/NVIDIA/k8s-device-plugin). Check the repo for the most up to date instructions but you should be able to run this:
+Once the cluster is created you will need to install the [NVIDIA Kubernetes device plugin](https://github.com/NVIDIA/k8s-device-plugin).
+Check the repo for the most up to date instructions but you should be able to
+run this:
 
-```
+```console
 kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v1.11/nvidia-device-plugin.yml
 ```
 
-> NOTE: Once `addon` support has been added as part of 0.2.0 it is envisioned that there will be a addon to install the NVIDIA Kubernetes Device Plugin. This addon could potentially be installed automatically as we know an GPU instance type is being used.
+> NOTE: Once `addon` support has been added as part of 0.2.0 it is envisioned
+> that there will be a addon to install the NVIDIA Kubernetes Device Plugin.
+> This addon could potentially be installed automatically as we know an GPU
+> instance type is being used.


### PR DESCRIPTION
### Description

Add support for EC2 instances of G4 type.
Follows up on #1353 (depends on f5fa999cf1fefb7057b06283a0123790f11c53cb), #1361, and #1377. 
Fixes #1344. 

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] ~Added/modified documentation as required (such as the `README.md`, and `examples` directory)~
- [ ] Manually tested (**WIP**, facing issues as the instances appear as not ready to join the cluster)
