### PR TITLE
Fix `update cluster` for EKS clusters below platform version `eks.3`

### DIFF
--- a/docs/release_notes/draft.md
+++ b/docs/release_notes/draft.md
@@ -10,4 +10,4 @@
 
 ## Bug fixes
 
-- lowercased, user-focused description of the bugfix (#0)
+- Fix `update cluster` for EKS clusters below platform version `eks.3` (#1583)

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -462,7 +462,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 		}
 
 		It("should add all resources and collect outputs without errors", func() {
-			crs = NewClusterResourceSet(p, cfg)
+			crs = NewClusterResourceSet(p, cfg, false)
 			err := crs.AddAllResources()
 			Expect(err).ShouldNot(HaveOccurred())
 			sampleStack := newStackWithOutputs(sampleOutputs)
@@ -479,13 +479,13 @@ var _ = Describe("CloudFormation template builder API", func() {
 		})
 	})
 
-	build := func(cfg *api.ClusterConfig, name string, ng *api.NodeGroup) {
+	assertBuildChecks := func(cfg *api.ClusterConfig, clusterStackName string, ng *api.NodeGroup, managedNodesSupport bool) {
 		It("should add all resources without errors", func() {
-			crs = NewClusterResourceSet(p, cfg)
+			crs = NewClusterResourceSet(p, cfg, managedNodesSupport)
 			err = crs.AddAllResources()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			ngrs = NewNodeGroupResourceSet(p, cfg, name, ng)
+			ngrs = NewNodeGroupResourceSet(p, cfg, clusterStackName, ng, managedNodesSupport)
 			err = ngrs.AddAllResources()
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -495,7 +495,16 @@ var _ = Describe("CloudFormation template builder API", func() {
 			templateBody, err := t.JSON()
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(templateBody).ShouldNot(BeEmpty())
+
+			outputs := crs.Template().Outputs
+			_, hasClusterSG := outputs["ClusterSecurityGroupId"]
+
+			Expect(hasClusterSG).To(Equal(managedNodesSupport))
 		})
+	}
+
+	build := func(cfg *api.ClusterConfig, name string, ng *api.NodeGroup) {
+		assertBuildChecks(cfg, name, ng, false)
 	}
 
 	roundtrip := func() {
@@ -526,6 +535,11 @@ var _ = Describe("CloudFormation template builder API", func() {
 
 		})
 	}
+
+	Context("Security group for managed nodes", func() {
+		cfg, ng := newClusterConfigAndNodegroup(true)
+		assertBuildChecks(cfg, "managed-cluster", ng, true)
+	})
 
 	Context("AutoNameTag", func() {
 		cfg, ng := newClusterConfigAndNodegroup(true)

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -15,27 +15,30 @@ import (
 
 // NodeGroupResourceSet stores the resource information of the nodegroup
 type NodeGroupResourceSet struct {
-	rs                 *resourceSet
-	clusterSpec        *api.ClusterConfig
-	spec               *api.NodeGroup
-	provider           api.ClusterProvider
-	clusterStackName   string
-	nodeGroupName      string
-	instanceProfileARN *gfn.Value
-	securityGroups     []*gfn.Value
-	vpc                *gfn.Value
-	userData           *gfn.Value
+	rs                   *resourceSet
+	clusterSpec          *api.ClusterConfig
+	spec                 *api.NodeGroup
+	supportsManagedNodes bool
+	provider             api.ClusterProvider
+	clusterStackName     string
+	nodeGroupName        string
+	instanceProfileARN   *gfn.Value
+	securityGroups       []*gfn.Value
+	vpc                  *gfn.Value
+	userData             *gfn.Value
 }
 
 // NewNodeGroupResourceSet returns a resource set for a nodegroup embedded in a cluster config
-func NewNodeGroupResourceSet(provider api.ClusterProvider, spec *api.ClusterConfig, clusterStackName string, ng *api.NodeGroup) *NodeGroupResourceSet {
+func NewNodeGroupResourceSet(provider api.ClusterProvider, spec *api.ClusterConfig, clusterStackName string, ng *api.NodeGroup,
+	supportsManagedNodes bool) *NodeGroupResourceSet {
 	return &NodeGroupResourceSet{
-		rs:               newResourceSet(),
-		clusterStackName: clusterStackName,
-		nodeGroupName:    ng.Name,
-		clusterSpec:      spec,
-		spec:             ng,
-		provider:         provider,
+		rs:                   newResourceSet(),
+		clusterStackName:     clusterStackName,
+		nodeGroupName:        ng.Name,
+		supportsManagedNodes: supportsManagedNodes,
+		clusterSpec:          spec,
+		spec:                 ng,
+		provider:             provider,
 	}
 }
 

--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -255,8 +255,11 @@ func (n *NodeGroupResourceSet) addResourcesForSecurityGroups() {
 		}},
 	})
 
-	defaultClusterSharedSecurityGroup := makeImportValue(n.clusterStackName, "ClusterSecurityGroupId")
-	n.securityGroups = append(n.securityGroups, refNodeGroupLocalSG, defaultClusterSharedSecurityGroup)
+	n.securityGroups = append(n.securityGroups, refNodeGroupLocalSG)
+	if n.supportsManagedNodes {
+		defaultClusterSharedSecurityGroup := makeImportValue(n.clusterStackName, outputs.ClusterDefaultSecurityGroup)
+		n.securityGroups = append(n.securityGroups, defaultClusterSharedSecurityGroup)
+	}
 
 	n.newResource("IngressInterCluster", &gfn.AWSEC2SecurityGroupIngress{
 		GroupId:               refNodeGroupLocalSG,

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -26,10 +26,10 @@ func (c *StackCollection) makeClusterStackName() string {
 }
 
 // createClusterTask creates the cluster
-func (c *StackCollection) createClusterTask(errs chan error) error {
+func (c *StackCollection) createClusterTask(errs chan error, supportsManagedNodes bool) error {
 	name := c.makeClusterStackName()
 	logger.Info("building cluster stack %q", name)
-	stack := builder.NewClusterResourceSet(c.provider, c.spec)
+	stack := builder.NewClusterResourceSet(c.provider, c.spec, supportsManagedNodes)
 	if err := stack.AddAllResources(); err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func (c *StackCollection) DescribeClusterStack() (*Stack, error) {
 
 // AppendNewClusterStackResource will update cluster
 // stack with new resources in append-only way
-func (c *StackCollection) AppendNewClusterStackResource(plan bool) (bool, error) {
+func (c *StackCollection) AppendNewClusterStackResource(plan, supportsManagedNodes bool) (bool, error) {
 	name := c.makeClusterStackName()
 
 	// NOTE: currently we can only append new resources to the stack,
@@ -79,7 +79,7 @@ func (c *StackCollection) AppendNewClusterStackResource(plan bool) (bool, error)
 	}
 
 	logger.Info("re-building cluster stack %q", name)
-	newStack := builder.NewClusterResourceSet(c.provider, c.spec)
+	newStack := builder.NewClusterResourceSet(c.provider, c.spec, supportsManagedNodes)
 	if err := newStack.AddAllResources(); err != nil {
 		return false, err
 	}

--- a/pkg/cfn/manager/create_tasks.go
+++ b/pkg/cfn/manager/create_tasks.go
@@ -10,17 +10,20 @@ import (
 
 // NewTasksToCreateClusterWithNodeGroups defines all tasks required to create a cluster along
 // with some nodegroups; see CreateAllNodeGroups for how onlyNodeGroupSubset works
-func (c *StackCollection) NewTasksToCreateClusterWithNodeGroups(nodeGroups []*api.NodeGroup, managedNodeGroups []*api.ManagedNodeGroup) *TaskTree {
+func (c *StackCollection) NewTasksToCreateClusterWithNodeGroups(nodeGroups []*api.NodeGroup,
+	managedNodeGroups []*api.ManagedNodeGroup, supportsManagedNodes bool) *TaskTree {
+
 	tasks := &TaskTree{Parallel: false}
 
 	tasks.Append(
-		&taskWithoutParams{
-			info: fmt.Sprintf("create cluster control plane %q", c.spec.Metadata.Name),
-			call: c.createClusterTask,
+		&createClusterTask{
+			info:                 fmt.Sprintf("create cluster control plane %q", c.spec.Metadata.Name),
+			stackCollection:      c,
+			supportsManagedNodes: supportsManagedNodes,
 		},
 	)
 
-	nodeGroupTasks := c.NewTasksToCreateNodeGroups(nodeGroups)
+	nodeGroupTasks := c.NewTasksToCreateNodeGroups(nodeGroups, supportsManagedNodes)
 
 	managedNodeGroupTasks := c.NewManagedNodeGroupTask(managedNodeGroups)
 	if managedNodeGroupTasks.Len() > 0 {
@@ -36,14 +39,15 @@ func (c *StackCollection) NewTasksToCreateClusterWithNodeGroups(nodeGroups []*ap
 }
 
 // NewTasksToCreateNodeGroups defines tasks required to create all of the nodegroups
-func (c *StackCollection) NewTasksToCreateNodeGroups(nodeGroups []*api.NodeGroup) *TaskTree {
+func (c *StackCollection) NewTasksToCreateNodeGroups(nodeGroups []*api.NodeGroup, supportsManagedNodes bool) *TaskTree {
 	tasks := &TaskTree{Parallel: true}
 
 	for _, ng := range nodeGroups {
-		tasks.Append(&taskWithNodeGroupSpec{
-			info:      fmt.Sprintf("create nodegroup %q", ng.NameString()),
-			nodeGroup: ng,
-			call:      c.createNodeGroupTask,
+		tasks.Append(&nodeGroupTask{
+			info:                 fmt.Sprintf("create nodegroup %q", ng.NameString()),
+			nodeGroup:            ng,
+			stackCollection:      c,
+			supportsManagedNodes: supportsManagedNodes,
 		})
 		// TODO: move authconfigmap tasks here using kubernetesTask and kubernetes.CallbackClientSet
 	}

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -42,10 +42,10 @@ func (c *StackCollection) makeNodeGroupStackName(name string) string {
 }
 
 // createNodeGroupTask creates the nodegroup
-func (c *StackCollection) createNodeGroupTask(errs chan error, ng *api.NodeGroup) error {
+func (c *StackCollection) createNodeGroupTask(errs chan error, ng *api.NodeGroup, supportsManagedNodes bool) error {
 	name := c.makeNodeGroupStackName(ng.Name)
 	logger.Info("building nodegroup stack %q", name)
-	stack := builder.NewNodeGroupResourceSet(c.provider, c.spec, c.makeClusterStackName(), ng)
+	stack := builder.NewNodeGroupResourceSet(c.provider, c.spec, c.makeClusterStackName(), ng, supportsManagedNodes)
 	if err := stack.AddAllResources(); err != nil {
 		return err
 	}

--- a/pkg/cfn/manager/tasks.go
+++ b/pkg/cfn/manager/tasks.go
@@ -142,15 +142,28 @@ type taskWithNameParam struct {
 func (t *taskWithNameParam) Describe() string         { return t.info }
 func (t *taskWithNameParam) Do(errs chan error) error { return t.call(errs, t.name) }
 
-type taskWithNodeGroupSpec struct {
-	info      string
-	nodeGroup *api.NodeGroup
-	call      func(chan error, *api.NodeGroup) error
+type createClusterTask struct {
+	info                 string
+	stackCollection      *StackCollection
+	supportsManagedNodes bool
 }
 
-func (t *taskWithNodeGroupSpec) Describe() string { return t.info }
-func (t *taskWithNodeGroupSpec) Do(errs chan error) error {
-	return t.call(errs, t.nodeGroup)
+func (t *createClusterTask) Describe() string { return t.info }
+
+func (t *createClusterTask) Do(errorCh chan error) error {
+	return t.stackCollection.createClusterTask(errorCh, t.supportsManagedNodes)
+}
+
+type nodeGroupTask struct {
+	info                 string
+	nodeGroup            *api.NodeGroup
+	supportsManagedNodes bool
+	stackCollection      *StackCollection
+}
+
+func (t *nodeGroupTask) Describe() string { return t.info }
+func (t *nodeGroupTask) Do(errs chan error) error {
+	return t.stackCollection.createNodeGroupTask(errs, t.nodeGroup, t.supportsManagedNodes)
 }
 
 type managedNodeGroupTask struct {

--- a/pkg/cfn/manager/tasks_test.go
+++ b/pkg/cfn/manager/tasks_test.go
@@ -655,41 +655,44 @@ var _ = Describe("StackCollection Tasks", func() {
 					}
 					return managedNodeGroups
 				}
+				// TODO use DescribeTable
 
+				// The supportsManagedNodes argument has no effect on the Describe call, so the values are alternated
+				// in these tests
 				{
-					tasks := stackManager.NewTasksToCreateNodeGroups(makeNodeGroups("bar", "foo"))
+					tasks := stackManager.NewTasksToCreateNodeGroups(makeNodeGroups("bar", "foo"), true)
 					Expect(tasks.Describe()).To(Equal(`2 parallel tasks: { create nodegroup "bar", create nodegroup "foo" }`))
 				}
 				{
-					tasks := stackManager.NewTasksToCreateNodeGroups(makeNodeGroups("bar"))
+					tasks := stackManager.NewTasksToCreateNodeGroups(makeNodeGroups("bar"), false)
 					Expect(tasks.Describe()).To(Equal(`1 task: { create nodegroup "bar" }`))
 				}
 				{
-					tasks := stackManager.NewTasksToCreateNodeGroups(makeNodeGroups("foo"))
+					tasks := stackManager.NewTasksToCreateNodeGroups(makeNodeGroups("foo"), true)
 					Expect(tasks.Describe()).To(Equal(`1 task: { create nodegroup "foo" }`))
 				}
 				{
-					tasks := stackManager.NewTasksToCreateNodeGroups(nil)
+					tasks := stackManager.NewTasksToCreateNodeGroups(nil, false)
 					Expect(tasks.Describe()).To(Equal(`no tasks`))
 				}
 				{
-					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar", "foo"), nil)
+					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar", "foo"), nil, true)
 					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 2 parallel sub-tasks: { create nodegroup "bar", create nodegroup "foo" } }`))
 				}
 				{
-					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar"), nil)
+					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar"), nil, false)
 					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", create nodegroup "bar" }`))
 				}
 				{
-					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(nil, nil)
+					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(nil, nil, true)
 					Expect(tasks.Describe()).To(Equal(`1 task: { create cluster control plane "test-cluster" }`))
 				}
 				{
-					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar", "foo"), makeManagedNodeGroups("m1", "m2"))
+					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar", "foo"), makeManagedNodeGroups("m1", "m2"), false)
 					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 4 parallel sub-tasks: { create nodegroup "bar", create nodegroup "foo", create managed nodegroup "m1", create managed nodegroup "m2" } }`))
 				}
 				{
-					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("foo"), makeManagedNodeGroups("m1"))
+					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("foo"), makeManagedNodeGroups("m1"), true)
 					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 2 parallel sub-tasks: { create nodegroup "foo", create managed nodegroup "m1" } }`))
 				}
 			})

--- a/pkg/cfn/outputs/api.go
+++ b/pkg/cfn/outputs/api.go
@@ -12,10 +12,11 @@ import (
 // Stack output names
 const (
 	// outputs from cluster stack
-	ClusterVPC            = "VPC"
-	ClusterSecurityGroup  = "SecurityGroup"
-	ClusterSubnetsPrivate = string("Subnets" + api.SubnetTopologyPrivate)
-	ClusterSubnetsPublic  = string("Subnets" + api.SubnetTopologyPublic)
+	ClusterVPC                  = "VPC"
+	ClusterDefaultSecurityGroup = "ClusterSecurityGroupId"
+	ClusterSecurityGroup        = "SecurityGroup"
+	ClusterSubnetsPrivate       = string("Subnets" + api.SubnetTopologyPrivate)
+	ClusterSubnetsPublic        = string("Subnets" + api.SubnetTopologyPublic)
 
 	ClusterSubnetsPublicLegacy = "Subnets"
 

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -314,7 +314,7 @@ func doCreateCluster(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *createCluster
 		}
 
 		logger.Info("if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=%s --cluster=%s'", meta.Region, meta.Name)
-		supportsManagedNodes, err := eks.SupportsManagedNodes(cfg.Metadata.Version)
+		supportsManagedNodes, err := eks.VersionSupportsManagedNodes(cfg.Metadata.Version)
 		if err != nil {
 			return err
 		}

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -150,7 +150,7 @@ func doCreateCluster(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *createCluster
 	logFiltered := cmdutils.ApplyFilter(cfg, ngFilter)
 	kubeNodeGroups := cmdutils.ToKubeNodeGroups(cfg)
 
-	if err := eks.ValidateWindowsCompatibility(kubeNodeGroups, cfg.Metadata.Version); err != nil {
+	if err := eks.ValidateFeatureCompatibility(cfg, kubeNodeGroups); err != nil {
 		return err
 	}
 	if params.installWindowsVPCController {
@@ -314,7 +314,11 @@ func doCreateCluster(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *createCluster
 		}
 
 		logger.Info("if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=%s --cluster=%s'", meta.Region, meta.Name)
-		tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(cfg.NodeGroups, cfg.ManagedNodeGroups)
+		supportsManagedNodes, err := eks.SupportsManagedNodes(cfg.Metadata.Version)
+		if err != nil {
+			return err
+		}
+		tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(cfg.NodeGroups, cfg.ManagedNodeGroups, supportsManagedNodes)
 		ctl.AppendExtraClusterConfigTasks(cfg, params.installWindowsVPCController, tasks)
 
 		logger.Info(tasks.Describe())

--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -100,7 +100,11 @@ func doUpdateClusterCmd(cmd *cmdutils.Cmd) error {
 
 	stackManager := ctl.NewStackManager(cfg)
 
-	stackUpdateRequired, err := stackManager.AppendNewClusterStackResource(cmd.Plan)
+	supportsManagedNodes, err := ctl.SupportsManagedNodes(cfg)
+	if err != nil {
+		return err
+	}
+	stackUpdateRequired, err := stackManager.AppendNewClusterStackResource(cmd.Plan, supportsManagedNodes)
 	if err != nil {
 		return err
 	}

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -68,7 +68,7 @@ func (c *ClusterProvider) RefreshClusterStatus(spec *api.ClusterConfig) error {
 	}
 }
 
-// VersionSupportsManagedNodes reports whether an existing cluster supports Managed Nodes
+// SupportsManagedNodes reports whether an existing cluster supports Managed Nodes
 // The minimum required control plane version and platform version are 1.14 and eks.3 respectively
 func (c *ClusterProvider) SupportsManagedNodes(clusterConfig *api.ClusterConfig) (bool, error) {
 	if err := c.maybeRefreshClusterStatus(clusterConfig); err != nil {

--- a/pkg/eks/nodegroup.go
+++ b/pkg/eks/nodegroup.go
@@ -62,7 +62,7 @@ func ValidateFeatureCompatibility(clusterConfig *api.ClusterConfig, kubeNodeGrou
 func ValidateManagedNodesSupport(clusterConfig *api.ClusterConfig) error {
 	if len(clusterConfig.ManagedNodeGroups) > 0 {
 		minRequiredVersion := api.Version1_14
-		supportsManagedNodes, err := SupportsManagedNodes(clusterConfig.Metadata.Version)
+		supportsManagedNodes, err := VersionSupportsManagedNodes(clusterConfig.Metadata.Version)
 		if err != nil {
 			return err
 		}
@@ -73,8 +73,8 @@ func ValidateManagedNodesSupport(clusterConfig *api.ClusterConfig) error {
 	return nil
 }
 
-// SupportsManagedNodes reports whether the control plane version can support Managed Nodes
-func SupportsManagedNodes(controlPlaneVersion string) (bool, error) {
+// VersionSupportsManagedNodes reports whether the control plane version can support Managed Nodes
+func VersionSupportsManagedNodes(controlPlaneVersion string) (bool, error) {
 	minRequiredVersion := api.Version1_14
 	supportsManagedNodes, err := utils.IsMinVersion(minRequiredVersion, controlPlaneVersion)
 	if err != nil {

--- a/pkg/eks/nodegroup.go
+++ b/pkg/eks/nodegroup.go
@@ -48,6 +48,41 @@ func getNodes(clientSet kubernetes.Interface, ng KubeNodeGroup) (int, error) {
 	return counter, nil
 }
 
+// ValidateFeatureCompatibility validates whether the cluster version supports the features specified in the
+// ClusterConfig. Support for Managed Nodegroups or Windows requires the EKS cluster version to be 1.14 and above.
+// If the version requirement isn't met, an error is returned
+func ValidateFeatureCompatibility(clusterConfig *api.ClusterConfig, kubeNodeGroups []KubeNodeGroup) error {
+	if err := ValidateManagedNodesSupport(clusterConfig); err != nil {
+		return err
+	}
+	return ValidateWindowsCompatibility(kubeNodeGroups, clusterConfig.Metadata.Version)
+}
+
+// ValidateManagedNodesSupport validates support for Managed Nodegroups
+func ValidateManagedNodesSupport(clusterConfig *api.ClusterConfig) error {
+	if len(clusterConfig.ManagedNodeGroups) > 0 {
+		minRequiredVersion := api.Version1_14
+		supportsManagedNodes, err := SupportsManagedNodes(clusterConfig.Metadata.Version)
+		if err != nil {
+			return err
+		}
+		if !supportsManagedNodes {
+			return fmt.Errorf("Managed Nodegroups are only supported on EKS version %s and above", minRequiredVersion)
+		}
+	}
+	return nil
+}
+
+// SupportsManagedNodes reports whether the control plane version can support Managed Nodes
+func SupportsManagedNodes(controlPlaneVersion string) (bool, error) {
+	minRequiredVersion := api.Version1_14
+	supportsManagedNodes, err := utils.IsMinVersion(minRequiredVersion, controlPlaneVersion)
+	if err != nil {
+		return false, err
+	}
+	return supportsManagedNodes, nil
+}
+
 // ValidateWindowsCompatibility validates Windows compatibility
 func ValidateWindowsCompatibility(kubeNodeGroups []KubeNodeGroup, controlPlaneVersion string) error {
 	if !hasWindowsNode(kubeNodeGroups) {


### PR DESCRIPTION
### Description

eksctl uses the ClusterSecurityGroupId to enable communication between both managed and unmanaged nodegroups. This field, however, was recently added to AWS EKS (in platform version eks.3) and the `update` command in eksctl wasn't amended to ignore it for older/existing clusters in the 0.10.0 release.

This PR exports that attribute only for new 1.14 clusters, and skips exporting it for existing clusters that are on platform version below `eks.3`.

Fixes #1574 

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Manually tested
