### PR TITLE
No longer default ng.SSH.allow to true when SSH Public Keys are defined.

### DIFF
--- a/examples/07-ssh-keys.yaml
+++ b/examples/07-ssh-keys.yaml
@@ -31,4 +31,10 @@ nodeGroups:
   - name: ng-5
     instanceType: m5.large
     desiredCapacity: 1
+    ssh: # use existing EC2 key but don't allow SSH access to nodegroup.
+      publicKeyName: ec2_dev_key
+      allow: false
+  - name: ng-6
+    instanceType: m5.large
+    desiredCapacity: 1
     # no SSH

--- a/humans.txt
+++ b/humans.txt
@@ -61,6 +61,7 @@ Tam Mach                @sayboras
 Leigh Capili            @stealthybox
 Miguel Pereira          @onemorepereira
 Pedro Tôrres            @t0rr3sp3dr0
+Michael Treacher        @treacher
 
 /* Thanks */
 

--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -67,7 +67,7 @@ func SetNodeGroupDefaults(ng *NodeGroup, meta *ClusterMeta) {
 		ng.SSH.PublicKeyPath,
 		ng.SSH.PublicKey)
 
-	if numSSHFlagsEnabled > 0 {
+	if numSSHFlagsEnabled > 0 && ng.SSH.Allow == nil {
 		ng.SSH.Allow = Enabled()
 	} else {
 		if IsEnabled(ng.SSH.Allow) {

--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -67,14 +67,15 @@ func SetNodeGroupDefaults(ng *NodeGroup, meta *ClusterMeta) {
 		ng.SSH.PublicKeyPath,
 		ng.SSH.PublicKey)
 
-	if numSSHFlagsEnabled > 0 && ng.SSH.Allow == nil {
-		ng.SSH.Allow = Enabled()
-	} else {
+	if numSSHFlagsEnabled == 0 {
 		if IsEnabled(ng.SSH.Allow) {
 			ng.SSH.PublicKeyPath = &DefaultNodeSSHPublicKeyPath
 		} else {
 			ng.SSH.Allow = Disabled()
 		}
+	} else if !IsDisabled(ng.SSH.Allow) {
+		// Enable SSH if not explicitly disabled when passing an SSH key
+		ng.SSH.Allow = Enabled()
 	}
 
 	if !IsSetAndNonEmptyString(ng.VolumeType) {

--- a/pkg/apis/eksctl.io/v1alpha5/defaults_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults_test.go
@@ -97,6 +97,7 @@ var _ = Describe("ClusterConfig validation", func() {
 			SetNodeGroupDefaults(&testNodeGroup, &ClusterMeta{})
 
 			Expect(*testNodeGroup.SSH.Allow).To(BeFalse())
+			Expect(*testNodeGroup.SSH.PublicKeyPath).To(BeIdenticalTo(testKeyPath))
 		})
 	})
 

--- a/pkg/apis/eksctl.io/v1alpha5/defaults_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults_test.go
@@ -55,13 +55,12 @@ var _ = Describe("ClusterConfig validation", func() {
 
 	Context("SSH settings", func() {
 
-		It("Providing an SSH key enables SSH", func() {
+		It("Providing an SSH key enables SSH when SSH.Allow not set", func() {
 			testKeyPath := "some/path/to/file.pub"
 
 			testNodeGroup := NodeGroup{
 				VolumeSize: &DefaultNodeVolumeSize,
 				SSH: &NodeGroupSSH{
-					Allow:         Disabled(),
 					PublicKeyPath: &testKeyPath,
 				},
 			}
@@ -82,6 +81,22 @@ var _ = Describe("ClusterConfig validation", func() {
 			SetNodeGroupDefaults(&testNodeGroup, &ClusterMeta{})
 
 			Expect(*testNodeGroup.SSH.PublicKeyPath).To(BeIdenticalTo("~/.ssh/id_rsa.pub"))
+		})
+
+		It("Providing an SSH key and explicitly disabling SSH keeps SSH disabled", func() {
+			testKeyPath := "some/path/to/file.pub"
+
+			testNodeGroup := NodeGroup{
+				VolumeSize: &DefaultNodeVolumeSize,
+				SSH: &NodeGroupSSH{
+					Allow:         Disabled(),
+					PublicKeyPath: &testKeyPath,
+				},
+			}
+
+			SetNodeGroupDefaults(&testNodeGroup, &ClusterMeta{})
+
+			Expect(*testNodeGroup.SSH.Allow).To(BeFalse())
 		})
 	})
 

--- a/pkg/apis/eksctl.io/v1alpha5/defaults_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults_test.go
@@ -68,6 +68,7 @@ var _ = Describe("ClusterConfig validation", func() {
 			SetNodeGroupDefaults(&testNodeGroup, &ClusterMeta{})
 
 			Expect(*testNodeGroup.SSH.Allow).To(BeTrue())
+			Expect(*testNodeGroup.SSH.PublicKeyPath).To(BeIdenticalTo(testKeyPath))
 		})
 
 		It("Enabling SSH without a key uses default key", func() {

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -110,7 +110,7 @@ func (n *NodeGroupResourceSet) addResourcesForNodeGroup() error {
 	launchTemplateName := gfn.MakeFnSubString(fmt.Sprintf("${%s}", gfn.StackName))
 	launchTemplateData := newLaunchTemplateData(n)
 
-	if api.IsSetAndNonEmptyString(n.spec.SSH.PublicKeyName) {
+	if n.spec.SSH != nil && api.IsSetAndNonEmptyString(n.spec.SSH.PublicKeyName) {
 		launchTemplateData.KeyName = gfn.NewString(*n.spec.SSH.PublicKeyName)
 	}
 

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -110,7 +110,7 @@ func (n *NodeGroupResourceSet) addResourcesForNodeGroup() error {
 	launchTemplateName := gfn.MakeFnSubString(fmt.Sprintf("${%s}", gfn.StackName))
 	launchTemplateData := newLaunchTemplateData(n)
 
-	if api.IsEnabled(n.spec.SSH.Allow) && api.IsSetAndNonEmptyString(n.spec.SSH.PublicKeyName) {
+	if api.IsSetAndNonEmptyString(n.spec.SSH.PublicKeyName) {
 		launchTemplateData.KeyName = gfn.NewString(*n.spec.SSH.PublicKeyName)
 	}
 

--- a/pkg/ctl/cmdutils/configfile_test.go
+++ b/pkg/ctl/cmdutils/configfile_test.go
@@ -189,8 +189,8 @@ var _ = Describe("cmdutils configfile", func() {
 				{"03-two-nodegroups.yaml", 2, false},
 				{"05-advanced-nodegroups.yaml", 3, true},
 				{"05-advanced-nodegroups.yaml", 3, false},
-				{"07-ssh-keys.yaml", 5, true},
-				{"07-ssh-keys.yaml", 5, false},
+				{"07-ssh-keys.yaml", 6, true},
+				{"07-ssh-keys.yaml", 6, false},
 			}
 
 			for _, loaderTest := range loaderParams {


### PR DESCRIPTION
### Description
As a consumer of EKSCTL I wanted to be able to define a KeyPair for my node groups without having to explicitly allow SSH. The reason for this is that I'd like to be able to define my own security group seperate to EKSCTL to attach to the node group which allows access to the node group from a particular jump host. In the organisation I'm working in we have all SSH actions go through a jumphost and then for each instance to have a security group which only allows access from that particular jumphost.

With the current implementation if we only define the SSH Key Name it also sets SSH.Allow to true which then opens up Port 22 to the entire VPC.

In this change I've removed the logic around setting SSH.Allow to true when SSH. PublicKeyName, SSH.PublicKeyPath or SSH.PublicKey are set.

I'm not 100% sure this solution fits with the original intention of this project, but it's a conversation starter. During the thought process of making this change, I got to thinking that it may be easier to completely decouple the KeyPair from SSH Access configuration as it empowers configurability and reduces the amount of logic required around different permutations.

### Testing done
Deployed a cluster with the following ssh configuration:
```
ssh:
  allow: false
  publicKeyName: <REDACTED>
```
With this configuration I observed that the Key Pair Name was set to <REDACTED> and there was 
no ingress rule opening port 22 to the entire VPC.

----

Deployed a cluster with the following ssh configuration:
```
ssh:
  publicKeyName: <REDACTED>
  allow: true
```
With this configuration I observed that the Key Pair Name was set to <REDACTED> and there was 
an ingress rule opening port 22 to the entire VPC.

----

Deployed a cluster with the following ssh configuration:
```
ssh:
  allow: true
```
With this configuration I observed that the Key Pair Name was set to the default key and there 
was an ingress rule opening port 22 to the entire VPC.

----

Deployed a cluster with the following ssh configuration:
```
ssh:
  publicKeyName: <REDACTED>
```
With this configuration I observed that the Key Pair Name was set to <REDACTED> and there was 
an ingress rule opening port 22 to the entire VPC.

----

Deployed a cluster with no ssh configuration:
With this configuration I observed that no Key Pair Name is set and that there was no ingress rule for port 22.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested

I was unable to get the integration tests working as I don't have a suitable account to run the tests against 😞 . I would highly appreciate it if somebody is able to do this on my behalf if the CI pipeline doesn't already do this.