### PR TITLE
snap: drop 'go-bindata' as build-dep, we get it from git

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,7 +46,6 @@ parts:
       - g++
       - gcc
       - git
-      - go-bindata
       - time
     build-environment:
       - GOBIN: '$SNAPCRAFT_PART_INSTALL/bin'


### PR DESCRIPTION
snap: drop 'go-bindata' as build-dep, we get it from git