### PR TITLE
Added support for overriding the EKS Endpoint

### DIFF
--- a/integration/creategetdelete_test.go
+++ b/integration/creategetdelete_test.go
@@ -438,7 +438,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					Expect(awsSession).To(HaveExistingStack(stackNamePrefix + "default-s3-read-only"))
 					Expect(awsSession).To(HaveExistingStack(stackNamePrefix + "app1-app-cache-access"))
 
-					clientSet, err := ctl.NewStdClientSet(cfg)
+					clientSet, err := ctl.NewStdClientSet(cfg, "")
 					Expect(err).ShouldNot(HaveOccurred())
 
 					{

--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -179,9 +179,9 @@ func AddUpdateAuthConfigMap(fs *pflag.FlagSet, updateAuthConfigMap *bool, descri
 	fs.BoolVar(updateAuthConfigMap, "update-auth-configmap", true, description)
 }
 
-// AddClusterEndpointOverrideFlag adds common cluster-endpoint-override flag
+// AddClusterEndpointOverrideFlag adds common cluster-endpoint flag
 func AddClusterEndpointOverrideFlag(fs *pflag.FlagSet, clusterEndpoint *string) {
-	fs.StringVar(clusterEndpoint, "cluster-endpoint-override", "", "cluster endpoint to use instead of the eks cluster endpoint provided by Cloudformation")
+	fs.StringVar(clusterEndpoint, "cluster-endpoint", "", "cluster endpoint to use instead of the eks cluster endpoint provided by Cloudformation")
 }
 
 // AddCommonFlagsForKubeconfig adds common flags for controlling how output kubeconfig is written

--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -179,6 +179,11 @@ func AddUpdateAuthConfigMap(fs *pflag.FlagSet, updateAuthConfigMap *bool, descri
 	fs.BoolVar(updateAuthConfigMap, "update-auth-configmap", true, description)
 }
 
+// AddClusterEndpointOverrideFlag adds common cluster-endpoint-override flag
+func AddClusterEndpointOverrideFlag(fs *pflag.FlagSet, clusterEndpoint *string) {
+	fs.StringVar(clusterEndpoint, "cluster-endpoint-override", "", "cluster endpoint to use instead of the eks cluster endpoint provided by Cloudformation")
+}
+
 // AddCommonFlagsForKubeconfig adds common flags for controlling how output kubeconfig is written
 func AddCommonFlagsForKubeconfig(fs *pflag.FlagSet, outputPath, authenticatorRoleARN *string, setContext, autoPath *bool, exampleName string) {
 	fs.StringVar(outputPath, "kubeconfig", kubeconfig.DefaultPath, "path to write kubeconfig (incompatible with --auto-kubeconfig)")

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -341,7 +341,7 @@ func doCreateCluster(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *cmdutils.Crea
 		}
 
 		// create Kubernetes client
-		clientSet, err := ctl.NewStdClientSet(cfg)
+		clientSet, err := ctl.NewStdClientSet(cfg, "")
 		if err != nil {
 			return err
 		}

--- a/pkg/ctl/create/fargate.go
+++ b/pkg/ctl/create/fargate.go
@@ -87,7 +87,7 @@ func doCreateFargateProfile(cmd *cmdutils.Cmd, options *fargate.CreateOptions) e
 }
 
 func clientSet(cfg *api.ClusterConfig, ctl *eks.ClusterProvider) (kubernetes.Interface, error) {
-	kubernetesClientConfigs, err := ctl.NewClient(cfg)
+	kubernetesClientConfigs, err := ctl.NewClient(cfg, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ctl/create/iamserviceaccount.go
+++ b/pkg/ctl/create/iamserviceaccount.go
@@ -46,7 +46,7 @@ func createIAMServiceAccountCmd(cmd *cmdutils.Cmd) {
 		cmdutils.AddClusterEndpointOverrideFlag(fs, &params.clusterEndpoint)
 	})
 
-	cmd.FlagSetGroup.InFlagSet("Create IAM service Account", func(fs *pflag.FlagSet) {
+	cmd.FlagSetGroup.InFlagSet("Create IAM service account", func(fs *pflag.FlagSet) {
 		fs.StringVar(&serviceAccount.Name, "name", "", "name of the iamserviceaccount to create")
 		fs.StringVar(&serviceAccount.Namespace, "namespace", "default", "namespace where to create the iamserviceaccount")
 		fs.StringSliceVar(&serviceAccount.AttachPolicyARNs, "attach-policy-arn", []string{}, "ARN of the policy where to create the iamserviceaccount")

--- a/pkg/ctl/delete/iamserviceaccount.go
+++ b/pkg/ctl/delete/iamserviceaccount.go
@@ -48,7 +48,7 @@ func deleteIAMServiceAccountCmd(cmd *cmdutils.Cmd) {
 		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 	})
 
-	cmd.FlagSetGroup.InFlagSet("Delete IAM service Account", func(fs *pflag.FlagSet) {
+	cmd.FlagSetGroup.InFlagSet("Delete IAM service account", func(fs *pflag.FlagSet) {
 		fs.StringVar(&params.serviceAccount.Name, "name", "", "name of the iamserviceaccount to delete")
 		fs.StringVar(&params.serviceAccount.Namespace, "namespace", "default", "namespace where to delete the iamserviceaccount")
 		fs.BoolVar(&params.onlyMissing, "only-missing", false, "Only delete nodegroups that are not defined in the given config file")

--- a/pkg/ctl/enable/utils.go
+++ b/pkg/ctl/enable/utils.go
@@ -22,7 +22,7 @@ func KubernetesClientAndConfigFrom(cmd *cmdutils.Cmd) (*kubernetes.Clientset, *r
 	if ok, err := ctl.CanOperate(cfg); !ok {
 		return nil, nil, err
 	}
-	kubernetesClientConfigs, err := ctl.NewClient(cfg)
+	kubernetesClientConfigs, err := ctl.NewClient(cfg, "")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/eks/client.go
+++ b/pkg/eks/client.go
@@ -28,8 +28,8 @@ type Client struct {
 }
 
 // NewClient creates a new client config by embedding the STS token
-func (c *ClusterProvider) NewClient(spec *api.ClusterConfig) (*Client, error) {
-	clientConfig, _, contextName := kubeconfig.New(spec, c.GetUsername(), "")
+func (c *ClusterProvider) NewClient(spec *api.ClusterConfig, clusterEndpoint string) (*Client, error) {
+	clientConfig, _, contextName := kubeconfig.New(spec, c.GetUsername(), "", clusterEndpoint)
 
 	config := &Client{
 		Config:      clientConfig,
@@ -87,8 +87,8 @@ func (c *Client) NewClientSet() (*kubernetes.Clientset, error) {
 }
 
 // NewStdClientSet creates a new API client in one go with an embedded STS token, this is most commonly used option
-func (c *ClusterProvider) NewStdClientSet(spec *api.ClusterConfig) (*kubernetes.Clientset, error) {
-	_, clientSet, err := c.newClientSetWithEmbeddedToken(spec)
+func (c *ClusterProvider) NewStdClientSet(spec *api.ClusterConfig, clusterEndpoint string) (*kubernetes.Clientset, error) {
+	_, clientSet, err := c.newClientSetWithEmbeddedToken(spec, clusterEndpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +96,8 @@ func (c *ClusterProvider) NewStdClientSet(spec *api.ClusterConfig) (*kubernetes.
 	return clientSet, nil
 }
 
-func (c *ClusterProvider) newClientSetWithEmbeddedToken(spec *api.ClusterConfig) (*Client, *kubernetes.Clientset, error) {
-	client, err := c.NewClient(spec)
+func (c *ClusterProvider) newClientSetWithEmbeddedToken(spec *api.ClusterConfig, clusterEndpoint string) (*Client, *kubernetes.Clientset, error) {
+	client, err := c.NewClient(spec, clusterEndpoint)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating Kubernetes client config with embedded token")
 	}
@@ -112,7 +112,7 @@ func (c *ClusterProvider) newClientSetWithEmbeddedToken(spec *api.ClusterConfig)
 
 // NewRawClient creates a new raw REST client in one go with an embedded STS token
 func (c *ClusterProvider) NewRawClient(spec *api.ClusterConfig) (*kubewrapper.RawClient, error) {
-	client, clientSet, err := c.newClientSetWithEmbeddedToken(spec)
+	client, clientSet, err := c.newClientSetWithEmbeddedToken(spec, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/eks/tasks.go
+++ b/pkg/eks/tasks.go
@@ -107,7 +107,7 @@ func (c *ClusterProvider) appendCreateTasksForIAMServiceAccounts(cfg *api.Cluste
 
 	clientSet := &kubernetes.CallbackClientSet{
 		Callback: func() (kubernetes.Interface, error) {
-			return c.NewStdClientSet(cfg)
+			return c.NewStdClientSet(cfg, "")
 		},
 	}
 

--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -67,7 +67,7 @@ func addFilesAndScripts(config *cloudconfig.CloudConfig, files configFiles, scri
 }
 
 func makeClientConfigData(spec *api.ClusterConfig, ng *api.NodeGroup) ([]byte, error) {
-	clientConfig, _, _ := kubeconfig.New(spec, "kubelet", configDir+"ca.crt")
+	clientConfig, _, _ := kubeconfig.New(spec, "kubelet", configDir+"ca.crt", "")
 	authenticator := kubeconfig.AWSIAMAuthenticator
 	if ng.AMIFamily == api.NodeImageFamilyUbuntu1804 {
 		authenticator = kubeconfig.HeptioAuthenticatorAWS

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -41,7 +41,7 @@ func AuthenticatorCommands() []string {
 // New creates Kubernetes client configuration for a given username
 // if certificateAuthorityPath is not empty, it is used instead of
 // embedded certificate-authority-data
-func New(spec *api.ClusterConfig, username, certificateAuthorityPath string) (*clientcmdapi.Config, string, string) {
+func New(spec *api.ClusterConfig, username, certificateAuthorityPath, eksEndpoint string) (*clientcmdapi.Config, string, string) {
 	clusterName := spec.Metadata.String()
 	contextName := fmt.Sprintf("%s@%s", username, clusterName)
 
@@ -69,12 +69,16 @@ func New(spec *api.ClusterConfig, username, certificateAuthorityPath string) (*c
 		c.Clusters[clusterName].CertificateAuthority = certificateAuthorityPath
 	}
 
+	if eksEndpoint != "" {
+		c.Clusters[clusterName].Server = eksEndpoint
+	}
+
 	return c, clusterName, contextName
 }
 
 // NewForKubectl creates configuration for kubectl using a suitable authenticator
 func NewForKubectl(spec *api.ClusterConfig, username, roleARN, profile string) *clientcmdapi.Config {
-	config, _, _ := New(spec, username, "")
+	config, _, _ := New(spec, username, "", "")
 	authenticator, found := LookupAuthenticator()
 	if !found {
 		// fall back to aws-iam-authenticator


### PR DESCRIPTION
### Description

Added support for overriding the EKS Endpoint for the following commands:

- `eksctl get iamidentitymapping`
- `eksctl create iamidentitymapping`
- `eksctl delete iamidentitymapping`
- `eksctl create iamserviceaccount`
- `eksctl delete iamserviceaccount`
- `eksctl create nodegroup`
- `eksctl delete nodegroup`
- `eksctl drain nodegroup`
- `eksctl delete cluster`

Updated the Kubeconfig class so that it accepts an override for the EKS Endpoint.

Refactored explicit arguments into a params object. I followed the pattern used in pkg/ctl/create/cluster.go.

Added an explicit `--cluster-endpoint-override` flag for defining the EKS Endpoint you'd like to use for the eksctl commands.

This change allows users with a private cluster to be able to use SSH tunnelling to access the cluster from their local machine via a specified port.

Issue #1552 

During the making of this change, I had considered that perhaps it makes more sense to allow a port override instead of the entire cluster URL. That being said changing the full URL gives you a bit more power if for example you decide to put your cluster endpoint behind a DNS record.

### Manual testing performed:
Ran the following commands with and without passing in the `--cluster-endpoint-override` flag:
- `eksctl get iamidentitymapping`
- `eksctl create iamidentitymapping`
- `eksctl delete iamidentitymapping`
- `eksctl create iamserviceaccount`
- `eksctl delete iamserviceaccount`
- `eksctl create nodegroup`
- `eksctl delete nodegroup`
- `eksctl drain nodegroup`
- `eksctl delete cluster`

1. I observed that the above commands were still using the EKSEndpoint output from the EKS Cluster stack when not passing in the `--cluster-endpoint-override` flag and that the command succeeded.
2. I observed that the above commands used my specified EKS Endpoint when passing the `--cluster-endpoint-override` flag and that the command succeeded.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested