### PR TITLE
Update Fargate docs & example manifest to follow naming convention

### DIFF
--- a/docs/release_notes/draft.md
+++ b/docs/release_notes/draft.md
@@ -7,6 +7,7 @@
 ## Improvements
 
 - `eksctl` now leverages `cobra` to print all errors in a more standardised way (#1664)
+- Improved Fargate documentation & example `ClusterConfig` manifest (#1666)
 
 ## Bug fixes
 

--- a/examples/16-fargate-profile.yaml
+++ b/examples/16-fargate-profile.yaml
@@ -13,7 +13,7 @@ nodeGroups:
     desiredCapacity: 1
 
 fargateProfiles:
-  - name: default
+  - name: fp-default
     selectors:
       # All workloads in the "default" Kubernetes namespace will be
       # scheduled onto Fargate:
@@ -21,7 +21,7 @@ fargateProfiles:
       # All workloads in the "kube-system" Kubernetes namespace will be
       # scheduled onto Fargate:
       - namespace: kube-system
-  - name: dev
+  - name: fp-dev
     selectors:
       # All workloads in the "dev" Kubernetes namespace matching the following
       # label selectors will be scheduled onto Fargate:

--- a/site/content/usage/16-fargate-support.md
+++ b/site/content/usage/16-fargate-support.md
@@ -71,7 +71,7 @@ The Fargate profile that was created can be checked with the following command:
 
 ```console
 $ eksctl get fargateprofile --cluster ridiculous-painting-1574859263 -o yaml
-- name: default
+- name: fp-default
   podExecutionRoleARN: arn:aws:iam::123456789012:role/eksctl-ridiculous-painting-1574859263-ServiceRole-EIFQOH0S1GE7
   selectors:
   - namespace: default
@@ -107,7 +107,7 @@ nodeGroups:
     desiredCapacity: 1
 
 fargateProfiles:
-  - name: default
+  - name: fp-default
     selectors:
       # All workloads in the "default" Kubernetes namespace will be
       # scheduled onto Fargate:
@@ -115,7 +115,7 @@ fargateProfiles:
       # All workloads in the "kube-system" Kubernetes namespace will be
       # scheduled onto Fargate:
       - namespace: kube-system
-  - name: dev
+  - name: fp-dev
     selectors:
       # All workloads in the "dev" Kubernetes namespace matching the following
       # label selectors will be scheduled onto Fargate:
@@ -157,10 +157,10 @@ $ eksctl create cluster -f cluster-fargate.yaml
 [ℹ]  waiting for at least 1 node(s) to become ready in "ng-1"
 [ℹ]  nodegroup "ng-1" has 1 node(s)
 [ℹ]  node "ip-192-168-71-83.ap-northeast-1.compute.internal" is ready
-[ℹ]  creating Fargate profile "default" on EKS cluster "fargate-cluster"
-[ℹ]  created Fargate profile "default" on EKS cluster "fargate-cluster"
-[ℹ]  creating Fargate profile "dev" on EKS cluster "fargate-cluster"
-[ℹ]  created Fargate profile "dev" on EKS cluster "fargate-cluster"
+[ℹ]  creating Fargate profile "fp-default" on EKS cluster "fargate-cluster"
+[ℹ]  created Fargate profile "fp-default" on EKS cluster "fargate-cluster"
+[ℹ]  creating Fargate profile "fp-dev" on EKS cluster "fargate-cluster"
+[ℹ]  created Fargate profile "fp-dev" on EKS cluster "fargate-cluster"
 [ℹ]  "coredns" is now schedulable onto Fargate
 [ℹ]  "coredns" is now scheduled onto Fargate
 [ℹ]  "coredns" is now scheduled onto Fargate
@@ -247,7 +247,7 @@ metadata:
   region: ap-northeast-1
 
 fargateProfiles:
-  - name: default
+  - name: fp-default
     selectors:
       # All workloads in the "default" Kubernetes namespace will be
       # scheduled onto Fargate:
@@ -255,7 +255,7 @@ fargateProfiles:
       # All workloads in the "kube-system" Kubernetes namespace will be
       # scheduled onto Fargate:
       - namespace: kube-system
-  - name: dev
+  - name: fp-dev
     selectors:
       # All workloads in the "dev" Kubernetes namespace matching the following
       # label selectors will be scheduled onto Fargate:
@@ -268,10 +268,10 @@ fargateProfiles:
 
 ```console
 $ eksctl create fargateprofile -f fargate-example-cluster.yaml
-[ℹ]  creating Fargate profile "default" on EKS cluster "fargate-example-cluster"
-[ℹ]  created Fargate profile "default" on EKS cluster "fargate-example-cluster"
-[ℹ]  creating Fargate profile "dev" on EKS cluster "fargate-example-cluster"
-[ℹ]  created Fargate profile "dev" on EKS cluster "fargate-example-cluster"
+[ℹ]  creating Fargate profile "fp-default" on EKS cluster "fargate-example-cluster"
+[ℹ]  created Fargate profile "fp-default" on EKS cluster "fargate-example-cluster"
+[ℹ]  creating Fargate profile "fp-dev" on EKS cluster "fargate-example-cluster"
+[ℹ]  created Fargate profile "fp-dev" on EKS cluster "fargate-example-cluster"
 [ℹ]  "coredns" is now scheduled onto Fargate
 [ℹ]  "coredns" pods are now scheduled onto Fargate
 ```

--- a/site/content/usage/16-fargate-support.md
+++ b/site/content/usage/16-fargate-support.md
@@ -280,8 +280,8 @@ To see existing Fargate profiles in a cluster:
 
 ```console
 $ eksctl get fargateprofile --cluster fargate-example-cluster
-NAME         POD_EXECUTION_ROLE_ARN                                                                   SUBNETS                                                                     SELECTOR_NAMESPACE  SELECTOR_LABELS
-fp-9bfc77ad  arn:aws:iam::123456789012:role/eksctl-fargate-example-cluster-ServiceRole-1T5F78E5FSH79  subnet-00adf1d8c99f83381,subnet-04affb163ffab17d4,subnet-035b34379d5ef5473  dev                 <none>
+NAME         SELECTOR_NAMESPACE  SELECTOR_LABELS  POD_EXECUTION_ROLE_ARN                                                                   SUBNETS
+fp-9bfc77ad  dev                 <none>           arn:aws:iam::123456789012:role/eksctl-fargate-example-cluster-ServiceRole-1T5F78E5FSH79  subnet-00adf1d8c99f83381,subnet-04affb163ffab17d4,subnet-035b34379d5ef5473
 ```
 
 And to see them in `yaml` format:

--- a/site/content/usage/16-fargate-support.md
+++ b/site/content/usage/16-fargate-support.md
@@ -56,15 +56,17 @@ $ eksctl create cluster --fargate
 This command will have created a cluster and a Fargate profile. This profile contains certain information needed by AWS to instantiate
 pods in Fargate. These are:
 
-  - pod execution role to define the permissions required to run the pod and the networking location (subnet) to run the
-  pod. This allows the same networking and security permissions to be applied to multiple Fargate pods and makes
-it easier to migrate existing pods on a cluster to Fargate.
-  - Selector to define which pods should run on Fargate. This is composed by a `namespace` and `labels`.
+- pod execution role to define the permissions required to run the pod and the
+  networking location (subnet) to run the pod. This allows the same networking
+  and security permissions to be applied to multiple Fargate pods and makes it
+  easier to migrate existing pods on a cluster to Fargate.
+- Selector to define which pods should run on Fargate. This is composed by a
+  `namespace` and `labels`.
 
 When the profile is not specified but support for Fargate is enabled with `--fargate` a default Fargate profile is
 created. This profile targets the `default` and the `kube-system` namespaces so pods in those namespaces will run on
 Fargate.
- 
+
 The Fargate profile that was created can be checked with the following command:
 
 ```console
@@ -123,9 +125,8 @@ fargateProfiles:
           checks: passed
 ```
 
-
 ```console
-$ eksctl create cluster -f cluster-fargate.yaml 
+$ eksctl create cluster -f cluster-fargate.yaml
 [ℹ]  eksctl version 0.11.0
 [ℹ]  using region ap-northeast-1
 [ℹ]  setting availability zones to [ap-northeast-1c ap-northeast-1a ap-northeast-1d]
@@ -181,8 +182,8 @@ state, as they were not authorized to run on Fargate.
 
 Profiles must meet the following requirements:
 
-  - One selector is mandatory per profile
-  - Each selector must include a namespace; labels are optional
+- One selector is mandatory per profile
+- Each selector must include a namespace; labels are optional
 
 #### Example: scheduling workload in Fargate
 
@@ -217,7 +218,7 @@ above, `eksctl` takes care of this by creating a default profile. Given an alrea
 create a Fargate profile with the `eksctl create fargateprofile` command:
 
 > NOTE: This operation is only supported on clusters that run on the EKS platform version `eks.5` or higher.
-
+>
 > NOTE: If the existing was created with a version of `eksctl` prior to 0.11.0, you will  need to run `eksctl update
 > cluster` before creating the Fargate profile.
 
@@ -266,22 +267,23 @@ fargateProfiles:
 ```
 
 ```console
-$ eksctl create fargateprofile -f fargate-example-cluster.yaml 
+$ eksctl create fargateprofile -f fargate-example-cluster.yaml
 [ℹ]  creating Fargate profile "default" on EKS cluster "fargate-example-cluster"
 [ℹ]  created Fargate profile "default" on EKS cluster "fargate-example-cluster"
 [ℹ]  creating Fargate profile "dev" on EKS cluster "fargate-example-cluster"
 [ℹ]  created Fargate profile "dev" on EKS cluster "fargate-example-cluster"
 [ℹ]  "coredns" is now scheduled onto Fargate
 [ℹ]  "coredns" pods are now scheduled onto Fargate
-``` 
+```
 
 To see existing Fargate profiles in a cluster:
 
 ```console
 $ eksctl get fargateprofile --cluster fargate-example-cluster
-NAME		POD_EXECUTION_ROLE_ARN										SUBNETS										SELECTOR_NAMESPACE	SELECTOR_LABELS
-fp-9bfc77ad	arn:aws:iam::123456789012:role/eksctl-fargate-example-cluster-ServiceRole-1T5F78E5FSH79	subnet-00adf1d8c99f83381,subnet-04affb163ffab17d4,subnet-035b34379d5ef5473	dev		<none>
+NAME         POD_EXECUTION_ROLE_ARN                                                                   SUBNETS                                                                     SELECTOR_NAMESPACE  SELECTOR_LABELS
+fp-9bfc77ad  arn:aws:iam::123456789012:role/eksctl-fargate-example-cluster-ServiceRole-1T5F78E5FSH79  subnet-00adf1d8c99f83381,subnet-04affb163ffab17d4,subnet-035b34379d5ef5473  dev                 <none>
 ```
+
 And to see them in `yaml` format:
 
 ```console
@@ -320,7 +322,6 @@ $ eksctl get fargateprofile --cluster fargate-example-cluster -o json
 
 Fargate profiles are immutable by design. To change something, create a new Fargate profile with the desired changes and
 delete the old one with the `eksctl delete fargateprofile` command like in the following example:
-
 
 ```console
 $ eksctl delete fargateprofile --cluster fargate-example-cluster --name fp-9bfc77ad --wait


### PR DESCRIPTION
### Description

Fargate profiles are typically named `fp-<something>`.
This PR updates:

- example `ClusterConfig`
- documentation

to also follow this convention.

### Checklist

- [x] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [x] Added note in `docs/release_notes/draft.md` (or relevant release note)
