### PR TITLE
Accept InstanceDistribution with only one instance type.

### DIFF
--- a/docs/release_notes/0.14.0-draft.md
+++ b/docs/release_notes/0.14.0-draft.md
@@ -7,6 +7,7 @@
 - Improve versioning of eksctl (#1726)
 - Added the ability to override the kube config cluster server using the
   following environment variable `KUBECONFIG_CLUSTER_ENDPOINT`. (#1746)
+- InstanceDistribution now accepts more than or equal to one instance type. (#1772)
 
 ## Bug fixes
 

--- a/examples/08-spot-instances.yaml
+++ b/examples/08-spot-instances.yaml
@@ -13,7 +13,7 @@ nodeGroups:
       maxSize: 5
       instancesDistribution:
         maxPrice: 0.017
-        instanceTypes: ["t3.small", "t3.medium"] # At least two instance types should be specified
+        instanceTypes: ["t3.small", "t3.medium"] # At least one instance type should be specified
         onDemandBaseCapacity: 0
         onDemandPercentageAboveBaseCapacity: 50
         spotInstancePools: 2

--- a/humans.txt
+++ b/humans.txt
@@ -63,6 +63,7 @@ Miguel Pereira          @onemorepereira
 Pedro Tôrres            @t0rr3sp3dr0
 Michael Treacher        @treacher
 Ajay Kemparaj           @ajayk
+Ryota Arai              @ryotarai
 
 /* Thanks */
 

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -410,8 +410,8 @@ func validateInstancesDistribution(ng *NodeGroup) error {
 		allInstanceTypes[instanceType] = true
 	}
 
-	if len(allInstanceTypes) < 2 || len(allInstanceTypes) > 20 {
-		return fmt.Errorf("mixed nodegroups should have between 2 and 20 different instance types")
+	if len(allInstanceTypes) < 1 || len(allInstanceTypes) > 20 {
+		return fmt.Errorf("mixed nodegroups should have between 1 and 20 different instance types")
 	}
 
 	if distribution.OnDemandBaseCapacity != nil && *distribution.OnDemandBaseCapacity < 0 {

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -414,15 +414,15 @@ var _ = Describe("ClusterConfig validation", func() {
 				Expect(err).To(HaveOccurred())
 			})
 
-			It("It fails when the instance distribution doesn't have at least 2 different instance types", func() {
+			It("It fails when the instance distribution doesn't have any instance type", func() {
 				ng.InstanceType = "mixed"
-				ng.InstancesDistribution.InstanceTypes = []string{"t3.medium", "t3.medium"}
+				ng.InstancesDistribution.InstanceTypes = []string{}
 
 				err := validateInstancesDistribution(ng)
 				Expect(err).To(HaveOccurred())
 
 				ng.InstanceType = "mixed"
-				ng.InstancesDistribution.InstanceTypes = []string{"t3.medium", "t3.small"}
+				ng.InstancesDistribution.InstanceTypes = []string{"t3.medium"}
 
 				err = validateInstancesDistribution(ng)
 				Expect(err).ToNot(HaveOccurred())

--- a/site/content/usage/08-spot-instances.md
+++ b/site/content/usage/08-spot-instances.md
@@ -17,7 +17,7 @@ nodeGroups:
     maxSize: 5
     instancesDistribution:
       maxPrice: 0.017
-      instanceTypes: ["t3.small", "t3.medium"] # At least two instance types should be specified
+      instanceTypes: ["t3.small", "t3.medium"] # At least one instance type should be specified
       onDemandBaseCapacity: 0
       onDemandPercentageAboveBaseCapacity: 50
       spotInstancePools: 2
@@ -46,7 +46,7 @@ Here is a minimal example:
 nodeGroups:
   - name: ng-1
     instancesDistribution:
-      instanceTypes: ["t3.small", "t3.medium"] # At least two instance types should be specified
+      instanceTypes: ["t3.small", "t3.medium"] # At least one instance type should be specified
 ```
 
 ### Parameters in instancesDistribution


### PR DESCRIPTION
### Description

Currently, InstanceDistribution must have more than or equal to 2 instance types but AWS auto scaling API accepts configuration with only one instance type too. This PR makes InstanceDistribution accept that case.

#### Q. Why we do not use just `instanceType` of nodegroup?

We want to launch spot instances with one instance type.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
  - To run tests, https://github.com/weaveworks/eksctl/pull/1771 is needed
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
