### PR TITLE
Fix attaching multiple SGs to unmanaged nodegroups

### DIFF
--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -209,6 +209,27 @@ func (c *ClusterResourceSet) addResourcesForSecurityGroups() {
 			FromPort:              sgPortZero,
 			ToPort:                sgMaxNodePort,
 		})
+		if c.supportsManagedNodes {
+			// To enable communication between both managed and unmanaged nodegroups, this allows ingress traffic from
+			// the default cluster security group ID that EKS creates by default
+			// EKS attaches this to Managed Nodegroups by default, but we need to handle this for unmanaged nodegroups
+			c.newResource("IngressDefaultClusterToNodeSG", &gfn.AWSEC2SecurityGroupIngress{
+				GroupId:               refClusterSharedNodeSG,
+				SourceSecurityGroupId: gfn.MakeFnGetAttString(makeAttrAccessor("ControlPlane", outputs.ClusterDefaultSecurityGroup)),
+				Description:           gfn.NewString("Allow managed and unmanaged nodes to communicate with each other (all ports)"),
+				IpProtocol:            gfn.NewString("-1"),
+				FromPort:              sgPortZero,
+				ToPort:                sgMaxNodePort,
+			})
+			c.newResource("IngressNodeToDefaultClusterSG", &gfn.AWSEC2SecurityGroupIngress{
+				GroupId:               gfn.MakeFnGetAttString(makeAttrAccessor("ControlPlane", outputs.ClusterDefaultSecurityGroup)),
+				SourceSecurityGroupId: refClusterSharedNodeSG,
+				Description:           gfn.NewString("Allow unmanaged nodes to communicate with control plane (all ports)"),
+				IpProtocol:            gfn.NewString("-1"),
+				FromPort:              sgPortZero,
+				ToPort:                sgMaxNodePort,
+			})
+		}
 	} else {
 		refClusterSharedNodeSG = gfn.NewString(c.spec.VPC.SharedNodeSecurityGroup)
 	}
@@ -256,10 +277,6 @@ func (n *NodeGroupResourceSet) addResourcesForSecurityGroups() {
 	})
 
 	n.securityGroups = append(n.securityGroups, refNodeGroupLocalSG)
-	if n.supportsManagedNodes {
-		defaultClusterSharedSecurityGroup := makeImportValue(n.clusterStackName, outputs.ClusterDefaultSecurityGroup)
-		n.securityGroups = append(n.securityGroups, defaultClusterSharedSecurityGroup)
-	}
 
 	n.newResource("IngressInterCluster", &gfn.AWSEC2SecurityGroupIngress{
 		GroupId:               refNodeGroupLocalSG,

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -79,7 +79,7 @@ func (c *ClusterProvider) SupportsManagedNodes(clusterConfig *api.ClusterConfig)
 }
 
 var (
-	platformVersionRegex = regexp.MustCompile(`^eks\.(\d+)`)
+	platformVersionRegex = regexp.MustCompile(`^eks\.(\d+)$`)
 )
 
 // ClusterSupportsManagedNodes reports whether the EKS cluster supports managed nodes


### PR DESCRIPTION
To support communication between managed nodes and unmanaged nodes, this change attaches an ingress rule to the default cluster SG that allows traffic from unmanaged nodes, and another ingress rule to the shared node SG that allows traffic from the default cluster SG (and in turn, from managed nodes)

Instead of attaching the EKS default cluster security group ID (which has the cluster tags) to unmanaged nodes and removing the part where we attach our own security groups (one of which also has cluster tags), this change:

* Adds an ingress rule to the shared node security group (that we currently create) for unmanaged nodes to allow traffic from the cluster default security group.
* Adds an ingress rule to the default cluster security group ID to allow traffic from the shared security group (that we create). I'm aware this will mutate a security group that's managed by EKS, but I've confirmed that EKS is able to delete the cluster even when the default SG is modified by adding an ingress rule.

For context, the main rationale behind adding the default cluster SG to unmanaged nodes was to allow communication between managed and unmanaged nodes, since managed nodes do not support attaching a custom SG.

Fixes #1581 

### Description

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
