### PR TITLE
Support attaching Classic Load Balancers to NodeGroups

### DIFF
--- a/examples/05-advanced-nodegroups.yaml
+++ b/examples/05-advanced-nodegroups.yaml
@@ -40,7 +40,7 @@ nodeGroups:
     desiredCapacity: 4
     labels:
       nodegroup-type: very-special-science-workloads
-    loadBalancerNames:
+    classicLoadBalancerNames:
       - ng3-classic-load-balancer
     taints:
       special: "true:NoSchedule"

--- a/examples/05-advanced-nodegroups.yaml
+++ b/examples/05-advanced-nodegroups.yaml
@@ -27,9 +27,11 @@ nodeGroups:
     desiredCapacity: 2
     labels:
       nodegroup-type: backend-cluster-addons
+    targetGroupARNs:
+      - arn:aws:elasticloadbalancing:eu-west-2:01234567890:targetgroup/target-group-1/abcdef0123456789
     privateNetworking: true
     preBootstrapCommands:
-      # allow docker registries to be deployed as cluster service 
+      # allow docker registries to be deployed as cluster service
       - 'echo {\"insecure-registries\": [\"172.20.0.0/16\",\"10.100.0.0/16\"]} > /etc/docker/daemon.json'
       - "systemctl restart docker"
 
@@ -38,6 +40,8 @@ nodeGroups:
     desiredCapacity: 4
     labels:
       nodegroup-type: very-special-science-workloads
