### PR TITLE
Remove impossible condition: nil != nil

### DIFF
--- a/pkg/authconfigmap/authconfigmap.go
+++ b/pkg/authconfigmap/authconfigmap.go
@@ -169,9 +169,6 @@ func (a *AuthConfigMap) RemoveIdentity(arnToDelete string, all bool) error {
 	newidentities := make([]iam.Identity, 0)
 	for i, identity := range identities {
 		arn := identity.ARN()
-		if err != nil {
-			return err
-		}
 		if arn == arnToDelete {
 			logger.Info("removing identity %q from auth ConfigMap (username = %q, groups = %q)", arnToDelete, identity.Username(), identity.Groups())
 			if !all {


### PR DESCRIPTION
### Description

Without this PR, `make test` fails:
```
pkg/authconfigmap/authconfigmap.go:172:10  govet  nilness: impossible condition: nil != nil
```

In L172, `err` is always `nil`.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
