### PR TITLE
Fix propagating errors from AssignSubnets

### DIFF
--- a/pkg/cfn/builder/managed_nodegroup.go
+++ b/pkg/cfn/builder/managed_nodegroup.go
@@ -82,6 +82,11 @@ func (m *ManagedNodeGroupResourceSet) AddAllResources() error {
 
 	createRole(m.resourceSet, m.nodeGroup.IAM)
 
+	subnets, err := AssignSubnets(m.nodeGroup.AvailabilityZones, m.clusterStackName, m.clusterConfig, false)
+	if err != nil {
+		return err
+	}
+
 	managedResource := &managedNodeGroup{
 		ClusterName:   m.clusterConfig.Metadata.Name,
 		NodegroupName: m.nodeGroup.Name,
@@ -91,7 +96,7 @@ func (m *ManagedNodeGroupResourceSet) AddAllResources() error {
 			DesiredSize: m.nodeGroup.DesiredCapacity,
 		},
 		// Only public subnets are supported at launch
-		Subnets: AssignSubnets(m.nodeGroup.AvailabilityZones, m.clusterStackName, m.clusterConfig, false),
+		Subnets: subnets,
 		// Currently the API supports specifying only one instance type
 		InstanceTypes: []string{m.nodeGroup.InstanceType},
 		AmiType:       getAMIType(m.nodeGroup.InstanceType),


### PR DESCRIPTION
### Description
Fixes propagating errors from `AssignSubnets`.

Fixes #1657 

### Checklist
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
