### PR TITLE
Add documentation about alternative ways to delete clusters

### DIFF
--- a/site/content/usage/01-creating-and-managing-clusters.md
+++ b/site/content/usage/01-creating-and-managing-clusters.md
@@ -106,5 +106,6 @@ eksctl delete cluster -f cluster.yaml
 > stack and won't wait for its deletion.
 > In some cases, AWS resources using the cluster or its VPC may cause cluster deletion to fail. To ensure any deletion
 > errors are propagated in `eksctl delete cluster`, the `--wait` flag must be used.
+> If your delete fails or you forget the wait flag, you may have to go to the CloudFormation GUI and delete the eks stacks from there.
 
 See [`examples/`](https://github.com/weaveworks/eksctl/tree/master/examples) directory for more sample config files.

--- a/site/content/usage/21-troubleshooting.md
+++ b/site/content/usage/21-troubleshooting.md
@@ -45,3 +45,6 @@ vpc:
       us-east-1a: {id: subnet-33333333}
       us-east-1b: {id: subnet-44444444}
 ```
+
+### Deletion issues
+If your delete does not work, or you forget to add `--wait` on the delete, you may need to go to use amazon's other tools to delete the cloudformation stacks. This can be accomplished via the gui or with the aws cli.


### PR DESCRIPTION
### Description

I added a couple of lines to help people delete the EKS cluster in the event of failures.

### Checklist

- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)

