### PR TITLE
Create Fargate role only if there is --fargate

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -193,11 +193,11 @@ func ClusterEndpointAccessDefaults() *ClusterEndpoints {
 // the "default" and "kube-system" Kubernetes namespaces.
 func (c *ClusterConfig) SetDefaultFargateProfile() {
 	c.FargateProfiles = []*FargateProfile{
-		&FargateProfile{
+		{
 			Name: "fp-default",
 			Selectors: []FargateProfileSelector{
-				FargateProfileSelector{Namespace: "default"},
-				FargateProfileSelector{Namespace: "kube-system"},
+				{Namespace: "default"},
+				{Namespace: "kube-system"},
 			},
 		},
 	}

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -399,7 +399,6 @@ var _ = Describe("CloudFormation template builder API", func() {
 			VPC:               testVPC(),
 			IAM: &api.ClusterIAM{
 				ServiceRoleARN:             aws.String(arn),
-				FargatePodExecutionRoleARN: aws.String(fargatePodExecutionRoleARN),
 			},
 			CloudWatch: &api.ClusterCloudWatch{
 				ClusterLogging: &api.ClusterCloudWatchLogging{},
@@ -2162,10 +2161,9 @@ var _ = Describe("CloudFormation template builder API", func() {
 
 		roundtrip()
 
-		It("should only have EKS and Fargate resources", func() {
+		It("should only have EKS resources", func() {
 			Expect(clusterTemplate.Resources).To(HaveKey("ControlPlane"))
-			Expect(clusterTemplate.Resources).To(HaveKey("FargatePodExecutionRole"))
-			Expect(clusterTemplate.Resources).To(HaveLen(2))
+			Expect(clusterTemplate.Resources).To(HaveLen(1))
 
 			cp := clusterTemplate.Resources["ControlPlane"].Properties
 
@@ -2193,10 +2191,9 @@ var _ = Describe("CloudFormation template builder API", func() {
 		It("should have EKS and IAM resources", func() {
 			Expect(clusterTemplate.Resources).To(HaveKey("ControlPlane"))
 			Expect(clusterTemplate.Resources).To(HaveKey("ServiceRole"))
-			Expect(clusterTemplate.Resources).To(HaveKey("FargatePodExecutionRole"))
 			Expect(clusterTemplate.Resources).To(HaveKey("PolicyNLB"))
 			Expect(clusterTemplate.Resources).To(HaveKey("PolicyCloudWatchMetrics"))
-			Expect(clusterTemplate.Resources).To(HaveLen(5))
+			Expect(clusterTemplate.Resources).To(HaveLen(4))
 		})
 
 		It("should have correct own IAM resources", func() {
@@ -2292,7 +2289,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 				}
 			}
 
-			Expect(len(clusterTemplate.Resources)).To(Equal(33))
+			Expect(len(clusterTemplate.Resources)).To(Equal(32))
 		})
 
 		It("should use own VPC and subnets", func() {
@@ -2387,7 +2384,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 				}
 			}
 
-			Expect(len(clusterTemplate.Resources)).To(Equal(40))
+			Expect(len(clusterTemplate.Resources)).To(Equal(39))
 		})
 
 		It("should use own VPC and subnets", func() {
@@ -2464,7 +2461,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 				Expect(clusterTemplate.Resources).To(HaveKey("RouteTableAssociationPrivate" + region + zone))
 			}
 
-			Expect(len(clusterTemplate.Resources)).To(Equal(37))
+			Expect(len(clusterTemplate.Resources)).To(Equal(36))
 		})
 
 		It("should route Internet traffic from private subnets through their corresponding NAT gateways", func() {
@@ -2510,7 +2507,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 				Expect(clusterTemplate.Resources).To(HaveKey("RouteTableAssociationPrivate" + region + zone))
 			}
 
-			Expect(len(clusterTemplate.Resources)).To(Equal(33))
+			Expect(len(clusterTemplate.Resources)).To(Equal(32))
 		})
 
 		It("should route Internet traffic from private subnets through the single NAT gateway", func() {
@@ -2553,7 +2550,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 				Expect(clusterTemplate.Resources).To(HaveKey("RouteTableAssociationPrivate" + region + zone))
 			}
 
-			Expect(len(clusterTemplate.Resources)).To(Equal(28))
+			Expect(len(clusterTemplate.Resources)).To(Equal(27))
 
 		})
 

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -2151,10 +2151,12 @@ var _ = Describe("CloudFormation template builder API", func() {
 		name := "test-fargate-profile"
 		cfg.Metadata.Name = name
 		cfg.FargateProfiles = []*api.FargateProfile{
+			// default fargate profile
 			{
-				Name: "fp-dev",
+				Name: "fp-default",
 				Selectors: []api.FargateProfileSelector{
-					{Namespace: "dev"},
+					{Namespace: "default"},
+					{Namespace: "kube-system"},
 				},
 			},
 		}

--- a/pkg/cfn/builder/cluster.go
+++ b/pkg/cfn/builder/cluster.go
@@ -70,7 +70,10 @@ func (c *ClusterResourceSet) AddAllResources() error {
 	c.addResourcesForSecurityGroups()
 	c.addResourcesForIAM()
 	c.addResourcesForControlPlane()
-	c.addResourcesForFargate()
+
+	if len(c.spec.FargateProfiles) > 0 {
+		c.addResourcesForFargate()
+	}
 
 	c.rs.defineOutput(outputs.ClusterStackName, gfn.RefStackName, false, func(v string) error {
 		if c.spec.Status == nil {


### PR DESCRIPTION
### Description

Resolves https://github.com/weaveworks/eksctl/issues/1669

If `--fargate` flag is enabled, we will have the 2 default fargate profiles, so this can be used to check if we need to create FargatePodExecutionRole or not (without progragate fargate flag from CLI to the handler)

I have tested manually with the below config

```
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig
metadata:
  name: sandbox-managed-nodegroup
  region: ap-southeast-2
iam:
  serviceRoleARN: "arn:aws:iam::XXXX:role/eks-sandbox-EKS-XXXX-EKSRole-XXXX"
managedNodeGroups:
  - name: standard-workers
    instanceType: t3.medium
    desiredCapacity: 1
    minSize: 1
    maxSize: 4
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
