### PR TITLE
Move release targets to `Makefile.docker`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - run: docker pull $BUILD_IMAGE
       - run:
           name: Create release candidate binaries for all plaforms and upload to GitHub
-          command: make release-candidate
+          command: make -f Makefile.docker release-candidate
           no_output_timeout: 21m
   release:
     machine:
@@ -44,7 +44,7 @@ jobs:
       - run: docker pull $BUILD_IMAGE
       - run:
           name: Create release binaries for all plaforms and upload to GitHub
-          command: make release
+          command: make -f Makefile.docker release
           no_output_timeout: 21m
 
 workflows:

--- a/Makefile
+++ b/Makefile
@@ -175,24 +175,6 @@ $(generated_code_aws_sdk_mocks): $(call godeps,pkg/eks/mocks/mocks.go)
 eksctl-image: ## Build the eksctl image that has release artefacts and no build dependencies
 	$(MAKE) -f Makefile.docker $@
 
-##@ Release
-
-docker_run_release_script = docker run \
-  --env=GITHUB_TOKEN \
-  --env=CIRCLE_TAG \
-  --env=CIRCLE_PROJECT_USERNAME \
-  --volume=$(git_toplevel):/src \
-  --workdir=/src \
-    $(intermediate_image_name)
-
-.PHONY: release-candidate
-release-candidate: eksctl-image ## Create a new eksctl release candidate
-	$(call docker_run_release_script) ./do-release-candidate.sh
-
-.PHONY: release
-release: eksctl-image ## Create a new eksctl release
-	$(call docker_run_release_script) ./do-release.sh
-
 ##@ Site
 
 HUGO := $(GOBIN)/hugo

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -91,3 +91,18 @@ build test: ## Run targets from Makefile using the build image
 	  --volume=$(git_toplevel):/src \
 	    $(build_image_name) make $@
 
+docker_run_release_script = docker run \
+  --env=GITHUB_TOKEN \
+  --env=CIRCLE_TAG \
+  --env=CIRCLE_PROJECT_USERNAME \
+  --volume=$(git_toplevel):/src \
+  --workdir=/src \
+    $(intermediate_image_name)
+
+.PHONY: release-candidate
+release-candidate: eksctl-image ## Create a new eksctl release candidate
+	$(call docker_run_release_script) ./do-release-candidate.sh
+
+.PHONY: release
+release: eksctl-image ## Create a new eksctl release
+	$(call docker_run_release_script) ./do-release.sh


### PR DESCRIPTION
Releasing [currently](https://circleci.com/gh/weaveworks/eksctl/5252) breaks as we call the version of Go local to CircleCI instead of the one from our build image.