### PR TITLE
Support Create of Cluster with Private VPC Endpoint

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -59,6 +59,7 @@ Hidde Beydals           @hiddeco
 Cedric Kring            @cedrickring
 Tam Mach                @sayboras
 Leigh Capili            @stealthybox
+Andrew Morin            @morinap
 
 /* Thanks */
 

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -20,7 +20,9 @@ var (
 		"commands/API calls from within the VPC.  Running these in the VPC requires making " +
 		"updates to some AWS resources.  See: " +
 		"https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html#private-access " +
-		"for more details")
+		"for more details. Specifying a SecurityGroup under the VPC configuration will suppress " +
+		"this error; the specified SecurityGroup can be used to allow eksctl traffic from a " +
+		"bastion host, for example.")
 )
 
 // NOTE: we don't use k8s.io/apimachinery/pkg/util/sets here to keep API package free of dependencies
@@ -91,7 +93,7 @@ func (c *ClusterConfig) ValidateClusterEndpointConfig() error {
 	if NoAccess(endpts) {
 		return ErrClusterEndpointNoAccess
 	}
-	if PrivateOnly(endpts) {
+	if PrivateOnly(endpts) && c.VPC.SecurityGroup == "" {
 		return ErrClusterEndpointPrivateOnly
 	}
 	return nil

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -318,7 +318,14 @@ var _ = Describe("ClusterConfig validation", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should error on private=true, public=false", func() {
+		It("should not error on private=true, public=false when a security group is specified", func() {
+			cfg.VPC.SecurityGroup = "test-sg"
+			cfg.VPC.ClusterEndpoints = &ClusterEndpoints{PrivateAccess: Enabled(), PublicAccess: Disabled()}
+			err = cfg.ValidateClusterEndpointConfig()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should error on private=true, public=false when no security group is specified", func() {
 			cfg.VPC.ClusterEndpoints = &ClusterEndpoints{PrivateAccess: Enabled(), PublicAccess: Disabled()}
 			err = cfg.ValidateClusterEndpointConfig()
 			Expect(err).To(BeIdenticalTo(ErrClusterEndpointPrivateOnly))

--- a/site/content/usage/06-vpc-networking.md
+++ b/site/content/usage/06-vpc-networking.md
@@ -183,9 +183,10 @@ There are some additional caveats when configuring Kubernetes API endpoint acces
    enabled.
 1. EKS does allow creating a configuration which allows only private access to be enabled, but eksctl doesn't
    support it during cluster creation as it prevents eksctl from being able to join the worker nodes to the cluster.
-1. To create private-only Kubernetes API endpoint access, one must first create the cluster *with* public Kubernetes API
-   endpoint access, and then use `/eksctl utils update-cluster-endpoints` to change it after the cluster is finished
-   creating.
+1. To create private-only Kubernetes API endpoint access, one must also specify a VPC security group. This group
+   should contain rules allowing access to the Control Plane from your bastion host or via some other method.
+   See:
+   [EKS user guide](https://docs.aws.amazon.com/en_pv/eks/latest/userguide/cluster-endpoint#private-access)
 1. Updating a cluster to have private only Kubernetes API endpoint access means that Kubernetes commands
    (e.g. `kubectl`) as well as `eksctl delete cluster`, `eksctl utils write-kubeconfig`, and possibly the command
    `eksctl utils update-kube-proxy` must be run within the cluster VPC.  This requires some changes to various AWS


### PR DESCRIPTION
### Description
This enables the cluster to be created without public access while allowing the creator to specify a control plane security group that can allow bastion or other hosts on the VPC to access the control plane for further eksctl calls.

This works well for our use case; I created a security group that allows HTTPS access inbound from our bastion host before creating the cluster, and then I specified that security group under `VPC` in my cluster create YML.

This addresses https://github.com/weaveworks/eksctl/issues/1358

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested

