### PR TITLE
Enable support for Managed Nodegroups when upgrading from EKS 1.13 to 1.14

### DIFF
--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -393,7 +393,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Status: &api.ClusterStatus{
 				Endpoint:                 endpoint,
 				CertificateAuthorityData: caCertData,
-				ARN:                      arn,
+				ARN: arn,
 			},
 			AvailabilityZones: testAZs,
 			VPC:               testVPC(),
@@ -450,12 +450,12 @@ var _ = Describe("CloudFormation template builder API", func() {
 		setSubnets(cfg)
 
 		sampleOutputs := map[string]string{
-			"SecurityGroup":              "sg-0b44c48bcba5b7362",
-			"SubnetsPublic":              subnetsPublic,
-			"SubnetsPrivate":             subnetsPrivate,
-			"VPC":                        vpcID,
-			"Endpoint":                   endpoint,
-			"CertificateAuthorityData":   caCert,
+			"SecurityGroup":            "sg-0b44c48bcba5b7362",
+			"SubnetsPublic":            subnetsPublic,
+			"SubnetsPrivate":           subnetsPrivate,
+			"VPC":                      vpcID,
+			"Endpoint":                 endpoint,
+			"CertificateAuthorityData": caCert,
 			"ARN":                        arn,
 			"ClusterStackName":           "",
 			"SharedNodeSecurityGroup":    "sg-shared",
@@ -466,7 +466,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 		}
 
 		It("should add all resources and collect outputs without errors", func() {
-			crs = NewClusterResourceSet(p, cfg, false)
+			crs = NewClusterResourceSet(p, cfg, false, nil)
 			err := crs.AddAllResources()
 			Expect(err).ShouldNot(HaveOccurred())
 			sampleStack := newStackWithOutputs(sampleOutputs)
@@ -485,7 +485,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 
 	assertBuildChecks := func(cfg *api.ClusterConfig, clusterStackName string, ng *api.NodeGroup, managedNodesSupport bool) {
 		It("should add all resources without errors", func() {
-			crs = NewClusterResourceSet(p, cfg, managedNodesSupport)
+			crs = NewClusterResourceSet(p, cfg, managedNodesSupport, nil)
 			err = crs.AddAllResources()
 			Expect(err).ShouldNot(HaveOccurred())
 

--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -13,6 +13,11 @@ import (
 
 var internetCIDR = gfn.NewString("0.0.0.0/0")
 
+const (
+	cfnControlPlaneSGResource = "ControlPlaneSecurityGroup"
+	cfnSharedNodeSGResource   = "ClusterSharedNodeSecurityGroup"
+)
+
 func (c *ClusterResourceSet) addSubnets(refRT *gfn.Value, topology api.SubnetTopology, subnets map[string]api.Network) {
 	var subnetIndexForIPv6 int
 	if api.IsEnabled(c.spec.VPC.AutoAllocateIPv6) {
@@ -187,7 +192,7 @@ func (c *ClusterResourceSet) addResourcesForSecurityGroups() {
 	var refControlPlaneSG, refClusterSharedNodeSG *gfn.Value
 
 	if c.spec.VPC.SecurityGroup == "" {
-		refControlPlaneSG = c.newResource("ControlPlaneSecurityGroup", &gfn.AWSEC2SecurityGroup{
+		refControlPlaneSG = c.newResource(cfnControlPlaneSGResource, &gfn.AWSEC2SecurityGroup{
 			GroupDescription: gfn.NewString("Communication between the control plane and worker nodegroups"),
 			VpcId:            c.vpc,
 		})
@@ -197,7 +202,7 @@ func (c *ClusterResourceSet) addResourcesForSecurityGroups() {
 	c.securityGroups = []*gfn.Value{refControlPlaneSG} // only this one SG is passed to EKS API, nodes are isolated
 
 	if c.spec.VPC.SharedNodeSecurityGroup == "" {
-		refClusterSharedNodeSG = c.newResource("ClusterSharedNodeSecurityGroup", &gfn.AWSEC2SecurityGroup{
+		refClusterSharedNodeSG = c.newResource(cfnSharedNodeSGResource, &gfn.AWSEC2SecurityGroup{
 			GroupDescription: gfn.NewString("Communication between all nodes in the cluster"),
 			VpcId:            c.vpc,
 		})

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -30,7 +30,7 @@ func (c *StackCollection) makeClusterStackName() string {
 func (c *StackCollection) createClusterTask(errs chan error, supportsManagedNodes bool) error {
 	name := c.makeClusterStackName()
 	logger.Info("building cluster stack %q", name)
-	stack := builder.NewClusterResourceSet(c.provider, c.spec, supportsManagedNodes)
+	stack := builder.NewClusterResourceSet(c.provider, c.spec, supportsManagedNodes, nil)
 	if err := stack.AddAllResources(); err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func (c *StackCollection) AppendNewClusterStackResource(plan, supportsManagedNod
 	}
 
 	logger.Info("re-building cluster stack %q", name)
-	newStack := builder.NewClusterResourceSet(c.provider, c.spec, supportsManagedNodes)
+	newStack := builder.NewClusterResourceSet(c.provider, c.spec, supportsManagedNodes, &currentResources)
 	if err := newStack.AddAllResources(); err != nil {
 		return false, err
 	}

--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -35,6 +35,7 @@ func updateClusterCmd(cmd *cmdutils.Cmd) {
 
 		cmd.Wait = true
 		cmdutils.AddWaitFlag(fs, &cmd.Wait, "all update operations to complete")
+		_ = fs.MarkDeprecated("wait", "--wait is no longer respected; the cluster update always waits to complete")
 		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 	})
 

--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -33,7 +33,6 @@ func updateClusterCmd(cmd *cmdutils.Cmd) {
 		fs.BoolVar(&cmd.Plan, "dry-run", cmd.Plan, "")
 		_ = fs.MarkDeprecated("dry-run", "see --approve")
 
-		cmd.Wait = true
 		cmdutils.AddWaitFlag(fs, &cmd.Wait, "all update operations to complete")
 		_ = fs.MarkDeprecated("wait", "--wait is no longer respected; the cluster update always waits to complete")
 		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
@@ -105,19 +104,11 @@ func doUpdateClusterCmd(cmd *cmdutils.Cmd) error {
 		msgNodeGroupsAndAddons := "you will need to follow the upgrade procedure for all of nodegroups and add-ons"
 		cmdutils.LogIntendedAction(cmd.Plan, "upgrade cluster %q control plane from current version %q to %q", cfg.Metadata.Name, currentVersion, cfg.Metadata.Version)
 		if !cmd.Plan {
-			if cmd.Wait {
-				if err := ctl.UpdateClusterVersionBlocking(cfg); err != nil {
-					return err
-				}
-				logger.Success("cluster %q control plane has been upgraded to version %q", cfg.Metadata.Name, cfg.Metadata.Version)
-				logger.Info(msgNodeGroupsAndAddons)
-			} else {
-				if _, err := ctl.UpdateClusterVersion(cfg); err != nil {
-					return err
-				}
-				logger.Success("a version update operation has been requested for cluster %q", cfg.Metadata.Name)
-				logger.Info("once it has been updated, %s", cfg.Metadata.Name, msgNodeGroupsAndAddons)
+			if err := ctl.UpdateClusterVersionBlocking(cfg); err != nil {
+				return err
 			}
+			logger.Success("cluster %q control plane has been upgraded to version %q", cfg.Metadata.Name, cfg.Metadata.Version)
+			logger.Info(msgNodeGroupsAndAddons)
 		}
 	}
 


### PR DESCRIPTION
### Description
Enable support for Managed Nodegroups when upgrading from EKS 1.13 to 1.14 by allowing new CloudFormation resources to be created during cluster stack update, and reordering the update logic to perform control plane version update first and then CloudFormation stack update. 

Fixes #1622 
Partially addresses #1655 

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
