### PR TITLE
Mention correct option `--name` when resource name missing

### DIFF
--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -274,7 +274,7 @@ func NewCreateNodeGroupLoader(cmd *Cmd, ng *api.NodeGroup, ngFilter *NodeGroupFi
 
 	l.validateWithoutConfigFile = func() error {
 		if l.ClusterConfig.Metadata.Name == "" {
-			return ErrMustBeSet("--cluster")
+			return ErrMustBeSet(ClusterNameFlag(cmd))
 		}
 		if managedNodeGroup {
 			for _, f := range incompatibleManagedNodesFlags() {
@@ -365,7 +365,7 @@ func NewDeleteNodeGroupLoader(cmd *Cmd, ng *api.NodeGroup, ngFilter *NodeGroupFi
 
 	l.validateWithoutConfigFile = func() error {
 		if l.ClusterConfig.Metadata.Name == "" {
-			return ErrMustBeSet("--cluster")
+			return ErrMustBeSet(ClusterNameFlag(cmd))
 		}
 
 		if ng.Name != "" && l.NameArg != "" {
@@ -451,7 +451,7 @@ func NewCreateIAMServiceAccountLoader(cmd *Cmd, saFilter *IAMServiceAccountFilte
 
 	l.validateWithoutConfigFile = func() error {
 		if l.ClusterConfig.Metadata.Name == "" {
-			return ErrMustBeSet("--cluster")
+			return ErrMustBeSet(ClusterNameFlag(cmd))
 		}
 
 		if len(l.ClusterConfig.IAM.ServiceAccounts) != 1 {
@@ -489,7 +489,7 @@ func NewGetIAMServiceAccountLoader(cmd *Cmd, sa *api.ClusterIAMServiceAccount) C
 		sa.AttachPolicyARNs = []string{""} // force to pass general validation
 
 		if l.ClusterConfig.Metadata.Name == "" {
-			return ErrMustBeSet("--cluster")
+			return ErrMustBeSet(ClusterNameFlag(cmd))
 		}
 
 		if l.NameArg != "" {
@@ -527,7 +527,7 @@ func NewDeleteIAMServiceAccountLoader(cmd *Cmd, sa *api.ClusterIAMServiceAccount
 		sa.AttachPolicyARNs = []string{""} // force to pass general validation
 
 		if l.ClusterConfig.Metadata.Name == "" {
-			return ErrMustBeSet("--cluster")
+			return ErrMustBeSet(ClusterNameFlag(cmd))
 		}
 
 		if sa.Name != "" && l.NameArg != "" {

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -377,7 +377,7 @@ func NewDeleteNodeGroupLoader(cmd *Cmd, ng *api.NodeGroup, ngFilter *NodeGroupFi
 		}
 
 		if ng.Name == "" {
-			return ErrMustBeSet(ClusterNameFlag(cmd))
+			return ErrMustBeSet("--name")
 		}
 
 		ngFilter.AppendIncludeNames(ng.Name)
@@ -539,7 +539,7 @@ func NewDeleteIAMServiceAccountLoader(cmd *Cmd, sa *api.ClusterIAMServiceAccount
 		}
 
 		if sa.Name == "" {
-			return ErrMustBeSet(ClusterNameFlag(cmd))
+			return ErrMustBeSet("--name")
 		}
 
 		l.Plan = false

--- a/pkg/ctl/cmdutils/gitops.go
+++ b/pkg/ctl/cmdutils/gitops.go
@@ -115,7 +115,7 @@ func NewGitOpsConfigLoader(cmd *Cmd) ClusterConfigLoader {
 	l.validateWithoutConfigFile = func() error {
 		meta := l.cmd.ClusterConfig.Metadata
 		if meta.Name == "" {
-			return ErrMustBeSet("--cluster")
+			return ErrMustBeSet(ClusterNameFlag(cmd))
 		}
 		if meta.Region == "" {
 			return ErrMustBeSet("--region")

--- a/pkg/ctl/create/iamidentitymapping.go
+++ b/pkg/ctl/create/iamidentitymapping.go
@@ -68,7 +68,7 @@ func doCreateIAMIdentityMapping(cmd *cmdutils.Cmd, arn string, username string, 
 	}
 
 	if cfg.Metadata.Name == "" {
-		return cmdutils.ErrMustBeSet("--cluster")
+		return cmdutils.ErrMustBeSet(cmdutils.ClusterNameFlag(cmd))
 	}
 
 	if ok, err := ctl.CanOperate(cfg); !ok {


### PR DESCRIPTION
When running `eksctl delete nodegroup --cluster=foo` or
`eksctl delete serviceaccount --cluster=foo` without specifying the
resource's name with `--name` it errored with `--cluster must be set`.

This fixes it to display `--name must be set`.

Fixes #1579 

### Checklist
- [x] Manually tested