### PR TITLE
Increase global timeout of Integration Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ build-integration-test: $(all_generated_code) ## Build integration test binary
 
 .PHONY: integration-test
 integration-test: build build-integration-test ## Run the integration tests (with cluster creation and cleanup)
-	cd integration; ../eksctl-integration-test -test.timeout 120m $(INTEGRATION_TEST_ARGS)
+	cd integration; ../eksctl-integration-test -test.timeout 140m $(INTEGRATION_TEST_ARGS)
 
 .PHONY: integration-test-container
 integration-test-container: eksctl-image ## Run the integration tests inside a Docker container


### PR DESCRIPTION
Now they are taking more than 2 hours.



The IT were failing with 

```
panic: test timed out after 2h0m0s
goroutine 525 [running]:
testing.(*M).startAlarm.func1()
	/usr/local/go/src/testing/testing.go:1334 +0xdf
created by time.goFunc
	/usr/local/go/src/time/sleep.go:169 +0x44
...
```

<!-- If you haven't done so already, you can add your name to the humans.txt file -->