+    loadBalancerNames:
+      - ng3-classic-load-balancer
     taints:
       special: "true:NoSchedule"
     privateNetworking: true

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -595,7 +595,7 @@ type NodeGroup struct {
 	Taints map[string]string `json:"taints,omitempty"`
 
 	// +optional
-	LoadBalancerNames []string `json:"loadBalancerNames,omitempty"`
+	ClassicLoadBalancerNames []string `json:"classicLoadBalancerNames,omitempty"`
 
 	// +optional
 	TargetGroupARNs []string `json:"targetGroupARNs,omitempty"`

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -595,6 +595,9 @@ type NodeGroup struct {
 	Taints map[string]string `json:"taints,omitempty"`
 
 	// +optional
+	LoadBalancerNames []string `json:"loadBalancerNames,omitempty"`
+
+	// +optional
 	TargetGroupARNs []string `json:"targetGroupARNs,omitempty"`
 
 	// +optional

--- a/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
@@ -687,8 +687,8 @@ func (in *NodeGroup) DeepCopyInto(out *NodeGroup) {
 			(*out)[key] = val
 		}
 	}
-	if in.LoadBalancerNames != nil {
-		in, out := &in.LoadBalancerNames, &out.LoadBalancerNames
+	if in.ClassicLoadBalancerNames != nil {
+		in, out := &in.ClassicLoadBalancerNames, &out.ClassicLoadBalancerNames
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
@@ -687,6 +687,11 @@ func (in *NodeGroup) DeepCopyInto(out *NodeGroup) {
 			(*out)[key] = val
 		}
 	}
+	if in.LoadBalancerNames != nil {
+		in, out := &in.LoadBalancerNames, &out.LoadBalancerNames
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.TargetGroupARNs != nil {
 		in, out := &in.TargetGroupARNs, &out.TargetGroupARNs
 		*out = make([]string, len(*in))

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -69,7 +69,7 @@ type Properties struct {
 
 	VPCZoneIdentifier interface{}
 
-	LoadBalancerNames                 []string
+	ClassicLoadBalancerNames          []string
 	TargetGroupARNs                   []string
 	DesiredCapacity, MinSize, MaxSize string
 
@@ -756,7 +756,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 	Context("NodeGroupAutoScaling", func() {
 		cfg, ng := newClusterConfigAndNodegroup(true)
 
-		ng.LoadBalancerNames = []string{"clb-1", "clb-2"}
+		ng.ClassicLoadBalancerNames = []string{"clb-1", "clb-2"}
 		ng.TargetGroupARNs = []string{"tg-arn-1", "tg-arn-2"}
 
 		ng.MinSize = new(int)
@@ -851,13 +851,13 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Expect(ngProps.Tags).To(Equal(expectedTags))
 		})
 
-		It("should have load balancer names set", func() {
+		It("should have classic load balancer names set", func() {
 			Expect(ngTemplate.Resources).To(HaveKey("NodeGroup"))
 			ng := ngTemplate.Resources["NodeGroup"]
 			Expect(ng).ToNot(BeNil())
 			Expect(ng.Properties).ToNot(BeNil())
 
-			Expect(ng.Properties.LoadBalancerNames).To(Equal([]string{"clb-1", "clb-2"}))
+			Expect(ng.Properties.ClassicLoadBalancerNames).To(Equal([]string{"clb-1", "clb-2"}))
 		})
 
 		It("should have target groups ARNs set", func() {

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -69,6 +69,7 @@ type Properties struct {
 
 	VPCZoneIdentifier interface{}
 
+	LoadBalancerNames                 []string
 	TargetGroupARNs                   []string
 	DesiredCapacity, MinSize, MaxSize string
 
@@ -755,6 +756,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 	Context("NodeGroupAutoScaling", func() {
 		cfg, ng := newClusterConfigAndNodegroup(true)
 
+		ng.LoadBalancerNames = []string{"clb-1", "clb-2"}
 		ng.TargetGroupARNs = []string{"tg-arn-1", "tg-arn-2"}
 
 		ng.MinSize = new(int)
@@ -847,6 +849,15 @@ var _ = Describe("CloudFormation template builder API", func() {
 
 			Expect(ngProps.Tags).ToNot(BeNil())
 			Expect(ngProps.Tags).To(Equal(expectedTags))
+		})
+
+		It("should have load balancer names set", func() {
+			Expect(ngTemplate.Resources).To(HaveKey("NodeGroup"))
+			ng := ngTemplate.Resources["NodeGroup"]
+			Expect(ng).ToNot(BeNil())
+			Expect(ng.Properties).ToNot(BeNil())
+
+			Expect(ng.Properties.LoadBalancerNames).To(Equal([]string{"clb-1", "clb-2"}))
 		})
 
 		It("should have target groups ARNs set", func() {

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -69,7 +69,7 @@ type Properties struct {
 
 	VPCZoneIdentifier interface{}
 
-	ClassicLoadBalancerNames          []string
+	LoadBalancerNames                 []string
 	TargetGroupARNs                   []string
 	DesiredCapacity, MinSize, MaxSize string
 
@@ -857,7 +857,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Expect(ng).ToNot(BeNil())
 			Expect(ng.Properties).ToNot(BeNil())
 
-			Expect(ng.Properties.ClassicLoadBalancerNames).To(Equal([]string{"clb-1", "clb-2"}))
+			Expect(ng.Properties.LoadBalancerNames).To(Equal([]string{"clb-1", "clb-2"}))
 		})
 
 		It("should have target groups ARNs set", func() {

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -269,6 +269,9 @@ func nodeGroupResource(launchTemplateName *gfn.Value, vpcZoneIdentifier interfac
 	if ng.MaxSize != nil {
 		ngProps["MaxSize"] = fmt.Sprintf("%d", *ng.MaxSize)
 	}
+	if len(ng.LoadBalancerNames) > 0 {
+		ngProps["LoadBalancerNames"] = ng.LoadBalancerNames
+	}
 	if len(ng.TargetGroupARNs) > 0 {
 		ngProps["TargetGroupARNs"] = ng.TargetGroupARNs
 	}

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -269,8 +269,8 @@ func nodeGroupResource(launchTemplateName *gfn.Value, vpcZoneIdentifier interfac
 	if ng.MaxSize != nil {
 		ngProps["MaxSize"] = fmt.Sprintf("%d", *ng.MaxSize)
 	}
-	if len(ng.LoadBalancerNames) > 0 {
-		ngProps["LoadBalancerNames"] = ng.LoadBalancerNames
+	if len(ng.ClassicLoadBalancerNames) > 0 {
+		ngProps["LoadBalancerNames"] = ng.ClassicLoadBalancerNames
 	}
 	if len(ng.TargetGroupARNs) > 0 {
 		ngProps["TargetGroupARNs"] = ng.TargetGroupARNs

--- a/site/content/usage/02-managing-nodegroups.md
+++ b/site/content/usage/02-managing-nodegroups.md
@@ -62,6 +62,35 @@ The nodegroups `ng-1-workers` and `ng-2-builders` can be created with this comma
 eksctl create nodegroup --config-file=dev-cluster.yaml
 ```
 
+If you have already prepared for attaching existing classic load balancers or/and target groups to the nodegroups,
+you can specify these in the config file. The classic load balancers or/and target groups are automatically associated with the ASG when creating nodegroups.
+
+```yaml
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: dev-cluster
+  region: eu-north-1
+
+nodeGroups:
+  - name: ng-1-web
+    labels: { role: web }
+    instanceType: m5.xlarge
+    desiredCapacity: 10
+    privateNetworking: true
+    classicLoadBalancerNames:
+      - dev-clb-1
+      - dev-clb-2
+  - name: ng-2-api
+    labels: { role: api }
+    instanceType: m5.2xlarge
+    desiredCapacity: 2
+    privateNetworking: true
+    targetGroupARNs:
+      - arn:aws:elasticloadbalancing:eu-north-1:01234567890:targetgroup/dev-target-group-1/abcdef0123456789
+```
+
 ### Listing nodegroups
 
 To list the details about a nodegroup or all of the nodegroups, use:

--- a/site/content/usage/15-eks-managed-nodes.md
+++ b/site/content/usage/15-eks-managed-nodes.md
@@ -183,7 +183,7 @@ the provisioned Autoscaling Group like in unmanaged nodegroups.
 - `instancesDistribution` field is not supported
 - `volumeSize` is the only field supported for configuring volumes
 - Control over the node bootstrapping process and customization of the kubelet are not supported. This includes the
-following fields: `maxPodsPerNode`, `taints`, `targetGroupARNs`, `preBootstrapCommands`, `overrideBootstrapCommand`,
+following fields: `loadBalancerNames`, `maxPodsPerNode`, `taints`, `targetGroupARNs`, `preBootstrapCommands`, `overrideBootstrapCommand`,
 `clusterDNS` and `kubeletExtraConfig`.
 
 ### Note for eksctl versions below 0.12.0

--- a/site/content/usage/15-eks-managed-nodes.md
+++ b/site/content/usage/15-eks-managed-nodes.md
@@ -183,7 +183,7 @@ the provisioned Autoscaling Group like in unmanaged nodegroups.
 - `instancesDistribution` field is not supported
 - `volumeSize` is the only field supported for configuring volumes
 - Control over the node bootstrapping process and customization of the kubelet are not supported. This includes the
-following fields: `loadBalancerNames`, `maxPodsPerNode`, `taints`, `targetGroupARNs`, `preBootstrapCommands`, `overrideBootstrapCommand`,
+following fields: `classicLoadBalancerNames`, `maxPodsPerNode`, `taints`, `targetGroupARNs`, `preBootstrapCommands`, `overrideBootstrapCommand`,
 `clusterDNS` and `kubeletExtraConfig`.
 
 ### Note for eksctl versions below 0.12.0

--- a/site/content/usage/20-schema.md
+++ b/site/content/usage/20-schema.md
@@ -338,6 +338,10 @@ NodeGroup:
       items:
         type: string
       type: array
+    classicLoadBalancerNames:
+      items:
+        type: string
+      type: array
     clusterDNS:
       type: string
     desiredCapacity:
@@ -363,10 +367,6 @@ NodeGroup:
         .*:
           type: string
       type: object
-    loadBalancerNames:
-      items:
-        type: string
-      type: array
     maxPodsPerNode:
       type: integer
     maxSize:

--- a/site/content/usage/20-schema.md
+++ b/site/content/usage/20-schema.md
@@ -363,6 +363,10 @@ NodeGroup:
         .*:
           type: string
       type: object
+    loadBalancerNames:
+      items:
+        type: string
+      type: array
     maxPodsPerNode:
       type: integer
     maxSize:


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->

resolves https://github.com/weaveworks/eksctl/issues/1706

We are able to attach the existing CLBs to nodegroups automatically when we define `loadBalancerNames` field in cluster.yaml and run `eksctl create nodegroup -f cluster.yaml`.

```yaml
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: cluster01
  region: us-east-1
  version: "1.14"

vpc:
  id: "vpc-012345"
  cidr: "10.0.0.0/16"
  subnets:
    ...

nodeGroups:
  - name: nodegroup1
    loadBalancerNames:
      - clb-name-1
      - clb-name-2
    ...
```