### PR TITLE
Notify us on slack when IT fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ commands:
           name: Prepare SSH keys to be mounted with the right permissions for Git
           command: |
             if [ ! -z "$SSH_KEY_NAME" ]; then
-              cp -r $HOME/.ssh $HOME/project/.ssh
-              sudo printf "Host github.com\n  IdentityFile /root/.ssh/$SSH_KEY_NAME\n" > $HOME/project/.ssh/config
+              sudo cp -r $HOME/.ssh $HOME/project/
+              printf "Host github.com\n  IdentityFile /root/.ssh/$SSH_KEY_NAME\n" | sudo tee $HOME/project/.ssh/config
               sudo chmod -R 600 $HOME/project/.ssh
               sudo chown -R root:root $HOME/project/.ssh
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  slack: circleci/slack@3.4.2
+
 commands:
   prepare-ssh-keys:
     description: Prepare SSH keys to be mounted with the right permissions for Git
@@ -64,6 +67,14 @@ commands:
           paths:
             - "/home/circleci/.cache/go-build/"
             - "/home/circleci/go/pkg/mod/"
+  notify-slack:
+    description: Notify failures via Slack
+    steps:
+      - run: exit 0
+      - slack/status:
+          fail_only: true
+          mentions: 'team-aws'
+          only_for_branches: master
 
 jobs:
   test-and-build:
@@ -191,6 +202,7 @@ jobs:
           path: ./test-results
       - store_artifacts:
           path: ./test-results
+      - notify-slack
 
 workflows:
   version: 2


### PR DESCRIPTION
Use the slack Orb for circleci to notify the team on Slack when the nightly run of IT fails.

- [x] Manually tested

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->