### PR TITLE
Refactor: no longer exit on nested cmd but propagate error

### DIFF
--- a/cmd/eksctl/main.go
+++ b/cmd/eksctl/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/kris-nova/logger"
@@ -75,7 +74,6 @@ func main() {
 	rootCmd.SetUsageFunc(flagGrouping.Usage)
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 }

--- a/docs/release_notes/draft.md
+++ b/docs/release_notes/draft.md
@@ -6,7 +6,7 @@
 
 ## Improvements
 
-- lowercased, user-focused description of the improvement (#0)
+- `eksctl` now leverages `cobra` to print all errors in a more standardised way (#1664)
 
 ## Bug fixes
 

--- a/pkg/ctl/cmdutils/cmd.go
+++ b/pkg/ctl/cmdutils/cmd.go
@@ -1,8 +1,6 @@
 package cmdutils
 
 import (
-	"os"
-
 	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
 
@@ -91,26 +89,4 @@ func (c *Cmd) SetDescription(use, short, long string, aliases ...string) {
 	c.CobraCommand.Short = short
 	c.CobraCommand.Long = long
 	c.CobraCommand.Aliases = aliases
-}
-
-// SetRunFunc registers a command function
-func (c *Cmd) SetRunFunc(cmd func() error) {
-	c.CobraCommand.Run = func(_ *cobra.Command, _ []string) {
-		run(cmd)
-	}
-}
-
-// SetRunFuncWithNameArg registers a command function with an optional name argument
-func (c *Cmd) SetRunFuncWithNameArg(cmd func() error) {
-	c.CobraCommand.Run = func(_ *cobra.Command, args []string) {
-		c.NameArg = GetNameArg(args)
-		run(cmd)
-	}
-}
-
-func run(cmd func() error) {
-	if err := cmd(); err != nil {
-		logger.Critical("%s\n", err.Error())
-		os.Exit(1)
-	}
 }

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/ssh"
@@ -30,9 +31,10 @@ func createClusterCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("cluster", "Create a cluster", "")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doCreateCluster(cmd, ng, params)
-	})
+	}
 
 	exampleClusterName := names.ForCluster("", "")
 	exampleNodeGroupName := names.ForNodeGroup("", "")

