### PR TITLE
[WIP] Add kubeconfig context flag in scale nodegroup

### DIFF
--- a/docs/release_notes/0.12.0.md
+++ b/docs/release_notes/0.12.0.md
@@ -22,6 +22,7 @@
 - improved Circleci build workflows (#1679)
 - update maxpods.go (#1659)
 - added `@weaveworks/team` to the pull-request template that mentions the maintainers (#1660)
+- add flag to select a kubeconfig context in scale nodegroups [//] #TODO list the commands with the flag
  
  
 ## Bug fixes

--- a/humans.txt
+++ b/humans.txt
@@ -63,6 +63,7 @@ Miguel Pereira          @onemorepereira
 Pedro Tôrres            @t0rr3sp3dr0
 Michael Treacher        @treacher
 Ajay Kemparaj           @ajayk
+Dinos Kousidis          @dinosk
 
 /* Thanks */
 

--- a/pkg/ctl/cmdutils/cmd.go
+++ b/pkg/ctl/cmdutils/cmd.go
@@ -23,6 +23,9 @@ type Cmd struct {
 	ProviderConfig *api.ProviderConfig
 	ClusterConfig  *api.ClusterConfig
 
+	KubeconfigContext string
+	KubeconfigPath    string
+
 	Include, Exclude []string
 }
 

--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -187,7 +187,18 @@ func AddCommonFlagsForKubeconfig(fs *pflag.FlagSet, outputPath, authenticatorRol
 	fs.BoolVar(autoPath, "auto-kubeconfig", false, fmt.Sprintf("save kubeconfig file by cluster name, e.g. %q", kubeconfig.AutoPath(exampleName)))
 }
 
-// AddCommonFlagsForGetCmd adds common flafs for get commands
+// AddCommonFlagsForKubeconfigContext adds flags for selecting the kubeconfig context
+func AddCommonFlagsForKubeconfigContext(fs *pflag.FlagSet, kubeconfigPath, context *string) {
+	fs.StringVar(kubeconfigPath, "kubeconfig-path", kubeconfig.DefaultPath, "specifies the path of the kubeconfig")
+	fs.StringVar(context, "use-kubeconfig-context", "", "specifies the kubeconfig context")
+}
+
+// KubeconfigContextFlag returns the flag to use for the kubeconfig context.
+func KubeconfigContextFlag(cmd *Cmd) string {
+	return "--use-kubeconfig-context"
+}
+
+// AddCommonFlagsForGetCmd adds common flags for get commands
 func AddCommonFlagsForGetCmd(fs *pflag.FlagSet, chunkSize *int, outputMode *printers.Type) {
 	fs.IntVar(chunkSize, "chunk-size", 100, "return large lists in chunks rather than all at once, pass 0 to disable")
 	fs.StringVarP(outputMode, "output", "o", "table", "specifies the output format (valid option: table, json, yaml)")
@@ -213,6 +224,11 @@ func ErrFlagAndArg(kind, flag, arg string) error {
 // ErrMustBeSet is a common error message
 func ErrMustBeSet(pathOrFlag string) error {
 	return fmt.Errorf("%s must be set", pathOrFlag)
+}
+
+// ErrAtLeastOneMustBeSet is a common error message
+func ErrAtLeastOneMustBeSet(pathsOrFlags ...string) error {
+	return fmt.Errorf("One of %s must be set", pathsOrFlags)
 }
 
 // ErrCannotUseWithConfigFile is a common error message

--- a/pkg/ctl/scale/nodegroup_test.go
+++ b/pkg/ctl/scale/nodegroup_test.go
@@ -1,0 +1,47 @@
+package scale
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("scale", func() {
+	Describe("scale nodegroup", func() {
+		It("requires the cluster's name, and if missing, prints an error and the usage", func() {
+			cmd := newMockScaleNodegroupCmd("nodegroup")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("One of [--cluster --use-kubeconfig-context] must be set"))
+			Expect(out).To(ContainSubstring("Error: One of [--cluster --use-kubeconfig-context] must be set"))
+			Expect(out).To(ContainSubstring("Usage:"))
+		})
+	})
+})
+
+func newMockScaleNodegroupCmd(args ...string) *mockScaleNodegroupCmd {
+	mockCmd := &mockScaleNodegroupCmd{}
+	grouping := cmdutils.NewGrouping()
+	parentCmd := cmdutils.NewVerbCmd("scale", "", "")
+	cmdutils.AddResourceCmd(grouping, parentCmd, func(cmd *cmdutils.Cmd) {
+		scaleNodeGroupCmd(cmd)
+	})
+	parentCmd.SetArgs(args)
+	mockCmd.parentCmd = parentCmd
+	return mockCmd
+}
+
+type mockScaleNodegroupCmd struct {
+	parentCmd *cobra.Command
+	cmd       *cmdutils.Cmd
+}
+
+func (c mockScaleNodegroupCmd) execute() (string, error) {
+	buf := new(bytes.Buffer)
+	c.parentCmd.SetOutput(buf)
+	err := c.parentCmd.Execute()
+	return buf.String(), err
+}

--- a/pkg/ctl/scale/scale_suite_test.go
+++ b/pkg/ctl/scale/scale_suite_test.go
@@ -1,0 +1,11 @@
+package scale_test
+
+import (
+	"testing"
+
+	"github.com/weaveworks/eksctl/pkg/testutils"
+)
+
+func TestSuite(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}


### PR DESCRIPTION
* Add kubeconfig context flag in scale nodegroup

Signed-off-by: Dinos Kousidis <dinkousidis@gmail.com>

### Description

Hi, this is a WIP PR with some changes addressing a part of #258
It implements flags: `--use-kubeconfig-context` and `--kubeconfig-path` in `eksctl scale nodegroup` which read the cluster name from a given context.

Some details in the combination of the flags and the cluster naming:
- If both `--cluster` and `--use-kubeconfig-context` are passed, the name is taken from the context, I'm not sure if the other way is better, or if an error should be raised instead.
- The path of the kubeconfig is expected to be absolute, from https://github.com/weaveworks/eksctl/blob/f920788fa4c4375493610f987d4fa1b3d6661f3b/pkg/utils/kubeconfig/kubeconfig.go#L159
- If the cluster name ends in ".eksctl.io" the name is split and the first part is stored, as the generated names in the kubeconfig have the suffix `.<region>.eksctl.io`.

If this is in the right direction, I can add some test cases and add it to other commands where it makes sense!

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [x] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
