### PR TITLE
Fix typo when kubectl is missing

### DIFF
--- a/pkg/utils/kubectl.go
+++ b/pkg/utils/kubectl.go
@@ -27,7 +27,7 @@ func CheckKubectlVersion(env []string) error {
 	ktl := &kubectl.LocalClient{Env: env}
 	kubectlPath, err := ktl.LookPath()
 	if err != nil {
-		return fmt.Errorf("kubectl not found, v1.10.0 or newever is required")
+		return fmt.Errorf("kubectl not found, v1.10.0 or newer is required")
 	}
 	logger.Debug("kubectl: %q", kubectlPath)
 


### PR DESCRIPTION
### Description

Fixes #1599

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