--- a/pkg/ctl/create/fargate.go
+++ b/pkg/ctl/create/fargate.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
@@ -26,9 +27,10 @@ func createFargateProfile(cmd *cmdutils.Cmd) {
 		"",
 	)
 	options := configureCreateFargateProfileCmd(cmd)
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doCreateFargateProfile(cmd, options)
-	})
+	}
 }
 
 func configureCreateFargateProfileCmd(cmd *cmdutils.Cmd) *fargate.CreateOptions {
@@ -48,7 +50,6 @@ func configureCreateFargateProfileCmd(cmd *cmdutils.Cmd) *fargate.CreateOptions 
 
 func doCreateFargateProfile(cmd *cmdutils.Cmd, options *fargate.CreateOptions) error {
 	if err := cmdutils.NewCreateFargateProfileLoader(cmd, options).Load(); err != nil {
-		cmd.CobraCommand.Help()
 		return err
 	}
 	ctl, err := cmd.NewCtl()

--- a/pkg/ctl/create/iamidentitymapping.go
+++ b/pkg/ctl/create/iamidentitymapping.go
@@ -3,6 +3,7 @@ package create
 import (
 	"github.com/kris-nova/logger"
 	"github.com/lithammer/dedent"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -28,9 +29,10 @@ func createIAMIdentityMappingCmd(cmd *cmdutils.Cmd) {
 	var username string
 	var groups []string
 
-	cmd.SetRunFunc(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doCreateIAMIdentityMapping(cmd, arn, username, groups)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&username, "username", "", "User name within Kubernetes to map to IAM role")

--- a/pkg/ctl/create/iamserviceaccount.go
+++ b/pkg/ctl/create/iamserviceaccount.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -26,9 +27,9 @@ func createIAMServiceAccountCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("iamserviceaccount", "Create an iamserviceaccount - AWS IAM role bound to a Kubernetes service account", "")
 
-	cmd.SetRunFunc(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, _ []string) error {
 		return doCreateIAMServiceAccount(cmd, overrideExistingServiceAccounts)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "name of the EKS cluster to add the iamserviceaccount to")

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/ssh"
@@ -33,9 +34,10 @@ func createNodeGroupCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("nodegroup", "Create a nodegroup", "", "ng")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doCreateNodeGroups(cmd, ng, params)
-	})
+	}
 
 	exampleNodeGroupName := names.ForNodeGroup("", "")
 

--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/fargate"
@@ -29,9 +30,10 @@ func deleteClusterCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("cluster", "Delete a cluster", "")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doDeleteCluster(cmd)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name")

--- a/pkg/ctl/delete/fargate.go
+++ b/pkg/ctl/delete/fargate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
@@ -18,9 +19,10 @@ func deleteFargateProfile(cmd *cmdutils.Cmd) {
 		"",
 	)
 	opts := configureDeleteFargateProfileCmd(cmd)
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doDeleteFargateProfile(cmd, opts)
-	})
+	}
 }
 
 func configureDeleteFargateProfileCmd(cmd *cmdutils.Cmd) *fargate.Options {
@@ -41,7 +43,6 @@ func configureDeleteFargateProfileCmd(cmd *cmdutils.Cmd) *fargate.Options {
 
 func doDeleteFargateProfile(cmd *cmdutils.Cmd, opts *fargate.Options) error {
 	if err := cmdutils.NewDeleteFargateProfileLoader(cmd, opts).Load(); err != nil {
-		cmd.CobraCommand.Help()
 		return err
 	}
 	ctl, err := cmd.NewCtl()

--- a/pkg/ctl/delete/iamidentitymapping.go
+++ b/pkg/ctl/delete/iamidentitymapping.go
@@ -2,6 +2,7 @@ package delete
 
 import (
 	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -20,9 +21,9 @@ func deleteIAMIdentityMappingCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("iamidentitymapping", "Delete a IAM identity mapping", "")
 
-	cmd.SetRunFunc(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		return doDeleteIAMIdentityMapping(cmd, arn, all)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.BoolVar(&all, "all", false, "Delete all matching mappings instead of just one")

--- a/pkg/ctl/delete/iamserviceaccount.go
+++ b/pkg/ctl/delete/iamserviceaccount.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -25,9 +26,9 @@ func deleteIAMServiceAccountCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("iamserviceaccount", "Delete an IAM service account", "")
 
-	cmd.SetRunFunc(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		return doDeleteIAMServiceAccount(cmd, serviceAccount, onlyMissing)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "name of the EKS cluster to delete the iamserviceaccount from")

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -2,6 +2,7 @@ package delete
 
 import (
 	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -19,9 +20,10 @@ func deleteNodeGroupCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("nodegroup", "Delete a nodegroup", "", "ng")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doDeleteNodeGroup(cmd, ng, updateAuthConfigMap, deleteNodeGroupDrain, onlyMissing)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")

--- a/pkg/ctl/drain/nodegroup.go
+++ b/pkg/ctl/drain/nodegroup.go
@@ -2,6 +2,7 @@ package drain
 
 import (
 	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -19,9 +20,10 @@ func drainNodeGroupCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("nodegroup", "Cordon and drain a nodegroup", "", "ng")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doDrainNodeGroup(cmd, ng, undo, onlyMissing)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")

--- a/pkg/ctl/enable/profile.go
+++ b/pkg/ctl/enable/profile.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -43,9 +44,10 @@ func enableProfileCmd(cmd *cmdutils.Cmd) {
 		"",
 	)
 	opts := configureProfileCmd(cmd)
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doEnableProfile(cmd, opts)
-	})
+	}
 }
 
 // configureProfileCmd configures the provided command object so that it can

--- a/pkg/ctl/enable/repo.go
+++ b/pkg/ctl/enable/repo.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
@@ -19,9 +20,10 @@ func enableRepo(cmd *cmdutils.Cmd) {
 		"",
 	)
 	opts := configureRepositoryCmd(cmd)
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doEnableRepository(cmd, opts)
-	})
+	}
 }
 
 // configureRepositoryCmd configures the provided command object so that it can

