### PR TITLE
Fix tar command if GOPATH is multiple paths

### DIFF
--- a/install-build-deps.sh
+++ b/install-build-deps.sh
@@ -33,4 +33,4 @@ go install \
 # a lot of work, so we install all of those from the release tarball
 METALINTER_VERSION="3.0.0"
 curl --silent --location "https://github.com/alecthomas/gometalinter/releases/download/v${METALINTER_VERSION}/gometalinter-${METALINTER_VERSION}-${OSARCH}.tar.gz" \
-  | tar -x -z -C "${GOBIN}" --strip-components 1
+  | tar -x -z -C "${GOBIN%%:*}" --strip-components 1

--- a/install-build-deps.sh
+++ b/install-build-deps.sh
@@ -4,7 +4,7 @@
 # `make -f Makefile.docker update-build-image-manifest && make -f Makefile.docker push-build-image`
 
 if [ -z "${GOBIN+x}" ]; then
- GOBIN="$(go env GOPATH)/bin"
+ GOBIN="${GOPATH%:*}/bin"
 fi
 
 if [ "$(uname)" = "Darwin" ] ; then
@@ -33,4 +33,4 @@ go install \
 # a lot of work, so we install all of those from the release tarball
 METALINTER_VERSION="3.0.0"
 curl --silent --location "https://github.com/alecthomas/gometalinter/releases/download/v${METALINTER_VERSION}/gometalinter-${METALINTER_VERSION}-${OSARCH}.tar.gz" \
-  | tar -x -z -C "${GOBIN%%:*}" --strip-components 1
+  | tar -x -z -C "${GOBIN}" --strip-components 1

--- a/install-build-deps.sh
+++ b/install-build-deps.sh
@@ -4,7 +4,7 @@
 # `make -f Makefile.docker update-build-image-manifest && make -f Makefile.docker push-build-image`
 
 if [ -z "${GOBIN+x}" ]; then
- GOBIN="${GOPATH%:*}/bin"
+ GOBIN="${GOPATH%%:*}/bin"
 fi
 
 if [ "$(uname)" = "Darwin" ] ; then


### PR DESCRIPTION
### Description

If a GOPATH has multiple paths (e.g. `/bin/go:$HOME/go`) then the tar command in install-build-deps.sh fails. This update will make it use the first directory in GOPATH instead.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
