### PR TITLE
Support Managed Nodegroups and Fargate for auto-upgraded clusters

### DIFF
--- a/pkg/cfn/builder/cluster.go
+++ b/pkg/cfn/builder/cluster.go
@@ -99,6 +99,12 @@ func (c *ClusterResourceSet) Template() gfn.Template {
 	return *c.rs.template
 }
 
+// HasManagedNodesSG reports whether the stack has the security group required for communication between
+// managed and unmanaged nodegroups
+func HasManagedNodesSG(stackResources *gjson.Result) bool {
+	return stackResources.Get(cfnIngressClusterToNodeSGResource).Exists()
+}
+
 func (c *ClusterResourceSet) newResource(name string, resource interface{}) *gfn.Value {
 	return c.rs.newResource(name, resource)
 }

--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -14,8 +14,9 @@ import (
 var internetCIDR = gfn.NewString("0.0.0.0/0")
 
 const (
-	cfnControlPlaneSGResource = "ControlPlaneSecurityGroup"
-	cfnSharedNodeSGResource   = "ClusterSharedNodeSecurityGroup"
+	cfnControlPlaneSGResource         = "ControlPlaneSecurityGroup"
+	cfnSharedNodeSGResource           = "ClusterSharedNodeSecurityGroup"
+	cfnIngressClusterToNodeSGResource = "IngressDefaultClusterToNodeSG"
 )
 
 func (c *ClusterResourceSet) addSubnets(refRT *gfn.Value, topology api.SubnetTopology, subnets map[string]api.Network) {
@@ -218,7 +219,7 @@ func (c *ClusterResourceSet) addResourcesForSecurityGroups() {
 			// To enable communication between both managed and unmanaged nodegroups, this allows ingress traffic from
 			// the default cluster security group ID that EKS creates by default
 			// EKS attaches this to Managed Nodegroups by default, but we need to handle this for unmanaged nodegroups
-			c.newResource("IngressDefaultClusterToNodeSG", &gfn.AWSEC2SecurityGroupIngress{
+			c.newResource(cfnIngressClusterToNodeSGResource, &gfn.AWSEC2SecurityGroupIngress{
 				GroupId:               refClusterSharedNodeSG,
 				SourceSecurityGroupId: gfn.MakeFnGetAttString(makeAttrAccessor("ControlPlane", outputs.ClusterDefaultSecurityGroup)),
 				Description:           gfn.NewString("Allow managed and unmanaged nodes to communicate with each other (all ports)"),

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -131,7 +131,7 @@ func (c *StackCollection) CreateStack(name string, stack builder.ResourceSet, ta
 }
 
 // UpdateStack will update a CloudFormation stack by creating and executing a ChangeSet
-func (c *StackCollection) UpdateStack(stackName string, changeSetName string, description string, template []byte, parameters map[string]string) error {
+func (c *StackCollection) UpdateStack(stackName, changeSetName, description string, template []byte, parameters map[string]string) error {
 	logger.Info(description)
 	i := &Stack{StackName: &stackName}
 	if err := c.doCreateChangeSetRequest(i, changeSetName, description, template, parameters, true); err != nil {

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -58,22 +58,34 @@ func (c *StackCollection) DescribeClusterStack() (*Stack, error) {
 }
 
 // RefreshFargatePodExecutionRoleARN reads the CloudFormation stacks and
-// their output values, and set the Fargate pod execution role ARN to
+// their output values, and sets the Fargate pod execution role ARN to
 // the ClusterConfig.
 func (c *StackCollection) RefreshFargatePodExecutionRoleARN() error {
+	fargateOutputs := map[string]outputs.Collector{
+		outputs.FargatePodExecutionRoleARN: func(v string) error {
+			c.spec.IAM.FargatePodExecutionRoleARN = &v
+			return nil
+		},
+	}
 	stack, err := c.DescribeClusterStack()
 	if err != nil {
 		return err
 	}
-	return outputs.Collect(*stack,
-		map[string]outputs.Collector{
-			outputs.FargatePodExecutionRoleARN: func(v string) error {
-				c.spec.IAM.FargatePodExecutionRoleARN = &v
-				return nil
-			},
-		},
-		nil,
-	)
+	if err := outputs.Collect(*stack, nil, fargateOutputs); err != nil {
+		return err
+	}
+
+	if c.spec.IAM.FargatePodExecutionRoleARN == nil {
+		if err := c.FixClusterCompatibility(); err != nil {
+			return errors.Wrap(err, "error fixing cluster compatibility")
+		}
+	}
+
+	stack, err = c.DescribeClusterStack()
+	if err != nil {
+		return err
+	}
+	return outputs.Collect(*stack, fargateOutputs, nil)
 }
 
 // AppendNewClusterStackResource will update cluster

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -76,6 +76,7 @@ func (c *StackCollection) RefreshFargatePodExecutionRoleARN() error {
 	}
 
 	if c.spec.IAM.FargatePodExecutionRoleARN == nil {
+		logger.Info("Fargate pod execution role is missing, fixing cluster stack to add Fargate resources")
 		if err := c.FixClusterCompatibility(); err != nil {
 			return errors.Wrap(err, "error fixing cluster compatibility")
 		}

--- a/pkg/cfn/manager/compat.go
+++ b/pkg/cfn/manager/compat.go
@@ -1,0 +1,75 @@
+package manager
+
+import (
+	"github.com/kris-nova/logger"
+	"github.com/pkg/errors"
+	"github.com/tidwall/gjson"
+	"github.com/weaveworks/eksctl/pkg/cfn/builder"
+	"github.com/weaveworks/eksctl/pkg/cfn/outputs"
+)
+
+// FixClusterCompatibility adds any resources missing in the CloudFormation stack in order to support new features
+// like Managed Nodegroups and Fargate
+func (c *StackCollection) FixClusterCompatibility() error {
+	logger.Info("checking cluster stack for missing resources")
+	stack, err := c.DescribeClusterStack()
+	if err != nil {
+		return err
+	}
+
+	var (
+		clusterDefaultSG string
+		fargateRole      string
+	)
+
+	featureOutputs := map[string]outputs.Collector{
+		// available on clusters created after Managed Nodes support was out
+		outputs.ClusterDefaultSecurityGroup: func(v string) error {
+			clusterDefaultSG = v
+			return nil
+		},
+		// available on 1.14 clusters created after Fargate support was out
+		outputs.FargatePodExecutionRoleARN: func(v string) error {
+			fargateRole = v
+			return nil
+		},
+	}
+
+	if err := outputs.Collect(*stack, nil, featureOutputs); err != nil {
+		return err
+	}
+
+	stackSupportsManagedNodes := false
+	if clusterDefaultSG != "" {
+		stackSupportsManagedNodes, err = c.hasManagedToUnmanagedSG()
+		if err != nil {
+			return err
+		}
+	}
+
+	stackSupportsFargate := fargateRole != ""
+
+	if stackSupportsManagedNodes && stackSupportsFargate {
+		logger.Info("cluster stack has all required resources")
+		return nil
+	}
+
+	if !stackSupportsManagedNodes {
+		logger.Info("cluster stack is missing resources for Managed Nodegroups")
+	}
+	if !stackSupportsFargate {
+		logger.Info("cluster stack is missing resources for Fargate")
+	}
+	logger.Info("adding missing resources to cluster stack")
+	_, err = c.AppendNewClusterStackResource(false, true)
+	return err
+}
+
+func (c *StackCollection) hasManagedToUnmanagedSG() (bool, error) {
+	stackTemplate, err := c.GetStackTemplate(c.makeClusterStackName())
+	if err != nil {
+		return false, errors.Wrap(err, "error getting cluster stack template")
+	}
+	stackResources := gjson.Get(stackTemplate, resourcesRootPath)
+	return builder.HasManagedNodesSG(&stackResources), nil
+}

--- a/pkg/cfn/manager/create_tasks.go
+++ b/pkg/cfn/manager/create_tasks.go
@@ -68,6 +68,15 @@ func (c *StackCollection) NewManagedNodeGroupTask(nodeGroups []*api.ManagedNodeG
 	return tasks
 }
 
+// NewClusterCompatTask creates a new task that checks for cluster compatibility with new features like
+// Managed Nodegroups and Fargate, and updates the CloudFormation cluster stack if the required resources are missing
+func (c *StackCollection) NewClusterCompatTask() Task {
+	return &clusterCompatTask{
+		stackCollection: c,
+		info:            "fix cluster compatibility",
+	}
+}
+
 // NewTasksToCreateIAMServiceAccounts defines tasks required to create all of the IAM ServiceAccounts
 func (c *StackCollection) NewTasksToCreateIAMServiceAccounts(serviceAccounts []*api.ClusterIAMServiceAccount, oidc *iamoidc.OpenIDConnectManager, clientSetGetter kubernetes.ClientSetGetter) *TaskTree {
 	tasks := &TaskTree{Parallel: true}

--- a/pkg/cfn/manager/tasks.go
+++ b/pkg/cfn/manager/tasks.go
@@ -178,6 +178,18 @@ func (t *managedNodeGroupTask) Do(errorCh chan error) error {
 	return t.stackCollection.createManagedNodeGroupTask(errorCh, t.nodeGroup)
 }
 
+type clusterCompatTask struct {
+	info            string
+	stackCollection *StackCollection
+}
+
+func (t *clusterCompatTask) Describe() string { return t.info }
+
+func (t *clusterCompatTask) Do(errorCh chan error) error {
+	defer close(errorCh)
+	return t.stackCollection.FixClusterCompatibility()
+}
+
 type taskWithClusterIAMServiceAccountSpec struct {
 	info           string
 	serviceAccount *api.ClusterIAMServiceAccount

--- a/pkg/ctl/create/fargate.go
+++ b/pkg/ctl/create/fargate.go
@@ -78,6 +78,10 @@ func doCreateFargateProfile(cmd *cmdutils.Cmd, options *fargate.CreateOptions) e
 		return fmt.Errorf("Fargate is not supported for this cluster version. Please update the cluster to be at least eks.%d", fargate.MinPlatformVersion)
 	}
 
+	if err := ctl.LoadClusterVPC(cfg); err != nil {
+		return err
+	}
+
 	// Read back the default Fargate pod execution role ARN from CloudFormation:
 	if err := ctl.NewStackManager(cfg).RefreshFargatePodExecutionRoleARN(); err != nil {
 		return err

--- a/site/content/usage/15-eks-managed-nodes.md
+++ b/site/content/usage/15-eks-managed-nodes.md
@@ -186,11 +186,12 @@ the provisioned Autoscaling Group like in unmanaged nodegroups.
 following fields: `maxPodsPerNode`, `taints`, `targetGroupARNs`, `preBootstrapCommands`, `overrideBootstrapCommand`,
 `clusterDNS` and `kubeletExtraConfig`.
 
-### Known issues
-- For clusters upgraded to EKS 1.14 from a previous version, or clusters created with eksctl versions below `0.10.2`,
-managed nodegroups will not be able to communicate with unmanaged nodegroups. As a result, pods in a managed nodegroup
-will be unable to reach pods in an unmanaged nodegroup, and vice versa.
-As a temporary workaround for fixing this, add ingress rules to the shared security group and the default cluster
+### Note for eksctl versions below 0.12.0
+- For clusters upgraded from EKS 1.13 to EKS 1.14, managed nodegroups will not be able to communicate with unmanaged
+nodegroups. As a result, pods in a managed nodegroup will be unable to reach pods in an unmanaged
+nodegroup, and vice versa.
+To fix this, use eksctl 0.12.0 or above and run `eksctl update cluster`.
+To fix this manually, add ingress rules to the shared security group and the default cluster
 security group to allow traffic from each other. The shared security group and the default cluster security groups have
 the naming convention `eksctl-<cluster>-cluster-ClusterSharedNodeSecurityGroup-<id>` and
 `eks-cluster-sg-<cluster>-<id>-<id>` respectively.


### PR DESCRIPTION
### Description
Adds support for Managed Nodegroups and Fargate for 1.14 clusters that were automatically upgraded to a newer EKS platform version.

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
