### PR TITLE
Add installation instructions for MacPorts on MacOS

### DIFF
--- a/site/content/introduction/02-installation.md
+++ b/site/content/introduction/02-installation.md
@@ -20,6 +20,12 @@ brew tap weaveworks/tap
 brew install weaveworks/tap/eksctl
 ```
 
+or [MacPorts](https://www.macports.org):
+
+```
+port install eksctl
+```
+
 and Windows users can use [chocolatey](https://chocolatey.org):
 
 ```


### PR DESCRIPTION
### Description

Add installation instructions for MacOS using MacPorts as an alternative to Homebrew.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
