### PR TITLE
Fix missing format string in log line

### DIFF
--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -276,7 +276,7 @@ func deleteClusterInfo(existing *clientcmdapi.Config, meta *api.ClusterMeta) boo
 
 	if existing.CurrentContext == currentContextName {
 		existing.CurrentContext = ""
-		logger.Debug("reset current-context in kubeconfig", currentContextName)
+		logger.Debug("reset current-context in kubeconfig to %q", currentContextName)
 		isChanged = true
 	}
 


### PR DESCRIPTION
This was printing:

```
2020-01-26T03:54:39Z [▶]  reset current-context in kubeconfig
%!!(MISSING)(EXTRA string=)2020-01-26T03:54:39Z [✔]  kubeconfig has been updated
2020-01-26T03:54:40Z [▶]  nodegroups = []
2020-01-26T03:54:40Z [▶]  waiting for CloudFormation stack "eksctl-managed-amazing-creature-1580..."
```


- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->