### PR TITLE
Fix test failed due to IPv6 

### DIFF
--- a/pkg/iam/oidc/api_test.go
+++ b/pkg/iam/oidc/api_test.go
@@ -54,12 +54,13 @@ var _ = Describe("EKS/IAM API wrapper", func() {
 		})
 
 		It("should get cluster, and fail to connect to fake issue URL", func() {
-			oidc, err := NewOpenIDConnectManager(p.IAM(), "12345", "https://127.0.0.1:10020/")
+			oidc, err := NewOpenIDConnectManager(p.IAM(), "12345", "https://localhost:10020/")
 			Expect(err).NotTo(HaveOccurred())
 
 			err = oidc.getIssuerCAThumbprint()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(HavePrefix("connecting to issuer OIDC: Get https://127.0.0.1:10020/: dial tcp 127.0.0.1:10020: connect: connection refused"))
+			Expect(err.Error()).To(HavePrefix("connecting to issuer OIDC: Get https://localhost:10020/"))
+			Expect(err.Error()).To(HaveSuffix("connect: connection refused"))
 		})
 
 		It("should get OIDC issuer's CA fingerprint", func() {

--- a/pkg/iam/oidc/api_test.go
+++ b/pkg/iam/oidc/api_test.go
@@ -54,12 +54,12 @@ var _ = Describe("EKS/IAM API wrapper", func() {
 		})
 
 		It("should get cluster, and fail to connect to fake issue URL", func() {
-			oidc, err := NewOpenIDConnectManager(p.IAM(), "12345", "https://127.0.01:10020/")
+			oidc, err := NewOpenIDConnectManager(p.IAM(), "12345", "https://127.0.0.1:10020/")
 			Expect(err).NotTo(HaveOccurred())
 
 			err = oidc.getIssuerCAThumbprint()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(HavePrefix("connecting to issuer OIDC: Get https://127.0.01:10020/: dial tcp 127.0.0.1:10020: connect: connection refused"))
+			Expect(err.Error()).To(HavePrefix("connecting to issuer OIDC: Get https://127.0.0.1:10020/: dial tcp 127.0.0.1:10020: connect: connection refused"))
 		})
 
 		It("should get OIDC issuer's CA fingerprint", func() {

--- a/pkg/iam/oidc/api_test.go
+++ b/pkg/iam/oidc/api_test.go
@@ -54,12 +54,12 @@ var _ = Describe("EKS/IAM API wrapper", func() {
 		})
 
 		It("should get cluster, and fail to connect to fake issue URL", func() {
-			oidc, err := NewOpenIDConnectManager(p.IAM(), "12345", "https://localhost:10020/")
+			oidc, err := NewOpenIDConnectManager(p.IAM(), "12345", "https://127.0.01:10020/")
 			Expect(err).NotTo(HaveOccurred())
 
 			err = oidc.getIssuerCAThumbprint()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(HavePrefix("connecting to issuer OIDC: Get https://localhost:10020/: dial tcp 127.0.0.1:10020: connect: connection refused"))
+			Expect(err.Error()).To(HavePrefix("connecting to issuer OIDC: Get https://127.0.01:10020/: dial tcp 127.0.0.1:10020: connect: connection refused"))
 		})
 
 		It("should get OIDC issuer's CA fingerprint", func() {


### PR DESCRIPTION
### Description

Address https://github.com/weaveworks/eksctl/issues/1730

**__Notes__**:
I was thinking about to update `localhost` to `127.0.0.1` to by pass lookup, but `NewOpenIDConnectManager` method parsed input and derive host, which might impact mock function. 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
