### PR TITLE
Added the ability to override the kube config cluster server.

### DIFF
--- a/docs/release_notes/0.14.0-draft.md
+++ b/docs/release_notes/0.14.0-draft.md
@@ -6,7 +6,7 @@
 
 - Improve versioning of eksctl (#1726)
 - Added the ability to override the kube config cluster server using the
-  following environment variable `KUBECONFIG_CLUSTER_ENDPOINT`.
+  following environment variable `KUBECONFIG_CLUSTER_ENDPOINT`. (#1746)
 
 ## Bug fixes
 

--- a/docs/release_notes/0.14.0-draft.md
+++ b/docs/release_notes/0.14.0-draft.md
@@ -5,8 +5,9 @@
 ## Improvements
 
 - Improve versioning of eksctl (#1726)
- 
- 
+- Added the ability to override the kube config cluster server using the
+  following environment variable `KUBECONFIG_CLUSTER_ENDPOINT`.
+
 ## Bug fixes
 
 - fix changing public/private endpoints setting from file (#1693)

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -63,6 +63,12 @@ func New(spec *api.ClusterConfig, username, certificateAuthorityPath string) (*c
 		CurrentContext: contextName,
 	}
 
+	clusterEndpoint, hasClusterEndpoint := os.LookupEnv("KUBECONFIG_CLUSTER_ENDPOINT")
+
+	if hasClusterEndpoint {
+		c.Clusters[clusterName].Server = clusterEndpoint
+	}
+
 	if certificateAuthorityPath == "" {
 		c.Clusters[clusterName].CertificateAuthorityData = spec.Status.CertificateAuthorityData
 	} else {

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -137,6 +137,33 @@ var _ = Describe("Kubeconfig", func() {
 		Expect(readConfig.CurrentContext).To(Equal("minikube"))
 	})
 
+	Context("KUBECONFIG_CLUSTER_ENDPOINT environment variable is set", func() {
+		var clusterConfig = eksctlapi.ClusterConfig{
+			Metadata: &eksctlapi.ClusterMeta{
+				Region: "us-west-2",
+				Name:   "foo",
+				Tags:   map[string]string{},
+			},
+			Status: &eksctlapi.ClusterStatus{
+				Endpoint: "https://eks-endpoint.com",
+			},
+		}
+
+		var expectedClusterName = "foo.us-west-2.eksctl.io"
+		var expectedContextName = "test-user@foo.us-west-2.eksctl.io"
+		var eksEndpoint = "http://my-eks-endpoint.com:8000"
+
+		os.Setenv("KUBECONFIG_CLUSTER_ENDPOINT", eksEndpoint)
+
+		It("sets the EKS Endpoint to be the value passed via the override", func() {
+			config, clusterName, contextName := kubeconfig.New(&clusterConfig, "test-user", "")
+
+			Expect(clusterName).To(Equal(expectedClusterName))
+			Expect(contextName).To(Equal(expectedContextName))
+			Expect(config.Clusters[expectedClusterName].Server).To(Equal(eksEndpoint))
+		})
+	})
+
 	Context("delete config", func() {
 		// Default cluster name is 'foo' and region is 'us-west-2'
 		var apiClusterConfigSample = eksctlapi.ClusterConfig{

--- a/site/content/usage/06-vpc-networking.md
+++ b/site/content/usage/06-vpc-networking.md
@@ -243,6 +243,6 @@ override the cluster endpoint that's generated when running eksctl commands.
 
 This can be achieved by setting the following environment variable `KUBECONFIG_CLUSTER_ENDPOINT` when running eksctl commands:
 ```
-export KUBECONFIG_CLUSTER_ENDPOINT=https://$KUBERNETES_API_ENDPOINT:8001
+export KUBECONFIG_CLUSTER_ENDPOINT=https://<local-url-for-cluster>:<port>
 eksctl get iamidentitymapping --cluster <cluster-name>
 ```

--- a/site/content/usage/06-vpc-networking.md
+++ b/site/content/usage/06-vpc-networking.md
@@ -235,3 +235,14 @@ won't change, and you will still have the option to disable the public endpoint 
 the internet. (Source: https://github.com/aws/containers-roadmap/issues/108#issuecomment-552766489)
 
 Implementation notes: https://github.com/aws/containers-roadmap/issues/108#issuecomment-552698875
+
+**Note for using port forwarding with eksctl commands:**
+
+If you access your private cluster locally using port forwarding you'll need to
+override the cluster endpoint that's generated when running eksctl commands.
+
+This can be achieved by setting the following environment variable `KUBECONFIG_CLUSTER_ENDPOINT` when running eksctl commands:
+```
+export KUBECONFIG_CLUSTER_ENDPOINT=https://$KUBERNETES_API_ENDPOINT:8001
+eksctl get iamidentitymapping --cluster <cluster-name>
+```


### PR DESCRIPTION
### Description

This change allows users with a private cluster to be able to use SSH
tunnelling to access the cluster from their local machine via a
port other than 443.

The KUBECONFIG_CLUSTER_ENDPOINT environment variable can now be
set to override the cluster endpoint in the kube config object
that's generated via kubeconfig.go.

This change references #1552 and #1618

### Manual Testing Performed

Ran the following commands with and without setting the `KUBECONFIG_CLUSTER_ENDPOINT`

- eksctl get iamidentitymapping
- eksctl create iamidentitymapping
- eksctl delete iamidentitymapping
- eksctl create iamserviceaccount
- eksctl delete iamserviceaccount
- eksctl create nodegroup
- eksctl delete nodegroup
- eksctl drain nodegroup
- eksctl delete cluster

I observed that the above commands were still using the EKSEndpoint output from the EKS Cluster stack when not setting the KUBECONFIG_CLUSTER_ENDPOINT environment variable.

I observed that the above commands used my specified endpoint when setting the KUBECONFIG_CLUSTER_ENDPOINT environment variable and that the command succeeded. 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [x] Added note in `docs/release_notes/draft.md` (or relevant release note)
