### PR TITLE
enable all logging by default

### DIFF
--- a/pkg/az/az.go
+++ b/pkg/az/az.go
@@ -93,7 +93,10 @@ type AvailabilityZoneSelector struct {
 // NewSelectorWithDefaults create a new AvailabilityZoneSelector with the
 // default selection strategy and usage rules
 func NewSelectorWithDefaults(ec2api ec2iface.EC2API) *AvailabilityZoneSelector {
-	avoidZones := map[string]bool{}
+	avoidZones := map[string]bool{
+		// well-known over-populated zones
+		"us-east1-e": true,
+	}
 
 	return &AvailabilityZoneSelector{
 		ec2api:   ec2api,
@@ -105,7 +108,10 @@ func NewSelectorWithDefaults(ec2api ec2iface.EC2API) *AvailabilityZoneSelector {
 // NewSelectorWithMinRequired create a new AvailabilityZoneSelector with the
 // minimum required selection strategy and usage rules
 func NewSelectorWithMinRequired(ec2api ec2iface.EC2API) *AvailabilityZoneSelector {
-	avoidZones := map[string]bool{}
+	avoidZones := map[string]bool{
+		// well-known over-populated zones
+		"us-east1-e": true,
+	}
 
 	return &AvailabilityZoneSelector{
 		ec2api:   ec2api,

--- a/pkg/az/az.go
+++ b/pkg/az/az.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/pkg/errors"
+	"github.com/kris-nova/logger"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 )
@@ -95,7 +96,7 @@ type AvailabilityZoneSelector struct {
 func NewSelectorWithDefaults(ec2api ec2iface.EC2API) *AvailabilityZoneSelector {
 	avoidZones := map[string]bool{
 		// well-known over-populated zones
-		"us-east1-e": true,
+		"us-east-1e": true,
 	}
 
 	return &AvailabilityZoneSelector{
@@ -110,7 +111,7 @@ func NewSelectorWithDefaults(ec2api ec2iface.EC2API) *AvailabilityZoneSelector {
 func NewSelectorWithMinRequired(ec2api ec2iface.EC2API) *AvailabilityZoneSelector {
 	avoidZones := map[string]bool{
 		// well-known over-populated zones
-		"us-east1-e": true,
+		"us-east-1e": true,
 	}
 
 	return &AvailabilityZoneSelector{
@@ -141,6 +142,10 @@ func (a *AvailabilityZoneSelector) getUsableZones(availableZones []*ec2.Availabi
 				zoneUsable = false
 				break
 			}
+		}
+		if *zone.ZoneName == "us-east-1e" {
+			logger.Warning("Ignoring zone 'us-east-1e' as hardcoded by andreas")
+			zoneUsable = false
 		}
 		if zoneUsable {
 			usableZones = append(usableZones, *zone.ZoneName)

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -88,6 +88,8 @@ func doCreateCluster(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *cmdutils.Crea
 
 	cfg := cmd.ClusterConfig
 	meta := cmd.ClusterConfig.Metadata
+	cfg.CloudWatch.ClusterLogging.EnableTypes=api.SupportedCloudWatchClusterLogTypes()
+	logger.Warning("Enabling all logging options for the EKS Cluster")
 
 	printer := printers.NewJSONPrinter()
 

--- a/pkg/utils/waiters/waiters.go
+++ b/pkg/utils/waiters/waiters.go
@@ -23,7 +23,7 @@ func Wait(name, msg string, acceptors []request.WaiterAcceptor, newRequest func(
 	defer cancel()
 	startTime := time.Now()
 	w := makeWaiter(ctx, name, msg, acceptors, newRequest)
-	logger.Debug("start %s", msg)
+	logger.Info("start %s", msg)
 	if waitErr := w.WaitWithContext(ctx); waitErr != nil {
 		if troubleshoot != nil {
 			if wrappedErr := troubleshoot(desiredStatus); wrappedErr != nil {
@@ -32,7 +32,7 @@ func Wait(name, msg string, acceptors []request.WaiterAcceptor, newRequest func(
 		}
 		return errors.Wrap(waitErr, msg)
 	}
-	logger.Debug("done after %s of %s", time.Since(startTime), msg)
+	logger.Info("done after %s of %s", time.Since(startTime), msg)
 	return nil
 }
 
@@ -43,7 +43,7 @@ func makeWaiter(ctx context.Context, name, msg string, acceptors []request.Waite
 		Delay:       makeWaiterDelay(),
 		Acceptors:   acceptors,
 		NewRequest: func(_ []request.Option) (*request.Request, error) {
-			logger.Debug(msg)
+			logger.Info(msg)
 			req := newRequest()
 			req.SetContext(ctx)
 			return req, nil


### PR DESCRIPTION
Industry CIS best practice is to enable logging for Kubernetes and EKS clusters, so enabling all logging options during creation.
