### PR TITLE
Fix `delete cluster` on AWS accounts not authorized to use Fargate

### DIFF
--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -193,8 +193,14 @@ func deleteFargateProfiles(cmd *cmdutils.Cmd, ctl *eks.ClusterProvider) error {
 	)
 	profileNames, err := awsClient.ListProfiles()
 	if err != nil {
+		if fargate.IsUnauthorizedError(err) {
+			logger.Debug("Fargate: unauthorized error: %v", err)
+			logger.Info("account is not authorized to use Fargate. Ignoring error")
+			return nil
+		}
 		return err
 	}
+
 	// Linearise the deleting of Fargate profiles by passing as the API
 	// otherwise errors out with:
 	//   ResourceInUseException: Cannot delete Fargate Profile ${name2} because

--- a/pkg/fargate/client.go
+++ b/pkg/fargate/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 	"github.com/kris-nova/logger"
@@ -46,6 +47,17 @@ type Client struct {
 	clusterName string
 	api         eksiface.EKSAPI
 	retryPolicy retry.Policy
+}
+
+// IsUnauthorizedError reports whether the error is an authorization error
+// Unauthorized errors are of the form:
+//   AccessDeniedException: Account <account> is not authorized to use this service
+func IsUnauthorizedError(err error) bool {
+	awsErr, ok := errors.Cause(err).(awserr.Error)
+	if !ok {
+		return false
+	}
+	return awsErr.Code() == "AccessDeniedException"
 }
 
 // CreateProfile creates the provided Fargate profile.


### PR DESCRIPTION
### Description
Fixes #1636, `eksctl delete cluster` on AWS accounts that are not authorized to use Fargate.

This has been tested on an AWS account that is not authorized to use Fargate:

```
$ eksctl delete cluster test
2019-12-05T14:55:14+05:30 [ℹ]  eksctl version 465a65ee139842d6be1bb91b751ab3eeeb5b8f11
2019-12-05T14:55:14+05:30 [ℹ]  using region us-west-2
2019-12-05T14:55:15+05:30 [ℹ]  deleting EKS cluster "test"
2019-12-05T14:55:16+05:30 [ℹ]  Account is not authorized to use Fargate. Ignoring error
2019-12-05T14:55:19+05:30 [ℹ]  cleaning up LoadBalancer services
2019-12-05T14:55:25+05:30 [ℹ]  2 sequential tasks: { delete nodegroup "ng-99174290", delete cluster control plane "test2" [async] }
2019-12-05T14:55:25+05:30 [ℹ]  will delete stack "eksctl-test2-nodegroup-ng-99174290"
2019-12-05T14:55:25+05:30 [ℹ]  waiting for stack "eksctl-test2-nodegroup-ng-99174290" to get deleted
```

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note) Will open a PR with new release notes instead.

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
