### PR TITLE
Remove repeated test and build steps from release pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,17 @@ jobs:
           cmd: go mod download
       - run:
           name: Create release candidate binaries for all plaforms and upload to GitHub
-          command: make -f Makefile.docker release-candidate
+          command: |
+            docker run \
+              --env=GITHUB_TOKEN \
+              --env=CIRCLE_TAG \
+              --env=CIRCLE_PROJECT_USERNAME \
+              --env=CIRCLE_PROJECT_REPONAME \
+              --env=GOPRIVATE \
+              --volume=$(pwd):/src \
+              --volume=/home/circleci/.cache/go-build/:/root/.cache/go-build \
+              --volume=/home/circleci/go/pkg/mod/:/go/pkg/mod \
+              weaveworks/eksctl-build:$(cat .docker/image_tag) ./do-release-candidate.sh
           no_output_timeout: 21m
   release:
     machine:
@@ -115,7 +125,17 @@ jobs:
           cmd: go mod download
       - run:
           name: Create release binaries for all plaforms and upload to GitHub
-          command: make -f Makefile.docker release
+          command: |
+            docker run \
+              --env=GITHUB_TOKEN \
+              --env=CIRCLE_TAG \
+              --env=CIRCLE_PROJECT_USERNAME \
+              --env=CIRCLE_PROJECT_REPONAME \
+              --env=GOPRIVATE \
+              --volume=$(pwd):/src \
+              --volume=/home/circleci/.cache/go-build/:/root/.cache/go-build \
+              --volume=/home/circleci/go/pkg/mod/:/go/pkg/mod \
+              weaveworks/eksctl-build:$(cat .docker/image_tag) ./do-release.sh
           no_output_timeout: 21m
   integration-tests:
     machine:

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -90,9 +90,9 @@ docker_run_release_script = docker run \
     $(build_image_name)
 
 .PHONY: release-candidate
-release-candidate: build test ## Create a new eksctl release candidate
+release-candidate: ## Create a new eksctl release candidate
 	$(call docker_run_release_script) ./do-release-candidate.sh
 
 .PHONY: release
-release: build test ## Create a new eksctl release
+release: ## Create a new eksctl release
 	$(call docker_run_release_script) ./do-release.sh


### PR DESCRIPTION
The release pipelines already call the build-and-test workflows so it shouldn't be
needed to call make build test again

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->