### PR TITLE
Fix Makefile. Broken release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ $(generated_code_aws_sdk_mocks): $(call godeps,pkg/eks/mocks/mocks.go)
 ##@ Docker
 
 .PHONY: eksctl-image
-eksctl-image: intermediate-image ## Build the eksctl image that has release artefacts and no build dependencies
+eksctl-image: ## Build the eksctl image that has release artefacts and no build dependencies
 	$(MAKE) -f Makefile.docker $@
 
 ##@ Release


### PR DESCRIPTION
Release process is broken. Check https://circleci.com/gh/weaveworks/eksctl/5252

```
Create release candidate binaries for all plaforms and upload to GitHub00:00
Exit code: 2
 #!/bin/bash -eo pipefail
make release-candidate
flag provided but not defined: -deps
usage: list [-e] [-f format] [-json] [build flags] [packages]
Run 'go help list' for details.
flag provided but not defined: -deps
usage: list [-e] [-f format] [-json] [build flags] [packages]
Run 'go help list' for details.
flag provided but not defined: -deps
usage: list [-e] [-f format] [-json] [build flags] [packages]
Run 'go help list' for details.
make: *** No rule to make target 'intermediate-image', needed by 'eksctl-image'.  Stop.
Exited with code 2
```

<!-- If you haven't done so already, you can add your name to the humans.txt file -->