### PR TITLE
Support taints and max pods for Windows nodegroups

### DIFF
--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -137,6 +137,14 @@ func kvs(kv map[string]string) string {
 	return strings.Join(params, ",")
 }
 
+func toCLIArgs(values map[string]string) string {
+	var args []string
+	for k, v := range values {
+		args = append(args, fmt.Sprintf("--%s=%s", k, v))
+	}
+	return strings.Join(args, " ")
+}
+
 func makeCommonKubeletEnvParams(spec *api.ClusterConfig, ng *api.NodeGroup) []string {
 	variables := []string{
 		fmt.Sprintf("NODE_LABELS=%s", kvs(ng.Labels)),


### PR DESCRIPTION
### Description
Adds support for `nodegroup.taints` and `nodegroup.maxPodsPerNode` for Windows nodegroups.

Closes #1590 
<!-- Please explain the changes you made here. -->

### Checklist
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
