### PR TITLE
Support public/private API endpoints settings from file

### DIFF
--- a/docs/release_notes/0.14.0-draft.md
+++ b/docs/release_notes/0.14.0-draft.md
@@ -5,3 +5,5 @@
 ## Improvements
 
 ## Bug fixes
+
+- fix changing public/private endpoints setting from file (#1693)

--- a/pkg/ctl/utils/update_cluster_endpoint_access.go
+++ b/pkg/ctl/utils/update_cluster_endpoint_access.go
@@ -85,12 +85,17 @@ func doUpdateClusterEndpoints(cmd *cmdutils.Cmd, newPrivate bool, newPublic bool
 	logger.Info("current Kubernetes API endpoint access: privateAccess=%v, publicAccess=%v",
 		curPrivate, curPublic)
 
-	privateSet, publicSet := accessFlagsSet(cmd)
-	if !privateSet {
-		newPrivate = curPrivate
-	}
-	if !publicSet {
-		newPublic = curPublic
+	if cfg.VPC.ClusterEndpoints.PublicAccess != nil && cfg.VPC.ClusterEndpoints.PrivateAccess != nil {
+		newPublic = *cfg.VPC.ClusterEndpoints.PublicAccess
+		newPrivate = *cfg.VPC.ClusterEndpoints.PrivateAccess
+	}else{
+		privateSet, publicSet := accessFlagsSet(cmd)
+		if !privateSet {
+			newPrivate = curPrivate
+		}
+		if !publicSet {
+			newPublic = curPublic
+		}
 	}
 
 	// Nothing changed?

--- a/pkg/ctl/utils/update_cluster_endpoint_access.go
+++ b/pkg/ctl/utils/update_cluster_endpoint_access.go
@@ -88,7 +88,7 @@ func doUpdateClusterEndpoints(cmd *cmdutils.Cmd, newPrivate bool, newPublic bool
 	if cfg.VPC.ClusterEndpoints.PublicAccess != nil && cfg.VPC.ClusterEndpoints.PrivateAccess != nil {
 		newPublic = *cfg.VPC.ClusterEndpoints.PublicAccess
 		newPrivate = *cfg.VPC.ClusterEndpoints.PrivateAccess
-	}else{
+	} else {
 		privateSet, publicSet := accessFlagsSet(cmd)
 		if !privateSet {
 			newPrivate = curPrivate

--- a/site/content/usage/06-vpc-networking.md
+++ b/site/content/usage/06-vpc-networking.md
@@ -201,7 +201,7 @@ eksctl utils update-cluster-endpoints --name=<clustername> --private-access=true
 To update the setting using a `ClusterConfig` file, use:
 
 ```console
-eksctl utils update-cluster-endpoints -f config.yaml
+eksctl utils update-cluster-endpoints -f config.yaml --approve
 ```
 
 Note that if you don't pass a flag in it will keep the current value. Once you are satisfied with the proposed changes,

--- a/site/content/usage/06-vpc-networking.md
+++ b/site/content/usage/06-vpc-networking.md
@@ -198,6 +198,12 @@ The following is an example of how one could configure the Kubernetes API endpoi
 eksctl utils update-cluster-endpoints --name=<clustername> --private-access=true --public-access=false
 ```
 
+To update the setting using a `ClusterConfig` file, use:
+
+```console
+eksctl utils update-cluster-endpoints -f config.yaml
+```
+
 Note that if you don't pass a flag in it will keep the current value. Once you are satisfied with the proposed changes,
 add the `approve` flag to make the change to the running cluster.
 


### PR DESCRIPTION
### Description

`update-cluster-endpoints` command changes API endpoint settings (https://github.com/weaveworks/eksctl/pull/1149)

But this command doesn't read config file.
So when we use `-f` option, `eksctl` doesn't change settings.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [x] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
