### PR TITLE
Fixes typo on gitops-quickstart docs page.

### DIFF
--- a/site/content/gitops-quickstart/01-apply-gitops.md
+++ b/site/content/gitops-quickstart/01-apply-gitops.md
@@ -78,7 +78,7 @@ ip-192-168-64-189.eu-central-1.compute.internal   Ready    <none>   38s   v1.13.
 ```
 
 ```console
-$ kube get pods --all-namespaces 
+$ kubectl get pods --all-namespaces 
 NAMESPACE     NAME                       READY   STATUS    RESTARTS   AGE
 kube-system   aws-node-l8mk7             1/1     Running   0          45s
 kube-system   aws-node-s2p2c             1/1     Running   0          45s


### PR DESCRIPTION

### Description

<!-- Please explain the changes you made here. -->
Fixes a typo in one of the examples on the `gitops-quickstart` page where the command shown was `kube`, but should have been `kubectl`.

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
Since this was not a code change, I have crossed out most of this list.

- [ ] ~Code compiles correctly (i.e `make build`)~
- [ ] ~Added tests that cover your change (if possible)~
- [ ] ~All unit tests passing (i.e. `make test`)~
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [ ] ~Manually tested~

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
