### PR TITLE
make build: update go.mod to latest dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/fluxcd/flux v1.15.0
 	github.com/fluxcd/helm-operator v1.0.0-rc2
 	github.com/go-ini/ini v1.37.0 // indirect
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gobuffalo/envy v1.7.0 // indirect
 	github.com/gobwas/glob v0.2.3
 	github.com/gofrs/flock v0.7.1 // indirect


### PR DESCRIPTION
### Description

Building latest `master` currently generates this diff in `go.mod`, which therefore should presumably be updated. This dependency was apparently introduced in https://github.com/weaveworks/eksctl/pull/1465, though I'm not sure why at the moment.