### PR TITLE
support .eksctlignore file

### DIFF
--- a/pkg/gitops/gitops_test.go
+++ b/pkg/gitops/gitops_test.go
@@ -87,6 +87,9 @@ var _ = Describe("gitops profile", func() {
 		})
 
 		It("can load files and ignore .git/ files", func() {
+			err := profile.ignoreFiles(testDir)
+			Expect(err).ToNot(HaveOccurred())
+
 			files, err := profile.loadFiles(testDir)
 
 			Expect(err).ToNot(HaveOccurred())
@@ -183,6 +186,9 @@ func createTestFiles(testDir string, memFs afero.Fs) {
 	createFile(memFs, filepath.Join(testDir, ".git/some-git-file"), "this is a git file and should be ignored")
 	createFile(memFs, filepath.Join(testDir, ".git/some-git-file.yaml"), "this is a git file and should be ignored")
 	createFile(memFs, filepath.Join(testDir, ".git/some-git-file.yaml.tmpl"), "this is a git file and should be ignored")
+
+	createFile(memFs, filepath.Join(testDir, ".eksctlignore"), "path/to/ignore")
+	createFile(memFs, filepath.Join(testDir, "path/to/ignore"), "this file should be ignored")
 }
 
 func createFile(memFs afero.Fs, path string, content string) error {


### PR DESCRIPTION
### Description

This PR fixes #1444 to support `.eksctlignore` file in quickstart profiles.
The code in this PR looks for the `.eksctlignore` file at the top level directory of the profile, parse it and then remove files on the filesystem per entries defined in the ignore file.

This process is done after the `profile` command clone a repo, and before the template processing is started.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Manually tested

Added a test and regression passed.

Manually tested on EKS:
```
Checking connectivity... done.
Already on 'master'
Your branch is up-to-date with 'origin/master'.
[ℹ]  ignoring files declared in .eksctlignore
[ℹ]  ignored "metallb-system"
[ℹ]  processing template files in repository
[ℹ]  writing new manifests to "/tmp/firekube-demo209952050/firekube-demo/base"
[eksctl-demo a5bfed8] Add https://github.com/chanwit/eks-quickstart-app-dev quickstart components
 28 files changed, 1384 insertions(+)
```
From the logs, we could see that the patch processed `.eksctlignore` and removed `metallb-system` out of the local repo. A fork of `app-dev` to demonstrate this PR is hosted here: https://github.com/chanwit/eks-quickstart-app-dev.

