### PR TITLE
Add NodeRole for managed group

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -354,10 +354,6 @@ func ValidateManagedNodeGroup(ng *ManagedNodeGroup, index int) error {
 		if ng.IAM.InstanceProfileARN != "" {
 			return errNotSupported("instanceProfileARN")
 		}
-
-		if ng.IAM.InstanceRoleARN != "" {
-			return errNotSupported("instanceRoleARN")
-		}
 	}
 
 	// TODO fix error messages to not use CLI flags

--- a/pkg/cfn/builder/managed_nodegroup.go
+++ b/pkg/cfn/builder/managed_nodegroup.go
@@ -81,7 +81,7 @@ func (m *ManagedNodeGroupResourceSet) AddAllResources() error {
 		"[created by eksctl]")
 
 	var nodeRole *gfn.Value
-	if !api.IsSetAndNonEmptyString(&m.nodeGroup.IAM.InstanceRoleARN) {
+	if m.nodeGroup.IAM.InstanceRoleARN == "" {
 		createRole(m.resourceSet, m.nodeGroup.IAM, true)
 		nodeRole = gfn.MakeFnGetAttString(fmt.Sprintf("%s.%s", cfnIAMInstanceRoleName, "Arn"))
 	} else {

--- a/pkg/cfn/builder/managed_nodegroup.go
+++ b/pkg/cfn/builder/managed_nodegroup.go
@@ -80,7 +80,13 @@ func (m *ManagedNodeGroupResourceSet) AddAllResources() error {
 		api.IsEnabled(m.nodeGroup.SSH.Allow),
 		"[created by eksctl]")
 
-	createRole(m.resourceSet, m.nodeGroup.IAM, true)
+	var nodeRole *gfn.Value
+	if !api.IsSetAndNonEmptyString(&m.nodeGroup.IAM.InstanceRoleARN) {
+		createRole(m.resourceSet, m.nodeGroup.IAM, true)
+		nodeRole = gfn.MakeFnGetAttString(fmt.Sprintf("%s.%s", cfnIAMInstanceRoleName, "Arn"))
+	} else {
+		nodeRole = gfn.NewString(m.nodeGroup.IAM.InstanceRoleARN)
+	}
 
 	subnets, err := AssignSubnets(m.nodeGroup.AvailabilityZones, m.clusterStackName, m.clusterConfig, false)
 	if err != nil {
@@ -100,11 +106,9 @@ func (m *ManagedNodeGroupResourceSet) AddAllResources() error {
 		// Currently the API supports specifying only one instance type
 		InstanceTypes: []string{m.nodeGroup.InstanceType},
 		AmiType:       getAMIType(m.nodeGroup.InstanceType),
-		// ManagedNodeGroup.IAM.InstanceRoleARN is not supported, so this field is always retrieved from the
-		// CFN resource
-		NodeRole: gfn.MakeFnGetAttString(fmt.Sprintf("%s.%s", cfnIAMInstanceRoleName, "Arn")),
-		Labels:   m.nodeGroup.Labels,
-		Tags:     m.nodeGroup.Tags,
+		NodeRole:      nodeRole,
+		Labels:        m.nodeGroup.Labels,
+		Tags:          m.nodeGroup.Tags,
 	}
 
 	if api.IsEnabled(m.nodeGroup.SSH.Allow) {

--- a/site/content/examples/01-reusing-iam-and-vpc.md
+++ b/site/content/examples/01-reusing-iam-and-vpc.md
@@ -47,6 +47,26 @@ nodeGroups:
       publicKeyName: 'my-instance-key'
     tags:
       'environment:basedomain': 'example.org'
+
+managedNodeGroups:
+  - name: managed-1
+    instanceType: m5.large
+    minSize: 2
+    desiredCapacity: 3
+    maxSize: 4
+    availabilityZones: ["us-west-2a", "us-west-2b"]
+    volumeSize: 20
+    ssh:
+      allow: false
+    labels: {role: worker}
+    tags:
+      'environment:basedomain': 'example.org'
+    iam:
+      instanceRoleARN: "arn:aws:iam::1111:role/eks-nodes-base-role"
+      withAddonPolicies:
+        externalDNS: true
+        certManager: true
+
 ```
 
 [comment]: <> (TODO explain in more detail)

--- a/site/content/usage/15-eks-managed-nodes.md
+++ b/site/content/usage/15-eks-managed-nodes.md
@@ -178,7 +178,7 @@ The unsupported options are noted below.
 - No support for private networking (`nodeGroups[*].privateNetworking`).
 - Tags (`managedNodeGroups[*].tags`) in managed nodegroups apply to the EKS Nodegroup resource and do not propagate to
 the provisioned Autoscaling Group like in unmanaged nodegroups.
-- `iam.instanceProfileARN` and `iam.instanceRoleARN` are not supported for managed nodegroups.
+- `iam.instanceProfileARN` is not supported for managed nodegroups.
 - The `amiFamily` field supports only `AmazonLinux2`
 - `instancesDistribution` field is not supported
 - `volumeSize` is the only field supported for configuring volumes


### PR DESCRIPTION
### Description
Fixes https://github.com/weaveworks/eksctl/issues/1682

I am using existing `instanceRoleARN` from NodeGroup object. We can also introduce the new name e.g. managedNodeRole or something similar

Changes are tested manual with the below config file:
```
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig
metadata:
  name: sandbox-managed-nodegroup
  region: ap-southeast-2

iam:
  serviceRoleARN: "arn:aws:iam::XXXXXXXX:role/eks-sandbox-EKS-XXXX-EKSRole-1MSYXRT9H5X5Q"
  fargatePodExecutionRoleARN: "arn:aws:iam::XXXXXXXX:role/eks-sandbox-EKS-XXXX-EKSRole-1MSYXRT9H5X5Q"

vpc:
  subnets:
    private:
      ap-southeast-2a:
        id: "subnet-XXXXXXdd"
      ap-southeast-2b:
        id: "subnet-XXXXXX17"
      ap-southeast-2c:
        id: "subnet-XXXXXX7d"
    public:
      ap-southeast-2a:
        id: "subnet-XXXXXX27c"
      ap-southeast-2b:
        id: "subnet-XXXXXX91"
      ap-southeast-2c:
        id: "subnet-XXXXXXd7"

managedNodeGroups:
  - name: standard-workers
    instanceType: t3.medium
    desiredCapacity: 1
    minSize: 1
    maxSize: 4
    iam:
      instanceRoleARN: "arn:aws:iam::XXXXXXXX:role/eks-sandbox-EKS-XXXX-EKSRole-1MSYXRT9H5X5Q"
```

```
./eksctl create cluster --cfn-role-arn arn:aws:iam::XXXX:role/eks-deploy-role --config-file test.yaml
[ℹ]  eksctl version 0.13.0-dev+19324e21.2020-01-23T21:05:03Z
[ℹ]  using region ap-southeast-2
[✔]  using existing VPC (vpc-XXX) and subnets (private:[subnet-XXX subnet-XXX subnet-019189ea518da77dd] public:[subnet-XXX subnet-XXX subnet-XXX])
[!]  custom VPC/subnets will be used; if resulting cluster doesn't function as expected, make sure to review the configuration of VPC/subnets
[ℹ]  using Kubernetes version 1.14
[ℹ]  creating EKS cluster "sandbox-managed-nodegroup" in "ap-southeast-2" region with managed nodes
[ℹ]  1 nodegroup (standard-workers) was included (based on the include/exclude rules)
[ℹ]  will create a CloudFormation stack for cluster itself and 0 nodegroup stack(s)
[ℹ]  will create a CloudFormation stack for cluster itself and 1 managed nodegroup stack(s)
[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=ap-southeast-2 --cluster=sandbox-managed-nodegroup'
[ℹ]  CloudWatch logging will not be enabled for cluster "sandbox-managed-nodegroup" in "ap-southeast-2"
[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --region=ap-southeast-2 --cluster=sandbox-managed-nodegroup'
[ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "sandbox-managed-nodegroup" in "ap-southeast-2"
[ℹ]  2 sequential tasks: { create cluster control plane "sandbox-managed-nodegroup", create managed nodegroup "standard-workers" }
[ℹ]  building cluster stack "eksctl-sandbox-managed-nodegroup-cluster"
[ℹ]  deploying stack "eksctl-sandbox-managed-nodegroup-cluster"
[ℹ]  building managed nodegroup stack "eksctl-sandbox-managed-nodegroup-nodegroup-standard-workers"
[ℹ]  deploying stack "eksctl-sandbox-managed-nodegroup-nodegroup-standard-workers"
[✔]  all EKS cluster resources for "sandbox-managed-nodegroup" have been created
[✔]  saved kubeconfig as "/home/XXX/.kube/config"
````
### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
