### PR TITLE
Permissions Boundary

### DIFF
--- a/examples/17-permissions-boundary.yaml
+++ b/examples/17-permissions-boundary.yaml
@@ -1,0 +1,29 @@
+# An example of ClusterConfig with PermissionsBoundary:
+# For more details on permissions boundaries:
+# https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_bound
+#
+# FIXME: Should the permissions boundary ARN provided be replaced by a real ARN?
+---
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: cluster-17
+  region: us-west-2
+
+iam:
+  withOIDC: true
+  serviceRolePermissionsBoundary: "arn:aws:iam:11111:policy/entity/boundary"
+  fargatePodExecutionRolePermissionsBoundary: "arn:aws:iam::11111:policy/entity/boundary"
+  serviceAccounts:
+    - metadata:
+        name: s3-reader
+      attachPolicyARNs:
+      - "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+      permissionsBoundary: "arn:aws:iam::11111:policy/entity/boundary"
+
+nodeGroups:
+  - name: "ng-1"
+    desiredCapacity: 1
+    iam:
+      instanceRolePermissionsBoundary: "arn:aws:iam::11111:policy/entity/boundary"

--- a/pkg/apis/eksctl.io/v1alpha5/iam.go
+++ b/pkg/apis/eksctl.io/v1alpha5/iam.go
@@ -17,7 +17,11 @@ type ClusterIAM struct {
 	// +optional
 	ServiceRoleARN *string `json:"serviceRoleARN,omitempty"`
 	// +optional
+	ServiceRolePermissionsBoundary *string `json:"serviceRolePermissionsBoundary,omitempty"`
+	// +optional
 	FargatePodExecutionRoleARN *string `json:"fargatePodExecutionRoleARN,omitempty"`
+	// +optional
+	FargatePodExecutionRolePermissionsBoundary *string `json:"fargatePodExecutionRolePermissionsBoundary,omitempty"`
 	// +optional
 	WithOIDC *bool `json:"withOIDC,omitempty"`
 	// +optional
@@ -31,6 +35,8 @@ type ClusterIAMServiceAccount struct {
 	AttachPolicyARNs []string `json:"attachPolicyARNs,omitempty"`
 	// +optional
 	AttachPolicy InlineDocument `json:"attachPolicy,omitempty"`
+	// +optional
+	PermissionsBoundary string `json:"permissionsBoundary,omitempty"`
 	// +optional
 	Status *ClusterIAMServiceAccountStatus `json:"status,omitempty"`
 }

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -657,6 +657,8 @@ type (
 		// +optional
 		InstanceRoleName string `json:"instanceRoleName,omitempty"`
 		// +optional
+		InstanceRolePermissionsBoundary string `json:"instanceRolePermissionsBoundary,omitempty"`
+		// +optional
 		WithAddonPolicies NodeGroupIAMAddonPolicies `json:"withAddonPolicies,omitempty"`
 	}
 	// NodeGroupIAMAddonPolicies holds all IAM addon policies

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -295,6 +295,9 @@ func validateNodeGroupIAM(iam *NodeGroupIAM, value, fieldName, path string) erro
 		if len(iam.AttachPolicyARNs) != 0 {
 			return fmtFieldConflictErr("attachPolicyARNs")
 		}
+		if iam.InstanceRolePermissionsBoundary != "" {
+			return fmtFieldConflictErr("instanceRolePermissionsBoundary")
+		}
 		prefix := "withAddonPolicies."
 		if IsEnabled(iam.WithAddonPolicies.AutoScaler) {
 			return fmtFieldConflictErr(prefix + "autoScaler")

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -113,6 +113,24 @@ var _ = Describe("ClusterConfig validation", func() {
 			Expect(err.Error()).To(Equal("nodeGroups[1].iam.instanceProfileARN and nodeGroups[1].iam.instanceRoleName cannot be set at the same time"))
 		})
 
+		It("should not allow setting instanceProfileARN and instanceRolePermissionsBoundary", func() {
+			ng1.IAM.InstanceProfileARN = "p1"
+			ng1.IAM.InstanceRolePermissionsBoundary = "aPolicy"
+
+			err = ValidateNodeGroup(1, ng1)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("nodeGroups[1].iam.instanceProfileARN and nodeGroups[1].iam.instanceRolePermissionsBoundary cannot be set at the same time"))
+		})
+
+		It("should not allow setting instanceRoleARN and instanceRolePermissionsBoundary", func() {
+			ng1.IAM.InstanceRoleARN = "r1"
+			ng1.IAM.InstanceRolePermissionsBoundary = "p1"
+
+			err = ValidateNodeGroup(1, ng1)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("nodeGroups[1].iam.instanceRoleARN and nodeGroups[1].iam.instanceRolePermissionsBoundary cannot be set at the same time"))
+		})
+
 		It("should not allow setting instanceRoleARN and instanceRoleName", func() {
 			ng1.IAM.InstanceRoleARN = "r1"
 			ng1.IAM.InstanceRoleName = "aRole"

--- a/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
@@ -222,13 +222,18 @@ func (in *ClusterIAM) DeepCopyInto(out *ClusterIAM) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ServiceRolePermissionsBoundary != nil {
+		in, out := &in.ServiceRolePermissionsBoundary, &out.ServiceRolePermissionsBoundary
+		*out = new(string)
+		**out = **in
+	}
 	if in.FargatePodExecutionRoleARN != nil {
 		in, out := &in.FargatePodExecutionRoleARN, &out.FargatePodExecutionRoleARN
 		*out = new(string)
 		**out = **in
 	}
-	if in.ServiceRolePermissionsBoundary != nil {
-		in, out := &in.ServiceRolePermissionsBoundary, &out.ServiceRolePermissionsBoundary
+	if in.FargatePodExecutionRolePermissionsBoundary != nil {
+		in, out := &in.FargatePodExecutionRolePermissionsBoundary, &out.FargatePodExecutionRolePermissionsBoundary
 		*out = new(string)
 		**out = **in
 	}

--- a/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
@@ -227,6 +227,11 @@ func (in *ClusterIAM) DeepCopyInto(out *ClusterIAM) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ServiceRolePermissionsBoundary != nil {
+		in, out := &in.ServiceRolePermissionsBoundary, &out.ServiceRolePermissionsBoundary
+		*out = new(string)
+		**out = **in
+	}
 	if in.WithOIDC != nil {
 		in, out := &in.WithOIDC, &out.WithOIDC
 		*out = new(bool)

--- a/pkg/cfn/builder/iam_helper.go
+++ b/pkg/cfn/builder/iam_helper.go
@@ -49,6 +49,10 @@ func createRole(cfnTemplate cfnTemplate, iamConfig *api.NodeGroupIAM, managed bo
 		role.RoleName = gfn.NewString(iamConfig.InstanceRoleName)
 	}
 
+	if iamConfig.InstanceRolePermissionsBoundary != "" {
+		role.PermissionsBoundary = gfn.NewString(iamConfig.InstanceRolePermissionsBoundary)
+	}
+
 	refIR := cfnTemplate.newResource(cfnIAMInstanceRoleName, &role)
 
 	if api.IsEnabled(iamConfig.WithAddonPolicies.AutoScaler) {

--- a/pkg/cfn/template/iam.go
+++ b/pkg/cfn/template/iam.go
@@ -26,6 +26,7 @@ type IAMRole struct {
 
 	AssumeRolePolicyDocument MapOfInterfaces `json:",omitempty"`
 	ManagedPolicyArns        []string        `json:",omitempty"`
+	PermissionsBoundary      string          `json:",omitempty"`
 }
 
 // Type will return the full type name for the resource

--- a/pkg/ctl/cmdutils/configfile_test.go
+++ b/pkg/ctl/cmdutils/configfile_test.go
@@ -81,7 +81,7 @@ var _ = Describe("cmdutils configfile", func() {
 			examples, err := filepath.Glob(examplesDir + "*.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(examples).To(HaveLen(16))
+			Expect(examples).To(HaveLen(17))
 			for _, example := range examples {
 				cmd := &Cmd{
 					CobraCommand:      newCmd(),

--- a/site/content/usage/17-permissions-boundary.md
+++ b/site/content/usage/17-permissions-boundary.md
@@ -1,0 +1,41 @@
+---
+title: "IAM permissions boundary"
+weight: 90
+url: usage/iam-permissions-boundary
+---
+
+## Providing IAM permissions boundary
+
+A [permissions boundary][permissions-boundary] is an advanced AWS IAM feature in which the maximum permissions that an identity-based policy can grant to an IAM entity have been set; where those entities are either users or roles. When a permissions boundary is set for an entity, that entity can only perform the actions that are allowed by both its identity-based policies and its permissions boundaries.
+
+You can provide your permissions boundary so that all identity-based entities created by eksctl are created within that boundary. This example demonstrates how a permissions boundary can be provided to the various identity-based entities that are created by eksctl:
+
+```yaml
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: cluster-17
+  region: us-west-2
+
+iam:
+  withOIDC: true
+  serviceRolePermissionsBoundary: "arn:aws:iam:11111:policy/entity/boundary"
+  fargatePodExecutionRolePermissionsBoundary: "arn:aws:iam::11111:policy/entity/boundary"
+  serviceAccounts:
+    - metadata:
+        name: s3-reader
+      attachPolicyARNs:
+      - "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+      permissionsBoundary: "arn:aws:iam::11111:policy/entity/boundary"
+
+nodeGroups:
+  - name: "ng-1"
+    desiredCapacity: 1
+    iam:
+      instanceRolePermissionsBoundary: "arn:aws:iam::11111:policy/entity/boundary"
+```
+
+_Important_: it is not possible to provide both a role ARN and a permissions boundary
+
+[permissions-boundary]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html

--- a/site/content/usage/20-schema.md
+++ b/site/content/usage/20-schema.md
@@ -77,12 +77,16 @@ ClusterIAM:
   properties:
     fargatePodExecutionRoleARN:
       type: string
+    fargatePodExecutionRolePermissionsBoundary:
+      type: string
     serviceAccounts:
       items:
         $ref: '#/definitions/ClusterIAMServiceAccount'
         $schema: http://json-schema.org/draft-04/schema#
       type: array
     serviceRoleARN:
+      type: string
+    serviceRolePermissionsBoundary:
       type: string
     withOIDC:
       type: boolean
@@ -103,6 +107,8 @@ ClusterIAMServiceAccount:
     metadata:
       $ref: '#/definitions/ObjectMeta'
       $schema: http://json-schema.org/draft-04/schema#
+    permissionsBoundary:
+      type: string
     status:
       $ref: '#/definitions/ClusterIAMServiceAccountStatus'
       $schema: http://json-schema.org/draft-04/schema#
@@ -425,6 +431,8 @@ NodeGroupIAM:
     instanceRoleARN:
       type: string
     instanceRoleName:
+      type: string
+    instanceRolePermissionsBoundary:
       type: string
     withAddonPolicies:
       $ref: '#/definitions/NodeGroupIAMAddonPolicies'


### PR DESCRIPTION
A permissions boundary is an advanced IAM feature in which you set the
maximum permissions that an identity-based policy can grant to an IAM
entity; where those entities are either users or roles. When you set
a permissions boundary for an entity, the entity can perform only the
actions that are allowed by both its identity-based policies and its
permissions boundaries.

This is relevant for eksctl, because eksctl is capable of managing,
i.e., creating, updating and deleting, the identity-based resources
required to operate a kubernetes cluster on AWS. While it is possible
to create these identity entities outside of eksctl and provide them
as configuration options, this adds an additional burden on the end-user,
which it is preferable to avoid.

Support for providing a permissions boundary to the identity-based entities
has been added to eksctl by extending the configuration file primarily.
This decision was made based on the fact that serviceRoleARN for a cluster
is provided in a similar way today. The assumption here is that providing
a permissions boundary is not the common case, and should therefore not
pollute the CLI more than necessary.

Issue #1221

### Description

It is now possible to provide a permissions boundary to those locations where an identity-based entity (role) is created in eksctl. If present this permissions boundary is passed on to the `IAMRole` before being created. The permissions boundary name has been bound up to its corresponding location, e.g., where `serviceRoleARN` was providable I have created a `serviceRolePermissionsBoundary` variable.

The podExecutionRoleARN under the FargateProfile defaults to the FargatePodExecutionRoleARN at the cluster level unless provided. As such, we do not provide a configuration option for podExecutionRolePermissionsBoundary as no role will be created here anyway.

### Questions
- examples/17-permissions-boundary.yaml currently refers to a fake permissions boundary ARN, does this have to be a real ARN?
- An integration test for this functionality could be created by setting up a permissions boundary (policy) and associating that with a role that is assumed by CloudFormation before creating the stack, in essence making use of the --cfn-role-arn flag.
- Should a CLI flag be added to places where there exists a precedence? The precedence being the existence of other policy overrides from the CLI, such as: "eksctl create iamserviceaccount". In that scenario, it might make sense to be able to provide such functionality from the CLI?


### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

### Output from manual run

```
Cluster configuration:

---
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: test-cluster
  region: eu-west-1

iam:
  serviceRolePermissionsBoundary: "arn:aws:iam::11111:policy/my/boundary"
  fargatePodExecutionRolePermissionsBoundary: "arn:aws:iam::11111:policy/my/boundary"

nodeGroups:
  - name: ng-1
    instanceType: m5.large
    desiredCapacity: 1
    iam:
      instanceRolePermissionsBoundary: "arn:aws:iam::11111:policy/my/boundary"

Creating cluster without providing fargatePodExecutionRolePermissionsBoundary:

./eksctl create cluster --profile saml2aws-terraform-profile --config-file cluster-test.yaml
[ℹ]  eksctl version 0.2.0-1010-g72b5b2cd-dirty
[ℹ]  using region eu-west-1
[ℹ]  setting availability zones to [eu-west-1a eu-west-1b eu-west-1c]
[ℹ]  subnets for eu-west-1a - public:192.168.0.0/19 private:192.168.96.0/19
[ℹ]  subnets for eu-west-1b - public:192.168.32.0/19 private:192.168.128.0/19
[ℹ]  subnets for eu-west-1c - public:192.168.64.0/19 private:192.168.160.0/19
[ℹ]  nodegroup "ng-1" will use "ami-059c6874350e63ca9" [AmazonLinux2/1.14]
[ℹ]  using Kubernetes version 1.14
[ℹ]  creating EKS cluster "test-cluster" in "eu-west-1" region with un-managed nodes
[ℹ]  1 nodegroup (ng-1) was included (based on the include/exclude rules)
[ℹ]  will create a CloudFormation stack for cluster itself and 1 nodegroup stack(s)
[ℹ]  will create a CloudFormation stack for cluster itself and 0 managed nodegroup stack(s)
[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=eu-west-1 --cluster=test-cluster'
[ℹ]  CloudWatch logging will not be enabled for cluster "test-cluster" in "eu-west-1"
[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --region=eu-west-1 --cluster=test-cluster'
[ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "test-cluster" in "eu-west-1"
[ℹ]  2 sequential tasks: { create cluster control plane "test-cluster", create nodegroup "ng-1" }
[ℹ]  building cluster stack "eksctl-test-cluster-cluster"
[ℹ]  deploying stack "eksctl-test-cluster-cluster"
[✖]  unexpected status "ROLLBACK_IN_PROGRESS" while waiting for CloudFormation stack "eksctl-test-cluster-cluster"
[ℹ]  fetching stack events in attempt to troubleshoot the root cause of the failure
[✖]  AWS::IAM::Role/ServiceRole: CREATE_FAILED – "Resource creation cancelled"
[✖]  AWS::EC2::VPC/VPC: CREATE_FAILED – "Resource creation cancelled"
[✖]  AWS::EC2::InternetGateway/InternetGateway: CREATE_FAILED – "Resource creation cancelled"
[✖]  AWS::EC2::EIP/NATIP: CREATE_FAILED – "Resource creation cancelled"
[✖]  AWS::IAM::Role/FargatePodExecutionRole: CREATE_FAILED – "API: iam:CreateRole User: arn:aws:sts::11111:assumed-role/iamadmin-SAML/fakeUser is not authorized to perform: iam:CreateRole on resource: arn:aws:iam::11111:role/eksctl-test-cluster-cluste-FargatePodExecutionRole-107ZH7TUDTA1B"
[ℹ]  1 error(s) occurred and cluster hasn't been created properly, you may wish to check CloudFormation console
[ℹ]  to cleanup resources, run 'eksctl delete cluster --region=eu-west-1 --name=test-cluster'
[✖]  waiting for CloudFormation stack "eksctl-test-cluster-cluster": ResourceNotReady: failed waiting for successful resource state
[✖]  failed to create cluster "test-cluster"

Creating cluster with fargatePodExecutionRolePermissionsBoundary:

./eksctl create cluster --profile saml2aws-terraform-profile --config-file cluster-test.yaml
[ℹ]  eksctl version 0.2.0-1010-g72b5b2cd-dirty
[ℹ]  using region eu-west-1
[ℹ]  setting availability zones to [eu-west-1a eu-west-1b eu-west-1c]
[ℹ]  subnets for eu-west-1a - public:192.168.0.0/19 private:192.168.96.0/19
[ℹ]  subnets for eu-west-1b - public:192.168.32.0/19 private:192.168.128.0/19
[ℹ]  subnets for eu-west-1c - public:192.168.64.0/19 private:192.168.160.0/19
[ℹ]  nodegroup "ng-1" will use "ami-059c6874350e63ca9" [AmazonLinux2/1.14]
[ℹ]  using Kubernetes version 1.14
[ℹ]  creating EKS cluster "test-cluster" in "eu-west-1" region with un-managed nodes
[ℹ]  1 nodegroup (ng-1) was included (based on the include/exclude rules)
[ℹ]  will create a CloudFormation stack for cluster itself and 1 nodegroup stack(s)
[ℹ]  will create a CloudFormation stack for cluster itself and 0 managed nodegroup stack(s)
[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=eu-west-1 --cluster=test-cluster'
[ℹ]  CloudWatch logging will not be enabled for cluster "test-cluster" in "eu-west-1"
[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --region=eu-west-1 --cluster=test-cluster'
[ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "test-cluster" in "eu-west-1"
[ℹ]  2 sequential tasks: { create cluster control plane "test-cluster", create nodegroup "ng-1" }
[ℹ]  building cluster stack "eksctl-test-cluster-cluster"
[ℹ]  deploying stack "eksctl-test-cluster-cluster"
[ℹ]  building nodegroup stack "eksctl-test-cluster-nodegroup-ng-1"
[ℹ]  --nodes-min=1 was set automatically for nodegroup ng-1
[ℹ]  --nodes-max=1 was set automatically for nodegroup ng-1
[ℹ]  deploying stack "eksctl-test-cluster-nodegroup-ng-1"
[✔]  all EKS cluster resources for "test-cluster" have been created
[✔]  saved kubeconfig as "/Users/pbeskow/.kube/config"
[ℹ]  adding identity "arn:aws:iam::11111:role/eksctl-test-cluster-nodegroup-ng-NodeInstanceRole-142D92TQ3BBUZ" to auth ConfigMap
[ℹ]  nodegroup "ng-1" has 0 node(s)
[ℹ]  waiting for at least 1 node(s) to become ready in "ng-1"
[ℹ]  nodegroup "ng-1" has 1 node(s)
[ℹ]  node "ip-192-168-31-172.eu-west-1.compute.internal" is ready
[ℹ]  kubectl command should work with "/Users/pbeskow/.kube/config", try 'kubectl get nodes'
[✔]  EKS cluster "test-cluster" in "eu-west-1" region is ready

Listing nodes:

kubectl get nodes
NAME                                           STATUS   ROLES    AGE     VERSION
ip-192-168-31-172.eu-west-1.compute.internal   Ready    <none>   5m20s   v1.14.7-eks-1861c5

Deleting cluster:

./eksctl delete cluster --profile saml2aws-terraform-profile --name=test-cluster --region=eu-west-1
[ℹ]  eksctl version 0.2.0-1010-g72b5b2cd-dirty
[ℹ]  using region eu-west-1
[ℹ]  deleting EKS cluster "test-cluster"
[ℹ]  deleted 0 Fargate profile(s)
[✔]  kubeconfig has been updated
[ℹ]  cleaning up LoadBalancer services
[ℹ]  2 sequential tasks: { delete nodegroup "ng-1", delete cluster control plane "test-cluster" [async] }
[ℹ]  will delete stack "eksctl-test-cluster-nodegroup-ng-1"
[ℹ]  waiting for stack "eksctl-test-cluster-nodegroup-ng-1" to get deleted
[ℹ]  will delete stack "eksctl-test-cluster-cluster"
[✔]  all cluster resources were deleted
```