### PR TITLE
Add release notes for 0.13.0 (+clean-up)

### DIFF
--- a/docs/release_notes/0.12.0.md
+++ b/docs/release_notes/0.12.0.md
@@ -1,4 +1,4 @@
-# Draft
+# Release 0.12.0
 
 ## Features
 
@@ -9,7 +9,6 @@
 - support using a proxy in the IAM OIDC provider configuration (#1620)
 - enable support for Managed Nodegroups when upgrading from EKS 1.13 to 1.14 (#1656)
   - `--wait` flag is no longer supported in `eksctl update cluster`
-
 
 ## Improvements
 
@@ -22,8 +21,7 @@
 - improved Circleci build workflows (#1679)
 - update maxpods.go (#1659)
 - added `@weaveworks/team` to the pull-request template that mentions the maintainers (#1660)
- 
- 
+
 ## Bug fixes
 
 - fix setup script if GOPATH contains multiple paths (#1632)

--- a/docs/release_notes/0.13.0.md
+++ b/docs/release_notes/0.13.0.md
@@ -1,0 +1,29 @@
+# Release 0.13.0
+
+## Improvements
+
+- enabled building snaps from source (#969)
+- added installation instructions for MacPorts on macOS (#1708)
+- added tests for `pkg/vpc/vpc.go` (#1712)
+- fixed test failing due to IPv6 (#1731)
+- added integration tests for backwards compatibility with older versions of eksctl (#1724)
+- sanitised & streamlined CI & release pipeline (#1443, #1691, #1689, #1700, #1715)
+- fixed typo in error message (#1694)
+
+## Bug fixes
+
+- fixed nodegroup creation when `imageBuilder` is enabled; fixed duplicate policies (#1705)
+- fixed path to SSH key in integration tests (#1704)
+
+## Acknowledgment
+
+Weaveworks would like to sincerely thank:
+
+- @clareliguori (#1694)
+- @dholbach (#969)
+- @mikeroyal (#969)
+- @sayboras (#1443, #1712, #1731)
+- @szczad (#1708)
+
+for their contributions to this release. Your work is highly appreciated and
+the project would not have gotten this far without people like you!

--- a/docs/release_notes/0.14.0-draft.md
+++ b/docs/release_notes/0.14.0-draft.md
@@ -1,4 +1,4 @@
-# Release X.Y.Z
+# Release 0.14.0
 
 ## Features
 

--- a/docs/release_notes/draft.md
+++ b/docs/release_notes/draft.md
@@ -1,0 +1,7 @@
+# Release X.Y.Z
+
+## Features
+
+## Improvements
+
+## Bug fixes


### PR DESCRIPTION
### Description

- Clean-up `0.12.0`'s release notes.
- Add draft.md back for the next release's notes.
- Add release notes for `0.13.0`.

### Checklist

- [x] ~Added tests that cover your change (if possible)~ (Irrelevant.)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] ~Manually tested~ (Irrelevant.)
- [x] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [x] Added note in `docs/release_notes/draft.md` (or relevant release note)
