### PR TITLE
Use --cluster for non-cluster commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ TEST_CLUSTER ?= integration-test-dev
 integration-test-dev: build-integration-test ## Run the integration tests without cluster teardown. For use when developing integration tests.
 	./eksctl utils write-kubeconfig \
 		--auto-kubeconfig \
-		--name=$(TEST_CLUSTER)
+		--cluster=$(TEST_CLUSTER)
 	$(info it is recommended to watch events with "kubectl get events --watch --all-namespaces --kubeconfig=$(HOME)/.kube/eksctl/clusters/$(TEST_CLUSTER)")
 	cd integration ; ../eksctl-integration-test -test.timeout 21m \
 		$(INTEGRATION_TEST_ARGS) \

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ eksctl create cluster
 [ℹ]  nodegroup "ng-98b3b83a" will use "ami-05ecac759c81e0b0c" [AmazonLinux2/1.11]
 [ℹ]  creating EKS cluster "floral-unicorn-1540567338" in "us-west-2" region
 [ℹ]  will create 2 separate CloudFormation stacks for cluster itself and the initial nodegroup
-[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-west-2 --name=floral-unicorn-1540567338'
+[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-west-2 --cluster=floral-unicorn-1540567338'
 [ℹ]  2 sequential tasks: { create cluster control plane "floral-unicorn-1540567338", create nodegroup "ng-98b3b83a" }
 [ℹ]  building cluster stack "eksctl-floral-unicorn-1540567338-cluster"
 [ℹ]  deploying stack "eksctl-floral-unicorn-1540567338-cluster"

--- a/integration/creategetdelete_test.go
+++ b/integration/creategetdelete_test.go
@@ -68,7 +68,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					cmd := eksctlUtilsCmd.WithArgs(
 						"write-kubeconfig",
 						"--verbose", "4",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--kubeconfig", kubeconfigPath,
 					)
 					Expect(cmd).To(RunSuccessfully())
@@ -290,7 +290,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				It("should plan to enable two of the types using flags", func() {
 					cmd := eksctlUtilsCmd.WithArgs(
 						"update-cluster-logging",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--enable-types", "api,controllerManager",
 					)
 					Expect(cmd).To(RunSuccessfully())
@@ -304,7 +304,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				It("should enable two of the types using flags", func() {
 					cmd := eksctlUtilsCmd.WithArgs(
 						"update-cluster-logging",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--approve",
 						"--enable-types", "api,controllerManager",
 					)
@@ -321,7 +321,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				It("should enable all of the types with --enable-types=all", func() {
 					cmd := eksctlUtilsCmd.WithArgs(
 						"update-cluster-logging",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--approve",
 						"--enable-types", "all",
 					)
@@ -336,7 +336,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				It("should enable all but one type", func() {
 					cmd := eksctlUtilsCmd.WithArgs(
 						"update-cluster-logging",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--approve",
 						"--enable-types", "all",
 						"--disable-types", "controllerManager",
@@ -354,7 +354,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				It("should disable all but one type", func() {
 					cmd := eksctlUtilsCmd.WithArgs(
 						"update-cluster-logging",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--approve",
 						"--disable-types", "all",
 						"--enable-types", "controllerManager",
@@ -372,7 +372,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				It("should disable all of the types with --disable-types=all", func() {
 					cmd := eksctlUtilsCmd.WithArgs(
 						"update-cluster-logging",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--approve",
 						"--disable-types", "all",
 					)
@@ -417,7 +417,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 
 					setupCmd := eksctlUtilsCmd.WithArgs(
 						"associate-iam-oidc-provider",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--approve",
 					)
 					Expect(setupCmd).To(RunSuccessfully())
@@ -710,7 +710,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				It("fails getting unknown role mapping", func() {
 					cmd := eksctlGetCmd.WithArgs(
 						"iamidentitymapping",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--arn", "arn:aws:iam::123456:role/idontexist",
 						"-o", "yaml",
 					)
@@ -719,7 +719,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				It("fails getting unknown user mapping", func() {
 					cmd := eksctlGetCmd.WithArgs(
 						"iamidentitymapping",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--arn", "arn:aws:iam::123456:user/bob",
 						"-o", "yaml",
 					)
@@ -757,7 +757,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 
 					get := eksctlGetCmd.WithArgs(
 						"iamidentitymapping",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--arn", user0.ARN(),
 						"-o", "yaml",
 					)
@@ -785,7 +785,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				It("creates a duplicate user mapping", func() {
 					createCmd := eksctlCreateCmd.WithArgs(
 						"iamidentitymapping",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--arn", user0.ARN(),
 						"--username", user0.Username(),
 						"--group", user0.Groups()[0],
@@ -795,7 +795,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 
 					getCmd := eksctlGetCmd.WithArgs(
 						"iamidentitymapping",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--arn", user0.ARN(),
 						"-o", "yaml",
 					)
@@ -804,7 +804,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				It("creates a duplicate role mapping with different identity", func() {
 					createCmd := eksctlCreateCmd.WithArgs(
 						"iamidentitymapping",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--arn", role1.ARN(),
 						"--group", role1.Groups()[0],
 					)
@@ -812,7 +812,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 
 					getCmd := eksctlGetCmd.WithArgs(
 						"iamidentitymapping",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--arn", role1.ARN(),
 						"-o", "yaml",
 					)
@@ -821,14 +821,14 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				It("deletes a single role mapping fifo", func() {
 					deleteCmd := eksctlDeleteCmd.WithArgs(
 						"iamidentitymapping",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--arn", role1.ARN(),
 					)
 					Expect(deleteCmd).To(RunSuccessfully())
 
 					getCmd := eksctlGetCmd.WithArgs(
 						"iamidentitymapping",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--arn", role1.ARN(),
 						"-o", "yaml",
 					)
@@ -837,7 +837,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				It("fails when deleting unknown mapping", func() {
 					deleteCmd := eksctlDeleteCmd.WithArgs(
 						"iamidentitymapping",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--arn", "arn:aws:iam::123456:role/idontexist",
 					)
 					Expect(deleteCmd).ToNot(RunSuccessfully())
@@ -862,7 +862,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				It("deletes duplicate user mappings with --all", func() {
 					deleteCmd := eksctlDeleteCmd.WithArgs(
 						"iamidentitymapping",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--arn", user0.ARN(),
 						"--all",
 					)
@@ -870,7 +870,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 
 					getCmd := eksctlGetCmd.WithArgs(
 						"iamidentitymapping",
-						"--name", clusterName,
+						"--cluster", clusterName,
 						"--arn", user0.ARN(),
 						"-o", "yaml",
 					)

--- a/integration/gitopscreateprofile_test.go
+++ b/integration/gitopscreateprofile_test.go
@@ -28,7 +28,7 @@ var _ = Describe("(Integration) generate profile", func() {
 			cmd := eksctlExperimentalCmd.WithArgs(
 				"generate", "profile",
 				"--verbose", "4",
-				"--name", clusterName,
+				"--cluster", clusterName,
 				"--git-url", "git@github.com:eksctl-bot/eksctl-profile-integration-tests.git",
 				"--profile-path", testDirectory,
 			)

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -107,7 +107,7 @@ func (l *commonClusterConfigLoader) validateMetadataWithoutConfigFile() error {
 	meta := l.ClusterConfig.Metadata
 
 	if meta.Name != "" && l.NameArg != "" {
-		return ErrNameFlagAndArg(meta.Name, l.NameArg)
+		return ErrClusterFlagAndArg(l.Cmd, meta.Name, l.NameArg)
 	}
 
 	if l.NameArg != "" {
@@ -115,7 +115,7 @@ func (l *commonClusterConfigLoader) validateMetadataWithoutConfigFile() error {
 	}
 
 	if meta.Name == "" {
-		return ErrMustBeSet("--name")
+		return ErrMustBeSet(ClusterNameFlag(l.Cmd))
 	}
 
 	return nil
@@ -227,7 +227,7 @@ func NewCreateClusterLoader(cmd *Cmd, ngFilter *NodeGroupFilter, ng *api.NodeGro
 
 		// generate cluster name or use either flag or argument
 		if ClusterName(meta.Name, l.NameArg) == "" {
-			return ErrNameFlagAndArg(meta.Name, l.NameArg)
+			return ErrClusterFlagAndArg(l.Cmd, meta.Name, l.NameArg)
 		}
 		meta.Name = ClusterName(meta.Name, l.NameArg)
 
@@ -289,7 +289,7 @@ func NewCreateNodeGroupLoader(cmd *Cmd, ngFilter *NodeGroupFilter) ClusterConfig
 			// generate nodegroup name or use either flag or argument
 			ngName := NodeGroupName(ng.Name, l.NameArg)
 			if ngName == "" {
-				return ErrNameFlagAndArg(ng.Name, l.NameArg)
+				return ErrClusterFlagAndArg(l.Cmd, ng.Name, l.NameArg)
 			}
 			ng.Name = ngName
 			return normalizeNodeGroup(ng, l)
@@ -334,7 +334,7 @@ func NewDeleteNodeGroupLoader(cmd *Cmd, ng *api.NodeGroup, ngFilter *NodeGroupFi
 		}
 
 		if ng.Name != "" && l.NameArg != "" {
-			return ErrNameFlagAndArg(ng.Name, l.NameArg)
+			return ErrClusterFlagAndArg(l.Cmd, ng.Name, l.NameArg)
 		}
 
 		if l.NameArg != "" {
@@ -342,7 +342,7 @@ func NewDeleteNodeGroupLoader(cmd *Cmd, ng *api.NodeGroup, ngFilter *NodeGroupFi
 		}
 
 		if ng.Name == "" {
-			return ErrMustBeSet("--name")
+			return ErrMustBeSet(ClusterNameFlag(cmd))
 		}
 
 		ngFilter.AppendIncludeNames(ng.Name)
@@ -426,7 +426,7 @@ func NewCreateIAMServiceAccountLoader(cmd *Cmd, saFilter *IAMServiceAccountFilte
 		serviceAccount := l.ClusterConfig.IAM.ServiceAccounts[0]
 
 		if serviceAccount.Name == "" {
-			return ErrMustBeSet("--name")
+			return ErrMustBeSet(ClusterNameFlag(cmd))
 		}
 
 		if len(serviceAccount.AttachPolicyARNs) == 0 {
@@ -496,7 +496,7 @@ func NewDeleteIAMServiceAccountLoader(cmd *Cmd, sa *api.ClusterIAMServiceAccount
 		}
 
 		if sa.Name != "" && l.NameArg != "" {
-			return ErrNameFlagAndArg(sa.Name, l.NameArg)
+			return ErrClusterFlagAndArg(l.Cmd, sa.Name, l.NameArg)
 		}
 
 		if l.NameArg != "" {
@@ -504,7 +504,7 @@ func NewDeleteIAMServiceAccountLoader(cmd *Cmd, sa *api.ClusterIAMServiceAccount
 		}
 
 		if sa.Name == "" {
-			return ErrMustBeSet("--name")
+			return ErrMustBeSet(ClusterNameFlag(cmd))
 		}
 
 		l.Plan = false

--- a/pkg/ctl/cmdutils/configfile_test.go
+++ b/pkg/ctl/cmdutils/configfile_test.go
@@ -48,7 +48,7 @@ var _ = Describe("cmdutils configfile", func() {
 
 				err := NewMetadataLoader(cmd).Load()
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("--name=foo-1 and argument foo-2 cannot be used at the same time"))
+				Expect(err.Error()).To(Equal("--cluster=foo-1 and argument foo-2 cannot be used at the same time"))
 			}
 
 			{
@@ -65,15 +65,15 @@ var _ = Describe("cmdutils configfile", func() {
 
 				fs := cmd.CobraCommand.Flags()
 
-				fs.StringVar(&cfg.Metadata.Name, "name", "", "")
-				cmd.CobraCommand.Flag("name").Changed = true
+				fs.StringVar(&cfg.Metadata.Name, "cluster", "", "")
+				cmd.CobraCommand.Flag("cluster").Changed = true
 
-				Expect(cmd.CobraCommand.Flag("name").Changed).To(BeTrue())
+				Expect(cmd.CobraCommand.Flag("cluster").Changed).To(BeTrue())
 
 				err = NewMetadataLoader(cmd).Load()
 
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal(ErrCannotUseWithConfigFile("--name").Error()))
+				Expect(err.Error()).To(Equal(ErrCannotUseWithConfigFile("--cluster").Error()))
 			}
 		})
 

--- a/pkg/ctl/cmdutils/iam_flags.go
+++ b/pkg/ctl/cmdutils/iam_flags.go
@@ -17,5 +17,5 @@ func AddIAMServiceAccountFilterFlags(fs *pflag.FlagSet, includeGlobs, excludeGlo
 func AddIAMIdentityMappingARNFlags(fs *pflag.FlagSet, cmd *Cmd, arn *string) {
 	fs.StringVar(arn, "arn", "", "ARN of the IAM role or user to create")
 	fs.StringVar(arn, "role", "", "")
-	_ = fs.MarkDeprecated("role", "use --arn instead")
+	_ = fs.MarkDeprecated("role", "use --arn")
 }

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -291,7 +291,7 @@ func doCreateCluster(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *createCluster
 			ngFilter.LogInfo(cfg.NodeGroups)
 			logger.Info("will create a CloudFormation stack for cluster itself and %d nodegroup stack(s)", len(filteredNodeGroups))
 		}
-		logger.Info("if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=%s --name=%s'", meta.Region, meta.Name)
+		logger.Info("if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=%s --cluster=%s'", meta.Region, meta.Name)
 		tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(filteredNodeGroups)
 		ctl.AppendExtraClusterConfigTasks(cfg, params.installWindowsVPCController, tasks)
 

--- a/pkg/ctl/create/iamidentitymapping.go
+++ b/pkg/ctl/create/iamidentitymapping.go
@@ -36,7 +36,7 @@ func createIAMIdentityMappingCmd(cmd *cmdutils.Cmd) {
 		fs.StringVar(&username, "username", "", "User name within Kubernetes to map to IAM role")
 		fs.StringArrayVar(&groups, "group", []string{}, "Group within Kubernetes to which IAM role is mapped")
 		cmdutils.AddIAMIdentityMappingARNFlags(fs, cmd, &arn)
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
@@ -68,7 +68,7 @@ func doCreateIAMIdentityMapping(cmd *cmdutils.Cmd, arn string, username string, 
 	}
 
 	if cfg.Metadata.Name == "" {
-		return cmdutils.ErrMustBeSet("--name")
+		return cmdutils.ErrMustBeSet("--cluster")
 	}
 
 	if ok, err := ctl.CanOperate(cfg); !ok {

--- a/pkg/ctl/create/iamserviceaccount.go
+++ b/pkg/ctl/create/iamserviceaccount.go
@@ -91,7 +91,7 @@ func doCreateIAMServiceAccount(cmd *cmdutils.Cmd, overrideExistingServiceAccount
 	}
 
 	if !providerExists {
-		logger.Warning("no IAM OIDC provider associated with cluster, try 'eksctl utils associate-iam-oidc-provider --region=%s --name=%s'", meta.Region, meta.Name)
+		logger.Warning("no IAM OIDC provider associated with cluster, try 'eksctl utils associate-iam-oidc-provider --region=%s --cluster=%s'", meta.Region, meta.Name)
 		return errors.New("unable to create iamserviceaccount(s) without IAM OIDC provider enabled")
 	}
 

--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -33,7 +33,7 @@ func deleteClusterCmd(cmd *cmdutils.Cmd) {
 	})
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name")
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 
 		cmd.Wait = false

--- a/pkg/ctl/delete/iamidentitymapping.go
+++ b/pkg/ctl/delete/iamidentitymapping.go
@@ -27,7 +27,7 @@ func deleteIAMIdentityMappingCmd(cmd *cmdutils.Cmd) {
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.BoolVar(&all, "all", false, "Delete all matching mappings instead of just one")
 		cmdutils.AddIAMIdentityMappingARNFlags(fs, cmd, &arn)
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
@@ -57,7 +57,7 @@ func doDeleteIAMIdentityMapping(cmd *cmdutils.Cmd, arn string, all bool) error {
 		return cmdutils.ErrMustBeSet("--arn")
 	}
 	if cfg.Metadata.Name == "" {
-		return cmdutils.ErrMustBeSet("--name")
+		return cmdutils.ErrMustBeSet(cmdutils.ClusterNameFlag(cmd))
 	}
 
 	if ok, err := ctl.CanOperate(cfg); !ok {

--- a/pkg/ctl/enable/profile.go
+++ b/pkg/ctl/enable/profile.go
@@ -86,7 +86,7 @@ func enableProfileCmd(cmd *cmdutils.Cmd) {
 
 func doEnableProfile(cmd *cmdutils.Cmd, opts options) error {
 	if cmd.NameArg != "" && opts.profileNameArg != "" {
-		return cmdutils.ErrNameFlagAndArg(cmd.NameArg, opts.profileNameArg)
+		return cmdutils.ErrClusterFlagAndArg(cmd, cmd.NameArg, opts.profileNameArg)
 	}
 	if cmd.NameArg != "" {
 		opts.profileNameArg = cmd.NameArg

--- a/pkg/ctl/generate/profile.go
+++ b/pkg/ctl/generate/profile.go
@@ -39,7 +39,7 @@ func generateProfileCmd(cmd *cmdutils.Cmd) {
 		fs.StringVarP(&o.ProfilePath, "profile-path", "", "./", "Path to generate the profile in")
 		_ = cobra.MarkFlagRequired(fs, "git-url")
 
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 	})

--- a/pkg/ctl/get/cluster.go
+++ b/pkg/ctl/get/cluster.go
@@ -24,7 +24,7 @@ func getClusterCmd(cmd *cmdutils.Cmd) {
 	})
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name")
 		fs.BoolVarP(&listAllRegions, "all-regions", "A", false, "List clusters across all supported regions")
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddCommonFlagsForGetCmd(fs, &params.chunkSize, &params.output)
@@ -48,7 +48,7 @@ func doGetCluster(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) 
 	}
 
 	if cfg.Metadata.Name != "" && cmd.NameArg != "" {
-		return cmdutils.ErrNameFlagAndArg(cfg.Metadata.Name, cmd.NameArg)
+		return cmdutils.ErrClusterFlagAndArg(cmd, cfg.Metadata.Name, cmd.NameArg)
 	}
 
 	if cmd.NameArg != "" {

--- a/pkg/ctl/get/iamidentitymapping.go
+++ b/pkg/ctl/get/iamidentitymapping.go
@@ -30,7 +30,7 @@ func getIAMIdentityMappingCmd(cmd *cmdutils.Cmd) {
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddIAMIdentityMappingARNFlags(fs, cmd, &arn)
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddCommonFlagsForGetCmd(fs, &params.chunkSize, &params.output)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
@@ -57,7 +57,7 @@ func doGetIAMIdentityMapping(cmd *cmdutils.Cmd, params *getCmdParams, arn string
 	}
 
 	if cfg.Metadata.Name == "" {
-		return cmdutils.ErrMustBeSet("--name")
+		return cmdutils.ErrMustBeSet(cmdutils.ClusterNameFlag(cmd))
 	}
 
 	if ok, err := ctl.CanOperate(cfg); !ok {

--- a/pkg/ctl/get/nodegroup.go
+++ b/pkg/ctl/get/nodegroup.go
@@ -43,11 +43,11 @@ func doGetNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *getCmdParams) 
 
 	// TODO: move this into a loader when --config-file gets added to this command
 	if cfg.Metadata.Name == "" {
-		return cmdutils.ErrMustBeSet("--cluster")
+		return cmdutils.ErrMustBeSet(cmdutils.ClusterNameFlag(cmd))
 	}
 
 	if ng.Name != "" && cmd.NameArg != "" {
-		return cmdutils.ErrNameFlagAndArg(ng.Name, cmd.NameArg)
+		return cmdutils.ErrFlagAndArg("--name", ng.Name, cmd.NameArg)
 	}
 
 	if cmd.NameArg != "" {

--- a/pkg/ctl/scale/nodegroup.go
+++ b/pkg/ctl/scale/nodegroup.go
@@ -44,11 +44,11 @@ func doScaleNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup) error {
 
 	// TODO: move this into a loader when --config-file gets added to this command
 	if cfg.Metadata.Name == "" {
-		return cmdutils.ErrMustBeSet("--cluster")
+		return cmdutils.ErrMustBeSet(cmdutils.ClusterNameFlag(cmd))
 	}
 
 	if ng.Name != "" && cmd.NameArg != "" {
-		return cmdutils.ErrNameFlagAndArg(ng.Name, cmd.NameArg)
+		return cmdutils.ErrFlagAndArg("--name", ng.Name, cmd.NameArg)
 	}
 
 	if cmd.NameArg != "" {

--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -23,7 +23,7 @@ func updateClusterCmd(cmd *cmdutils.Cmd) {
 	})
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name")
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 

--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -31,7 +31,7 @@ func updateClusterCmd(cmd *cmdutils.Cmd) {
 
 		cmdutils.AddApproveFlag(fs, cmd)
 		fs.BoolVar(&cmd.Plan, "dry-run", cmd.Plan, "")
-		_ = fs.MarkDeprecated("dry-run", "see --aprove")
+		_ = fs.MarkDeprecated("dry-run", "see --approve")
 
 		cmd.Wait = true
 		cmdutils.AddWaitFlag(fs, &cmd.Wait, "all update operations to complete")

--- a/pkg/ctl/utils/associate_iam_oidc_provider.go
+++ b/pkg/ctl/utils/associate_iam_oidc_provider.go
@@ -20,7 +20,7 @@ func associateIAMOIDCProviderCmd(cmd *cmdutils.Cmd) {
 	})
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 		cmdutils.AddApproveFlag(fs, cmd)

--- a/pkg/ctl/utils/describe_stacks.go
+++ b/pkg/ctl/utils/describe_stacks.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"fmt"
-
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/kris-nova/logger"
 	"github.com/spf13/pflag"
@@ -24,7 +22,7 @@ func describeStacksCmd(cmd *cmdutils.Cmd) {
 	})
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		fs.BoolVar(&all, "all", false, "include deleted stacks")
 		fs.BoolVar(&events, "events", false, "include stack events")
@@ -49,7 +47,7 @@ func doDescribeStacksCmd(cmd *cmdutils.Cmd, all, events, trail bool) error {
 	}
 
 	if cfg.Metadata.Name != "" && cmd.NameArg != "" {
-		return fmt.Errorf("--name=%s and argument %s cannot be used at the same time", cfg.Metadata.Name, cmd.NameArg)
+		return cmdutils.ErrFlagAndArg(cmdutils.ClusterNameFlag(cmd), cfg.Metadata.Name, cmd.NameArg)
 	}
 
 	if cmd.NameArg != "" {
@@ -57,7 +55,7 @@ func doDescribeStacksCmd(cmd *cmdutils.Cmd, all, events, trail bool) error {
 	}
 
 	if cfg.Metadata.Name == "" {
-		return cmdutils.ErrMustBeSet("--name")
+		return cmdutils.ErrMustBeSet(cmdutils.ClusterNameFlag(cmd))
 	}
 
 	stackManager := ctl.NewStackManager(cfg)

--- a/pkg/ctl/utils/install_vpc_controllers.go
+++ b/pkg/ctl/utils/install_vpc_controllers.go
@@ -21,7 +21,7 @@ func installWindowsVPCController(cmd *cmdutils.Cmd) {
 	})
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 		cmdutils.AddApproveFlag(fs, cmd)

--- a/pkg/ctl/utils/update_aws_node.go
+++ b/pkg/ctl/utils/update_aws_node.go
@@ -19,7 +19,7 @@ func updateAWSNodeCmd(cmd *cmdutils.Cmd) {
 	})
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 		cmdutils.AddApproveFlag(fs, cmd)

--- a/pkg/ctl/utils/update_cluster_endpoint_access.go
+++ b/pkg/ctl/utils/update_cluster_endpoint_access.go
@@ -24,7 +24,7 @@ func updateClusterEndpointsCmd(cmd *cmdutils.Cmd) {
 	})
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 		cmdutils.AddApproveFlag(fs, cmd)

--- a/pkg/ctl/utils/update_cluster_logging.go
+++ b/pkg/ctl/utils/update_cluster_logging.go
@@ -27,7 +27,7 @@ func enableLoggingCmd(cmd *cmdutils.Cmd) {
 	})
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 		cmdutils.AddApproveFlag(fs, cmd)

--- a/pkg/ctl/utils/update_coredns.go
+++ b/pkg/ctl/utils/update_coredns.go
@@ -19,7 +19,7 @@ func updateCoreDNSCmd(cmd *cmdutils.Cmd) {
 	})
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 		cmdutils.AddApproveFlag(fs, cmd)

--- a/pkg/ctl/utils/update_kube_proxy.go
+++ b/pkg/ctl/utils/update_kube_proxy.go
@@ -19,7 +19,7 @@ func updateKubeProxyCmd(cmd *cmdutils.Cmd) {
 	})
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 		cmdutils.AddApproveFlag(fs, cmd)

--- a/pkg/ctl/utils/write_kubeconfig.go
+++ b/pkg/ctl/utils/write_kubeconfig.go
@@ -29,7 +29,7 @@ func writeKubeconfigCmd(cmd *cmdutils.Cmd) {
 	})
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
-		cmdutils.AddNameFlag(fs, cfg.Metadata)
+		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 	})
@@ -46,7 +46,7 @@ func doWriteKubeconfigCmd(cmd *cmdutils.Cmd, outputPath, roleARN string, setCont
 
 	// TODO: move this into a loader when --config-file gets added to this command
 	if cfg.Metadata.Name != "" && cmd.NameArg != "" {
-		return cmdutils.ErrNameFlagAndArg(cfg.Metadata.Name, cmd.NameArg)
+		return cmdutils.ErrClusterFlagAndArg(cmd, cfg.Metadata.Name, cmd.NameArg)
 	}
 
 	if cmd.NameArg != "" {
@@ -54,7 +54,7 @@ func doWriteKubeconfigCmd(cmd *cmdutils.Cmd, outputPath, roleARN string, setCont
 	}
 
 	if cfg.Metadata.Name == "" {
-		return cmdutils.ErrMustBeSet("--name")
+		return cmdutils.ErrMustBeSet(cmdutils.ClusterNameFlag(cmd))
 	}
 
 	if autoPath {

--- a/pkg/eks/tasks.go
+++ b/pkg/eks/tasks.go
@@ -54,7 +54,7 @@ func (c *ClusterProvider) AppendExtraClusterConfigTasks(cfg *api.ClusterConfig, 
 	}
 	if !cfg.HasClusterCloudWatchLogging() {
 		logger.Info("CloudWatch logging will not be enabled for cluster %q in %q", cfg.Metadata.Name, cfg.Metadata.Region)
-		logger.Info("you can enable it with 'eksctl utils update-cluster-logging --region=%s --name=%s'", cfg.Metadata.Region, cfg.Metadata.Name)
+		logger.Info("you can enable it with 'eksctl utils update-cluster-logging --region=%s --cluster=%s'", cfg.Metadata.Region, cfg.Metadata.Name)
 
 	} else {
 		newTasks.Append(&clusterConfigTask{

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -41,7 +41,7 @@ $ eksctl create cluster
 [ℹ]  nodegroup "ng-98b3b83a" will use "ami-05ecac759c81e0b0c" [AmazonLinux2/1.11]
 [ℹ]  creating EKS cluster "floral-unicorn-1540567338" in "us-west-2" region
 [ℹ]  will create 2 separate CloudFormation stacks for cluster itself and the initial nodegroup
-[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-west-2 --name=floral-unicorn-1540567338'
+[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-west-2 --cluster=floral-unicorn-1540567338'
 [ℹ]  2 sequential tasks: { create cluster control plane "floral-unicorn-1540567338", create nodegroup "ng-98b3b83a" }
 [ℹ]  building cluster stack "eksctl-floral-unicorn-1540567338-cluster"
 [ℹ]  deploying stack "eksctl-floral-unicorn-1540567338-cluster"

--- a/site/content/gitops-quickstart/01-apply-gitops.md
+++ b/site/content/gitops-quickstart/01-apply-gitops.md
@@ -349,7 +349,7 @@ Now please run:
 
 ```console
 EKSCTL_EXPERIMENTAL=true eksctl generate profile \
-        --name wonderful-wardrobe-1565767990 \
+        --cluster wonderful-wardrobe-1565767990 \
         --git-url git@github.com:weaveworks/eks-quickstart-app-dev.git \
         --profile-path ~/dev/flux-get-started/cluster-config
 ```
@@ -357,7 +357,7 @@ EKSCTL_EXPERIMENTAL=true eksctl generate profile \
 Let's break this down here. `eksctl generate profile` at the very
 least wants:
 
-- `--name`: the name of the cluster - check `eksctl get cluster`
+- `--cluster`: the name of the cluster - check `eksctl get cluster`
   to see what the name of yours is
 - `--git-url`: the Git URL of the Quick Start profile to deploy to the cluster
 - `--profile-path`: a local path: this is an empty new directory

--- a/site/content/introduction/01-getting-started.md
+++ b/site/content/introduction/01-getting-started.md
@@ -62,7 +62,7 @@ To obtain cluster credentials at any point in time, run:
 
 ```
 
-eksctl utils write-kubeconfig --name=<name> [--kubeconfig=<path>][--set-kubeconfig-context=<bool>]
+eksctl utils write-kubeconfig --cluster=<name> [--kubeconfig=<path>][--set-kubeconfig-context=<bool>]
 
 ```
 

--- a/site/content/usage/10-iam-identity-mappings.md
+++ b/site/content/usage/10-iam-identity-mappings.md
@@ -12,25 +12,25 @@ called `aws-auth`. `eksctl` provides commands to read and edit this config map.
 Get all identity mappings:
 
 ```bash
-eksctl get iamidentitymapping --name my-cluster-1
+eksctl get iamidentitymapping --cluster my-cluster-1
 ```
 
 Get all identity mappings matching an arn:
 
 ```bash
-eksctl get iamidentitymapping --name my-cluster-1 --arn arn:aws:iam::123456:role/testing-role
+eksctl get iamidentitymapping --cluster my-cluster-1 --arn arn:aws:iam::123456:role/testing-role
 ```
 
 Create an identity mapping:
 
 ```bash
- eksctl create iamidentitymapping --name  my-cluster-1 --arn arn:aws:iam::123456:role/testing --group system:masters --username admin
+ eksctl create iamidentitymapping --cluster  my-cluster-1 --arn arn:aws:iam::123456:role/testing --group system:masters --username admin
 ```
 
 Delete a mapping:
 
 ```bash
-eksctl delete iamidentitymapping --name  my-cluster-1 --arn arn:aws:iam::123456:role/testing
+eksctl delete iamidentitymapping --cluster  my-cluster-1 --arn arn:aws:iam::123456:role/testing
 ```
 
 _Note_: this deletes a single mapping FIFO unless `--all`is given in which case it removes all matching. Will warn if

--- a/site/content/usage/13-iamserviceaccounts.md
+++ b/site/content/usage/13-iamserviceaccounts.md
@@ -31,7 +31,7 @@ In `eksctl` the name of the resource is _iamserviceaccount_, which represents an
 The IAM OIDC Provider is not enabled by default, you can use the following command to enable it, or use config file (see below):
 
 ```console
-eksctl utils associate-iam-oidc-provider --name=<clusterName>
+eksctl utils associate-iam-oidc-provider --cluster=<clusterName>
 ```
 
 Once you have the IAM OIDC Provider associated with the cluster, to create a IAM role bound to a service account, run:


### PR DESCRIPTION
Commands act on a principal resource which may be a cluster or not. Most
commands act in the context of a cluster and as such need to receive its
name.

In case of the prinicpal resource being a cluster (such as `eksctl get cluster`)
the flag name is `--name`. For all other commands, the cluster name is
being passed in as `--cluster`.

Closes #1329

- [x] Once this is merged, create an issue to update AWS EKS documentation to use the renamed flags instead #1394 

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
