### PR TITLE
Add CloudMap permissions to App Mesh profile

### DIFF
--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -902,6 +902,17 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Expect(policy3.PolicyDocument.Statement[0].Resource).To(Equal("*"))
 			Expect(policy3.PolicyDocument.Statement[0].Action).To(Equal([]string{
 				"appmesh:*",
+				"servicediscovery:CreateService",
+				"servicediscovery:GetService",
+				"servicediscovery:RegisterInstance",
+				"servicediscovery:DeregisterInstance",
+				"servicediscovery:ListInstances",
+				"servicediscovery:ListNamespaces",
+				"route53:GetHealthCheck",
+				"route53:CreateHealthCheck",
+				"route53:UpdateHealthCheck",
+				"route53:ChangeResourceRecordSets",
+				"route53:DeleteHealthCheck",
 			}))
 
 			Expect(ngTemplate.Resources).ToNot(HaveKey("PolicyEBS"))

--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -158,7 +158,7 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 	}
 
 	role := gfn.AWSIAMRole{
-		Path: gfn.NewString("/"),
+		Path:                     gfn.NewString("/"),
 		AssumeRolePolicyDocument: cft.MakeAssumeRolePolicyDocumentForServices("ec2.amazonaws.com"),
 		ManagedPolicyArns:        makeStringSlice(n.spec.IAM.AttachPolicyARNs...),
 	}
@@ -225,6 +225,17 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() {
 		n.rs.attachAllowPolicy("PolicyAppMesh", refIR, "*",
 			[]string{
 				"appmesh:*",
+				"servicediscovery:CreateService",
+				"servicediscovery:GetService",
+				"servicediscovery:RegisterInstance",
+				"servicediscovery:DeregisterInstance",
+				"servicediscovery:ListInstances",
+				"servicediscovery:ListNamespaces",
+				"route53:GetHealthCheck",
+				"route53:CreateHealthCheck",
+				"route53:UpdateHealthCheck",
+				"route53:ChangeResourceRecordSets",
+				"route53:DeleteHealthCheck",
 			},
 		)
 	}


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->
Added cloudmap permissions to the `--appmesh-access` flag.  https://github.com/weaveworks/eksctl/issues/1397
### Checklist

- [x] Code compiles correctly (i.e `make build`)
- [x] Added tests that cover your change (if possible)
- [x] All unit tests passing (i.e. `make test`)
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
