### PR TITLE
Improve the error when resource is not known

### DIFF
--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -30,6 +30,9 @@ func NewVerbCmd(use, short, long string) *cobra.Command {
 				logger.Debug("ignoring error %q", err.Error())
 			}
 		},
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
 	}
 }
 

--- a/pkg/ctl/create/create_test.go
+++ b/pkg/ctl/create/create_test.go
@@ -1,0 +1,56 @@
+package create
+
+import (
+	"bytes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("create", func() {
+	Describe("invalid-resource", func() {
+		It("with no flag", func() {
+			cmd := newMockCmd("invalid-resource")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"create\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and some flag", func() {
+			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"create\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and additional argument", func() {
+			cmd := newMockCmd("invalid-resource", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"create\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+	})
+})
+
+func newMockCmd(args ...string) *mockVerbCmd {
+	flagGrouping := cmdutils.NewGrouping()
+	cmd := Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+type mockVerbCmd struct {
+	parentCmd *cobra.Command
+	cmd       *cmdutils.Cmd
+}
+
+func (c mockVerbCmd) execute() (string, error) {
+	buf := new(bytes.Buffer)
+	c.parentCmd.SetOut(buf)
+	err := c.parentCmd.Execute()
+	return buf.String(), err
+}

--- a/pkg/ctl/delete/delete_suite_test.go
+++ b/pkg/ctl/delete/delete_suite_test.go
@@ -1,0 +1,10 @@
+package delete
+
+import (
+	"github.com/weaveworks/eksctl/pkg/testutils"
+	"testing"
+)
+
+func TestSuite(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}

--- a/pkg/ctl/delete/delete_test.go
+++ b/pkg/ctl/delete/delete_test.go
@@ -1,0 +1,56 @@
+package delete
+
+import (
+	"bytes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("delete", func() {
+	Describe("invalid-resource", func() {
+		It("with no flag", func() {
+			cmd := newMockVerbCmd("invalid-resource")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"delete\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and some flag", func() {
+			cmd := newMockVerbCmd("invalid-resource", "--invalid-flag", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"delete\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and additional argument", func() {
+			cmd := newMockVerbCmd("invalid-resource", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"delete\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+	})
+})
+
+func newMockVerbCmd(args ...string) *mockVerbCmd {
+	flagGrouping := cmdutils.NewGrouping()
+	cmd := Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+type mockVerbCmd struct {
+	parentCmd *cobra.Command
+	cmd       *cmdutils.Cmd
+}
+
+func (c mockVerbCmd) execute() (string, error) {
+	buf := new(bytes.Buffer)
+	c.parentCmd.SetOut(buf)
+	err := c.parentCmd.Execute()
+	return buf.String(), err
+}

--- a/pkg/ctl/delete/fargate_test.go
+++ b/pkg/ctl/delete/fargate_test.go
@@ -2,19 +2,12 @@ package delete
 
 import (
 	"bytes"
-	"testing"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/fargate"
-	"github.com/weaveworks/eksctl/pkg/testutils"
 )
-
-func TestSuite(t *testing.T) {
-	testutils.RegisterAndRun(t)
-}
 
 var _ = Describe("delete", func() {
 	Describe("delete fargateprofile", func() {

--- a/pkg/ctl/drain/drain_suite_test.go
+++ b/pkg/ctl/drain/drain_suite_test.go
@@ -1,0 +1,10 @@
+package drain
+
+import (
+	"github.com/weaveworks/eksctl/pkg/testutils"
+	"testing"
+)
+
+func TestSuite(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}

--- a/pkg/ctl/drain/drain_test.go
+++ b/pkg/ctl/drain/drain_test.go
@@ -1,0 +1,56 @@
+package drain
+
+import (
+	"bytes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("drain", func() {
+	Describe("invalid-resource", func() {
+		It("with no flag", func() {
+			cmd := newMockCmd("invalid-resource")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"drain\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and some flag", func() {
+			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"drain\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and additional argument", func() {
+			cmd := newMockCmd("invalid-resource", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"drain\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+	})
+})
+
+func newMockCmd(args ...string) *mockVerbCmd {
+	flagGrouping := cmdutils.NewGrouping()
+	cmd := Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+type mockVerbCmd struct {
+	parentCmd *cobra.Command
+	cmd       *cmdutils.Cmd
+}
+
+func (c mockVerbCmd) execute() (string, error) {
+	buf := new(bytes.Buffer)
+	c.parentCmd.SetOut(buf)
+	err := c.parentCmd.Execute()
+	return buf.String(), err
+}

--- a/pkg/ctl/enable/enable_suite_test.go
+++ b/pkg/ctl/enable/enable_suite_test.go
@@ -1,0 +1,10 @@
+package enable
+
+import (
+	"github.com/weaveworks/eksctl/pkg/testutils"
+	"testing"
+)
+
+func TestSuite(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}

--- a/pkg/ctl/enable/enable_test.go
+++ b/pkg/ctl/enable/enable_test.go
@@ -1,0 +1,57 @@
+package enable
+
+import (
+	"bytes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("enable", func() {
+	Describe("invalid-resource", func() {
+		It("with no flag", func() {
+			cmd := newMockCmd("invalid-resource")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"enable\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and some flag", func() {
+			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"enable\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and additional argument", func() {
+			cmd := newMockCmd("invalid-resource", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"enable\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+	})
+})
+
+func newMockCmd(args ...string) *mockVerbCmd {
+	flagGrouping := cmdutils.NewGrouping()
+	cmd := Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+type mockVerbCmd struct {
+	parentCmd *cobra.Command
+	cmd       *cmdutils.Cmd
+}
+
+func (c mockVerbCmd) execute() (string, error) {
+	buf := new(bytes.Buffer)
+	c.parentCmd.SetOut(buf)
+	err := c.parentCmd.Execute()
+	return buf.String(), err
+}
+

--- a/pkg/ctl/generate/generate_suite_test.go
+++ b/pkg/ctl/generate/generate_suite_test.go
@@ -1,0 +1,11 @@
+package generate
+
+import (
+	"github.com/weaveworks/eksctl/pkg/testutils"
+	"testing"
+)
+
+func TestSuite(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}
+

--- a/pkg/ctl/generate/generate_test.go
+++ b/pkg/ctl/generate/generate_test.go
@@ -1,4 +1,4 @@
-package upgrade
+package generate
 
 import (
 	"bytes"
@@ -8,35 +8,34 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-var _ = Describe("upgrade", func() {
+var _ = Describe("generate", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
 			cmd := newMockCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"upgrade\""))
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
 			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"upgrade\""))
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
 			cmd := newMockCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"upgrade\""))
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 	})
 })
 
 func newMockCmd(args ...string) *mockVerbCmd {
-	flagGrouping := cmdutils.NewGrouping()
-	cmd := Command(flagGrouping)
+	cmd := Command(cmdutils.NewGrouping())
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/get/cluster_test.go
+++ b/pkg/ctl/get/cluster_test.go
@@ -1,0 +1,17 @@
+package get
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("get", func() {
+	Describe("cluster", func() {
+		It("with invalid flags", func() {
+			cmd := newMockCmd("cluster", "--invalid", "dummy")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
+		})
+	})
+})

--- a/pkg/ctl/get/fargate_test.go
+++ b/pkg/ctl/get/fargate_test.go
@@ -6,13 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
-	"github.com/weaveworks/eksctl/pkg/testutils"
-	"testing"
 )
-
-func TestSuite(t *testing.T) {
-	testutils.RegisterAndRun(t)
-}
 
 var _ = Describe("get", func() {
 	Describe("get fargateprofile", func() {

--- a/pkg/ctl/get/get_suite_test.go
+++ b/pkg/ctl/get/get_suite_test.go
@@ -1,0 +1,10 @@
+package get
+
+import (
+	"github.com/weaveworks/eksctl/pkg/testutils"
+	"testing"
+)
+
+func TestSuite(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}

--- a/pkg/ctl/get/get_test.go
+++ b/pkg/ctl/get/get_test.go
@@ -1,0 +1,55 @@
+package get
+
+import (
+	"bytes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("get", func() {
+	Describe("invalid-resource", func() {
+		It("with no flag", func() {
+			cmd := newMockCmd("invalid-resource")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"get\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and some flag", func() {
+			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"get\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and additional argument", func() {
+			cmd := newMockCmd("invalid-resource", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"get\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+	})
+})
+
+func newMockCmd(args ...string) *mockVerbCmd {
+	cmd := Command(cmdutils.NewGrouping())
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+type mockVerbCmd struct {
+	parentCmd *cobra.Command
+	cmd       *cmdutils.Cmd
+}
+
+func (c mockVerbCmd) execute() (string, error) {
+	buf := new(bytes.Buffer)
+	c.parentCmd.SetOut(buf)
+	err := c.parentCmd.Execute()
+	return buf.String(), err
+}

--- a/pkg/ctl/get/iamidentitymapping_test.go
+++ b/pkg/ctl/get/iamidentitymapping_test.go
@@ -1,0 +1,24 @@
+package get
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("get", func() {
+	Describe("iamidentitymapping", func() {
+		It("missing required flag --cluster", func() {
+			cmd := newMockCmd( "iamidentitymapping")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--cluster must be set"))
+		})
+
+		It("invalid flag --dummy", func() {
+			cmd := newMockCmd("iamidentitymapping", "--invalid", "dummy")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
+		})
+	})
+})

--- a/pkg/ctl/get/iamserviceaccount_test.go
+++ b/pkg/ctl/get/iamserviceaccount_test.go
@@ -1,0 +1,25 @@
+package get
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("get", func() {
+	Describe("iamserviceaccount", func() {
+		It("missing required flag --cluster", func() {
+			cmd := newMockCmd( "iamserviceaccount")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--cluster must be set"))
+		})
+
+		It("invalid flag --dummy", func() {
+			cmd := newMockCmd("iamserviceaccount", "--invalid", "dummy")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
+		})
+	})
+})
+

--- a/pkg/ctl/get/labels_test.go
+++ b/pkg/ctl/get/labels_test.go
@@ -1,0 +1,31 @@
+package get
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("get", func() {
+	Describe("labels", func() {
+		It("missing required flag --cluster", func() {
+			cmd := newMockCmd( "labels")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--cluster must be set"))
+		})
+
+		It("missing required flag --cluster, but with --nodegroup", func() {
+			cmd := newMockCmd( "labels", "--nodegroup", "dummyNodeGroup")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--cluster must be set"))
+		})
+
+		It("setting name argument", func() {
+			cmd := newMockCmd("labels", "--cluster", "dummy", "dummyName")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("name argument is not supported"))
+		})
+	})
+})

--- a/pkg/ctl/get/nodegroup_test.go
+++ b/pkg/ctl/get/nodegroup_test.go
@@ -1,0 +1,31 @@
+package get
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("get", func() {
+	Describe("nodegroup", func() {
+		It("missing required flag --cluster", func() {
+			cmd := newMockCmd( "nodegroup")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--cluster must be set"))
+		})
+
+		It("setting --name and argument at the same time", func() {
+			cmd := newMockCmd("nodegroup", "ng", "--cluster", "dummy", "--name", "ng")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--name=ng and argument ng cannot be used at the same time"))
+		})
+
+		It("invalid flag", func() {
+			cmd := newMockCmd( "nodegroup", "--invalid", "dummy")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
+		})
+	})
+})

--- a/pkg/ctl/scale/scale_suite_test.go
+++ b/pkg/ctl/scale/scale_suite_test.go
@@ -1,0 +1,11 @@
+package scale
+
+import (
+	"testing"
+
+	"github.com/weaveworks/eksctl/pkg/testutils"
+)
+
+func TestSuite(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}

--- a/pkg/ctl/scale/scale_test.go
+++ b/pkg/ctl/scale/scale_test.go
@@ -1,0 +1,57 @@
+package scale
+
+import (
+	"bytes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/ctl/generate"
+)
+
+var _ = Describe("generate", func() {
+	Describe("invalid-resource", func() {
+		It("with no flag", func() {
+			cmd := newMockCmd("invalid-resource")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and some flag", func() {
+			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and additional argument", func() {
+			cmd := newMockCmd("invalid-resource", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+	})
+})
+
+func newMockCmd(args ...string) *mockVerbCmd {
+	flagGrouping := cmdutils.NewGrouping()
+	cmd := generate.Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+type mockVerbCmd struct {
+	parentCmd *cobra.Command
+	cmd       *cmdutils.Cmd
+}
+
+func (c mockVerbCmd) execute() (string, error) {
+	buf := new(bytes.Buffer)
+	c.parentCmd.SetOut(buf)
+	err := c.parentCmd.Execute()
+	return buf.String(), err
+}

--- a/pkg/ctl/scale/scale_test.go
+++ b/pkg/ctl/scale/scale_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
-	"github.com/weaveworks/eksctl/pkg/ctl/generate"
 )
 
 var _ = Describe("generate", func() {
@@ -15,21 +14,21 @@ var _ = Describe("generate", func() {
 			cmd := newMockCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"scale\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
 			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"scale\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
 			cmd := newMockCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"scale\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 	})
@@ -37,7 +36,7 @@ var _ = Describe("generate", func() {
 
 func newMockCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
-	cmd := generate.Command(flagGrouping)
+	cmd := Command(flagGrouping)
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/set/set_suite_test.go
+++ b/pkg/ctl/set/set_suite_test.go
@@ -1,0 +1,11 @@
+package set
+
+import (
+	"testing"
+
+	"github.com/weaveworks/eksctl/pkg/testutils"
+)
+
+func TestSuite(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}

--- a/pkg/ctl/set/set_test.go
+++ b/pkg/ctl/set/set_test.go
@@ -6,30 +6,29 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
-	"github.com/weaveworks/eksctl/pkg/ctl/generate"
 )
 
-var _ = Describe("generate", func() {
+var _ = Describe("set", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
 			cmd := newMockCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"set\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
 			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"set\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
 			cmd := newMockCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"set\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 	})
@@ -37,7 +36,7 @@ var _ = Describe("generate", func() {
 
 func newMockCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
-	cmd := generate.Command(flagGrouping)
+	cmd := Command(flagGrouping)
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/set/set_test.go
+++ b/pkg/ctl/set/set_test.go
@@ -1,0 +1,57 @@
+package set
+
+import (
+	"bytes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/ctl/generate"
+)
+
+var _ = Describe("generate", func() {
+	Describe("invalid-resource", func() {
+		It("with no flag", func() {
+			cmd := newMockCmd("invalid-resource")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and some flag", func() {
+			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and additional argument", func() {
+			cmd := newMockCmd("invalid-resource", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+	})
+})
+
+func newMockCmd(args ...string) *mockVerbCmd {
+	flagGrouping := cmdutils.NewGrouping()
+	cmd := generate.Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+type mockVerbCmd struct {
+	parentCmd *cobra.Command
+	cmd       *cmdutils.Cmd
+}
+
+func (c mockVerbCmd) execute() (string, error) {
+	buf := new(bytes.Buffer)
+	c.parentCmd.SetOut(buf)
+	err := c.parentCmd.Execute()
+	return buf.String(), err
+}

--- a/pkg/ctl/unset/unset_suite_test.go
+++ b/pkg/ctl/unset/unset_suite_test.go
@@ -1,0 +1,11 @@
+package unset
+
+import (
+	"testing"
+
+	"github.com/weaveworks/eksctl/pkg/testutils"
+)
+
+func TestSuite(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}

--- a/pkg/ctl/unset/unset_test.go
+++ b/pkg/ctl/unset/unset_test.go
@@ -6,30 +6,29 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
-	"github.com/weaveworks/eksctl/pkg/ctl/generate"
 )
 
-var _ = Describe("generate", func() {
+var _ = Describe("unset", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
 			cmd := newMockCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"unset\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
 			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"unset\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
 			cmd := newMockCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"unset\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 	})
@@ -37,7 +36,7 @@ var _ = Describe("generate", func() {
 
 func newMockCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
-	cmd := generate.Command(flagGrouping)
+	cmd := Command(flagGrouping)
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/unset/unset_test.go
+++ b/pkg/ctl/unset/unset_test.go
@@ -1,0 +1,57 @@
+package unset
+
+import (
+	"bytes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/ctl/generate"
+)
+
+var _ = Describe("generate", func() {
+	Describe("invalid-resource", func() {
+		It("with no flag", func() {
+			cmd := newMockCmd("invalid-resource")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and some flag", func() {
+			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and additional argument", func() {
+			cmd := newMockCmd("invalid-resource", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+	})
+})
+
+func newMockCmd(args ...string) *mockVerbCmd {
+	flagGrouping := cmdutils.NewGrouping()
+	cmd := generate.Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+type mockVerbCmd struct {
+	parentCmd *cobra.Command
+	cmd       *cmdutils.Cmd
+}
+
+func (c mockVerbCmd) execute() (string, error) {
+	buf := new(bytes.Buffer)
+	c.parentCmd.SetOut(buf)
+	err := c.parentCmd.Execute()
+	return buf.String(), err
+}

--- a/pkg/ctl/update/update_suite_test.go
+++ b/pkg/ctl/update/update_suite_test.go
@@ -1,0 +1,11 @@
+package update
+
+import (
+	"testing"
+
+	"github.com/weaveworks/eksctl/pkg/testutils"
+)
+
+func TestSuite(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}

--- a/pkg/ctl/update/update_test.go
+++ b/pkg/ctl/update/update_test.go
@@ -1,0 +1,57 @@
+package update
+
+import (
+	"bytes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/ctl/generate"
+)
+
+var _ = Describe("generate", func() {
+	Describe("invalid-resource", func() {
+		It("with no flag", func() {
+			cmd := newMockCmd("invalid-resource")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and some flag", func() {
+			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and additional argument", func() {
+			cmd := newMockCmd("invalid-resource", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+	})
+})
+
+func newMockCmd(args ...string) *mockVerbCmd {
+	flagGrouping := cmdutils.NewGrouping()
+	cmd := generate.Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+type mockVerbCmd struct {
+	parentCmd *cobra.Command
+	cmd       *cmdutils.Cmd
+}
+
+func (c mockVerbCmd) execute() (string, error) {
+	buf := new(bytes.Buffer)
+	c.parentCmd.SetOut(buf)
+	err := c.parentCmd.Execute()
+	return buf.String(), err
+}

--- a/pkg/ctl/update/update_test.go
+++ b/pkg/ctl/update/update_test.go
@@ -6,30 +6,29 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
-	"github.com/weaveworks/eksctl/pkg/ctl/generate"
 )
 
-var _ = Describe("generate", func() {
+var _ = Describe("update", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
 			cmd := newMockCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"update\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
 			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"update\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
 			cmd := newMockCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"update\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 	})
@@ -37,7 +36,7 @@ var _ = Describe("generate", func() {
 
 func newMockCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
-	cmd := generate.Command(flagGrouping)
+	cmd := Command(flagGrouping)
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/upgrade/upgrade_suite_test.go
+++ b/pkg/ctl/upgrade/upgrade_suite_test.go
@@ -1,0 +1,11 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/weaveworks/eksctl/pkg/testutils"
+)
+
+func TestSuite(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}

--- a/pkg/ctl/upgrade/upgrade_test.go
+++ b/pkg/ctl/upgrade/upgrade_test.go
@@ -1,0 +1,57 @@
+package upgrade
+
+import (
+	"bytes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/ctl/generate"
+)
+
+var _ = Describe("generate", func() {
+	Describe("invalid-resource", func() {
+		It("with no flag", func() {
+			cmd := newMockCmd("invalid-resource")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and some flag", func() {
+			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and additional argument", func() {
+			cmd := newMockCmd("invalid-resource", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+	})
+})
+
+func newMockCmd(args ...string) *mockVerbCmd {
+	flagGrouping := cmdutils.NewGrouping()
+	cmd := generate.Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+type mockVerbCmd struct {
+	parentCmd *cobra.Command
+	cmd       *cmdutils.Cmd
+}
+
+func (c mockVerbCmd) execute() (string, error) {
+	buf := new(bytes.Buffer)
+	c.parentCmd.SetOut(buf)
+	err := c.parentCmd.Execute()
+	return buf.String(), err
+}

--- a/pkg/ctl/utils/utils_suite_test.go
+++ b/pkg/ctl/utils/utils_suite_test.go
@@ -1,0 +1,11 @@
+package utils
+
+
+import (
+	"github.com/weaveworks/eksctl/pkg/testutils"
+	"testing"
+)
+
+func TestSuite(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}

--- a/pkg/ctl/utils/utils_test.go
+++ b/pkg/ctl/utils/utils_test.go
@@ -1,6 +1,11 @@
 package utils
 
 import (
+	"bytes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"strconv"
 	"strings"
 	"testing"
@@ -97,4 +102,51 @@ func TestValidateLoggingFlags(t *testing.T) {
 		})
 	}
 
+}
+
+var _ = Describe("utils", func() {
+	Describe("invalid-resource", func() {
+		It("with no flag", func() {
+			cmd := newMockCmd("invalid-resource")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"utils\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and some flag", func() {
+			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"utils\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+		It("with invalid-resource and additional argument", func() {
+			cmd := newMockCmd("invalid-resource", "foo")
+			out, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"utils\""))
+			Expect(out).To(ContainSubstring("usage"))
+		})
+	})
+})
+
+func newMockCmd(args ...string) *mockVerbCmd {
+	flagGrouping := cmdutils.NewGrouping()
+	cmd := Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+type mockVerbCmd struct {
+	parentCmd *cobra.Command
+	cmd       *cmdutils.Cmd
+}
+
+func (c mockVerbCmd) execute() (string, error) {
+	buf := new(bytes.Buffer)
+	c.parentCmd.SetOut(buf)
+	err := c.parentCmd.Execute()
+	return buf.String(), err
 }


### PR DESCRIPTION
### Description

fixes https://github.com/weaveworks/eksctl/issues/1642

### Approach
Currently, all of our commands (except eksctl version) are following the format `eksctl "verb" "resource" --flag a --flag b ...`

If the `resource` is invalid, the current logic will treat it as `argument` (instead of treating it as subcommand), hence the handler logic will be still belong to `verb` command. This is why we have issue invalid flag while running `eksctl get fargateprofiles --cluster martina-test-1` as `get` command didn't support flag `cluster`.

__**Changes:**__
- Delegate flag checking to resource command from verb command (e.g. do not check flags in verb command)
- Add the method to capture invalid resource command

__**Note:**__
Unit tests are added to `only` cover for invalid resource with and without flags. Currently, all test cases in each verb command are look similar. A little bit refactoring is required to actually test positive scenarios e.g. functional style like below (thanks to @marccarre). I don't want to extend the scope of this PR, so I will address this issue in other PR later. 

```
func getFargateProfileWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, options *options) error) {
        ...
	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
		cmd.NameArg = cmdutils.GetNameArg(args)
		if err := cmdutils.NewGetFargateProfileLoader(cmd, &options.Options).Load(); err != nil {
			return err
		}
		return runFunc(cmd, options)
	}
}
```

### Testing snapshot

```
./eksctl get yaddayadda --region ap-northeast-1 --cluster martina-test-all                               
Error: unknown resource type "yaddayadda"

Get resource(s)

Usage: eksctl get [flags]

Commands:
  eksctl get cluster                 Get cluster(s)
  eksctl get nodegroup               Get nodegroup(s)
  eksctl get iamserviceaccount       Get iamserviceaccount(s)
  eksctl get iamidentitymapping      Get IAM identity mapping(s)
  eksctl get labels                  Get nodegroup labels
  eksctl get fargateprofile          Get Fargate profile(s)

Common flags:
  -C, --color string   toggle colorized logs (valid options: true, false, fabulous) (default "true")
  -h, --help           help for this command
  -v, --verbose int    set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging (default 3)

Use 'eksctl get [command] --help' for more information about a command.

Error: unknown resource type "yaddayadda"
```

```
./eksctl get fargateprofiles --cluster martina-test-1                                                                       
Error: unknown resource type "fargateprofiles"

Get resource(s)

Usage: eksctl get [flags]

Commands:
  eksctl get cluster                 Get cluster(s)
  eksctl get nodegroup               Get nodegroup(s)
  eksctl get iamserviceaccount       Get iamserviceaccount(s)
  eksctl get iamidentitymapping      Get IAM identity mapping(s)
  eksctl get labels                  Get nodegroup labels
  eksctl get fargateprofile          Get Fargate profile(s)

Common flags:
  -C, --color string   toggle colorized logs (valid options: true, false, fabulous) (default "true")
  -h, --help           help for this command
  -v, --verbose int    set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging (default 3)

Use 'eksctl get [command] --help' for more information about a command.

Error: unknown resource type "fargateprofiles"
```

```
./eksctl get fargateprofiles                         
Error: unknown resource type "fargateprofiles"

Get resource(s)

Usage: eksctl get [flags]

Commands:
  eksctl get cluster                 Get cluster(s)
  eksctl get nodegroup               Get nodegroup(s)
  eksctl get iamserviceaccount       Get iamserviceaccount(s)
  eksctl get iamidentitymapping      Get IAM identity mapping(s)
  eksctl get labels                  Get nodegroup labels
  eksctl get fargateprofile          Get Fargate profile(s)

Common flags:
  -C, --color string   toggle colorized logs (valid options: true, false, fabulous) (default "true")
  -h, --help           help for this command
  -v, --verbose int    set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging (default 3)

Use 'eksctl get [command] --help' for more information about a command.

Error: unknown resource type "fargateprofiles"
```

**Positive case to make sure it didn't break :disappointed_relieved:** 
```
 ./eksctl create cluster --region us-east-2 --name fargate2 --fargate
[ℹ]  eksctl version 0.13.0-dev+336991e1.2020-01-31T23:35:27Z
[ℹ]  using region us-east-2
[ℹ]  setting availability zones to [us-east-2a us-east-2c us-east-2b]
[ℹ]  subnets for us-east-2a - public:192.168.0.0/19 private:192.168.96.0/19
[ℹ]  subnets for us-east-2c - public:192.168.32.0/19 private:192.168.128.0/19
[ℹ]  subnets for us-east-2b - public:192.168.64.0/19 private:192.168.160.0/19
[ℹ]  using Kubernetes version 1.14
[ℹ]  creating EKS cluster "fargate2" in "us-east-2" region with Fargate profile
[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-east-2 --cluster=fargate2'
[ℹ]  CloudWatch logging will not be enabled for cluster "fargate2" in "us-east-2"
[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --region=us-east-2 --cluster=fargate2'
[ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "fargate2" in "us-east-2"
[ℹ]  1 task: { create cluster control plane "fargate2" }
[ℹ]  building cluster stack "eksctl-fargate2-cluster"
[ℹ]  deploying stack "eksctl-fargate2-cluster"
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