--- a/pkg/ctl/generate/profile.go
+++ b/pkg/ctl/generate/profile.go
@@ -29,9 +29,10 @@ func generateProfileCmd(cmd *cmdutils.Cmd) {
 
 	var o options
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doGenerateProfile(cmd, o)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&o.GitOptions.URL, "git-url", "", "", "URL for the quickstart base repository")

--- a/pkg/ctl/get/cluster.go
+++ b/pkg/ctl/get/cluster.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
@@ -19,9 +20,10 @@ func getClusterCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("cluster", "Get cluster(s)", "", "clusters")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doGetCluster(cmd, params, listAllRegions)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name")

--- a/pkg/ctl/get/fargate.go
+++ b/pkg/ctl/get/fargate.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
@@ -24,9 +25,10 @@ func getFargateProfile(cmd *cmdutils.Cmd) {
 		"",
 	)
 	options := configureGetFargateProfileCmd(cmd)
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doGetFargateProfile(cmd, options)
-	})
+	}
 }
 
 func configureGetFargateProfileCmd(cmd *cmdutils.Cmd) *options {
@@ -46,7 +48,6 @@ func configureGetFargateProfileCmd(cmd *cmdutils.Cmd) *options {
 
 func doGetFargateProfile(cmd *cmdutils.Cmd, options *options) error {
 	if err := cmdutils.NewGetFargateProfileLoader(cmd, &options.Options).Load(); err != nil {
-		cmd.CobraCommand.Help()
 		return err
 	}
 

--- a/pkg/ctl/get/iamidentitymapping.go
+++ b/pkg/ctl/get/iamidentitymapping.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -24,9 +25,10 @@ func getIAMIdentityMappingCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("iamidentitymapping", "Get IAM identity mapping(s)", "")
 
-	cmd.SetRunFunc(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doGetIAMIdentityMapping(cmd, params, arn)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddIAMIdentityMappingARNFlags(fs, cmd, &arn)

--- a/pkg/ctl/get/iamserviceaccount.go
+++ b/pkg/ctl/get/iamserviceaccount.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -26,9 +27,10 @@ func getIAMServiceAccountCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("iamserviceaccount", "Get iamserviceaccount(s)", "", "iamserviceaccounts")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doGetIAMServiceAccount(cmd, serviceAccount, params)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")

--- a/pkg/ctl/get/labels.go
+++ b/pkg/ctl/get/labels.go
@@ -3,6 +3,7 @@ package get
 import (
 	"os"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 	"github.com/weaveworks/eksctl/pkg/managed"
@@ -21,9 +22,10 @@ func getLabelsCmd(cmd *cmdutils.Cmd) {
 	cmd.SetDescription("labels", "Get nodegroup labels", "")
 
 	var nodeGroupName string
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return getLabels(cmd, nodeGroupName)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")

--- a/pkg/ctl/get/nodegroup.go
+++ b/pkg/ctl/get/nodegroup.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -23,9 +24,10 @@ func getNodeGroupCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("nodegroup", "Get nodegroup(s)", "", "ng", "nodegroups")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doGetNodeGroup(cmd, ng, params)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")

--- a/pkg/ctl/scale/nodegroup.go
+++ b/pkg/ctl/scale/nodegroup.go
@@ -17,9 +17,10 @@ func scaleNodeGroupCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("nodegroup", "Scale a nodegroup", "", "ng")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doScaleNodeGroup(cmd, ng)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")

--- a/pkg/ctl/set/labels.go
+++ b/pkg/ctl/set/labels.go
@@ -23,9 +23,10 @@ func setLabelsCmd(cmd *cmdutils.Cmd) {
 	cmd.SetDescription("labels", "Create or overwrite labels", "")
 
 	var options labelOptions
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return setLabels(cmd, options)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")

--- a/pkg/ctl/unset/labels.go
+++ b/pkg/ctl/unset/labels.go
@@ -21,9 +21,10 @@ func unsetLabelsCmd(cmd *cmdutils.Cmd) {
 		nodeGroupName string
 		removeLabels  []string
 	)
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return unsetLabels(cmd, nodeGroupName, removeLabels)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")

--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -18,9 +19,10 @@ func updateClusterCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("cluster", "Update cluster", "")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doUpdateClusterCmd(cmd)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name")

--- a/pkg/ctl/upgrade/nodegroup.go
+++ b/pkg/ctl/upgrade/nodegroup.go
@@ -1,6 +1,7 @@
 package upgrade
 
 import (
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 	"github.com/weaveworks/eksctl/pkg/managed"
@@ -22,9 +23,10 @@ func upgradeNodeGroupCmd(cmd *cmdutils.Cmd) {
 	cmd.SetDescription("nodegroup", "Upgrade nodegroup", "")
 
 	var options upgradeOptions
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return upgradeNodeGroup(cmd, options)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&cfg.Metadata.Name, "cluster", "", "", "EKS cluster name")

--- a/pkg/ctl/utils/associate_iam_oidc_provider.go
+++ b/pkg/ctl/utils/associate_iam_oidc_provider.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -15,9 +16,10 @@ func associateIAMOIDCProviderCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("associate-iam-oidc-provider", "Setup IAM OIDC provider for a cluster to enable IAM roles for pods", "")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doAssociateIAMOIDCProvider(cmd)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)

--- a/pkg/ctl/utils/describe_stacks.go
+++ b/pkg/ctl/utils/describe_stacks.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -17,9 +18,10 @@ func describeStacksCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("describe-stacks", "Describe CloudFormation stack for a given cluster", "")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doDescribeStacksCmd(cmd, all, events, trail)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)

--- a/pkg/ctl/utils/install_vpc_controllers.go
+++ b/pkg/ctl/utils/install_vpc_controllers.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/weaveworks/eksctl/pkg/addons"
 
@@ -16,9 +17,10 @@ func installWindowsVPCController(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("install-vpc-controllers", "Install Windows VPC controller to support running Windows workloads", "")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doInstallWindowsVPCController(cmd)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)

--- a/pkg/ctl/utils/nodegroup_health.go
+++ b/pkg/ctl/utils/nodegroup_health.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 	"github.com/weaveworks/eksctl/pkg/managed"
@@ -19,9 +20,10 @@ func nodeGroupHealthCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("nodegroup-health", "Get nodegroup health for a managed node", "")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return getNodeGroupHealth(cmd, nodeGroupName)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")

--- a/pkg/ctl/utils/update_aws_node.go
+++ b/pkg/ctl/utils/update_aws_node.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	defaultaddons "github.com/weaveworks/eksctl/pkg/addons/default"
@@ -14,9 +15,10 @@ func updateAWSNodeCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("update-aws-node", "Update aws-node add-on to latest released version", "")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doUpdateAWSNode(cmd)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)

--- a/pkg/ctl/utils/update_cluster_endpoint_access.go
+++ b/pkg/ctl/utils/update_cluster_endpoint_access.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -19,9 +20,9 @@ func updateClusterEndpointsCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("update-cluster-endpoints", "Update Kubernetes API endpoint access configuration", "")
 
-	cmd.SetRunFunc(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, _ []string) error {
 		return doUpdateClusterEndpoints(cmd, private, public)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)

--- a/pkg/ctl/utils/update_cluster_logging.go
+++ b/pkg/ctl/utils/update_cluster_logging.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/kris-nova/logger"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -22,9 +23,10 @@ func enableLoggingCmd(cmd *cmdutils.Cmd) {
 
 	var typesEnabled []string
 	var typesDisabled []string
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doEnableLogging(cmd, typesEnabled, typesDisabled)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)

--- a/pkg/ctl/utils/update_coredns.go
+++ b/pkg/ctl/utils/update_coredns.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	defaultaddons "github.com/weaveworks/eksctl/pkg/addons/default"
@@ -14,9 +15,10 @@ func updateCoreDNSCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("update-coredns", "Update coredns add-on to ensure image matches the standard Amazon EKS version", "")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doUpdateCoreDNS(cmd)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)

--- a/pkg/ctl/utils/update_kube_proxy.go
+++ b/pkg/ctl/utils/update_kube_proxy.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	defaultaddons "github.com/weaveworks/eksctl/pkg/addons/default"
@@ -14,9 +15,10 @@ func updateKubeProxyCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("update-kube-proxy", "Update kube-proxy add-on to ensure image matches Kubernetes control plane version", "")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doUpdateKubeProxy(cmd)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)

--- a/pkg/ctl/utils/wait_nodes.go
+++ b/pkg/ctl/utils/wait_nodes.go
@@ -19,9 +19,10 @@ func waitNodesCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("wait-nodes", "Wait for nodes", "")
 
-	cmd.SetRunFunc(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doWaitNodes(cmd, ng, kubeconfigPath)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&kubeconfigPath, "kubeconfig", "kubeconfig", "path to read kubeconfig")

--- a/pkg/ctl/utils/write_kubeconfig.go
+++ b/pkg/ctl/utils/write_kubeconfig.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -24,9 +25,10 @@ func writeKubeconfigCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("write-kubeconfig", "Write kubeconfig file for a given cluster", "")
 
-	cmd.SetRunFuncWithNameArg(func() error {
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
 		return doWriteKubeconfigCmd(cmd, outputPath, authenticatorRoleARN, setContext, autoPath)
-	})
+	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)


### PR DESCRIPTION
### Description

This is to:

- help harmonise the way we do error handling
- help with testing on nested commands' input validation
- generally have a cleaner structure, with one exit path, etc.

As part of #1641, I'd like to be able to test the various combinations of CLI arguments and `ClusterConfig` in some automated unit tests. However, currently, the structure of our CLI is such that this is impossible. This PR is a first step towards that. Note that for now, in order to un-entangle things, there is a bit of copy-pasting introduced, but we can later remove that once a better way to factorise & abstract emerges.

### Checklist

- [x] ~Added tests that cover your change (if possible)~ not possible
- [x] ~Added/modified documentation as required (such as the `README.md`, and `examples` directory)~ irrelevant
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [x] Added note in `docs/release_notes/draft.md` (or relevant release note)

### Manual tests

#### 1. Create a cluster

```console
$ ./eksctl create cluster --name mc-1664-test
[ℹ]  eksctl version 0.2.0-1056-gbd8666b8-dirty
[ℹ]  using region ap-northeast-1
[ℹ]  setting availability zones to [ap-northeast-1a ap-northeast-1d ap-northeast-1c]
[ℹ]  subnets for ap-northeast-1a - public:192.168.0.0/19 private:192.168.96.0/19
[ℹ]  subnets for ap-northeast-1d - public:192.168.32.0/19 private:192.168.128.0/19
[ℹ]  subnets for ap-northeast-1c - public:192.168.64.0/19 private:192.168.160.0/19
[ℹ]  nodegroup "ng-86ff3688" will use "ami-02e124a380df41614" [AmazonLinux2/1.14]
[ℹ]  using Kubernetes version 1.14
[ℹ]  creating EKS cluster "mc-1664-test" in "ap-northeast-1" region with un-managed nodes
[ℹ]  will create 2 separate CloudFormation stacks for cluster itself and the initial nodegroup
[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=ap-northeast-1 --cluster=mc-1664-test'
[ℹ]  CloudWatch logging will not be enabled for cluster "mc-1664-test" in "ap-northeast-1"
[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --region=ap-northeast-1 --cluster=mc-1664-test'
[ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "mc-1664-test" in "ap-northeast-1"
[ℹ]  2 sequential tasks: { create cluster control plane "mc-1664-test", create nodegroup "ng-86ff3688" }
[ℹ]  building cluster stack "eksctl-mc-1664-test-cluster"
[ℹ]  deploying stack "eksctl-mc-1664-test-cluster"
[ℹ]  building nodegroup stack "eksctl-mc-1664-test-nodegroup-ng-86ff3688"
[ℹ]  --nodes-min=2 was set automatically for nodegroup ng-86ff3688
[ℹ]  --nodes-max=2 was set automatically for nodegroup ng-86ff3688
[ℹ]  deploying stack "eksctl-mc-1664-test-nodegroup-ng-86ff3688"
[✔]  all EKS cluster resources for "mc-1664-test" have been created
[✔]  saved kubeconfig as "${HOME}/.kube/config"
[ℹ]  adding identity "arn:aws:iam::083751696308:role/eksctl-mc-1664-test-nodegroup-ng-NodeInstanceRole-1TJYHKRQ4V4RW" to auth ConfigMap
[ℹ]  nodegroup "ng-86ff3688" has 0 node(s)
[ℹ]  waiting for at least 2 node(s) to become ready in "ng-86ff3688"
[ℹ]  nodegroup "ng-86ff3688" has 2 node(s)
[ℹ]  node "ip-192-168-54-5.ap-northeast-1.compute.internal" is ready
[ℹ]  node "ip-192-168-71-200.ap-northeast-1.compute.internal" is ready
[ℹ]  kubectl command should work with "${HOME}/.kube/config", try 'kubectl get nodes'
[✔]  EKS cluster "mc-1664-test" in "ap-northeast-1" region is ready
```

#### 2. Create a Fargate profile without any cluster name

```console
$ ./eksctl create fargateprofile
Error: --cluster must be set
Usage: eksctl create fargateprofile [flags]
[...]
Use 'eksctl create fargateprofile [command] --help' for more information about a command.

```

#### 3. Create a Fargate profile without any namespace

```console
$ ./eksctl create fargateprofile --cluster mc-1664-test
Error: invalid Fargate profile: empty selector namespace
Usage: eksctl create fargateprofile [flags]
[...]
Use 'eksctl create fargateprofile [command] --help' for more information about a command.

```

#### 4. Create a Fargate profile

```console
$ ./eksctl create fargateprofile --cluster mc-1664-test --namespace default
[ℹ]  creating Fargate profile "fp-bc364107" on EKS cluster "mc-1664-test"
[ℹ]  created Fargate profile "fp-bc364107" on EKS cluster "mc-1664-test"
```

#### 5. Create a Fargate profile with a specific name provided as argument

```console
$ ./eksctl create fargateprofile --cluster mc-1664-test --namespace dev fp-dev
[ℹ]  creating Fargate profile "fp-dev" on EKS cluster "mc-1664-test"
[ℹ]  created Fargate profile "fp-dev" on EKS cluster "mc-1664-test"
```

#### 6. Create a Fargate profile with a specific name provided via flag

```console
$ ./eksctl create fargateprofile --cluster mc-1664-test --namespace test --name fp-test
[ℹ]  creating Fargate profile "fp-test" on EKS cluster "mc-1664-test"
[ℹ]  created Fargate profile "fp-test" on EKS cluster "mc-1664-test"
```