### PR TITLE
eksctl {get,delete} fargateprofile now reads the cluster name & region from ClusterConfig

### DIFF
--- a/docs/release_notes/draft.md
+++ b/docs/release_notes/draft.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-- lowercased, user-focused description of the new feature (#0)
+- `eksctl {get,delete} fargateprofile` can now read the cluster name & region from a `ClusterConfig` file (#1667)
 
 ## Improvements
 

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -29,27 +29,32 @@ type commonClusterConfigLoader struct {
 	validateWithConfigFile, validateWithoutConfigFile func() error
 }
 
+var (
+	defaultFlagsIncompatibleWithConfigFile = sets.NewString(
+		"name",
+		"region",
+		"version",
+		"cluster",
+		"namepace",
+	)
+	defaultFlagsIncompatibleWithoutConfigFile = sets.NewString(
+		"only",
+		"include",
+		"exclude",
+		"only-missing",
+	)
+)
+
 func newCommonClusterConfigLoader(cmd *Cmd) *commonClusterConfigLoader {
 	nilValidatorFunc := func() error { return nil }
 
 	return &commonClusterConfigLoader{
 		Cmd: cmd,
 
-		validateWithConfigFile: nilValidatorFunc,
-		flagsIncompatibleWithConfigFile: sets.NewString(
-			"name",
-			"region",
-			"version",
-			"cluster",
-			"namepace",
-		),
-		validateWithoutConfigFile: nilValidatorFunc,
-		flagsIncompatibleWithoutConfigFile: sets.NewString(
-			"only",
-			"include",
-			"exclude",
-			"only-missing",
-		),
+		validateWithConfigFile:             nilValidatorFunc,
+		flagsIncompatibleWithConfigFile:    defaultFlagsIncompatibleWithConfigFile,
+		validateWithoutConfigFile:          nilValidatorFunc,
+		flagsIncompatibleWithoutConfigFile: defaultFlagsIncompatibleWithoutConfigFile,
 	}
 }
 

--- a/pkg/ctl/cmdutils/fargate.go
+++ b/pkg/ctl/cmdutils/fargate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/pflag"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/fargate"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -97,7 +98,10 @@ func validateNameFlagAndArgCreate(cmd *Cmd, options *fargate.CreateOptions) erro
 // 'eksctl get fargateprofile'
 func NewGetFargateProfileLoader(cmd *Cmd, options *fargate.Options) ClusterConfigLoader {
 	l := newCommonClusterConfigLoader(cmd)
-	l.flagsIncompatibleWithConfigFile.Insert(fargateProfileFlagsIncompatibleWithConfigFile...)
+	flagsIncompatibleWithConfigFile := sets.NewString(fargateProfileFlagsIncompatibleWithConfigFile...).Union(defaultFlagsIncompatibleWithConfigFile)
+	// We optionally want to be able to filter profiles by name:
+	flagsIncompatibleWithConfigFile.Delete(fargateProfileName)
+	l.flagsIncompatibleWithConfigFile = flagsIncompatibleWithConfigFile
 	l.flagsIncompatibleWithoutConfigFile.Insert(fargateProfileFlagsIncompatibleWithoutConfigFile...)
 	l.validateWithoutConfigFile = func() error {
 		return validate(cmd, options)

--- a/pkg/ctl/cmdutils/fargate.go
+++ b/pkg/ctl/cmdutils/fargate.go
@@ -148,5 +148,11 @@ func NewDeleteFargateProfileLoader(cmd *Cmd, options *fargate.Options) ClusterCo
 		}
 		return options.Validate()
 	}
+	l.validateWithConfigFile = func() error {
+		if err := validate(cmd, options); err != nil {
+			return err
+		}
+		return options.Validate()
+	}
 	return l
 }

--- a/pkg/ctl/create/fargate_test.go
+++ b/pkg/ctl/create/fargate_test.go
@@ -1,0 +1,125 @@
+package create
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/fargate"
+)
+
+var _ = Describe("create", func() {
+	Describe("create fargateprofile", func() {
+		It("requires the cluster's name, and if missing, prints an error and the usage", func() {
+			cmd := newMockCreateFargateProfileCmd("fargateprofile")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--cluster must be set"))
+			Expect(out).To(ContainSubstring("Error: --cluster must be set"))
+			Expect(out).To(ContainSubstring("Usage:"))
+		})
+
+		It("requires a Kubernetes namespace to be provided, and if missing, prints an error and the usage", func() {
+			cmd := newMockCreateFargateProfileCmd("fargateprofile", "--cluster", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("invalid Fargate profile: empty selector namespace"))
+			Expect(out).To(ContainSubstring("Error: invalid Fargate profile: empty selector namespace"))
+			Expect(out).To(ContainSubstring("Usage:"))
+		})
+
+		It("requires at least a Kubernetes namespace to be provided, in which case it generates the profile name", func() {
+			cmd := newMockCreateFargateProfileCmd("fargateprofile", "--cluster", "foo", "--namespace", "default")
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(cmd.cmd.ClusterConfig.Metadata.Name).To(Equal("foo"))
+			profiles := cmd.cmd.ClusterConfig.FargateProfiles
+			Expect(profiles).To(HaveLen(1))
+			profile := profiles[0]
+			Expect(profile.Name).To(MatchRegexp("fp-[abcdef0123456789]{8}"))
+			Expect(profile.Selectors).To(HaveLen(1))
+			selector := profile.Selectors[0]
+			Expect(selector.Namespace).To(Equal("default"))
+		})
+
+		It("the profile name can be provided as an argument", func() {
+			cmd := newMockCreateFargateProfileCmd("fargateprofile", "--cluster", "foo", "--namespace", "default", "fp-default")
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(cmd.cmd.ClusterConfig.Metadata.Name).To(Equal("foo"))
+			profiles := cmd.cmd.ClusterConfig.FargateProfiles
+			Expect(profiles).To(HaveLen(1))
+			profile := profiles[0]
+			Expect(profile.Name).To(Equal("fp-default"))
+			Expect(profile.Selectors).To(HaveLen(1))
+			selector := profile.Selectors[0]
+			Expect(selector.Namespace).To(Equal("default"))
+		})
+
+		It("the profile name can be provided via the --name flag", func() {
+			cmd := newMockCreateFargateProfileCmd("fargateprofile", "--cluster", "foo", "--namespace", "default", "--name", "fp-default")
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(cmd.cmd.ClusterConfig.Metadata.Name).To(Equal("foo"))
+			profiles := cmd.cmd.ClusterConfig.FargateProfiles
+			Expect(profiles).To(HaveLen(1))
+			profile := profiles[0]
+			Expect(profile.Name).To(Equal("fp-default"))
+			Expect(profile.Selectors).To(HaveLen(1))
+			selector := profile.Selectors[0]
+			Expect(selector.Namespace).To(Equal("default"))
+		})
+
+		It("supports all arguments to be provided by a ClusterConfig file", func() {
+			cmd := newMockCreateFargateProfileCmd("fargateprofile", "-f", "../../../examples/16-fargate-profile.yaml")
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(cmd.cmd.ClusterConfig.Metadata.Name).To(Equal("cluster-16"))
+			profiles := cmd.cmd.ClusterConfig.FargateProfiles
+			Expect(profiles).To(HaveLen(2))
+			Expect(profiles[0].Name).To(Equal("fp-default"))
+			Expect(profiles[0].Selectors).To(HaveLen(2))
+			Expect(profiles[0].Selectors[0].Namespace).To(Equal("default"))
+			Expect(profiles[0].Selectors[0].Labels).To(BeEmpty())
+			Expect(profiles[0].Selectors[1].Namespace).To(Equal("kube-system"))
+			Expect(profiles[0].Selectors[1].Labels).To(BeEmpty())
+			Expect(profiles[1].Name).To(Equal("fp-dev"))
+			Expect(profiles[1].Selectors).To(HaveLen(1))
+			Expect(profiles[1].Selectors[0].Namespace).To(Equal("dev"))
+			Expect(profiles[1].Selectors[0].Labels).To(HaveLen(2))
+			Expect(profiles[1].Selectors[0].Labels).To(HaveKeyWithValue("env", "dev"))
+			Expect(profiles[1].Selectors[0].Labels).To(HaveKeyWithValue("checks", "passed"))
+		})
+	})
+})
+
+func newMockCreateFargateProfileCmd(args ...string) *mockCreateFargateProfileCmd {
+	mockCmd := &mockCreateFargateProfileCmd{}
+	grouping := cmdutils.NewGrouping()
+	parentCmd := cmdutils.NewVerbCmd("create", "", "")
+	cmdutils.AddResourceCmd(grouping, parentCmd, func(cmd *cmdutils.Cmd) {
+		createFargateProfileWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options *fargate.CreateOptions) error {
+			mockCmd.cmd = cmd
+			mockCmd.options = options
+			return nil // no-op, to only test input aggregation & validation.
+		})
+	})
+	parentCmd.SetArgs(args)
+	mockCmd.parentCmd = parentCmd
+	return mockCmd
+}
+
+type mockCreateFargateProfileCmd struct {
+	parentCmd *cobra.Command
+	cmd       *cmdutils.Cmd
+	options   *fargate.CreateOptions
+}
+
+func (c mockCreateFargateProfileCmd) execute() (string, error) {
+	buf := new(bytes.Buffer)
+	c.parentCmd.SetOutput(buf)
+	err := c.parentCmd.Execute()
+	return buf.String(), err
+}

