### PR TITLE
Add draft.md to gather temporary release notes

### DIFF
--- a/docs/release_notes/draft.md
+++ b/docs/release_notes/draft.md
@@ -1,0 +1,13 @@
+# Draft
+
+## Features
+
+- lowercased, user-focused description of the new feature (#0)
+
+## Improvements
+
+- lowercased, user-focused description of the improvement (#0)
+
+## Bug fixes
+
+- lowercased, user-focused description of the bugfix (#0)


### PR DESCRIPTION
### Description

... in order to:

- allow developers to gradually add the description of their work
  in the release notes to-be as they open PRs, and
- allow whoever is triggering the next release to simply move content
  from `draft.md` to `X.Y.Z.md` without having to scan all issues/PRs,
  understand them, and potentially rephrase them.

Related: #1507, #1508.