### PR TITLE
No longer print usage/help on errors

### DIFF
--- a/cmd/eksctl/main.go
+++ b/cmd/eksctl/main.go
@@ -52,6 +52,7 @@ func main() {
 				logger.Debug("ignoring cobra error %q", err.Error())
 			}
 		},
+		SilenceUsage: true,
 	}
 
 	flagGrouping := cmdutils.NewGrouping()

--- a/docs/release_notes/draft.md
+++ b/docs/release_notes/draft.md
@@ -7,6 +7,7 @@
 ## Improvements
 
 - `eksctl` now leverages `cobra` to print all errors in a more standardised way (#1664)
+- `eksctl` now no longer print usage/help on invalid user input (#1677)
 - Improved Fargate documentation & example `ClusterConfig` manifest (#1666)
 
 ## Bug fixes


### PR DESCRIPTION
### Description

This is to avoid printing usage/help on genuine runtime errors, and to fix #1676.
However, a side effect of this is that we now also no longer print usage/help on input validation errors either.

That being said, given:

- we're trying to sanitise/simplify `eksctl`'s code at the moment,
- other CLI also do NOT print any usage/help on input validation errors
  e.g. `kubectl`,

it was decided between @martina-if, @cPu1 and I that it didn't matter too much for now.

### Checklist
- [x] ~Added tests that cover your change (if possible)~
- [x] ~Added/modified documentation as required (such as the `README.md`, and `examples` directory)~
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [x] Added note in `docs/release_notes/draft.md` (or relevant release note)
