### PR TITLE
Add Makefile rule for generating builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,11 @@ godeps = $(shell $(call godeps_cmd,$(1)))
 build: generate-always ## Build main binary
 	CGO_ENABLED=0 time go build -ldflags "-X $(version_pkg).gitCommit=$(git_commit) -X $(version_pkg).builtAt=$(built_at)" ./cmd/eksctl
 
+# Build binaries for Linux, Windows and Mac and place them in dist/
+.PHONY: build-all
+build-all: generate-always
+	goreleaser --config=goreleaser-local.yaml --snapshot --skip-publish --rm-dist
+
 ##@ Testing & CI
 
 ifneq ($(TEST_V),)

--- a/goreleaser-local.yaml
+++ b/goreleaser-local.yaml
@@ -1,0 +1,33 @@
+builds:
+  - id: default
+    main: ./cmd/eksctl
+    binary: eksctl
+    flags:
+      - -tags
+      - netgo
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/weaveworks/eksctl/pkg/version.builtAt={{.Date}} -X github.com/weaveworks/eksctl/pkg/version.gitCommit={{.Commit}}
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64
+
+archives:
+  - id: default
+    builds:
+    - default
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+    - none*


### PR DESCRIPTION
### Description
Adds a Makefile rule for generating builds for multiple OSes. 
We may want to rethink the need for separate files for `release` and normal builds later.

Additionally, the need for a separate goreleaser config could have been avoided if this feature of supplying an override config (via --extra-config) was supported: https://github.com/aidenkeating/goreleaser/commit/ffd8ea2c0444902e2facebab467296488b49ec6f
But it doesn't seem to be available in upstream goreleaser.


<!-- Please explain the changes you made here. -->

### Checklist
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
