### PR TITLE
Add reminder about labels & release note to PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,5 +6,6 @@
 - [ ] Added tests that cover your change (if possible)
 - [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
 - [ ] Manually tested
+- [ ] Added labels for change area and target version
 
 <!-- If you haven't done so already, you can add your name to the humans.txt file -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,5 +7,6 @@
 - [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
 - [ ] Manually tested
 - [ ] Added labels for change area and target version
+- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)
 
 <!-- If you haven't done so already, you can add your name to the humans.txt file -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 - [ ] Added tests that cover your change (if possible)
 - [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
 - [ ] Manually tested
-- [ ] Added labels for change area and target version
+- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
 - [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)
 
 <!-- If you haven't done so already, you can add your name to the humans.txt file -->


### PR DESCRIPTION
### Description

We keep forgetting about labels & release notes to `draft.md` as we open & merge PRs, which leads to inefficiencies when:

- looking for specific issues/PRs,
- the time to cut a release comes.

Until we (maybe) fully automate this, I suggest we add such reminders so we reduce the chance of forgetting.
