### PR TITLE
Add EKSCTL version tag in cloudformation

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -133,7 +133,7 @@ const (
 	// using an SSM GetParameter query
 	NodeImageResolverAutoSSM = "auto-ssm"
 
-	// EksctlVersionTag defines the tag of the cluster name
+	// EksctlVersionTag defines the version of eksctl which is used to provision or update EKS cluster
 	EksctlVersionTag = "alpha.eksctl.io/eksctl-version"
 
 	// ClusterNameTag defines the tag of the cluster name

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -133,6 +133,9 @@ const (
 	// using an SSM GetParameter query
 	NodeImageResolverAutoSSM = "auto-ssm"
 
+	// EksctlVersionTag defines the tag of the cluster name
+	EksctlVersionTag = "alpha.eksctl.io/eksctl-version"
+
 	// ClusterNameTag defines the tag of the cluster name
 	ClusterNameTag = "alpha.eksctl.io/cluster-name"
 

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"fmt"
+	"github.com/weaveworks/eksctl/pkg/version"
 	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -53,6 +54,7 @@ func NewStackCollection(provider api.ClusterProvider, spec *api.ClusterConfig) *
 	tags := []*cloudformation.Tag{
 		newTag(api.ClusterNameTag, spec.Metadata.Name),
 		newTag(api.OldClusterNameTag, spec.Metadata.Name),
+		newTag(api.EksctlVersionTag, version.GetVersionInfo().Version),
 	}
 	for key, value := range spec.Metadata.Tags {
 		tags = append(tags, newTag(key, value))

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -463,7 +463,7 @@ func (c *StackCollection) LookupCloudTrailEvents(i *Stack) ([]*cloudtrail.Event,
 		return true
 	}
 	if err := c.provider.CloudTrail().LookupEventsPages(input, pager); err != nil {
-		return nil, errors.Wrapf(err, "looking up CloduTrail events for stack %q", *i.StackName)
+		return nil, errors.Wrapf(err, "looking up CloudTrail events for stack %q", *i.StackName)
 	}
 
 	return events, nil

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -2,8 +2,9 @@ package manager
 
 import (
 	"fmt"
-	"github.com/weaveworks/eksctl/pkg/version"
 	"regexp"
+
+	"github.com/weaveworks/eksctl/pkg/version"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -476,10 +476,7 @@ func (c *StackCollection) doCreateChangeSetRequest(i *Stack, changeSetName strin
 		ChangeSetName: &changeSetName,
 		Description:   &description,
 		Tags: []*cloudformation.Tag{
-			{
-				Key:   aws.String(api.EksctlVersionTag),
-				Value: aws.String(version.GetVersionInfo().Version),
-			},
+			newTag(api.EksctlVersionTag, version.GetVersionInfo().Version),
 		},
 	}
 

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -55,7 +55,7 @@ func NewStackCollection(provider api.ClusterProvider, spec *api.ClusterConfig) *
 	tags := []*cloudformation.Tag{
 		newTag(api.ClusterNameTag, spec.Metadata.Name),
 		newTag(api.OldClusterNameTag, spec.Metadata.Name),
-		newTag(api.EksctlVersionTag, version.GetVersionInfo().Version),
+		newTag(api.EksctlVersionTag, version.GetVersion()),
 	}
 	for key, value := range spec.Metadata.Tags {
 		tags = append(tags, newTag(key, value))
@@ -476,7 +476,7 @@ func (c *StackCollection) doCreateChangeSetRequest(i *Stack, changeSetName strin
 		ChangeSetName: &changeSetName,
 		Description:   &description,
 		Tags: []*cloudformation.Tag{
-			newTag(api.EksctlVersionTag, version.GetVersionInfo().Version),
+			newTag(api.EksctlVersionTag, version.GetVersion()),
 		},
 	}
 

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -244,7 +244,7 @@ func (c *StackCollection) ListStacks(statusFilters ...string) ([]*Stack, error) 
 	return c.ListStacksMatching(fmtStacksRegexForCluster(c.spec.Metadata.Name))
 }
 
-// StackStatusIsNotTransitional will return true when stack statate is non-transitional
+// StackStatusIsNotTransitional will return true when stack status is non-transitional
 func (*StackCollection) StackStatusIsNotTransitional(s *Stack) bool {
 	for _, state := range nonTransitionalReadyStackStatuses() {
 		if *s.StackStatus == state {
@@ -475,6 +475,12 @@ func (c *StackCollection) doCreateChangeSetRequest(i *Stack, changeSetName strin
 		StackName:     i.StackName,
 		ChangeSetName: &changeSetName,
 		Description:   &description,
+		Tags: []*cloudformation.Tag{
+			{
+				Key:   aws.String(api.EksctlVersionTag),
+				Value: aws.String(version.GetVersionInfo().Version),
+			},
+		},
 	}
 
 	input.SetChangeSetType(cloudformation.ChangeSetTypeUpdate)


### PR DESCRIPTION
### Description

Address https://github.com/weaveworks/eksctl/issues/1671

The tag name is `alpha.eksctl.io/eksctl-version` as per below screen shots. This tag will be updated upon create stack and update.

![image](https://user-images.githubusercontent.com/9019229/73150381-386f6100-411a-11ea-827b-288421a9af11.png)


### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
