### PR TITLE
Add groff in Dockerfile for "aws help"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apk add --no-cache --initdb --root /out \
     git \
     libc6-compat \
     openssh \
+    groff \
     && true
 
 ENV KUBECTL_VERSION v1.11.5

--- a/humans.txt
+++ b/humans.txt
@@ -63,6 +63,7 @@ Miguel Pereira          @onemorepereira
 Pedro Tôrres            @t0rr3sp3dr0
 Michael Treacher        @treacher
 Ajay Kemparaj           @ajayk
+Shawn Friedel           @gitshawn
 
 /* Thanks */
 


### PR DESCRIPTION
### Description

Running "aws help" causes an error due to missing groff executable. Patched Dockerfile to install this and "aws help" is now working. 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [X] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
DONE
