### PR TITLE
Bump eksctl-dep image version to 0.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ git_toplevel := $(shell git rev-parse --show-toplevel)
 version_pkg := github.com/weaveworks/eksctl/pkg/version
 
 # The dependencies version should be bumped every time the build dependencies are updated
-EKSCTL_DEPENDENCIES_IMAGE ?= weaveworks/eksctl-build:deps-0.16
+EKSCTL_DEPENDENCIES_IMAGE ?= weaveworks/eksctl-build:deps-0.17
 EKSCTL_BUILDER_IMAGE ?= weaveworks/eksctl-builder:latest
 EKSCTL_IMAGE ?= weaveworks/eksctl:latest
 


### PR DESCRIPTION
Bump deps image to 0.17 after updating different dependency versions

<!-- If you haven't done so already, you can add your name to the humans.txt file -->