### PR TITLE
Move aws-sdk-go dep to weaveworks/aws-sdk-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v10.14.0+incompatible
 	// Needed due to to Sirupsen/sirupsen case clash
 	github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.4.2
-	github.com/aws/aws-sdk-go => github.com/weaveworks-experiments/aws-sdk-go v1.25.14-0.20191128064856-d39dadebcc3f
+	github.com/aws/aws-sdk-go => github.com/weaveworks/aws-sdk-go v1.25.14-0.20191128064856-d39dadebcc3f
 	github.com/awslabs/goformation => github.com/errordeveloper/goformation v0.0.0-20190507151947-a31eae35e596
 	// Override version since auto-detected one fails with GOPROXY
 	github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -953,6 +953,8 @@ github.com/voxelbrain/goptions v0.0.0-20180630082107-58cddc247ea2 h1:txplJASvd6b
 github.com/voxelbrain/goptions v0.0.0-20180630082107-58cddc247ea2/go.mod h1:DGCIhurYgnLz8J9ga1fMV/fbLDyUvTyrWXVWUIyJon4=
 github.com/weaveworks-experiments/aws-sdk-go v1.25.14-0.20191128064856-d39dadebcc3f h1:mfgf9Q8ERQpAVlJHQJSQ2lmH5yIoG9KZeBj+S4EebLw=
 github.com/weaveworks-experiments/aws-sdk-go v1.25.14-0.20191128064856-d39dadebcc3f/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/weaveworks/aws-sdk-go v1.25.14-0.20191128064856-d39dadebcc3f h1:fer1sbNWB5v7KKDq7fzdLeTtRMbg1fNjIY6nrWw1plc=
+github.com/weaveworks/aws-sdk-go v1.25.14-0.20191128064856-d39dadebcc3f/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/weaveworks/common v0.0.0-20190410110702-87611edc252e/go.mod h1:pSm+0KR57BG3pvGoJWFXJSAC7+sEPewcvdt5StevL3A=
 github.com/weaveworks/flux v0.0.0-20190729133003-c78ccd3706b5 h1:NAlFNFqpgBqufg0m/FCVmnsQxXVH5gO/Efxi/Hbdiiw=
 github.com/weaveworks/flux v0.0.0-20190729133003-c78ccd3706b5/go.mod h1:ZKP5adRfgMH9xY8/nG+Z+Z+fylHgimnL6/+/wzfQJr8=


### PR DESCRIPTION
We are moving our fork into the weaveworks org

~TODO: Fix, for now it's failing with 410 Gone.~

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->