--- a/pkg/ctl/delete/fargate_test.go
+++ b/pkg/ctl/delete/fargate_test.go
@@ -60,6 +60,14 @@ var _ = Describe("delete", func() {
 			Expect(out).To(ContainSubstring("Error: invalid Fargate profile: empty name"))
 			Expect(out).To(ContainSubstring("Usage:"))
 		})
+
+		It("supports the cluster name to be provided by a ClusterConfig file, and requires a profile name provided via the --name flag", func() {
+			cmd := newMockDeleteFargateProfileCmd("fargateprofile", "-f", "../../../examples/01-simple-cluster.yaml", "--name", "fp-default")
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(cmd.cmd.ClusterConfig.Metadata.Name).To(Equal("cluster-1"))
+			Expect(cmd.options.ProfileName).To(Equal("fp-default"))
+		})
 	})
 })
 

--- a/pkg/ctl/delete/fargate_test.go
+++ b/pkg/ctl/delete/fargate_test.go
@@ -1,0 +1,93 @@
+package delete
+
+import (
+	"bytes"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/fargate"
+	"github.com/weaveworks/eksctl/pkg/testutils"
+)
+
+func TestSuite(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}
+
+var _ = Describe("delete", func() {
+	Describe("delete fargateprofile", func() {
+		It("requires the cluster's name, and if missing, prints an error and the usage", func() {
+			cmd := newMockDeleteFargateProfileCmd("fargateprofile")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--cluster must be set"))
+			Expect(out).To(ContainSubstring("Error: --cluster must be set"))
+			Expect(out).To(ContainSubstring("Usage:"))
+		})
+
+		It("requires a profile name, and if missing, prints an error and the usage", func() {
+			cmd := newMockDeleteFargateProfileCmd("fargateprofile", "--cluster", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("invalid Fargate profile: empty name"))
+			Expect(out).To(ContainSubstring("Error: invalid Fargate profile: empty name"))
+			Expect(out).To(ContainSubstring("Usage:"))
+		})
+
+		It("requires a profile name, which can be provided as an argument", func() {
+			cmd := newMockDeleteFargateProfileCmd("fargateprofile", "--cluster", "foo", "fp-default")
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(cmd.cmd.ClusterConfig.Metadata.Name).To(Equal("foo"))
+			Expect(cmd.options.ProfileName).To(Equal("fp-default"))
+		})
+
+		It("requires a profile name, which can be provided via the --name flag", func() {
+			cmd := newMockDeleteFargateProfileCmd("fargateprofile", "--cluster", "foo", "--name", "fp-default")
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(cmd.cmd.ClusterConfig.Metadata.Name).To(Equal("foo"))
+			Expect(cmd.options.ProfileName).To(Equal("fp-default"))
+		})
+
+		It("supports the cluster name to be provided by a ClusterConfig file, but still requires a profile name, and if missing, prints an error and the usage", func() {
+			cmd := newMockDeleteFargateProfileCmd("fargateprofile", "-f", "../../../examples/01-simple-cluster.yaml")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("invalid Fargate profile: empty name"))
+			Expect(out).To(ContainSubstring("Error: invalid Fargate profile: empty name"))
+			Expect(out).To(ContainSubstring("Usage:"))
+		})
+	})
+})
+
+func newMockDeleteFargateProfileCmd(args ...string) *mockDeleteFargateProfileCmd {
+	mockCmd := &mockDeleteFargateProfileCmd{}
+	grouping := cmdutils.NewGrouping()
+	parentCmd := cmdutils.NewVerbCmd("delete", "", "")
+	cmdutils.AddResourceCmd(grouping, parentCmd, func(cmd *cmdutils.Cmd) {
+		deleteFargateProfileWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options *fargate.Options) error {
+			mockCmd.cmd = cmd
+			mockCmd.options = options
+			return nil // no-op, to only test input aggregation & validation.
+		})
+	})
+	parentCmd.SetArgs(args)
+	mockCmd.parentCmd = parentCmd
+	return mockCmd
+}
+
+type mockDeleteFargateProfileCmd struct {
+	parentCmd *cobra.Command
+	cmd       *cmdutils.Cmd
+	options   *fargate.Options
+}
+
+func (c mockDeleteFargateProfileCmd) execute() (string, error) {
+	buf := new(bytes.Buffer)
+	c.parentCmd.SetOutput(buf)
+	err := c.parentCmd.Execute()
+	return buf.String(), err
+}

