### PR TITLE
Remove unused Fargate-related code and Improve Fargate documentation

### DIFF
--- a/pkg/ctl/create/fargate.go
+++ b/pkg/ctl/create/fargate.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func createFargateProfileWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, options *fargate.CreateOptions) error) {
+func createFargateProfileWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd) error) {
 	cmd.ClusterConfig = api.NewClusterConfig()
 	cmd.SetDescription(
 		"fargateprofile",
@@ -32,14 +32,12 @@ func createFargateProfileWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmduti
 		if err := cmdutils.NewCreateFargateProfileLoader(cmd, options).Load(); err != nil {
 			return err
 		}
-		return runFunc(cmd, options)
+		return runFunc(cmd)
 	}
 }
 
 func createFargateProfile(cmd *cmdutils.Cmd) {
-	createFargateProfileWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options *fargate.CreateOptions) error {
-		return doCreateFargateProfile(cmd, options)
-	})
+	createFargateProfileWithRunFunc(cmd, doCreateFargateProfile)
 }
 
 func configureCreateFargateProfileCmd(cmd *cmdutils.Cmd) *fargate.CreateOptions {
@@ -57,7 +55,7 @@ func configureCreateFargateProfileCmd(cmd *cmdutils.Cmd) *fargate.CreateOptions 
 	return &options
 }
 
-func doCreateFargateProfile(cmd *cmdutils.Cmd, options *fargate.CreateOptions) error {
+func doCreateFargateProfile(cmd *cmdutils.Cmd) error {
 	ctl, err := cmd.NewCtl()
 	if err != nil {
 		return err

--- a/pkg/ctl/create/fargate_test.go
+++ b/pkg/ctl/create/fargate_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
-	"github.com/weaveworks/eksctl/pkg/fargate"
 )
 
 var _ = Describe("create", func() {
@@ -100,9 +99,8 @@ func newMockCreateFargateProfileCmd(args ...string) *mockCreateFargateProfileCmd
 	grouping := cmdutils.NewGrouping()
 	parentCmd := cmdutils.NewVerbCmd("create", "", "")
 	cmdutils.AddResourceCmd(grouping, parentCmd, func(cmd *cmdutils.Cmd) {
-		createFargateProfileWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options *fargate.CreateOptions) error {
+		createFargateProfileWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
 			mockCmd.cmd = cmd
-			mockCmd.options = options
 			return nil // no-op, to only test input aggregation & validation.
 		})
 	})
@@ -114,7 +112,6 @@ func newMockCreateFargateProfileCmd(args ...string) *mockCreateFargateProfileCmd
 type mockCreateFargateProfileCmd struct {
 	parentCmd *cobra.Command
 	cmd       *cmdutils.Cmd
-	options   *fargate.CreateOptions
 }
 
 func (c mockCreateFargateProfileCmd) execute() (string, error) {

--- a/site/content/usage/16-fargate-support.md
+++ b/site/content/usage/16-fargate-support.md
@@ -231,7 +231,7 @@ $ eksctl create fargateprofile --namespace dev --cluster fargate-example-cluster
 You can also specify the name of the Fargate profile to be created. This name must not start with the prefix `eks-`.
 
 ```console
-$ eksctl create fargateprofile --name eks-dev --namespace dev --cluster fargate-example-cluster --name fp-development
+$ eksctl create fargateprofile --namespace dev --cluster fargate-example-cluster --name fp-development
 [ℹ]  created Fargate profile "fp-development" on EKS cluster "fargate-example-cluster"
 ```
 
@@ -332,8 +332,8 @@ $ eksctl delete fargateprofile --cluster fargate-example-cluster --name fp-9bfc7
 ```
 
 Note that the profile deletion is a process that can take up to a few minutes. When the `--wait` flag is not specified,
-`eksctl` optimistically expects the profile to be deleted and returns as soon as the aws request has been sent. To make
-`eksctl` wait until it has been successfully deleted use `--wait` like in the example above.
+`eksctl` optimistically expects the profile to be deleted and returns as soon as the AWS API request has been sent. To make
+`eksctl` wait until the profile has been successfully deleted, use `--wait` like in the example above.
 
 ### Further reading
 


### PR DESCRIPTION
### Description

- Remove unused CLI args `struct` for Fargate profiles' creation.
- Improve/Fix Fargate documentation.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
