### PR TITLE
Add servicediscovery:ListServices to App Mesh policy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/fluxcd/flux v1.15.0
 	github.com/fluxcd/helm-operator v1.0.0-rc2
 	github.com/go-ini/ini v1.37.0 // indirect
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gobuffalo/envy v1.7.0 // indirect
 	github.com/gobwas/glob v0.2.3
 	github.com/gofrs/flock v0.7.1 // indirect

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -391,7 +391,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Status: &api.ClusterStatus{
 				Endpoint:                 endpoint,
 				CertificateAuthorityData: caCertData,
-				ARN: arn,
+				ARN:                      arn,
 			},
 			AvailabilityZones: testAZs,
 			VPC:               testVPC(),
@@ -453,12 +453,12 @@ var _ = Describe("CloudFormation template builder API", func() {
 			"VPC":                      vpcID,
 			"Endpoint":                 endpoint,
 			"CertificateAuthorityData": caCert,
-			"ARN":                     arn,
-			"ClusterStackName":        "",
-			"SharedNodeSecurityGroup": "sg-shared",
-			"ServiceRoleARN":          arn,
-			"FeatureNATMode":          "Single",
-			"ClusterSecurityGroupId":  "sg-09ef4509a37f28b4c",
+			"ARN":                      arn,
+			"ClusterStackName":         "",
+			"SharedNodeSecurityGroup":  "sg-shared",
+			"ServiceRoleARN":           arn,
+			"FeatureNATMode":           "Single",
+			"ClusterSecurityGroupId":   "sg-09ef4509a37f28b4c",
 		}
 
 		It("should add all resources and collect outputs without errors", func() {
@@ -927,6 +927,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 				"servicediscovery:DeregisterInstance",
 				"servicediscovery:ListInstances",
 				"servicediscovery:ListNamespaces",
+				"servicediscovery:ListServices",
 				"route53:GetHealthCheck",
 				"route53:CreateHealthCheck",
 				"route53:UpdateHealthCheck",

--- a/pkg/cfn/builder/iam_helper.go
+++ b/pkg/cfn/builder/iam_helper.go
@@ -29,7 +29,7 @@ func createRole(cfnTemplate cfnTemplate, iamConfig *api.NodeGroupIAM) {
 	}
 
 	role := gfn.AWSIAMRole{
-		Path: gfn.NewString("/"),
+		Path:                     gfn.NewString("/"),
 		AssumeRolePolicyDocument: cft.MakeAssumeRolePolicyDocumentForServices("ec2.amazonaws.com"),
 		ManagedPolicyArns:        makeStringSlice(attachPolicyARNs...),
 	}
@@ -96,6 +96,7 @@ func createRole(cfnTemplate cfnTemplate, iamConfig *api.NodeGroupIAM) {
 				"servicediscovery:DeregisterInstance",
 				"servicediscovery:ListInstances",
 				"servicediscovery:ListNamespaces",
+				"servicediscovery:ListServices",
 				"route53:GetHealthCheck",
 				"route53:CreateHealthCheck",
 				"route53:UpdateHealthCheck",


### PR DESCRIPTION
### Description

Add `servicediscovery:ListServices` to the App Mesh node policy.  Required by the App Mesh controller Cloud Map integration (https://github.com/aws/aws-app-mesh-controller-for-k8s/blob/master/pkg/aws/cloudmap.go#L357).

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested