### PR TITLE
Fix validation of git origin in release scripts

### DIFF
--- a/tag-release-candidate.sh
+++ b/tag-release-candidate.sh
@@ -23,7 +23,7 @@ if ! [[ "${release_branch}" =~ ^release-[0-9]+\.[0-9]+$ ]] ; then
   exit 3
 fi
 
-if [ ! "$(git remote get-url origin)" = "git@github.com:weaveworks/eksctl" ] ; then
+if [[ ! "$(git remote get-url origin)" =~ ^git@github.com:weaveworks/eksctl(\.git)?$ ]] ; then
   echo "Invalid origin: $(git remote get-url origin)"
   exit 3
 fi

--- a/tag-release.sh
+++ b/tag-release.sh
@@ -22,7 +22,7 @@ if ! [[ "${release_branch}" =~ ^release-[0-9]+\.[0-9]+$ ]] ; then
   exit 3
 fi
 
-if [ ! "$(git remote get-url origin)" = "git@github.com:weaveworks/eksctl" ] ; then
+if [[ ! "$(git remote get-url origin)" =~ ^git@github.com:weaveworks/eksctl(\.git)?$ ]] ; then
   echo "Invalid origin: $(git remote get-url origin)"
   exit 3
 fi


### PR DESCRIPTION
### Description

#1189 broke the validation of `git origin` URLs, see also [this diff](https://github.com/weaveworks/eksctl/pull/1189/files#r344676551).

### Checklist
- [x] ~Added tests that cover your change (if possible)~ (irrelevant)
- [x] ~Added/modified documentation as required (such as the `README.md`, and `examples` directory)~ (irrelevant)
- [x] Manually tested:

```console
$ git remote set-url origin git@github.com:marccarre/eksctl.git
$ [[ ! "$(git remote get-url origin)" =~ ^git@github.com:weaveworks/eksctl(\.git)?$ ]] && echo "Invalid origin: $(git remote get-url origin)"
Invalid origin: git@github.com:marccarre/eksctl.git

$ git remote set-url origin git@github.com:weaveworks/eksctl
$ [[ ! "$(git remote get-url origin)" =~ ^git@github.com:weaveworks/eksctl(\.git)?$ ]] && echo "Invalid origin: $(git remote get-url origin)"
### Nothing printed, i.e.: success!

$ git remote set-url origin git@github.com:weaveworks/eksctl.git
$ [[ ! "$(git remote get-url origin)" =~ ^git@github.com:weaveworks/eksctl(\.git)?$ ]] && echo "Invalid origin: $(git remote get-url origin)"
### Nothing printed, i.e.: success!
```

```console
$ shellcheck tag-release.sh 
### Nothing printed, i.e.: success!

$ shellcheck tag-release-candidate.sh 
### Nothing printed, i.e.: success!
```
