### PR TITLE
Fix generation of vpc cni plugin version 1.5.4 yaml

### DIFF
--- a/pkg/addons/default/generate.go
+++ b/pkg/addons/default/generate.go
@@ -1,5 +1,5 @@
 package defaultaddons
 
-//go:generate curl --silent --location https://github.com/aws/amazon-vpc-cni-k8s/blob/dd631108e61a977809f9b1a1c40232637e734184/config/v1.5/aws-k8s-cni.yaml?raw=1 --output assets/aws-node.yaml
+//go:generate curl --silent --location https://github.com/aws/amazon-vpc-cni-k8s/blob/release-1.5.4/config/v1.5/aws-k8s-cni.yaml?raw=1 --output assets/aws-node.yaml
 
 //go:generate ${GOBIN}/go-bindata -pkg ${GOPACKAGE} -prefix assets -nometadata -o assets.go assets


### PR DESCRIPTION
While this is not changed circleci will fail for all PRs because every time it
buids eksctl it downloads the old version of the cni plugin (1.5) through a
generate rule.

<!-- If you haven't done so already, you can add your name to the humans.txt file -->