### PR TITLE
Add private endpoint functionality to release notes 0.8

### DIFF
--- a/docs/release_notes/0.8.0.md
+++ b/docs/release_notes/0.8.0.md
@@ -3,6 +3,7 @@
 ## Features
 
 - add support for resolving AMIs using SSM Parameter Store (#1393)
+- allow changing cluster API public/private access.  See [aws docs] (https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html#private-access) when enabling private access (#1149)
 
 ## Improvements
 


### PR DESCRIPTION
The support for specifying private/public access to the API endpoint was not
added to the release notes in time.