### PR TITLE
Fix CircleCI config for IT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,11 +78,10 @@ jobs:
             --volume=$(pwd):/src \
             --volume=$HOME/project/.ssh:/root/.ssh \
             $BUILD_IMAGE make integration-test TEST_V=1 SSH_KEY_PATH="/root/.ssh/id_rsa_82cbed40f32705e6169d6825407d8307"
-            - store_test_results:
-                path: ./test-results
-            - store_artifacts:
-                path: ./test-results
-          no_output_timeout: 140m
+      - store_test_results:
+        path: ./test-results
+      - store_artifacts:
+        path: ./test-results
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
                 path: ./test-results
             - store_artifacts:
                 path: ./test-results
-          no_output_timeout: 120m
+          no_output_timeout: 140m
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ jobs:
             --volume=$(pwd):/src \
             --volume=$HOME/project/.ssh:/root/.ssh \
             $BUILD_IMAGE make integration-test TEST_V=1 SSH_KEY_PATH="/root/.ssh/id_rsa_82cbed40f32705e6169d6825407d8307"
+          no_output_timeout: 35m
       - store_test_results:
         path: ./test-results
       - store_artifacts:


### PR DESCRIPTION
Changed two things in the IT configuration for CircleCI:

- changed the no_output_timeout to 35m
- Fixed a configuration error. For successful builds we were getting:

```
------------------------------

Ran 63 of 63 Specs in 7840.439 seconds
SUCCESS! -- 63 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestSuite (7840.44s)
PASS
/bin/bash: line 8: -: command not found

Exited with code exit status 127
```