### PR TITLE
Increase timeout for public/private endpoint tests

### DIFF
--- a/integration/createdeletebeforeactive_test.go
+++ b/integration/createdeletebeforeactive_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	pollInterval = 15   //seconds
-	timeOut      = 1200 //seconds = 20 minutes
+	pollInterval   = 15   //seconds
+	timeOutSeconds = 1200 // 20 minutes
 )
 
 var _ = Describe("(Integration) Create & Delete before Active", func() {
@@ -44,7 +44,7 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 			)
 			cmd.Start()
 			awsSession := NewSession(region)
-			Eventually(awsSession, timeOut, pollInterval).Should(
+			Eventually(awsSession, timeOutSeconds, pollInterval).Should(
 				HaveExistingCluster(delBeforeActiveName, awseks.ClusterStatusCreating, version))
 		})
 	})
@@ -61,11 +61,11 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 	Context("after the delete of the cluster in progress has been initiated", func() {
 		It("should eventually delete the EKS cluster and both CloudFormation stacks", func() {
 			awsSession := NewSession(region)
-			Eventually(awsSession, timeOut, pollInterval).ShouldNot(
+			Eventually(awsSession, timeOutSeconds, pollInterval).ShouldNot(
 				HaveExistingCluster(delBeforeActiveName, awseks.ClusterStatusActive, version))
-			Eventually(awsSession, timeOut, pollInterval).ShouldNot(
+			Eventually(awsSession, timeOutSeconds, pollInterval).ShouldNot(
 				HaveExistingStack(fmt.Sprintf("eksctl-%s-cluster", delBeforeActiveName)))
-			Eventually(awsSession, timeOut, pollInterval).ShouldNot(
+			Eventually(awsSession, timeOutSeconds, pollInterval).ShouldNot(
 				HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", delBeforeActiveName, initNG)))
 		})
 	})


### PR DESCRIPTION
Since they are failing with timeouts in circleci



Integration tests are failing in circleci every night. I see a timeout
in two cluster api endpoint tests so I am increasing the timeout from
30s to 2m to see if that fixes them.

**Before**
```
------------------------------
(Integration) Create and Update Cluster with Endpoint Configs Can create/update Cluster Endpoint Access 
  Update cluster3 to Private=false, Public=true, should succeed
  /go/pkg/mod/github.com/onsi/ginkgo@v1.8.0/extensions/table/table_entry.go:46
starting '../eksctl "--region" "us-west-2" "utils" "update-cluster-endpoints" "--name" "cluster3-floral-sculpture-1574919634" "--private-access=false" "--public-access=true" "--approve"'
Flag --name has been deprecated, use --cluster
[ℹ]  using region us-west-2
[ℹ]  current Kubernetes API endpoint access: privateAccess=true, publicAccess=false
[ℹ]  will update Kubernetes API endpoint access for cluster "cluster3-floral-sculpture-1574919634" in "us-west-2" to: privateAccess=false, publicAccess=true
[✔]  the Kubernetes API endpoint access for cluster "cluster1-floral-sculpture-1574919634" in "us-west-2" has been updated to: privateAccess=true, publicAccess=false

• Failure [300.002 seconds]
(Integration) Create and Update Cluster with Endpoint Configs
/src/integration/cluster_api_endpoints_test.go:49
  Can create/update Cluster Endpoint Access
  /go/pkg/mod/github.com/onsi/ginkgo@v1.8.0/extensions/table/table.go:92
    Update cluster3 to Private=false, Public=true, should succeed [It]
    /go/pkg/mod/github.com/onsi/ginkgo@v1.8.0/extensions/table/table_entry.go:46

    Timed out after 300.000s.
    Expected process to exit.  It did not.

    /src/integration/runner/runner.go:113
```

- [ ] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->