--- a/pkg/ctl/get/fargate.go
+++ b/pkg/ctl/get/fargate.go
@@ -17,7 +17,7 @@ type options struct {
 	getCmdParams
 }
 
-func getFargateProfile(cmd *cmdutils.Cmd) {
+func getFargateProfileWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, options *options) error) {
 	cmd.ClusterConfig = api.NewClusterConfig()
 	cmd.SetDescription(
 		"fargateprofile",
@@ -27,8 +27,17 @@ func getFargateProfile(cmd *cmdutils.Cmd) {
 	options := configureGetFargateProfileCmd(cmd)
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return doGetFargateProfile(cmd, options)
+		if err := cmdutils.NewGetFargateProfileLoader(cmd, &options.Options).Load(); err != nil {
+			return err
+		}
+		return runFunc(cmd, options)
 	}
+}
+
+func getFargateProfile(cmd *cmdutils.Cmd) {
+	getFargateProfileWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options *options) error {
+		return doGetFargateProfile(cmd, options)
+	})
 }
 
 func configureGetFargateProfileCmd(cmd *cmdutils.Cmd) *options {
@@ -47,10 +56,6 @@ func configureGetFargateProfileCmd(cmd *cmdutils.Cmd) *options {
 }
 
 func doGetFargateProfile(cmd *cmdutils.Cmd, options *options) error {
-	if err := cmdutils.NewGetFargateProfileLoader(cmd, &options.Options).Load(); err != nil {
-		return err
-	}
-
 	ctl, err := cmd.NewCtl()
 	if err != nil {
 		return err

--- a/pkg/ctl/get/fargate.go
+++ b/pkg/ctl/get/fargate.go
@@ -48,6 +48,7 @@ func configureGetFargateProfileCmd(cmd *cmdutils.Cmd) *options {
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		cmdutils.AddClusterFlag(fs, cmd.ClusterConfig.Metadata)
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
+		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 		cmdutils.AddCommonFlagsForGetCmd(fs, &options.chunkSize, &options.output)
 	})

--- a/pkg/ctl/get/fargate_test.go
+++ b/pkg/ctl/get/fargate_test.go
@@ -48,6 +48,22 @@ var _ = Describe("get", func() {
 			Expect(cmd.cmd.ClusterConfig.Metadata.Name).To(Equal("foo"))
 			Expect(cmd.options.ProfileName).To(Equal("fp-default"))
 		})
+
+		It("supports the cluster name to be provided by a ClusterConfig file", func() {
+			cmd := newMockGetFargateProfileCmd("fargateprofile", "-f", "../../../examples/01-simple-cluster.yaml")
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(cmd.cmd.ClusterConfig.Metadata.Name).To(Equal("cluster-1"))
+			Expect(cmd.options.ProfileName).To(Equal(""))
+		})
+
+		It("supports the cluster name to be provided by a ClusterConfig file, and an optional profile name provided via the --name flag", func() {
+			cmd := newMockGetFargateProfileCmd("fargateprofile", "-f", "../../../examples/01-simple-cluster.yaml", "--name", "fp-default")
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(cmd.cmd.ClusterConfig.Metadata.Name).To(Equal("cluster-1"))
+			Expect(cmd.options.ProfileName).To(Equal("fp-default"))
+		})
 	})
 })
 

--- a/pkg/ctl/get/fargate_test.go
+++ b/pkg/ctl/get/fargate_test.go
@@ -1,0 +1,81 @@
+package get
+
+import (
+	"bytes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/testutils"
+	"testing"
+)
+
+func TestSuite(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}
+
+var _ = Describe("get", func() {
+	Describe("get fargateprofile", func() {
+		It("requires the cluster's name, and if missing, prints an error and the usage", func() {
+			cmd := newMockGetFargateProfileCmd("fargateprofile")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--cluster must be set"))
+			Expect(out).To(ContainSubstring("Error: --cluster must be set"))
+			Expect(out).To(ContainSubstring("Usage:"))
+		})
+
+		It("requires the cluster's name, and does not have any profile name filter by default", func() {
+			cmd := newMockGetFargateProfileCmd("fargateprofile", "--cluster", "foo")
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(cmd.cmd.ClusterConfig.Metadata.Name).To(Equal("foo"))
+			Expect(cmd.options.ProfileName).To(Equal(""))
+		})
+
+		It("optionally accepts a profile name, which can be provided as an argument", func() {
+			cmd := newMockGetFargateProfileCmd("fargateprofile", "--cluster", "foo", "fp-default")
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(cmd.cmd.ClusterConfig.Metadata.Name).To(Equal("foo"))
+			Expect(cmd.options.ProfileName).To(Equal("fp-default"))
+		})
+
+		It("optionally accepts a profile name, which can be provided via the --name flag", func() {
+			cmd := newMockGetFargateProfileCmd("fargateprofile", "--cluster", "foo", "--name", "fp-default")
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(cmd.cmd.ClusterConfig.Metadata.Name).To(Equal("foo"))
+			Expect(cmd.options.ProfileName).To(Equal("fp-default"))
+		})
+	})
+})
+
+func newMockGetFargateProfileCmd(args ...string) *mockGetFargateProfileCmd {
+	mockCmd := &mockGetFargateProfileCmd{}
+	grouping := cmdutils.NewGrouping()
+	parentCmd := cmdutils.NewVerbCmd("get", "", "")
+	cmdutils.AddResourceCmd(grouping, parentCmd, func(cmd *cmdutils.Cmd) {
+		getFargateProfileWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options *options) error {
+			mockCmd.cmd = cmd
+			mockCmd.options = options
+			return nil // no-op, to only test input aggregation & validation.
+		})
+	})
+	parentCmd.SetArgs(args)
+	mockCmd.parentCmd = parentCmd
+	return mockCmd
+}
+
+type mockGetFargateProfileCmd struct {
+	parentCmd *cobra.Command
+	cmd       *cmdutils.Cmd
+	options   *options
+}
+
+func (c mockGetFargateProfileCmd) execute() (string, error) {
+	buf := new(bytes.Buffer)
+	c.parentCmd.SetOutput(buf)
+	err := c.parentCmd.Execute()
+	return buf.String(), err
+}


### PR DESCRIPTION
### Description

- `eksctl {create,get,delete} fargateprofile` are now testable (and tested)
- `eksctl {get,delete} fargateprofile -f` now reads the cluster name & region from `ClusterConfig`

Fixes #1641.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [x] Added note in `docs/release_notes/draft.md` (or relevant release note)

### Manual testing

#### `get fargateprofile`

```console
$ ./eksctl get clusters
NAME            REGION
mc-1664-test    ap-northeast-1

$ ./eksctl get fargateprofile
Error: --cluster must be set
Usage: eksctl get fargateprofile [flags]
[...]
Use 'eksctl get fargateprofile [command] --help' for more information about a command.


$ cat <<EOF >mc-1664-test.yaml
> ---
> apiVersion: eksctl.io/v1alpha5
> kind: ClusterConfig
> 
> metadata:
>   name: mc-1664-test
>   region: ap-northeast-1
> EOF


$ ./eksctl get fargateprofile -f mc-1664-test.yaml 
NAME		SELECTOR_NAMESPACE	SELECTOR_LABELS	POD_EXECUTION_ROLE_ARN										SUBNETS
fp-bc364107	default			<none>		arn:aws:iam::083751696308:role/eksctl-mc-1664-test-cluste-FargatePodExecutionRole-VHHN3M9X5IBX	subnet-01f27f9c008fe197d,subnet-0b42d9d42f7eb92bf,subnet-06de09d669eb78152
fp-dev		dev			<none>		arn:aws:iam::083751696308:role/eksctl-mc-1664-test-cluste-FargatePodExecutionRole-VHHN3M9X5IBX	subnet-01f27f9c008fe197d,subnet-0b42d9d42f7eb92bf,subnet-06de09d669eb78152
fp-test		test			<none>		arn:aws:iam::083751696308:role/eksctl-mc-1664-test-cluste-FargatePodExecutionRole-VHHN3M9X5IBX	subnet-01f27f9c008fe197d,subnet-0b42d9d42f7eb92bf,subnet-06de09d669eb78152

$ ./eksctl get fargateprofile -f mc-1664-test.yaml --name fp-dev
NAME	SELECTOR_NAMESPACE	SELECTOR_LABELS	POD_EXECUTION_ROLE_ARN										SUBNETS
fp-dev	dev			<none>		arn:aws:iam::083751696308:role/eksctl-mc-1664-test-cluste-FargatePodExecutionRole-VHHN3M9X5IBX	subnet-01f27f9c008fe197d,subnet-0b42d9d42f7eb92bf,subnet-06de09d669eb78152


$ ./eksctl get fargateprofile --cluster mc-1664-test
NAME		SELECTOR_NAMESPACE	SELECTOR_LABELS	POD_EXECUTION_ROLE_ARN										SUBNETS
fp-bc364107	default			<none>		arn:aws:iam::083751696308:role/eksctl-mc-1664-test-cluste-FargatePodExecutionRole-VHHN3M9X5IBX	subnet-01f27f9c008fe197d,subnet-0b42d9d42f7eb92bf,subnet-06de09d669eb78152
fp-dev		dev			<none>		arn:aws:iam::083751696308:role/eksctl-mc-1664-test-cluste-FargatePodExecutionRole-VHHN3M9X5IBX	subnet-01f27f9c008fe197d,subnet-0b42d9d42f7eb92bf,subnet-06de09d669eb78152
fp-test		test			<none>		arn:aws:iam::083751696308:role/eksctl-mc-1664-test-cluste-FargatePodExecutionRole-VHHN3M9X5IBX	subnet-01f27f9c008fe197d,subnet-0b42d9d42f7eb92bf,subnet-06de09d669eb78152

$ ./eksctl get fargateprofile --cluster mc-1664-test --name fp-dev
NAME	SELECTOR_NAMESPACE	SELECTOR_LABELS	POD_EXECUTION_ROLE_ARN										SUBNETS
fp-dev	dev			<none>		arn:aws:iam::083751696308:role/eksctl-mc-1664-test-cluste-FargatePodExecutionRole-VHHN3M9X5IBX	subnet-01f27f9c008fe197d,subnet-0b42d9d42f7eb92bf,subnet-06de09d669eb78152
```

