### PR TITLE
Add integration tests for backwards compatibility

### DIFF
--- a/eksctl-image-builder.sh
+++ b/eksctl-image-builder.sh
@@ -8,5 +8,5 @@ make build \
     && cp ./eksctl /out/usr/local/bin/eksctl
 make build-integration-test \
     && mkdir -p /out/usr/local/share/eksctl \
-    && cp integration/*.yaml /out/usr/local/share/eksctl \
+    && cp -r integration/*.yaml integration/scripts /out/usr/local/share/eksctl \
     && cp ./eksctl-integration-test /out/usr/local/bin/eksctl-integration-test

--- a/integration/backwards_compatibility_test.go
+++ b/integration/backwards_compatibility_test.go
@@ -1,0 +1,133 @@
+// +build integration
+
+package integration_test
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/weaveworks/eksctl/integration/runner"
+	. "github.com/weaveworks/eksctl/integration/runner"
+	"github.com/weaveworks/eksctl/pkg/utils/names"
+)
+
+const (
+	goBackVersions = 2
+)
+
+var _ = Describe("(Integration) [Backwards compatibility test]", func() {
+
+	var (
+		clusterName   = names.ForCluster("", "")
+		initialNgName = "ng-1"
+		newNgName     = "ng-2"
+	)
+
+	It("should support clusters created with a previous version of eksctl", func() {
+		By("downloading a previous release")
+		eksctlDir, err := ioutil.TempDir(os.TempDir(), "eksctl")
+		Expect(err).ToNot(HaveOccurred())
+
+		defer func() {
+			Expect(os.RemoveAll(eksctlDir)).ToNot(HaveOccurred())
+		}()
+
+		downloadRelease(eksctlDir)
+
+		eksctlPath := path.Join(eksctlDir, "eksctl")
+
+		version, err := getVersion(eksctlPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		By(fmt.Sprintf("creating a cluster with release %q", version))
+		cmd := runner.NewCmd(eksctlPath).
+			WithArgs(
+				"create",
+				"cluster",
+				"--name", clusterName,
+				"--nodegroup-name", initialNgName,
+				"-v4",
+				"--region", region,
+			).
+			WithTimeout(20 * time.Minute)
+
+		Expect(cmd).To(RunSuccessfully())
+
+		By("fetching the new cluster")
+		cmd = eksctlGetCmd.WithArgs(
+			"cluster",
+			clusterName,
+			"--output", "json",
+		)
+
+		Expect(cmd).To(RunSuccessfullyWithOutputString(ContainSubstring(clusterName)))
+
+		By("adding a nodegroup")
+		cmd = eksctlCreateCmd.WithArgs(
+			"nodegroup",
+			"--cluster", clusterName,
+			"--nodes", "2",
+			newNgName,
+		)
+		Expect(cmd).To(RunSuccessfully())
+
+		By("scaling the initial nodegroup")
+		cmd = eksctlScaleNodeGroupCmd.WithArgs(
+			"--cluster", clusterName,
+			"--nodes", "3",
+			"--name", initialNgName,
+		)
+		Expect(cmd).To(RunSuccessfully())
+
+		By("deleting the new nodegroup")
+		cmd = eksctlDeleteCmd.WithArgs(
+			"nodegroup",
+			"--verbose", "4",
+			"--cluster", clusterName,
+			newNgName,
+		)
+		Expect(cmd).To(RunSuccessfully())
+
+		By("deleting the initial nodegroup")
+		cmd = eksctlDeleteCmd.WithArgs(
+			"nodegroup",
+			"--verbose", "4",
+			"--cluster", clusterName,
+			initialNgName,
+		)
+		Expect(cmd).To(RunSuccessfully())
+
+		By("deleting the cluster")
+		cmd = eksctlDeleteClusterCmd.WithArgs(
+			"--name", clusterName,
+		)
+		Expect(cmd).To(RunSuccessfully())
+	})
+})
+
+func downloadRelease(dir string) {
+	cmd := runner.NewCmd("./scripts/download-previous-release.sh").
+		WithEnv(
+			fmt.Sprintf("GO_BACK_VERSIONS=%d", goBackVersions),
+			fmt.Sprintf("DOWNLOAD_DIR=%s", dir),
+		).
+		WithTimeout(30 * time.Second)
+
+	ExpectWithOffset(1, cmd).To(RunSuccessfully())
+}
+
+func getVersion(eksctlPath string) (string, error) {
+	cmd := runner.NewCmd(eksctlPath).WithArgs("version")
+	session := cmd.Run()
+	if session.ExitCode() != 0 {
+		return "", errors.New(string(session.Err.Contents()))
+	}
+	return string(session.Buffer().Contents()), nil
+}

--- a/integration/scripts/download-previous-release.sh
+++ b/integration/scripts/download-previous-release.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -ex
+
+
+GIT_REPO_URL="git@github.com:weaveworks/eksctl"
+RELEASE_URL_FORMAT="https://github.com/weaveworks/eksctl/releases/download/%s/eksctl_Linux_amd64.tar.gz"
+
+download_previous_release() {
+    previous_tag=$(git ls-remote --tags $GIT_REPO_URL | egrep -v "latest_release|\-rc|{}" | cut -d/ -f3 | sort -Vr \
+        | tail -n "+${GO_BACK_VERSIONS}" | head -1)
+
+    download_url=$(printf "$RELEASE_URL_FORMAT" "$previous_tag")
+    curl -sL "${download_url}" | tar -xz -C "${DOWNLOAD_DIR}"
+}
+
+download_previous_release

--- a/pkg/vpc/vpc_test.go
+++ b/pkg/vpc/vpc_test.go
@@ -3,12 +3,13 @@ package vpc
 import (
 	"errors"
 	"fmt"
+	"net"
+
 	cfn "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/weaveworks/eksctl/pkg/utils/ipnet"
 	"github.com/weaveworks/eksctl/pkg/utils/strings"
-	"net"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"


### PR DESCRIPTION
### Description

Adds a backwards compatibility test that downloads a previous version of eksctl, creates a new cluster using that version, and tests `create nodegroup`, `scale nodegroup`, `delete nodegroup` and `delete cluster` operations using the current version.

Closes #1723 
<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
