### PR TITLE
Fix (plan) output when updating k8s addons

### DIFF
--- a/pkg/addons/default/aws_node_test.go
+++ b/pkg/addons/default/aws_node_test.go
@@ -86,5 +86,11 @@ var _ = Describe("default addons - aws-node", func() {
 				Equal("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:v1.6.0"),
 			)
 		})
+		It("detects matching image version when determining plan", func() {
+			// updating from latest to latest needs no updating
+			needsUpdate, err := UpdateAWSNode(rawClient, "eu-west-2", true)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needsUpdate).To(BeFalse())
+		})
 	})
 })

--- a/pkg/addons/default/coredns.go
+++ b/pkg/addons/default/coredns.go
@@ -23,7 +23,8 @@ const (
 	KubeDNS = "kube-dns"
 )
 
-// UpdateCoreDNS will update the `coredns` add-on
+// UpdateCoreDNS will update the `coredns` add-on and returns true
+// if an update is available
 func UpdateCoreDNS(rawClient kubernetes.RawClientInterface, region, controlPlaneVersion string, plan bool) (bool, error) {
 	kubeDNSSevice, err := rawClient.ClientSet().CoreV1().Services(metav1.NamespaceSystem).Get(KubeDNS, metav1.GetOptions{})
 	if err != nil {
@@ -34,7 +35,7 @@ func UpdateCoreDNS(rawClient kubernetes.RawClientInterface, region, controlPlane
 		return false, errors.Wrapf(err, "getting %q service", KubeDNS)
 	}
 
-	_, err = rawClient.ClientSet().AppsV1().Deployments(metav1.NamespaceSystem).Get(CoreDNS, metav1.GetOptions{})
+	kubeDNSDeployment, err := rawClient.ClientSet().AppsV1().Deployments(metav1.NamespaceSystem).Get(CoreDNS, metav1.GetOptions{})
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			logger.Warning("%q was not found", CoreDNS)
@@ -49,6 +50,7 @@ func UpdateCoreDNS(rawClient kubernetes.RawClientInterface, region, controlPlane
 		return false, err
 	}
 
+	tagMismatch := true
 	for _, rawObj := range list.Items {
 		resource, err := rawClient.NewRawResource(rawObj.Object)
 		if err != nil {
@@ -66,6 +68,13 @@ func UpdateCoreDNS(rawClient kubernetes.RawClientInterface, region, controlPlane
 			if err := addons.UseRegionalImage(&deployment.Spec.Template, region); err != nil {
 				return false, err
 			}
+			tagMismatch, err = addons.ImageTagsDiffer(
+				deployment.Spec.Template.Spec.Containers[0].Image,
+				kubeDNSDeployment.Spec.Template.Spec.Containers[0].Image,
+			)
+			if err != nil {
+				return false, err
+			}
 		case "Service":
 			resource.Info.Object.(*corev1.Service).SetResourceVersion(kubeDNSSevice.GetResourceVersion())
 			resource.Info.Object.(*corev1.Service).Spec.ClusterIP = kubeDNSSevice.Spec.ClusterIP
@@ -79,8 +88,12 @@ func UpdateCoreDNS(rawClient kubernetes.RawClientInterface, region, controlPlane
 	}
 
 	if plan {
-		logger.Critical("(plan) %q is not up-to-date", CoreDNS)
-		return true, nil
+		if tagMismatch {
+			logger.Critical("(plan) %q is not up-to-date", CoreDNS)
+			return true, nil
+		}
+		logger.Info("(plan) %q is already up-to-date", CoreDNS)
+		return false, nil
 	}
 
 	logger.Info("%q is now up-to-date", CoreDNS)

--- a/pkg/addons/default/coredns_test.go
+++ b/pkg/addons/default/coredns_test.go
@@ -132,6 +132,16 @@ var _ = Describe("default addons - coredns", func() {
 			checkCoreDNSImage(rawClient, "eu-west-1", "v1.2.2", true)
 		})
 
+		It("detects coredns version match local vs cluster", func() {
+			needsUpdate, err := UpdateCoreDNS(rawClient, "eu-west-2", "1.12.x", true)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needsUpdate).To(BeFalse())
+
+			needsUpdate, err = UpdateCoreDNS(rawClient, "eu-west-2", "1.13.x", true)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needsUpdate).To(BeTrue())
+		})
+
 		It("can update to correct version", func() {
 			_, err := UpdateCoreDNS(rawClient, "eu-west-2", "1.13.x", false)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/addons/default/helpers.go
+++ b/pkg/addons/default/helpers.go
@@ -3,7 +3,6 @@ package defaultaddons
 import (
 	"github.com/pkg/errors"
 	"github.com/weaveworks/eksctl/pkg/kubernetes"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/addons/image.go
+++ b/pkg/addons/image.go
@@ -2,6 +2,7 @@ package addons
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -29,4 +30,28 @@ func UseRegionalImage(spec *corev1.PodTemplateSpec, region string) error {
 	regionalImage := fmt.Sprintf(imageFormat, api.EKSResourceAccountID(region), region, dnsSuffix)
 	spec.Spec.Containers[0].Image = regionalImage
 	return nil
+}
+
+// imageTag extracts the container image's tag.
+func imageTag(image string) (string, error) {
+	parts := strings.Split(image, ":")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("unexpected image format %q", image)
+	}
+
+	return parts[1], nil
+}
+
+// ImageTagsDiffer returns true if the image tags are not the same
+// while ignoring the image name.
+func ImageTagsDiffer(image1, image2 string) (bool, error) {
+	tag1, err := imageTag(image1)
+	if err != nil {
+		return false, err
+	}
+	tag2, err := imageTag(image2)
+	if err != nil {
+		return false, err
+	}
+	return tag1 != tag2, nil
 }


### PR DESCRIPTION
Closes #926 

For the commands `utils update-aws-node` and `utils update-coredns` when
used in dry-run mode, it now returns `already up-to-date` if the image
tag of the deployment/daemonset matches what is in the built-in assets.

While this does _not_ confirm a run with `--approve` is a no-op (since the
current image might not be region-aware or other parts in the manifest
differ), it will tell you whether the version is up-to-date.

When running the commands with `--approve`, the built-in manifests will be
applied idempotently in any case no matter whether the image tags match
or not.

### Checklist
- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
