### PR TITLE
Fix circleci configuration for IT job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,9 +80,9 @@ jobs:
             $BUILD_IMAGE make integration-test TEST_V=1 SSH_KEY_PATH="/root/.ssh/id_rsa_82cbed40f32705e6169d6825407d8307"
           no_output_timeout: 35m
       - store_test_results:
-        path: ./test-results
+          path: ./test-results
       - store_artifacts:
-        path: ./test-results
+          path: ./test-results
 
 workflows:
   version: 2


### PR DESCRIPTION
From circleci: 
https://circleci.com/gh/weaveworks/eksctl/5819

```
Build-agent version 1.0.22073-f42bda98 (2019-12-10T12:59:15+0000)
Configuration errors: 1 error occurred:

* In step 6 definition: Step

  - store_test_results: 
    path: ./test-results

has incorrect indentation, it should be formatted like:

  - step:
      option1: value
      option2: value
```