### PR TITLE
Print go-bindata version when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ godeps_cmd = go list -deps -f '{{if not .Standard}}{{ $$dep := . }}{{range .GoFi
 godeps = $(shell $(call godeps_cmd,$(1)))
 
 .PHONY: build
-build: $(all_generated_code) ## Build main binary
+build: print-go-bindata-version $(all_generated_code) ## Build main binary
 	CGO_ENABLED=0 time go build -ldflags "-X $(version_pkg).gitCommit=$(git_commit) -X $(version_pkg).builtAt=$(built_at)" ./cmd/eksctl
 
 ##@ Testing & CI
@@ -127,9 +127,14 @@ delete-integration-test-dev-cluster: build ## Delete the test cluster for use wh
 
 ##@ Code Generation
 
+.PHONY: print-go-bindata-version
+# In order to help debug issues & discrepancies when building:
+print-go-bindata-version:
+	go-bindata --version
+
 .PHONY: generate-all
 # TODO: generate-ami is broken (see https://github.com/weaveworks/eksctl/issues/949 ), include it when fixed
-generate-all: $(all_generated_files) # generate-ami ## Re-generate all the automatically-generated source files
+generate-all: print-go-bindata-version $(all_generated_files) # generate-ami ## Re-generate all the automatically-generated source files
 
 .PHONY: check-all-generated-files-up-to-date
 check-all-generated-files-up-to-date: generate-all

--- a/go.sum
+++ b/go.sum
@@ -1280,6 +1280,7 @@ k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6 h1:4s3/R4+OYYYUKptXPhZKjQ04WJ6Eh
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190822140433-26a664648505 h1:ZY6yclUKVbZ+SdWnkfY+Je5vrMpKOxmGeKRbsXVmqYM=
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20190907103519-ebc107f98eab h1:j4L8spMe0tFfBvvW6lrc0c+Ql8+nnkcV3RYfi3eSwGY=
 k8s.io/gengo v0.0.0-20190907103519-ebc107f98eab/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/helm v2.13.1+incompatible h1:qt0LBsHQ7uxCtS3F2r3XI0DNm8ml0xQeSJixUorDyn0=
 k8s.io/helm v2.13.1+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=


### PR DESCRIPTION
### Description

Not sure if just me, but I keep getting odd `diff`s for the generated files. In the past it was because I had a different version of `go-bindata`, [this time](https://circleci.com/gh/weaveworks/eksctl/5143), it seems to be something else.
However, in case the former issue happens again, and to help ruling it out in case of the latter, I thought it could be useful to systematically print `go-bindata`'s version.

### Checklist
- [x] ~Added tests that cover your change (if possible)~ Irrelevant.
- [x] ~Added/modified documentation as required (such as the `README.md`, and `examples` directory)~ Irrelevant.
- [x] Manually tested:

<img width="603" alt="Screenshot 2019-10-18 at 19 43 25" src="https://user-images.githubusercontent.com/836014/67088538-5acf1580-f1e0-11e9-8d4f-974e3ebd0b56.png">
