### PR TITLE
Support `only-missing` filter and append globs for managed nodegroups

### DIFF
--- a/pkg/ctl/cmdutils/cluster.go
+++ b/pkg/ctl/cmdutils/cluster.go
@@ -52,3 +52,15 @@ func ToKubeNodeGroups(clusterConfig *api.ClusterConfig) []eks.KubeNodeGroup {
 	}
 	return kubeNodeGroups
 }
+
+// getAllNodeGroupNames collects and returns names for both managed and unmanaged nodegroups
+func getAllNodeGroupNames(clusterConfig *api.ClusterConfig) []string {
+	var ngNames []string
+	for _, ng := range clusterConfig.NodeGroups {
+		ngNames = append(ngNames, ng.NameString())
+	}
+	for _, ng := range clusterConfig.ManagedNodeGroups {
+		ngNames = append(ngNames, ng.NameString())
+	}
+	return ngNames
+}

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -269,7 +269,7 @@ func NewCreateNodeGroupLoader(cmd *Cmd, ng *api.NodeGroup, ngFilter *NodeGroupFi
 	)
 
 	l.validateWithConfigFile = func() error {
-		return ngFilter.AppendGlobs(l.Include, l.Exclude, l.ClusterConfig.NodeGroups)
+		return ngFilter.AppendGlobs(l.Include, l.Exclude, getAllNodeGroupNames(l.ClusterConfig))
 	}
 
 	l.validateWithoutConfigFile = func() error {
@@ -356,7 +356,7 @@ func NewDeleteNodeGroupLoader(cmd *Cmd, ng *api.NodeGroup, ngFilter *NodeGroupFi
 	l := newCommonClusterConfigLoader(cmd)
 
 	l.validateWithConfigFile = func() error {
-		return ngFilter.AppendGlobs(l.Include, l.Exclude, l.ClusterConfig.NodeGroups)
+		return ngFilter.AppendGlobs(l.Include, l.Exclude, getAllNodeGroupNames(l.ClusterConfig))
 	}
 
 	l.flagsIncompatibleWithoutConfigFile.Insert(

--- a/pkg/ctl/cmdutils/nodegroup_filter.go
+++ b/pkg/ctl/cmdutils/nodegroup_filter.go
@@ -70,19 +70,11 @@ func (f *NodeGroupFilter) SetIncludeOrExcludeMissingFilter(lister stackLister, i
 		return err
 	}
 
-	stackExists := func(name string) bool {
-		for _, s := range stacks {
-			if s.NodeGroupName == name {
-				return true
-			}
-		}
-		return false
-	}
 	local := sets.NewString()
 
 	for _, localNodeGroup := range getAllNodeGroupNames(clusterConfig) {
 		local.Insert(localNodeGroup)
-		if !stackExists(localNodeGroup) {
+		if !stackExists(stacks, localNodeGroup) {
 			logger.Info("nodegroup %q present in the given config, but missing in the cluster", localNodeGroup)
 			f.AppendExcludeNames(localNodeGroup)
 		} else if includeOnlyMissing {
@@ -109,6 +101,15 @@ func (f *NodeGroupFilter) SetIncludeOrExcludeMissingFilter(lister stackLister, i
 	}
 
 	return nil
+}
+
+func stackExists(stacks []manager.NodeGroupStack, stackName string) bool {
+	for _, s := range stacks {
+		if s.NodeGroupName == stackName {
+			return true
+		}
+	}
+	return false
 }
 
 // LogInfo prints out a user-friendly message about how filter was applied

--- a/pkg/ctl/cmdutils/nodegroup_filter.go
+++ b/pkg/ctl/cmdutils/nodegroup_filter.go
@@ -2,7 +2,6 @@ package cmdutils
 
 import (
 	"github.com/kris-nova/logger"
-	"github.com/weaveworks/eksctl/pkg/eks"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -26,58 +25,81 @@ func NewNodeGroupFilter() *NodeGroupFilter {
 }
 
 // AppendGlobs appends globs for inclusion and exclusion rules
-func (f *NodeGroupFilter) AppendGlobs(includeGlobExprs, excludeGlobExprs []string, nodeGroups []*api.NodeGroup) error {
-	if err := f.AppendIncludeGlobs(nodeGroups, includeGlobExprs...); err != nil {
+func (f *NodeGroupFilter) AppendGlobs(includeGlobExprs, excludeGlobExprs []string, ngNames []string) error {
+	if err := f.AppendIncludeGlobs(ngNames, includeGlobExprs...); err != nil {
 		return err
 	}
 	return f.AppendExcludeGlobs(excludeGlobExprs...)
 }
 
 // AppendIncludeGlobs sets globs for inclusion rules
-func (f *NodeGroupFilter) AppendIncludeGlobs(nodeGroups []*api.NodeGroup, globExprs ...string) error {
-	return f.doAppendIncludeGlobs(f.collectNames(nodeGroups), "nodegroup", globExprs...)
+func (f *NodeGroupFilter) AppendIncludeGlobs(ngNames []string, globExprs ...string) error {
+	return f.doAppendIncludeGlobs(ngNames, "nodegroup", globExprs...)
+}
+
+// A stackLister lists nodegroup stacks
+type stackLister interface {
+	ListNodeGroupStacks() ([]manager.NodeGroupStack, error)
 }
 
 // SetExcludeExistingFilter uses stackManager to list existing nodegroup stacks and configures
 // the filter accordingly
-func (f *NodeGroupFilter) SetExcludeExistingFilter(stackManager *manager.StackCollection) error {
+func (f *NodeGroupFilter) SetExcludeExistingFilter(lister stackLister) error {
 	if f.ExcludeAll {
 		return nil
 	}
 
-	existing, err := stackManager.ListNodeGroupStacks()
+	existingStacks, err := lister.ListNodeGroupStacks()
 	if err != nil {
 		return err
 	}
 
-	return f.doSetExcludeExistingFilter(existing, "nodegroup")
+	var ngNames []string
+	for _, s := range existingStacks {
+		ngNames = append(ngNames, s.NodeGroupName)
+	}
+
+	return f.doSetExcludeExistingFilter(ngNames, "nodegroup")
 }
 
 // SetIncludeOrExcludeMissingFilter uses stackManager to list existing nodegroup stacks and configures
 // the filter to either explicitly exclude or include nodegroups that are missing from given nodeGroups
-func (f *NodeGroupFilter) SetIncludeOrExcludeMissingFilter(stackManager *manager.StackCollection, includeOnlyMissing bool, nodeGroups []eks.KubeNodeGroup) error {
-	existing, err := stackManager.ListNodeGroupStacks()
+func (f *NodeGroupFilter) SetIncludeOrExcludeMissingFilter(lister stackLister, includeOnlyMissing bool, clusterConfig *api.ClusterConfig) error {
+	stacks, err := lister.ListNodeGroupStacks()
 	if err != nil {
 		return err
 	}
 
-	remote := sets.NewString(existing...)
+	stackExists := func(name string) bool {
+		for _, s := range stacks {
+			if s.NodeGroupName == name {
+				return true
+			}
+		}
+		return false
+	}
 	local := sets.NewString()
 
-	for _, localNodeGroup := range nodeGroups {
-		local.Insert(localNodeGroup.NameString())
-		if !remote.Has(localNodeGroup.NameString()) {
-			logger.Info("nodegroup %q present in the given config, but missing in the cluster", localNodeGroup.NameString())
-			f.AppendExcludeNames(localNodeGroup.NameString())
+	for _, localNodeGroup := range getAllNodeGroupNames(clusterConfig) {
+		local.Insert(localNodeGroup)
+		if !stackExists(localNodeGroup) {
+			logger.Info("nodegroup %q present in the given config, but missing in the cluster", localNodeGroup)
+			f.AppendExcludeNames(localNodeGroup)
 		} else if includeOnlyMissing {
-			f.AppendExcludeNames(localNodeGroup.NameString())
+			f.AppendExcludeNames(localNodeGroup)
 		}
 	}
 
-	for remoteNodeGroupName := range remote {
+	for _, s := range stacks {
+		remoteNodeGroupName := s.NodeGroupName
 		if !local.Has(remoteNodeGroupName) {
-			logger.Info("nodegroup %q present in the cluster, but missing from the given config", remoteNodeGroupName)
+			logger.Info("nodegroup %q present in the cluster, but missing from the given config", s.NodeGroupName)
 			if includeOnlyMissing {
+				if s.Type == api.NodeGroupTypeManaged {
+					clusterConfig.ManagedNodeGroups = append(clusterConfig.ManagedNodeGroups, &api.ManagedNodeGroup{Name: s.NodeGroupName})
+				} else {
+					clusterConfig.NodeGroups = append(clusterConfig.NodeGroups, &api.NodeGroup{Name: s.NodeGroupName})
+				}
 				// make sure it passes it through the filter, so that one can use `--only-missing` along with `--exclude`
 				if f.Match(remoteNodeGroupName) {
 					f.AppendIncludeNames(remoteNodeGroupName)

--- a/pkg/ctl/cmdutils/nodegroup_filter.go
+++ b/pkg/ctl/cmdutils/nodegroup_filter.go
@@ -62,7 +62,7 @@ func (f *NodeGroupFilter) SetExcludeExistingFilter(lister stackLister) error {
 	return f.doSetExcludeExistingFilter(ngNames, "nodegroup")
 }
 
-// SetIncludeOrExcludeMissingFilter uses stackManager to list existing nodegroup stacks and configures
+// SetIncludeOrExcludeMissingFilter uses stackLister to list existing nodegroup stacks and configures
 // the filter to either explicitly exclude or include nodegroups that are missing from given nodeGroups
 func (f *NodeGroupFilter) SetIncludeOrExcludeMissingFilter(lister stackLister, includeOnlyMissing bool, clusterConfig *api.ClusterConfig) error {
 	stacks, err := lister.ListNodeGroupStacks()

--- a/pkg/ctl/cmdutils/nodegroup_filter.go
+++ b/pkg/ctl/cmdutils/nodegroup_filter.go
@@ -25,7 +25,7 @@ func NewNodeGroupFilter() *NodeGroupFilter {
 }
 
 // AppendGlobs appends globs for inclusion and exclusion rules
-func (f *NodeGroupFilter) AppendGlobs(includeGlobExprs, excludeGlobExprs []string, ngNames []string) error {
+func (f *NodeGroupFilter) AppendGlobs(includeGlobExprs, excludeGlobExprs, ngNames []string) error {
 	if err := f.AppendIncludeGlobs(ngNames, includeGlobExprs...); err != nil {
 		return err
 	}

--- a/pkg/ctl/cmdutils/nodegroup_filter_test.go
+++ b/pkg/ctl/cmdutils/nodegroup_filter_test.go
@@ -14,6 +14,14 @@ import (
 
 var _ = Describe("nodegroup filter", func() {
 
+	getNodeGroupNames := func(clusterConfig *api.ClusterConfig) []string {
+		var ngNames []string
+		for _, ng := range clusterConfig.NodeGroups {
+			ngNames = append(ngNames, ng.NameString())
+		}
+		return ngNames
+	}
+
 	Context("Match", func() {
 		var (
 			filter *NodeGroupFilter
@@ -64,7 +72,7 @@ var _ = Describe("nodegroup filter", func() {
 
 		It("should match include filter", func() {
 			filter.AppendIncludeNames("test-ng3b")
-			err := filter.AppendIncludeGlobs(cfg.NodeGroups, "test-ng1?", "x*")
+			err := filter.AppendIncludeGlobs(getNodeGroupNames(cfg), "test-ng1?", "x*")
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(filter.Match("test-ng3x")).To(BeFalse())
@@ -84,7 +92,7 @@ var _ = Describe("nodegroup filter", func() {
 
 		It("should match non-overlapping exclude and include filters with explicit inclusion", func() {
 			filter.AppendIncludeNames("test-ng1a", "test-ng2b")
-			err := filter.AppendIncludeGlobs(cfg.NodeGroups, "test-ng?a", "*-ng3?")
+			err := filter.AppendIncludeGlobs(getNodeGroupNames(cfg), "test-ng?a", "*-ng3?")
 			Expect(err).ToNot(HaveOccurred())
 
 			filter.AppendExcludeNames("test-ng1b")
@@ -99,7 +107,7 @@ var _ = Describe("nodegroup filter", func() {
 
 		It("should match non-overlapping exclude and include filters with fallback inclusion", func() {
 			filter.AppendIncludeNames("test-ng1X")
-			err := filter.AppendIncludeGlobs(cfg.NodeGroups, "test-ng?a")
+			err := filter.AppendIncludeGlobs(getNodeGroupNames(cfg), "test-ng?a")
 			Expect(err).ToNot(HaveOccurred())
 
 			filter.AppendExcludeNames("test-ng1b")
@@ -113,7 +121,7 @@ var _ = Describe("nodegroup filter", func() {
 		})
 
 		It("should match overlapping exclude and include filters", func() {
-			err := filter.AppendIncludeGlobs(cfg.NodeGroups, "test-ng?a", "test-?g2b")
+			err := filter.AppendIncludeGlobs(getNodeGroupNames(cfg), "test-ng?a", "test-?g2b")
 			Expect(err).ToNot(HaveOccurred())
 
 			filter.AppendExcludeNames("test-ng1b", "test-ng2a")
@@ -226,11 +234,11 @@ var _ = Describe("nodegroup filter", func() {
 
 			names = []string{}
 
-			err := filter.AppendIncludeGlobs(cfg.NodeGroups, "t?xyz?", "ab*z123?")
+			err := filter.AppendIncludeGlobs(getNodeGroupNames(cfg), "t?xyz?", "ab*z123?")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal(`no nodegroups match include glob filter specification: "t?xyz?,ab*z123?"`))
 
-			err = filter.AppendIncludeGlobs(cfg.NodeGroups, "test-ng1?", "te*-ng3?")
+			err = filter.AppendIncludeGlobs(getNodeGroupNames(cfg), "test-ng1?", "te*-ng3?")
 			Expect(err).ToNot(HaveOccurred())
 			filter.ForEach(cfg.NodeGroups, func(i int, nodeGroup *api.NodeGroup) error {
 				Expect(nodeGroup).To(Equal(cfg.NodeGroups[i]))

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -74,8 +74,7 @@ func doDeleteNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, updateAuthConfigMap
 
 	if cmd.ClusterConfigFile != "" {
 		logger.Info("comparing %d nodegroups defined in the given config (%q) against remote state", len(cfg.NodeGroups), cmd.ClusterConfigFile)
-		allNodeGroups := cmdutils.ToKubeNodeGroups(cfg)
-		if err := ngFilter.SetIncludeOrExcludeMissingFilter(stackManager, onlyMissing, allNodeGroups); err != nil {
+		if err := ngFilter.SetIncludeOrExcludeMissingFilter(stackManager, onlyMissing, cfg); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/ctl/drain/nodegroup.go
+++ b/pkg/ctl/drain/nodegroup.go
@@ -70,11 +70,9 @@ func doDrainNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, undo, onlyMissing bo
 
 	if cmd.ClusterConfigFile != "" {
 		logger.Info("comparing %d nodegroups defined in the given config (%q) against remote state", len(cfg.NodeGroups), cmd.ClusterConfigFile)
-		allNodeGroups := cmdutils.ToKubeNodeGroups(cfg)
-		if err := ngFilter.SetIncludeOrExcludeMissingFilter(stackManager, onlyMissing, allNodeGroups); err != nil {
+		if err := ngFilter.SetIncludeOrExcludeMissingFilter(stackManager, onlyMissing, cfg); err != nil {
 			return err
 		}
-		// TODO support filter for managed nodegroups
 	}
 	logFiltered := cmdutils.ApplyFilter(cfg, ngFilter)
 


### PR DESCRIPTION
### Description
Adds support for `only-missing` filter, and include and exclude globs for managed nodes.

Also fixes #1591 
<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
