### PR TITLE
A couple of nodegroup.ssh fixes

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -517,7 +517,8 @@ type NodeGroup struct {
 	// +optional
 	TargetGroupARNs []string `json:"targetGroupARNs,omitempty"`
 
-	SSH *NodeGroupSSH `json:"ssh"`
+	// +optional
+	SSH *NodeGroupSSH `json:"ssh,omitempty"`
 
 	// +optional
 	IAM *NodeGroupIAM `json:"iam"`

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -156,7 +156,7 @@ func ValidateNodeGroup(i int, ng *NodeGroup) error {
 		}
 
 		if err := validateNodeGroupSSH(ng.SSH); err != nil {
-			return fmt.Errorf("only one ssh public key can be specified per node-group")
+			return err
 		}
 	}
 

--- a/site/content/usage/20-schema.md
+++ b/site/content/usage/20-schema.md
@@ -326,7 +326,6 @@ NodeGroup:
   - volumeSize
   - volumeType
   - volumeIOPS
-  - ssh
   - iam
   type: object
 NodeGroupIAM:


### PR DESCRIPTION
- That field is actually optional, make sure to mark it as is
- A small fixup that makes sure the `validateNodeGroupSSH` error is propagated instead of being overriden