#### `delete fargateprofile`

```console
$ ./eksctl get clusters
NAME            REGION
mc-1664-test    ap-northeast-1

$ ./eksctl get fargateprofile --cluster mc-1664-test
NAME            SELECTOR_NAMESPACE      SELECTOR_LABELS POD_EXECUTION_ROLE_ARN                                                                          SUBNETS
fp-bc364107     default                 <none>          arn:aws:iam::083751696308:role/eksctl-mc-1664-test-cluste-FargatePodExecutionRole-VHHN3M9X5IBX  subnet-01f27f9c008fe197d,subnet-0b42d9d42f7eb92bf,subnet-06de09d669eb78152
fp-dev          dev                     <none>          arn:aws:iam::083751696308:role/eksctl-mc-1664-test-cluste-FargatePodExecutionRole-VHHN3M9X5IBX  subnet-01f27f9c008fe197d,subnet-0b42d9d42f7eb92bf,subnet-06de09d669eb78152
fp-test         test                    <none>          arn:aws:iam::083751696308:role/eksctl-mc-1664-test-cluste-FargatePodExecutionRole-VHHN3M9X5IBX  subnet-01f27f9c008fe197d,subnet-0b42d9d42f7eb92bf,subnet-06de09d669eb78152

$ ./eksctl delete fargateprofile
Error: --cluster must be set
Usage: eksctl delete fargateprofile [flags]
[...]
Use 'eksctl delete fargateprofile [command] --help' for more information about a command.

$ cat <<EOF >mc-1664-test.yaml
> ---
> apiVersion: eksctl.io/v1alpha5
> kind: ClusterConfig
>
> metadata:
>   name: mc-1664-test
>   region: ap-northeast-1
> EOF

$ ./eksctl delete fargateprofile -f mc-1664-test.yaml --name fp-bc364107
[ℹ]  deleted Fargate profile "fp-bc364107" on EKS cluster "mc-1664-test"

$ ./eksctl delete fargateprofile --cluster mc-1664-test --name fp-test
[ℹ]  deleted Fargate profile "fp-test" on EKS cluster "mc-1664-test"

$ ./eksctl get fargateprofile --cluster mc-1664-test
NAME    SELECTOR_NAMESPACE      SELECTOR_LABELS POD_EXECUTION_ROLE_ARN                                                                          SUBNETS
fp-dev  dev                     <none>          arn:aws:iam::083751696308:role/eksctl-mc-1664-test-cluste-FargatePodExecutionRole-VHHN3M9X5IBX  subnet-01f27f9c008fe197d,subnet-0b42d9d42f7eb92bf,subnet-06de09d669eb78152
```