### PR TITLE
Fix running backwards compatibility tests in the built container image

### DIFF
--- a/integration/scripts/download-previous-release.sh
+++ b/integration/scripts/download-previous-release.sh
@@ -9,7 +9,7 @@ download_previous_release() {
         | tail -n "+${GO_BACK_VERSIONS}" | head -1)
 
     download_url=$(printf "$RELEASE_URL_FORMAT" "$previous_tag")
-    curl -sL "${download_url}" | tar -xz -C "${DOWNLOAD_DIR}"
+    wget -q -O - "${download_url}" | tar -xz -C "${DOWNLOAD_DIR}"
 }
 
 download_previous_release


### PR DESCRIPTION
### Description
Prefer using wget over curl, as wget is already available in BusyBox. 
curl is installed in the base layer of the container image (used for installing build-time dependencies), but not copied in the final layer, so it's not available.

Closes #1723 
<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
