### PR TITLE
Update PR template with mention of the maintainer GH team

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,3 +10,4 @@
 - [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)
 
 <!-- If you haven't done so already, you can add your name to the humans.txt file -->
+<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->


### PR DESCRIPTION
This PR updates the PR template with a comment for external contributors prompting
them to use @ @weaveworks/eksctl to ping maintainers. Hopefully this way we weon't
get notified individually.

- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->