### PR TITLE
Add release notes for 0.9.0

### DIFF
--- a/docs/release_notes/0.9.0.md
+++ b/docs/release_notes/0.9.0.md
@@ -1,0 +1,12 @@
+# Release 0.9.0
+
+## Features
+
+- mark Kubernetes 1.11 as [deprecated](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html) (#1384)
+
+## Improvements
+
+- separate responsibilities between experimental GitOps commands
+  `eksctl enable repo` and `eksctl enable profile` (#1509)
+- fix some typos in the VPC documentation on the site (#1515)
+- refactor Nodegroup, IAM and SSH configuration (#1530)


### PR DESCRIPTION
### Description

Add release notes for 0.9.0, as part of preparing for 0.9.0's release.
See also: https://github.com/weaveworks/eksctl/pulls?utf8=%E2%9C%93&q=is%3Aclosed+label%3Aversion%2F0.9.0