### PR TITLE
Fix AMI selection for CF template in Managed Node Groups

### DIFF
--- a/pkg/cfn/builder/managed_nodegroup.go
+++ b/pkg/cfn/builder/managed_nodegroup.go
@@ -94,7 +94,7 @@ func (m *ManagedNodeGroupResourceSet) AddAllResources() error {
 		Subnets: AssignSubnets(m.nodeGroup.AvailabilityZones, m.clusterStackName, m.clusterConfig, false),
 		// Currently the API supports specifying only one instance type
 		InstanceTypes: []string{m.nodeGroup.InstanceType},
-		AmiType:       getAMIType(m.nodeGroup.AMIFamily),
+		AmiType:       getAMIType(m.nodeGroup.InstanceType),
 		// ManagedNodeGroup.IAM.InstanceRoleARN is not supported, so this field is always retrieved from the
 		// CFN resource
 		NodeRole: gfn.MakeFnGetAttString(fmt.Sprintf("%s.%s", cfnIAMInstanceRoleName, "Arn")),
@@ -117,8 +117,8 @@ func (m *ManagedNodeGroupResourceSet) AddAllResources() error {
 	return nil
 }
 
-func getAMIType(amiFamily string) string {
-	if utils.IsGPUInstanceType(amiFamily) {
+func getAMIType(instanceType string) string {
+	if utils.IsGPUInstanceType(instanceType) {
 		return eks.AMITypesAl2X8664Gpu
 	}
 	return eks.AMITypesAl2X8664


### PR DESCRIPTION
The current implementation is trying to determine the AMI for managed
node groups based on the AMI family value. This is incorrect because
utils.IsGPUInstanceType is expecting an instanceType value.

Therefore, when trying to create GPU managed node groups, it isn't
actually selecting the correct GPU AMI, and the creation is failing.
(Nodegroups fail to stabilize from an Internal Failure)

This is the current CF template being generated when the instance type
is `g4dn.4xlarge`:

```
"ManagedNodeGroup": {
      "Type": "AWS::EKS::Nodegroup",
      "Properties": {
        "ClusterName": "XXXX",
        "NodegroupName": "gpu-1",
        "ScalingConfig": {
          "MinSize": 1,
          "MaxSize": 2,
          "DesiredSize": 1
        },
        "Subnets": {
          "Fn::Split": [
            ",",
            {
              "Fn::ImportValue": "eksctl-XXXX-cluster::SubnetsPublic"
            }
          ]
        },
        "InstanceTypes": [
          "g4dn.4xlarge"
        ],
        "AmiType": "AL2_x86_64",
        "RemoteAccess": {
          "Ec2SshKey": "XXXX"
        },
        "NodeRole": {
          "Fn::GetAtt": "NodeInstanceRole.Arn"
        },
        "Labels": {
          "alpha.eksctl.io/cluster-name": "XXXX",
          "alpha.eksctl.io/nodegroup-name": "XXXX"
        },
        "Tags": {
          "alpha.eksctl.io/nodegroup-name": "XXXX",
          "alpha.eksctl.io/nodegroup-type": "managed"
        }
      }
    },
```

`AL2_x86_64` should be `AL2_x86_64_GPU`

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
