### PR TITLE
cfn: Fully internalize the regex to list stacks

### DIFF
--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -167,7 +167,8 @@ func (c *StackCollection) DescribeStack(i *Stack) (*Stack, error) {
 	return resp.Stacks[0], nil
 }
 
-func (c *StackCollection) listStacks(nameRegex string, statusFilters ...string) ([]*Stack, error) {
+// ListStacksMatching gets all of CloudFormation stacks with names matching nameRegex.
+func (c *StackCollection) ListStacksMatching(nameRegex string, statusFilters ...string) ([]*Stack, error) {
 	var (
 		subErr error
 		stack  *Stack
@@ -208,7 +209,7 @@ func (c *StackCollection) listStacks(nameRegex string, statusFilters ...string) 
 
 // ListStacks gets all of CloudFormation stacks
 func (c *StackCollection) ListStacks(statusFilters ...string) ([]*Stack, error) {
-	return c.listStacks(fmtStacksRegexForCluster(c.spec.Metadata.Name))
+	return c.ListStacksMatching(fmtStacksRegexForCluster(c.spec.Metadata.Name))
 }
 
 // StackStatusIsNotTransitional will return true when stack statate is non-transitional
@@ -288,7 +289,7 @@ func (c *StackCollection) DeleteStackByName(name string) (*Stack, error) {
 	s, err := c.DescribeStack(i)
 	if err != nil {
 		err = errors.Wrapf(err, "not able to get stack %q for deletion", name)
-		stacks, newErr := c.listStacks(fmt.Sprintf("^%s$", name), cloudformation.StackStatusDeleteComplete)
+		stacks, newErr := c.ListStacksMatching(fmt.Sprintf("^%s$", name), cloudformation.StackStatusDeleteComplete)
 		if newErr != nil {
 			logger.Critical("not able double-check if stack was already deleted: %s", newErr.Error())
 		}

--- a/pkg/cfn/manager/deprecated.go
+++ b/pkg/cfn/manager/deprecated.go
@@ -25,7 +25,7 @@ func fmtDeprecatedStacksRegexForCluster(name string) string {
 
 // DeleteTasksForDeprecatedStacks all deprecated stacks
 func (c *StackCollection) DeleteTasksForDeprecatedStacks() (*TaskTree, error) {
-	stacks, err := c.ListStacks(fmtDeprecatedStacksRegexForCluster(c.spec.Metadata.Name))
+	stacks, err := c.listStacks(fmtDeprecatedStacksRegexForCluster(c.spec.Metadata.Name))
 	if err != nil {
 		return nil, errors.Wrapf(err, "describing deprecated CloudFormation stacks for %q", c.spec.Metadata.Name)
 	}

--- a/pkg/cfn/manager/deprecated.go
+++ b/pkg/cfn/manager/deprecated.go
@@ -25,7 +25,7 @@ func fmtDeprecatedStacksRegexForCluster(name string) string {
 
 // DeleteTasksForDeprecatedStacks all deprecated stacks
 func (c *StackCollection) DeleteTasksForDeprecatedStacks() (*TaskTree, error) {
-	stacks, err := c.listStacks(fmtDeprecatedStacksRegexForCluster(c.spec.Metadata.Name))
+	stacks, err := c.ListStacksMatching(fmtDeprecatedStacksRegexForCluster(c.spec.Metadata.Name))
 	if err != nil {
 		return nil, errors.Wrapf(err, "describing deprecated CloudFormation stacks for %q", c.spec.Metadata.Name)
 	}

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -259,7 +259,7 @@ func (c *ClusterProvider) doGetCluster(clusterName string, printer printers.Outp
 	if *output.Cluster.Status == awseks.ClusterStatusActive {
 		if logger.Level >= 4 {
 			spec := &api.ClusterConfig{Metadata: &api.ClusterMeta{Name: clusterName}}
-			stacks, err := c.NewStackManager(spec).ListStacks(fmt.Sprintf("^(eksclt|EKS)-%s-.*$", clusterName))
+			stacks, err := c.NewStackManager(spec).ListStacks()
 			if err != nil {
 				return errors.Wrapf(err, "listing CloudFormation stack for %q", clusterName)
 			}


### PR DESCRIPTION
I've noticed a little buglet in `get` code: we were using a regex with a typo:
eksclt.

Instead of exposing the regex parameter to people wanting to use ListStacks
outside the package, make sure it stays an implementation detail that only the
cfn code will know about.