### PR TITLE
WIP: Added --cache as authorizer option in kubeconf

### DIFF
--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -95,7 +95,7 @@ func AppendAuthenticator(config *clientcmdapi.Config, spec *api.ClusterConfig, a
 
 	switch authenticatorCMD {
 	case AWSIAMAuthenticator, HeptioAuthenticatorAWS:
-		args = []string{"token", "-i", spec.Metadata.Name}
+		args = []string{"token", "-i", spec.Metadata.Name, "--cache"}
 		roleARNFlag = "-r"
 	case AWSEKSAuthenticator:
 		args = []string{"eks", "get-token", "--cluster-name", spec.Metadata.Name}


### PR DESCRIPTION
### Description

I think the credential cache option should be added to the aws-iam-authorizer call as a default, since awscli also uses caching by default. https://github.com/kubernetes-sigs/aws-iam-authenticator/pull/193

This is how the resulting config would look after the PR:

```
       users:
        - name: kubelet@ferocious-mushroom-1532594698.us-west-2.eksctl.io
          user:
            exec:
              apiVersion: client.authentication.k8s.io/v1alpha1
              args:
              - token
              - -i
              - ferocious-mushroom-1532594698
              - --cache
              command: heptio-authenticator-aws
              env: null
```

Comments requested: Should I use this as the default or make it configurable? Then I'll complete the PR.

BTW, why doesn't everyone use roles & MFA for doing anything on AWS? Or am I missing something?