### PR TITLE
eksctl does not report error if it can not write kubeconfig file due to permission

### DIFF
--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -149,7 +149,7 @@ func Write(path string, newConfig clientcmdapi.Config, setContext bool) (string,
 	}
 
 	if err := clientcmd.ModifyConfig(configAccess, *merged, true); err != nil {
-		return "", nil
+		return "", err
 	}
 
 	return configAccess.GetDefaultFilename(), nil

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -63,6 +63,13 @@ var _ = Describe("Kubeconfig", func() {
 		Expect(readConfig.Contexts["test-context"].Namespace).To(Equal(testConfig.Contexts["test-context"].Namespace))
 	})
 
+	It("creating new Kubeconfig with no permission", func() {
+		filename, err := kubeconfig.Write("/no-permission", testConfig, false)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring("permission denied"))
+		Expect(filename).To(BeEmpty())
+	})
+
 	It("sets new Kubeconfig context", func() {
 		testConfigContext := testConfig
 		testConfigContext.CurrentContext = "test-context"


### PR DESCRIPTION
### Description
Fixed issue mentioned in https://github.com/weaveworks/eksctl/issues/1402

### Checklist
<!-- Delete any items if not applicable, e.g. if your name is already in `humans.txt` or doc updates are not needed. -->
- [ ] Code compiles correctly (i.e `make build`)
- [ ] Added tests that cover your change (if possible)
- [ ] All unit tests passing (i.e. `make test`)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [ ] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
