### PR TITLE
Add tags flag in create nodegroup CLI

### DIFF
--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -44,6 +44,7 @@ func createNodeGroupCmd(cmd *cmdutils.Cmd) {
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "name of the EKS cluster to add the nodegroup to")
+		fs.StringToStringVarP(&cfg.Metadata.Tags, "tags", "", map[string]string{}, `A list of KV pairs used to tag the AWS resources (e.g. "Owner=John Doe,Team=Some Team")`)
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddVersionFlag(fs, cfg.Metadata, `for nodegroups "auto" and "latest" can be used to automatically inherit version from the control plane or force latest`)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)


### PR DESCRIPTION
### Description

fix: https://github.com/weaveworks/eksctl/issues/1759

`Tags` are supported in config file for both managed and un-manged node group, but the respective flag is not available for `create nodegroup` CLI. 

Manually testing with the below commands.

```
./eksctl create nodegroup --region us-east-2 --cluster fargate --name testing-tag --tags "cli=tag"
[ℹ]  eksctl version 0.13.0-dev+a2be66b9.2020-01-27T22:08:40Z
[ℹ]  using region us-east-2
[ℹ]  will use version 1.14 for new nodegroup(s) based on control plane version
[ℹ]  nodegroup "testing-tag" will use "ami-080fbb09ee2d4d3fa" [AmazonLinux2/1.14]
[ℹ]  1 nodegroup (testing-tag) was included (based on the include/exclude rules)
[ℹ]  will create a CloudFormation stack for each of 1 nodegroups in cluster "fargate"
[ℹ]  2 sequential tasks: { fix cluster compatibility, 1 task: { 1 task: { create nodegroup "testing-tag" } } }
[ℹ]  checking cluster stack for missing resources
[ℹ]  cluster stack has all required resources
[ℹ]  building nodegroup stack "eksctl-fargate-nodegroup-testing-tag"
[ℹ]  --nodes-min=2 was set automatically for nodegroup testing-tag
[ℹ]  --nodes-max=2 was set automatically for nodegroup testing-tag
[ℹ]  deploying stack "eksctl-fargate-nodegroup-testing-tag"
```

![image](https://user-images.githubusercontent.com/9019229/73170811-72a92480-4153-11ea-8219-a8b47cb42732.png)

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
