### PR TITLE
WIP CLI command unit test

### DIFF
--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -385,7 +385,7 @@ func NewDeleteNodeGroupLoader(cmd *Cmd, ng *api.NodeGroup, ngFilter *NodeGroupFi
 		}
 
 		if ng.Name != "" && l.NameArg != "" {
-			return ErrClusterFlagAndArg(l.Cmd, ng.Name, l.NameArg)
+			return ErrFlagAndArg("--name", ng.Name, l.NameArg)
 		}
 
 		if l.NameArg != "" {

--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -5,14 +5,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+
+	"github.com/kris-nova/logger"
+	"github.com/pkg/errors"
 	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/fargate"
 
-	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/elb"
@@ -25,6 +26,12 @@ import (
 )
 
 func deleteClusterCmd(cmd *cmdutils.Cmd) {
+	deleteClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
+		return doDeleteCluster(cmd)
+	})
+}
+
+func deleteClusterWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd) error) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
 
@@ -32,7 +39,7 @@ func deleteClusterCmd(cmd *cmdutils.Cmd) {
 
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return doDeleteCluster(cmd)
+		return runFunc(cmd)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/delete/cluster_test.go
+++ b/pkg/ctl/delete/cluster_test.go
@@ -1,0 +1,75 @@
+package delete
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("delete", func() {
+	Describe("cluster", func() {
+		It("without cluster name", func() {
+			cmd := newMockDefaultCmd("cluster")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--name must be set"))
+		})
+
+		It("with cluster name as flag", func() {
+			count := 0
+			cmd := newMockEmptyCmd("cluster", "--name", "clusterName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				deleteClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with cluster name as argument", func() {
+			count := 0
+			cmd := newMockEmptyCmd("cluster", "clusterName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				deleteClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
+					Expect(cmd.NameArg).To(Equal("clusterName"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with cluster name as argument and flag", func() {
+			cmd := newMockDefaultCmd("cluster", "clusterName", "--name", "clusterName")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--name=clusterName and argument clusterName cannot be used at the same time"))
+		})
+
+		It("with invalid flags", func() {
+			cmd := newMockDefaultCmd("cluster", "--invalid", "dummy")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
+		})
+
+		It("failed due to any reason", func() {
+			cmd := newMockEmptyCmd("cluster", "clusterName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				deleteClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
+					return fmt.Errorf("unable to fetch the cluster")
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unable to fetch the cluster"))
+		})
+	})
+})

--- a/pkg/ctl/delete/delete_test.go
+++ b/pkg/ctl/delete/delete_test.go
@@ -11,21 +11,21 @@ import (
 var _ = Describe("delete", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockVerbCmd("invalid-resource")
+			cmd := newMockDefaultCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"delete\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockVerbCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"delete\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockVerbCmd("invalid-resource", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"delete\""))
@@ -34,9 +34,17 @@ var _ = Describe("delete", func() {
 	})
 })
 
-func newMockVerbCmd(args ...string) *mockVerbCmd {
+func newMockDefaultCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
 	cmd := Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+func newMockEmptyCmd(args ...string) *mockVerbCmd {
+	cmd := cmdutils.NewVerbCmd("delete", "Delete resource(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/delete/iamidentitymapping.go
+++ b/pkg/ctl/delete/iamidentitymapping.go
@@ -11,6 +11,12 @@ import (
 )
 
 func deleteIAMIdentityMappingCmd(cmd *cmdutils.Cmd) {
+	deleteIAMIdentityMappingWithRunFunc(cmd, func(cmd *cmdutils.Cmd, arn string, all bool) error {
+		return doDeleteIAMIdentityMapping(cmd, arn, all)
+	})
+}
+
+func deleteIAMIdentityMappingWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, arn string, all bool) error) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
 
@@ -22,7 +28,7 @@ func deleteIAMIdentityMappingCmd(cmd *cmdutils.Cmd) {
 	cmd.SetDescription("iamidentitymapping", "Delete a IAM identity mapping", "")
 
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
-		return doDeleteIAMIdentityMapping(cmd, arn, all)
+		return runFunc(cmd, arn, all)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/delete/iamidentitymapping_test.go
+++ b/pkg/ctl/delete/iamidentitymapping_test.go
@@ -1,0 +1,55 @@
+package delete
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("delete", func() {
+	Describe("iamidentitymapping", func() {
+		It("with cluster name argument", func() {
+			count := 0
+			cmd := newMockEmptyCmd("iamidentitymapping", "--all")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				deleteIAMIdentityMappingWithRunFunc(cmd, func(cmd *cmdutils.Cmd, arn string, all bool) error {
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with cluster name flag (--cluster)", func() {
+			count := 0
+			cmd := newMockEmptyCmd("iamidentitymapping", "--cluster", "dummyName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				deleteIAMIdentityMappingWithRunFunc(cmd, func(cmd *cmdutils.Cmd, arn string, all bool) error {
+					Expect(cmd.NameArg).To(Equal(""))
+					count++
+					return nil
+				})
+			})
+			out, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+			Expect(out).To(Not(ContainSubstring("Flag --name has been deprecated, use --cluster")))
+		})
+
+		It("no cluster name", func() {
+			cmd := newMockDefaultCmd("iamidentitymapping")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--cluster must be set"))
+		})
+
+		It("invalid flag --dummy", func() {
+			cmd := newMockDefaultCmd("iamidentitymapping", "--invalid", "dummy")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
+		})
+	})
+})

--- a/pkg/ctl/delete/iamserviceaccount.go
+++ b/pkg/ctl/delete/iamserviceaccount.go
@@ -14,6 +14,12 @@ import (
 )
 
 func deleteIAMServiceAccountCmd(cmd *cmdutils.Cmd) {
+	deleteIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, onlyMissing bool) error {
+		return doDeleteIAMServiceAccount(cmd, serviceAccount, onlyMissing)
+	})
+}
+
+func deleteIAMServiceAccountWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, onlyMissing bool) error) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
 
@@ -27,7 +33,7 @@ func deleteIAMServiceAccountCmd(cmd *cmdutils.Cmd) {
 	cmd.SetDescription("iamserviceaccount", "Delete an IAM service account", "")
 
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
-		return doDeleteIAMServiceAccount(cmd, serviceAccount, onlyMissing)
+		return runFunc(cmd, serviceAccount, onlyMissing)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/delete/iamserviceaccount_test.go
+++ b/pkg/ctl/delete/iamserviceaccount_test.go
@@ -1,4 +1,4 @@
-package get
+package delete
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -13,7 +13,7 @@ var _ = Describe("get", func() {
 			count := 0
 			cmd := newMockEmptyCmd("iamserviceaccount", "--cluster", "dummyName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
-				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
+				deleteIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, onlyMissing bool) error {
 					Expect(cmd.NameArg).To(Equal(""))
 					count++
 					return nil
@@ -28,8 +28,7 @@ var _ = Describe("get", func() {
 			count := 0
 			cmd := newMockEmptyCmd("iamserviceaccount", "dummyName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
-				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
-					Expect(cmd.NameArg).To(Equal("dummyName"))
+				deleteIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, onlyMissing bool) error {
 					count++
 					return nil
 				})
@@ -41,10 +40,9 @@ var _ = Describe("get", func() {
 
 		It("with cluster and name flag", func() {
 			count := 0
-			cmd := newMockEmptyCmd("iamserviceaccount", "dummyName", "--name", "serviceAccount")
+			cmd := newMockEmptyCmd("iamserviceaccount", "--name", "serviceAccount")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
-				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
-					Expect(cmd.NameArg).To(Equal("dummyName"))
+				deleteIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, onlyMissing bool) error {
 					Expect(serviceAccount.Name).To(Equal("serviceAccount"))
 					Expect(serviceAccount.Namespace).To(Equal("default"))
 					count++
@@ -58,10 +56,9 @@ var _ = Describe("get", func() {
 
 		It("with cluster and namespace flag", func() {
 			count := 0
-			cmd := newMockEmptyCmd("iamserviceaccount", "dummyName", "--namespace", "dummyNS")
+			cmd := newMockEmptyCmd("iamserviceaccount", "--namespace", "dummyNS")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
-				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
-					Expect(cmd.NameArg).To(Equal("dummyName"))
+				deleteIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, onlyMissing bool) error {
 					Expect(serviceAccount.Namespace).To(Equal("dummyNS"))
 					count++
 					return nil
@@ -75,7 +72,7 @@ var _ = Describe("get", func() {
 		It("missing required flag --cluster", func() {
 			cmd := newMockDefaultCmd("iamserviceaccount")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
-				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
+				deleteIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, onlyMissing bool) error {
 					return nil
 				})
 			})

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -12,6 +12,12 @@ import (
 )
 
 func deleteNodeGroupCmd(cmd *cmdutils.Cmd) {
+	deleteNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *api.NodeGroup, updateAuthConfigMap, deleteNodeGroupDrain, onlyMissing bool) error {
+		return doDeleteNodeGroup(cmd, ng, updateAuthConfigMap, deleteNodeGroupDrain, onlyMissing)
+	})
+}
+
+func deleteNodeGroupWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, ng *api.NodeGroup, updateAuthConfigMap, deleteNodeGroupDrain, onlyMissing bool) error) {
 	cfg := api.NewClusterConfig()
 	ng := api.NewNodeGroup()
 	cmd.ClusterConfig = cfg
@@ -22,7 +28,7 @@ func deleteNodeGroupCmd(cmd *cmdutils.Cmd) {
 
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return doDeleteNodeGroup(cmd, ng, updateAuthConfigMap, deleteNodeGroupDrain, onlyMissing)
+		return runFunc(cmd, ng, updateAuthConfigMap, deleteNodeGroupDrain, onlyMissing)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/delete/nodegroup_test.go
+++ b/pkg/ctl/delete/nodegroup_test.go
@@ -1,0 +1,49 @@
+package delete
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("delete", func() {
+	Describe("nodegroup", func() {
+		It("with valid details", func() {
+			count := 0
+			cmd := newMockEmptyCmd("nodegroup", "--cluster", "clusterName", "--name", "ng")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				deleteNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *v1alpha5.NodeGroup, updateAuthConfigMap, deleteNodeGroupDrain, onlyMissing bool) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(ng.Name).To(Equal("ng"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("missing required flag --cluster", func() {
+			cmd := newMockDefaultCmd("nodegroup")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--cluster must be set"))
+		})
+
+		It("setting --name and argument at the same time", func() {
+			cmd := newMockDefaultCmd("nodegroup", "--cluster", "dummy", "--name", "ng", "ng")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--name=ng and argument ng cannot be used at the same time"))
+		})
+
+		It("invalid flag", func() {
+			cmd := newMockDefaultCmd("nodegroup", "--invalid", "dummy")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
+		})
+	})
+})

--- a/pkg/ctl/drain/drain_test.go
+++ b/pkg/ctl/drain/drain_test.go
@@ -11,21 +11,21 @@ import (
 var _ = Describe("drain", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockCmd("invalid-resource")
+			cmd := newMockDefaultCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"drain\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"drain\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockCmd("invalid-resource", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"drain\""))
@@ -34,9 +34,16 @@ var _ = Describe("drain", func() {
 	})
 })
 
-func newMockCmd(args ...string) *mockVerbCmd {
-	flagGrouping := cmdutils.NewGrouping()
-	cmd := Command(flagGrouping)
+func newMockDefaultCmd(args ...string) *mockVerbCmd {
+	cmd := Command(cmdutils.NewGrouping())
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+func newMockEmptyCmd(args ...string) *mockVerbCmd {
+	cmd := cmdutils.NewVerbCmd("get", "Get resource(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/drain/nodegroup.go
+++ b/pkg/ctl/drain/nodegroup.go
@@ -12,6 +12,12 @@ import (
 )
 
 func drainNodeGroupCmd(cmd *cmdutils.Cmd) {
+	drainNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *api.NodeGroup, undo, onlyMissing bool) error {
+		return doDrainNodeGroup(cmd, ng, undo, onlyMissing)
+	})
+}
+
+func drainNodeGroupWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, ng *api.NodeGroup, undo, onlyMissing bool) error) {
 	cfg := api.NewClusterConfig()
 	ng := cfg.NewNodeGroup()
 	cmd.ClusterConfig = cfg
@@ -22,7 +28,7 @@ func drainNodeGroupCmd(cmd *cmdutils.Cmd) {
 
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return doDrainNodeGroup(cmd, ng, undo, onlyMissing)
+		return runFunc(cmd, ng, undo, onlyMissing)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/drain/nodegroup_test.go
+++ b/pkg/ctl/drain/nodegroup_test.go
@@ -1,0 +1,81 @@
+package drain
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("drain", func() {
+	Describe("nodegroup", func() {
+		It("with valid details", func() {
+			count := 0
+			cmd := newMockEmptyCmd("nodegroup", "--cluster", "clusterName", "--name", "ng")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				drainNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *v1alpha5.NodeGroup, undo, onlyMissing bool) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(ng.Name).To(Equal("ng"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with deprecated flag --only", func() {
+			count := 0
+			cmd := newMockEmptyCmd("nodegroup", "--cluster", "clusterName", "--name", "ng", "--only", "ng")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				drainNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *v1alpha5.NodeGroup, undo, onlyMissing bool) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(cmd.Include).To(ContainElement("ng"))
+					count++
+					return nil
+				})
+			})
+			out, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+			Expect(out).To(ContainSubstring("Flag --only has been deprecated, use --include"))
+		})
+
+		It("with cluster name as flag", func() {
+			count := 0
+			cmd := newMockEmptyCmd("nodegroup", "--cluster", "clusterName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				drainNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *v1alpha5.NodeGroup, undo, onlyMissing bool) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("missing required flag --cluster", func() {
+			cmd := newMockDefaultCmd("nodegroup")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--cluster must be set"))
+		})
+
+		It("setting --name and argument at the same time", func() {
+			cmd := newMockDefaultCmd("nodegroup", "ng", "--cluster", "dummy", "--name", "dummy")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--cluster=dummy and argument ng cannot be used at the same time"))
+		})
+
+		It("invalid flag", func() {
+			cmd := newMockDefaultCmd("nodegroup", "--invalid", "dummy")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
+		})
+	})
+})

--- a/pkg/ctl/drain/nodegroup_test.go
+++ b/pkg/ctl/drain/nodegroup_test.go
@@ -65,10 +65,10 @@ var _ = Describe("drain", func() {
 		})
 
 		It("setting --name and argument at the same time", func() {
-			cmd := newMockDefaultCmd("nodegroup", "ng", "--cluster", "dummy", "--name", "dummy")
+			cmd := newMockDefaultCmd("nodegroup", "ng", "--cluster", "dummy", "--name", "ng")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("--cluster=dummy and argument ng cannot be used at the same time"))
+			Expect(err.Error()).To(Equal("--name=ng and argument ng cannot be used at the same time"))
 		})
 
 		It("invalid flag", func() {

--- a/pkg/ctl/enable/enable_test.go
+++ b/pkg/ctl/enable/enable_test.go
@@ -11,21 +11,21 @@ import (
 var _ = Describe("enable", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockCmd("invalid-resource")
+			cmd := newMockDefaultCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"enable\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"enable\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockCmd("invalid-resource", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"enable\""))
@@ -34,9 +34,16 @@ var _ = Describe("enable", func() {
 	})
 })
 
-func newMockCmd(args ...string) *mockVerbCmd {
-	flagGrouping := cmdutils.NewGrouping()
-	cmd := Command(flagGrouping)
+func newMockDefaultCmd(args ...string) *mockVerbCmd {
+	cmd := Command(cmdutils.NewGrouping())
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+func newMockEmptyCmd(args ...string) *mockVerbCmd {
+	cmd := cmdutils.NewVerbCmd("enable", "Get resource(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,
@@ -54,4 +61,3 @@ func (c mockVerbCmd) execute() (string, error) {
 	err := c.parentCmd.Execute()
 	return buf.String(), err
 }
-

--- a/pkg/ctl/enable/profile.go
+++ b/pkg/ctl/enable/profile.go
@@ -37,6 +37,12 @@ func (opts ProfileOptions) Validate() error {
 }
 
 func enableProfileCmd(cmd *cmdutils.Cmd) {
+	enableProfileWithRunFunc(cmd, func(cmd *cmdutils.Cmd, opts *ProfileOptions) error {
+		return doEnableProfile(cmd, opts)
+	})
+}
+
+func enableProfileWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, opts *ProfileOptions) error) {
 	cmd.ClusterConfig = api.NewClusterConfig()
 	cmd.SetDescription(
 		"profile",
@@ -46,7 +52,7 @@ func enableProfileCmd(cmd *cmdutils.Cmd) {
 	opts := configureProfileCmd(cmd)
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return doEnableProfile(cmd, opts)
+		return runFunc(cmd, opts)
 	}
 }
 

--- a/pkg/ctl/enable/profile_test.go
+++ b/pkg/ctl/enable/profile_test.go
@@ -1,0 +1,57 @@
+package enable
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("enable", func() {
+	Describe("profile", func() {
+		It("with required flag", func() {
+			count := 0
+			cmd := newMockEmptyCmd("profile", "--git-url", "git://dummy-repo", "--git-email", "test@test.com")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				enableProfileWithRunFunc(cmd, func(cmd *cmdutils.Cmd, opts *ProfileOptions) error {
+					Expect(opts.gitOptions.Email).To(Equal("test@test.com"))
+					Expect(opts.gitOptions.URL).To(Equal("git://dummy-repo"))
+					Expect(opts.profileOptions.Name).To(Equal(""))
+					Expect(opts.profileOptions.Revision).To(Equal("master"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("missing required flag --git-email", func() {
+			cmd := newMockDefaultCmd("profile", "--git-url", "git://dummy-repo")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("required flag(s) \"git-email\" not set"))
+		})
+
+		It("missing required flag --git-url", func() {
+			cmd := newMockDefaultCmd("profile", "--git-email", "test@test.com")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("required flag(s) \"git-url\" not set"))
+		})
+
+		It("missing all required flags", func() {
+			cmd := newMockDefaultCmd("profile")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("required flag(s) \"git-email\", \"git-url\" not set"))
+		})
+
+		It("invalid flag --dummy", func() {
+			cmd := newMockDefaultCmd("profile", "--invalid", "dummy")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
+		})
+	})
+})

--- a/pkg/ctl/enable/repo.go
+++ b/pkg/ctl/enable/repo.go
@@ -13,6 +13,12 @@ import (
 )
 
 func enableRepo(cmd *cmdutils.Cmd) {
+	enableRepoWithRunFunc(cmd, func(cmd *cmdutils.Cmd, opts *flux.InstallOpts) error {
+		return doEnableRepository(cmd, opts)
+	})
+}
+
+func enableRepoWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, opts *flux.InstallOpts) error) {
 	cmd.ClusterConfig = api.NewClusterConfig()
 	cmd.SetDescription(
 		"repo",
@@ -22,7 +28,7 @@ func enableRepo(cmd *cmdutils.Cmd) {
 	opts := configureRepositoryCmd(cmd)
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return doEnableRepository(cmd, opts)
+		return runFunc(cmd, opts)
 	}
 }
 

--- a/pkg/ctl/enable/repo_test.go
+++ b/pkg/ctl/enable/repo_test.go
@@ -1,0 +1,54 @@
+package enable
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/gitops/flux"
+)
+
+var _ = Describe("enable", func() {
+	Describe("repo", func() {
+		It("with required flag", func() {
+			count := 0
+			cmd := newMockEmptyCmd("repo", "--git-url", "git://dummy-repo", "--git-email", "test@test.com")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				enableRepoWithRunFunc(cmd, func(cmd *cmdutils.Cmd, opts *flux.InstallOpts) error {
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("missing required flag --git-email", func() {
+			cmd := newMockDefaultCmd("repo", "--git-url", "git://dummy-repo")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("required flag(s) \"git-email\" not set"))
+		})
+
+		It("missing required flag --git-url", func() {
+			cmd := newMockDefaultCmd("repo", "--git-email", "test@test.com")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("required flag(s) \"git-url\" not set"))
+		})
+
+		It("missing all required flags", func() {
+			cmd := newMockDefaultCmd("repo")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("required flag(s) \"git-email\", \"git-url\" not set"))
+		})
+
+		It("invalid flag --dummy", func() {
+			cmd := newMockDefaultCmd("repo", "--invalid", "dummy")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
+		})
+	})
+})

--- a/pkg/ctl/generate/generate_test.go
+++ b/pkg/ctl/generate/generate_test.go
@@ -11,21 +11,21 @@ import (
 var _ = Describe("generate", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockCmd("invalid-resource")
+			cmd := newMockDefaultCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockCmd("invalid-resource", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"generate\""))
@@ -34,8 +34,16 @@ var _ = Describe("generate", func() {
 	})
 })
 
-func newMockCmd(args ...string) *mockVerbCmd {
+func newMockDefaultCmd(args ...string) *mockVerbCmd {
 	cmd := Command(cmdutils.NewGrouping())
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+func newMockEmptyCmd(args ...string) *mockVerbCmd {
+	cmd := cmdutils.NewVerbCmd("get", "Get resource(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/generate/profile.go
+++ b/pkg/ctl/generate/profile.go
@@ -22,6 +22,12 @@ type options struct {
 }
 
 func generateProfileCmd(cmd *cmdutils.Cmd) {
+	generateProfileWithRunFunc(cmd, func(cmd *cmdutils.Cmd, o options) error {
+		return doGenerateProfile(cmd, o)
+	})
+}
+
+func generateProfileWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, o options) error) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
 
@@ -31,7 +37,7 @@ func generateProfileCmd(cmd *cmdutils.Cmd) {
 
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return doGenerateProfile(cmd, o)
+		return runFunc(cmd, o)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/generate/profile_test.go
+++ b/pkg/ctl/generate/profile_test.go
@@ -1,0 +1,74 @@
+package generate
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("generate", func() {
+	Describe("profile", func() {
+		It("with required flag", func() {
+			count := 0
+			cmd := newMockEmptyCmd("profile", "--git-url", "git://dummy-repo")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				generateProfileWithRunFunc(cmd, func(cmd *cmdutils.Cmd, o options) error {
+					Expect(o.GitOptions.URL).To(Equal("git://dummy-repo"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("without required flag", func() {
+			cmd := newMockDefaultCmd("profile")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("required flag(s) \"git-url\" not set"))
+		})
+
+		It("with all flags", func() {
+			count := 0
+			cmd := newMockEmptyCmd("profile", "--git-url", "git://dummy-repo", "--git-branch", "master", "--profile-path", "/")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				generateProfileWithRunFunc(cmd, func(cmd *cmdutils.Cmd, o options) error {
+					Expect(o.GitOptions.URL).To(Equal("git://dummy-repo"))
+					Expect(o.GitOptions.Branch).To(Equal("master"))
+					Expect(o.ProfilePath).To(Equal("/"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with deprecated cluster flag", func() {
+			count := 0
+			cmd := newMockEmptyCmd("profile", "--git-url", "git://dummy-repo", "--name", "clusterName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				generateProfileWithRunFunc(cmd, func(cmd *cmdutils.Cmd, o options) error {
+					Expect(o.GitOptions.URL).To(Equal("git://dummy-repo"))
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					count++
+					return nil
+				})
+			})
+			out, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+			Expect(out).To(ContainSubstring("Flag --name has been deprecated, use --cluster"))
+		})
+
+		It("invalid flag --dummy", func() {
+			cmd := newMockDefaultCmd("profile", "--invalid", "dummy")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
+		})
+	})
+})

--- a/pkg/ctl/get/cluster.go
+++ b/pkg/ctl/get/cluster.go
@@ -11,6 +11,12 @@ import (
 )
 
 func getClusterCmd(cmd *cmdutils.Cmd) {
+	getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
+		return doGetCluster(cmd, params, listAllRegions)
+	})
+}
+
+func getClusterWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
 
@@ -22,7 +28,7 @@ func getClusterCmd(cmd *cmdutils.Cmd) {
 
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return doGetCluster(cmd, params, listAllRegions)
+		return runFunc(cmd, params, listAllRegions)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/get/cluster_test.go
+++ b/pkg/ctl/get/cluster_test.go
@@ -1,17 +1,113 @@
 package get
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
 var _ = Describe("get", func() {
 	Describe("cluster", func() {
+		It("without cluster name", func() {
+			count := 0
+			cmd := newMockEmptyGetCmd("cluster")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with cluster name as flag", func() {
+			count := 0
+			cmd := newMockEmptyGetCmd("cluster", "--name", "clusterName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with cluster name as argument", func() {
+			count := 0
+			cmd := newMockEmptyGetCmd("cluster", "clusterName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with cluster name as argument and flag", func() {
+			cmd := newMockEmptyGetCmd("cluster", "clusterName", "--name", "clusterName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
+					return doGetCluster(cmd, params, listAllRegions)
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--name=clusterName and argument clusterName cannot be used at the same time"))
+		})
+
+		It("with all-regions flags", func() {
+			count := 0
+			cmd := newMockEmptyGetCmd("cluster", "--all-regions")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with both cluster name argument and --all-regions flag", func() {
+			cmd := newMockDefaultGetCmd("cluster", "clusterName", "--all-regions")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--all-regions is for listing all clusters, it must be used without cluster name flag/argument"))
+		})
+
+		It("with both cluster name and --all-regions flags", func() {
+			cmd := newMockDefaultGetCmd("cluster", "--name", "clusterName", "--all-regions")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--all-regions is for listing all clusters, it must be used without cluster name flag/argument"))
+		})
+
 		It("with invalid flags", func() {
-			cmd := newMockCmd("cluster", "--invalid", "dummy")
+			cmd := newMockDefaultGetCmd("cluster", "--invalid", "dummy")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
+		})
+
+		It("failed due to any reason", func() {
+			cmd := newMockEmptyGetCmd("cluster")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
+					return fmt.Errorf("unable to fetch the cluster")
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unable to fetch the cluster"))
 		})
 	})
 })

--- a/pkg/ctl/get/cluster_test.go
+++ b/pkg/ctl/get/cluster_test.go
@@ -11,7 +11,7 @@ var _ = Describe("get", func() {
 	Describe("cluster", func() {
 		It("without cluster name", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd("cluster")
+			cmd := newMockEmptyCmd("cluster")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
 					count++
@@ -25,7 +25,7 @@ var _ = Describe("get", func() {
 
 		It("with cluster name as flag", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd("cluster", "--name", "clusterName")
+			cmd := newMockEmptyCmd("cluster", "--name", "clusterName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
 					count++
@@ -39,7 +39,7 @@ var _ = Describe("get", func() {
 
 		It("with cluster name as argument", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd("cluster", "clusterName")
+			cmd := newMockEmptyCmd("cluster", "clusterName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
 					count++
@@ -52,7 +52,7 @@ var _ = Describe("get", func() {
 		})
 
 		It("with cluster name as argument and flag", func() {
-			cmd := newMockDefaultGetCmd("cluster", "clusterName", "--name", "clusterName")
+			cmd := newMockDefaultCmd("cluster", "clusterName", "--name", "clusterName")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--name=clusterName and argument clusterName cannot be used at the same time"))
@@ -60,7 +60,7 @@ var _ = Describe("get", func() {
 
 		It("with all-regions flags", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd("cluster", "--all-regions")
+			cmd := newMockEmptyCmd("cluster", "--all-regions")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
 					count++
@@ -73,28 +73,28 @@ var _ = Describe("get", func() {
 		})
 
 		It("with both cluster name argument and --all-regions flag", func() {
-			cmd := newMockDefaultGetCmd("cluster", "clusterName", "--all-regions")
+			cmd := newMockDefaultCmd("cluster", "clusterName", "--all-regions")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--all-regions is for listing all clusters, it must be used without cluster name flag/argument"))
 		})
 
 		It("with both cluster name and --all-regions flags", func() {
-			cmd := newMockDefaultGetCmd("cluster", "--name", "clusterName", "--all-regions")
+			cmd := newMockDefaultCmd("cluster", "--name", "clusterName", "--all-regions")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--all-regions is for listing all clusters, it must be used without cluster name flag/argument"))
 		})
 
 		It("with invalid flags", func() {
-			cmd := newMockDefaultGetCmd("cluster", "--invalid", "dummy")
+			cmd := newMockDefaultCmd("cluster", "--invalid", "dummy")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
 		})
 
 		It("failed due to any reason", func() {
-			cmd := newMockEmptyGetCmd("cluster")
+			cmd := newMockEmptyCmd("cluster")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
 					return fmt.Errorf("unable to fetch the cluster")

--- a/pkg/ctl/get/get_test.go
+++ b/pkg/ctl/get/get_test.go
@@ -11,21 +11,21 @@ import (
 var _ = Describe("get", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockCmd("invalid-resource")
+			cmd := newMockDefaultGetCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"get\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newMockDefaultGetCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"get\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockCmd("invalid-resource", "foo")
+			cmd := newMockDefaultGetCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"get\""))
@@ -34,8 +34,18 @@ var _ = Describe("get", func() {
 	})
 })
 
-func newMockCmd(args ...string) *mockVerbCmd {
+// newMockDefaultGetCmd instantiates mock GET command with all the resource commands
+func newMockDefaultGetCmd(args ...string) *mockVerbCmd {
 	cmd := Command(cmdutils.NewGrouping())
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+// newMockEmptyGetCmd instantiates mock GET command without any resource command
+func newMockEmptyGetCmd(args ...string) *mockVerbCmd {
+	cmd := cmdutils.NewVerbCmd("get", "Get resource(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/get/get_test.go
+++ b/pkg/ctl/get/get_test.go
@@ -11,21 +11,21 @@ import (
 var _ = Describe("get", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockDefaultGetCmd("invalid-resource")
+			cmd := newMockDefaultCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"get\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockDefaultGetCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"get\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockDefaultGetCmd("invalid-resource", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"get\""))
@@ -34,8 +34,8 @@ var _ = Describe("get", func() {
 	})
 })
 
-// newMockDefaultGetCmd instantiates mock GET command with all the resource commands
-func newMockDefaultGetCmd(args ...string) *mockVerbCmd {
+// newMockDefaultCmd instantiates mock GET command with all the resource commands
+func newMockDefaultCmd(args ...string) *mockVerbCmd {
 	cmd := Command(cmdutils.NewGrouping())
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
@@ -43,8 +43,8 @@ func newMockDefaultGetCmd(args ...string) *mockVerbCmd {
 	}
 }
 
-// newMockEmptyGetCmd instantiates mock GET command without any resource command
-func newMockEmptyGetCmd(args ...string) *mockVerbCmd {
+// newMockEmptyCmd instantiates mock GET command without any resource command
+func newMockEmptyCmd(args ...string) *mockVerbCmd {
 	cmd := cmdutils.NewVerbCmd("get", "Get resource(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{

--- a/pkg/ctl/get/iamidentitymapping.go
+++ b/pkg/ctl/get/iamidentitymapping.go
@@ -16,6 +16,12 @@ import (
 )
 
 func getIAMIdentityMappingCmd(cmd *cmdutils.Cmd) {
+	getIAMIdentityMappingWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, arn string) error {
+		return doGetIAMIdentityMapping(cmd, params, arn)
+	})
+}
+
+func getIAMIdentityMappingWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, params *getCmdParams, arn string) error) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
 
@@ -27,7 +33,7 @@ func getIAMIdentityMappingCmd(cmd *cmdutils.Cmd) {
 
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return doGetIAMIdentityMapping(cmd, params, arn)
+		return runFunc(cmd, params, arn)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/get/iamidentitymapping_test.go
+++ b/pkg/ctl/get/iamidentitymapping_test.go
@@ -11,7 +11,7 @@ var _ = Describe("get", func() {
 
 		It("with cluster name argument", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd( "iamidentitymapping", "dummyName")
+			cmd := newMockEmptyCmd( "iamidentitymapping", "dummyName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getIAMIdentityMappingWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, arn string) error {
 					Expect(cmd.NameArg).To(Equal("dummyName"))
@@ -26,7 +26,7 @@ var _ = Describe("get", func() {
 
 		It("with cluster name flag (--cluster)", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd( "iamidentitymapping", "--cluster", "dummyName")
+			cmd := newMockEmptyCmd( "iamidentitymapping", "--cluster", "dummyName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getIAMIdentityMappingWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, arn string) error {
 					Expect(cmd.NameArg).To(Equal(""))
@@ -42,7 +42,7 @@ var _ = Describe("get", func() {
 
 		It("with cluster name flag (--name) (deprecated)", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd( "iamidentitymapping", "--name", "dummyName")
+			cmd := newMockEmptyCmd( "iamidentitymapping", "--name", "dummyName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getIAMIdentityMappingWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, arn string) error {
 					count++
@@ -56,21 +56,21 @@ var _ = Describe("get", func() {
 		})
 
 		It("cluster name argument and --cluster flag", func() {
-			cmd := newMockDefaultGetCmd( "iamidentitymapping", "dummyName", "--cluster", "dummyName")
+			cmd := newMockDefaultCmd( "iamidentitymapping", "dummyName", "--cluster", "dummyName")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--cluster=dummyName and argument dummyName cannot be used at the same time"))
 		})
 
 		It("no cluster name argument or flag", func() {
-			cmd := newMockDefaultGetCmd( "iamidentitymapping")
+			cmd := newMockDefaultCmd( "iamidentitymapping")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--cluster must be set"))
 		})
 
 		It("invalid flag --dummy", func() {
-			cmd := newMockDefaultGetCmd("iamidentitymapping", "--invalid", "dummy")
+			cmd := newMockDefaultCmd("iamidentitymapping", "--invalid", "dummy")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown flag: --invalid"))

--- a/pkg/ctl/get/iamidentitymapping_test.go
+++ b/pkg/ctl/get/iamidentitymapping_test.go
@@ -3,19 +3,74 @@ package get
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
 var _ = Describe("get", func() {
 	Describe("iamidentitymapping", func() {
-		It("missing required flag --cluster", func() {
-			cmd := newMockCmd( "iamidentitymapping")
+
+		It("with cluster name argument", func() {
+			count := 0
+			cmd := newMockEmptyGetCmd( "iamidentitymapping", "dummyName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getIAMIdentityMappingWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, arn string) error {
+					Expect(cmd.NameArg).To(Equal("dummyName"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with cluster name flag (--cluster)", func() {
+			count := 0
+			cmd := newMockEmptyGetCmd( "iamidentitymapping", "--cluster", "dummyName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getIAMIdentityMappingWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, arn string) error {
+					Expect(cmd.NameArg).To(Equal(""))
+					count++
+					return nil
+				})
+			})
+			out, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+			Expect(out).To(Not(ContainSubstring("Flag --name has been deprecated, use --cluster")))
+		})
+
+		It("with cluster name flag (--name) (deprecated)", func() {
+			count := 0
+			cmd := newMockEmptyGetCmd( "iamidentitymapping", "--name", "dummyName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getIAMIdentityMappingWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, arn string) error {
+					count++
+					return nil
+				})
+			})
+			out, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+			Expect(out).To(ContainSubstring("Flag --name has been deprecated, use --cluster"))
+		})
+
+		It("cluster name argument and --cluster flag", func() {
+			cmd := newMockDefaultGetCmd( "iamidentitymapping", "dummyName", "--cluster", "dummyName")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--cluster=dummyName and argument dummyName cannot be used at the same time"))
+		})
+
+		It("no cluster name argument or flag", func() {
+			cmd := newMockDefaultGetCmd( "iamidentitymapping")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--cluster must be set"))
 		})
 
 		It("invalid flag --dummy", func() {
-			cmd := newMockCmd("iamidentitymapping", "--invalid", "dummy")
+			cmd := newMockDefaultGetCmd("iamidentitymapping", "--invalid", "dummy")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown flag: --invalid"))

--- a/pkg/ctl/get/iamidentitymapping_test.go
+++ b/pkg/ctl/get/iamidentitymapping_test.go
@@ -9,9 +9,9 @@ import (
 var _ = Describe("get", func() {
 	Describe("iamidentitymapping", func() {
 
-		It("with cluster name argument", func() {
+		It("with name argument", func() {
 			count := 0
-			cmd := newMockEmptyCmd( "iamidentitymapping", "dummyName")
+			cmd := newMockEmptyCmd("iamidentitymapping", "dummyName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getIAMIdentityMappingWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, arn string) error {
 					Expect(cmd.NameArg).To(Equal("dummyName"))
@@ -26,7 +26,7 @@ var _ = Describe("get", func() {
 
 		It("with cluster name flag (--cluster)", func() {
 			count := 0
-			cmd := newMockEmptyCmd( "iamidentitymapping", "--cluster", "dummyName")
+			cmd := newMockEmptyCmd("iamidentitymapping", "--cluster", "dummyName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getIAMIdentityMappingWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, arn string) error {
 					Expect(cmd.NameArg).To(Equal(""))
@@ -42,7 +42,7 @@ var _ = Describe("get", func() {
 
 		It("with cluster name flag (--name) (deprecated)", func() {
 			count := 0
-			cmd := newMockEmptyCmd( "iamidentitymapping", "--name", "dummyName")
+			cmd := newMockEmptyCmd("iamidentitymapping", "--name", "dummyName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getIAMIdentityMappingWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, arn string) error {
 					count++
@@ -56,14 +56,14 @@ var _ = Describe("get", func() {
 		})
 
 		It("cluster name argument and --cluster flag", func() {
-			cmd := newMockDefaultCmd( "iamidentitymapping", "dummyName", "--cluster", "dummyName")
+			cmd := newMockDefaultCmd("iamidentitymapping", "dummyName", "--cluster", "dummyName")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--cluster=dummyName and argument dummyName cannot be used at the same time"))
 		})
 
 		It("no cluster name argument or flag", func() {
-			cmd := newMockDefaultCmd( "iamidentitymapping")
+			cmd := newMockDefaultCmd("iamidentitymapping")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--cluster must be set"))

--- a/pkg/ctl/get/iamserviceaccount.go
+++ b/pkg/ctl/get/iamserviceaccount.go
@@ -15,6 +15,12 @@ import (
 )
 
 func getIAMServiceAccountCmd(cmd *cmdutils.Cmd) {
+	getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
+		return doGetIAMServiceAccount(cmd, serviceAccount, params)
+	})
+}
+
+func getIAMServiceAccountWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
 
@@ -29,14 +35,14 @@ func getIAMServiceAccountCmd(cmd *cmdutils.Cmd) {
 
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return doGetIAMServiceAccount(cmd, serviceAccount, params)
+		return runFunc(cmd, serviceAccount, params)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")
 
-		fs.StringVar(&serviceAccount.Name, "name", "", "name of the iamserviceaccount to delete")
-		fs.StringVar(&serviceAccount.Namespace, "namespace", "default", "namespace where to delete the iamserviceaccount")
+		fs.StringVar(&serviceAccount.Name, "name", "", "name of the iamserviceaccount")
+		fs.StringVar(&serviceAccount.Namespace, "namespace", "default", "namespace where to retrieve the iamserviceaccount")
 
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)

--- a/pkg/ctl/get/iamserviceaccount_test.go
+++ b/pkg/ctl/get/iamserviceaccount_test.go
@@ -3,23 +3,97 @@ package get
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
 var _ = Describe("get", func() {
 	Describe("iamserviceaccount", func() {
+		It("with cluster flag", func() {
+			count := 0
+			cmd := newMockEmptyGetCmd("iamserviceaccount", "--cluster", "dummyName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
+					Expect(cmd.NameArg).To(Equal(""))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with cluster argument", func() {
+			count := 0
+			cmd := newMockEmptyGetCmd("iamserviceaccount", "dummyName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
+					Expect(cmd.NameArg).To(Equal("dummyName"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with cluster and name flag", func() {
+			count := 0
+			cmd := newMockEmptyGetCmd("iamserviceaccount", "dummyName", "--name", "serviceAccount")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
+					Expect(cmd.NameArg).To(Equal("dummyName"))
+					Expect(serviceAccount.Name).To(Equal("serviceAccount"))
+					Expect(serviceAccount.Namespace).To(Equal("default"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with cluster and namespace flag", func() {
+			count := 0
+			cmd := newMockEmptyGetCmd("iamserviceaccount", "dummyName", "--namespace", "dummyNS")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
+					Expect(cmd.NameArg).To(Equal("dummyName"))
+					Expect(serviceAccount.Namespace).To(Equal("dummyNS"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
 		It("missing required flag --cluster", func() {
-			cmd := newMockCmd( "iamserviceaccount")
+			cmd := newMockDefaultGetCmd("iamserviceaccount")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
+					return nil
+				})
+			})
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--cluster must be set"))
 		})
 
 		It("invalid flag --dummy", func() {
-			cmd := newMockCmd("iamserviceaccount", "--invalid", "dummy")
+			cmd := newMockDefaultGetCmd("iamserviceaccount", "--invalid", "dummy")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
+					return nil
+				})
+			})
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
 		})
 	})
 })
-

--- a/pkg/ctl/get/iamserviceaccount_test.go
+++ b/pkg/ctl/get/iamserviceaccount_test.go
@@ -11,7 +11,7 @@ var _ = Describe("get", func() {
 	Describe("iamserviceaccount", func() {
 		It("with cluster flag", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd("iamserviceaccount", "--cluster", "dummyName")
+			cmd := newMockEmptyCmd("iamserviceaccount", "--cluster", "dummyName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
 					Expect(cmd.NameArg).To(Equal(""))
@@ -26,7 +26,7 @@ var _ = Describe("get", func() {
 
 		It("with cluster argument", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd("iamserviceaccount", "dummyName")
+			cmd := newMockEmptyCmd("iamserviceaccount", "dummyName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
 					Expect(cmd.NameArg).To(Equal("dummyName"))
@@ -41,7 +41,7 @@ var _ = Describe("get", func() {
 
 		It("with cluster and name flag", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd("iamserviceaccount", "dummyName", "--name", "serviceAccount")
+			cmd := newMockEmptyCmd("iamserviceaccount", "dummyName", "--name", "serviceAccount")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
 					Expect(cmd.NameArg).To(Equal("dummyName"))
@@ -58,7 +58,7 @@ var _ = Describe("get", func() {
 
 		It("with cluster and namespace flag", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd("iamserviceaccount", "dummyName", "--namespace", "dummyNS")
+			cmd := newMockEmptyCmd("iamserviceaccount", "dummyName", "--namespace", "dummyNS")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
 					Expect(cmd.NameArg).To(Equal("dummyName"))
@@ -73,7 +73,7 @@ var _ = Describe("get", func() {
 		})
 
 		It("missing required flag --cluster", func() {
-			cmd := newMockDefaultGetCmd("iamserviceaccount")
+			cmd := newMockDefaultCmd("iamserviceaccount")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
 					return nil
@@ -85,7 +85,7 @@ var _ = Describe("get", func() {
 		})
 
 		It("invalid flag --dummy", func() {
-			cmd := newMockDefaultGetCmd("iamserviceaccount", "--invalid", "dummy")
+			cmd := newMockDefaultCmd("iamserviceaccount", "--invalid", "dummy")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getIAMServiceAccountWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, params *getCmdParams) error {
 					return nil

--- a/pkg/ctl/get/labels.go
+++ b/pkg/ctl/get/labels.go
@@ -16,6 +16,12 @@ import (
 )
 
 func getLabelsCmd(cmd *cmdutils.Cmd) {
+	getLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, nodeGroupName string) error {
+		return getLabels(cmd, nodeGroupName)
+	})
+}
+
+func getLabelsWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, nodeGroupName string) error) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
 
@@ -24,7 +30,7 @@ func getLabelsCmd(cmd *cmdutils.Cmd) {
 	var nodeGroupName string
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return getLabels(cmd, nodeGroupName)
+		return runFunc(cmd, nodeGroupName)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/get/labels_test.go
+++ b/pkg/ctl/get/labels_test.go
@@ -10,7 +10,7 @@ var _ = Describe("get", func() {
 	Describe("labels", func() {
 		It("with cluster name as flag", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd("labels", "--cluster", "clusterName")
+			cmd := newMockEmptyCmd("labels", "--cluster", "clusterName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, nodeGroupName string) error {
 					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
@@ -25,7 +25,7 @@ var _ = Describe("get", func() {
 
 		It("with cluster name and node group flags", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd("labels", "--cluster", "clusterName", "--nodegroup", "nodeGroup")
+			cmd := newMockEmptyCmd("labels", "--cluster", "clusterName", "--nodegroup", "nodeGroup")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, nodeGroupName string) error {
 					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
@@ -40,28 +40,28 @@ var _ = Describe("get", func() {
 		})
 
 		It("with one name argument", func() {
-			cmd := newMockDefaultGetCmd("labels", "clusterName", "--cluster", "dummyName")
+			cmd := newMockDefaultCmd("labels", "clusterName", "--cluster", "dummyName")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("name argument is not supported"))
 		})
 
 		It("missing required flag --cluster", func() {
-			cmd := newMockDefaultGetCmd( "labels")
+			cmd := newMockDefaultCmd( "labels")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--cluster must be set"))
 		})
 
 		It("missing required flag --cluster, but with --nodegroup", func() {
-			cmd := newMockDefaultGetCmd( "labels", "--nodegroup", "dummyNodeGroup")
+			cmd := newMockDefaultCmd( "labels", "--nodegroup", "dummyNodeGroup")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--cluster must be set"))
 		})
 
 		It("setting name argument", func() {
-			cmd := newMockDefaultGetCmd("labels", "--cluster", "dummy", "dummyName")
+			cmd := newMockDefaultCmd("labels", "--cluster", "dummy", "dummyName")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("name argument is not supported"))

--- a/pkg/ctl/get/labels_test.go
+++ b/pkg/ctl/get/labels_test.go
@@ -3,26 +3,65 @@ package get
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
 var _ = Describe("get", func() {
 	Describe("labels", func() {
+		It("with cluster name as flag", func() {
+			count := 0
+			cmd := newMockEmptyGetCmd("labels", "--cluster", "clusterName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, nodeGroupName string) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with cluster name and node group flags", func() {
+			count := 0
+			cmd := newMockEmptyGetCmd("labels", "--cluster", "clusterName", "--nodegroup", "nodeGroup")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, nodeGroupName string) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(nodeGroupName).To(Equal("nodeGroup"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with one name argument", func() {
+			cmd := newMockDefaultGetCmd("labels", "clusterName", "--cluster", "dummyName")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("name argument is not supported"))
+		})
+
 		It("missing required flag --cluster", func() {
-			cmd := newMockCmd( "labels")
+			cmd := newMockDefaultGetCmd( "labels")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--cluster must be set"))
 		})
 
 		It("missing required flag --cluster, but with --nodegroup", func() {
-			cmd := newMockCmd( "labels", "--nodegroup", "dummyNodeGroup")
+			cmd := newMockDefaultGetCmd( "labels", "--nodegroup", "dummyNodeGroup")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--cluster must be set"))
 		})
 
 		It("setting name argument", func() {
-			cmd := newMockCmd("labels", "--cluster", "dummy", "dummyName")
+			cmd := newMockDefaultGetCmd("labels", "--cluster", "dummy", "dummyName")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("name argument is not supported"))

--- a/pkg/ctl/get/nodegroup.go
+++ b/pkg/ctl/get/nodegroup.go
@@ -16,6 +16,12 @@ import (
 )
 
 func getNodeGroupCmd(cmd *cmdutils.Cmd) {
+	getNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *getCmdParams) error {
+		return doGetNodeGroup(cmd, ng, params)
+	})
+}
+
+func getNodeGroupWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *getCmdParams) error) {
 	cfg := api.NewClusterConfig()
 	ng := api.NewNodeGroup()
 	cmd.ClusterConfig = cfg
@@ -26,7 +32,7 @@ func getNodeGroupCmd(cmd *cmdutils.Cmd) {
 
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return doGetNodeGroup(cmd, ng, params)
+		return runFunc(cmd, ng, params)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
@@ -70,8 +76,8 @@ func doGetNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *getCmdParams) 
 		return err
 	}
 
-	manager := ctl.NewStackManager(cfg)
-	summaries, err := manager.GetNodeGroupSummaries(ng.Name)
+	mng := ctl.NewStackManager(cfg)
+	summaries, err := mng.GetNodeGroupSummaries(ng.Name)
 	if err != nil {
 		return errors.Wrap(err, "getting nodegroup stack summaries")
 	}

--- a/pkg/ctl/get/nodegroup_test.go
+++ b/pkg/ctl/get/nodegroup_test.go
@@ -3,26 +3,59 @@ package get
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
 var _ = Describe("get", func() {
 	Describe("nodegroup", func() {
+		It("with cluster name as flag", func() {
+			count := 0
+			cmd := newMockEmptyGetCmd("nodegroup", "--cluster", "clusterName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *v1alpha5.NodeGroup, params *getCmdParams) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with cluster name and node group flags", func() {
+			count := 0
+			cmd := newMockEmptyGetCmd("nodegroup", "--cluster", "clusterName", "--name", "nodeGroup")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				getNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *v1alpha5.NodeGroup, params *getCmdParams) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(ng.Name).To(Equal("nodeGroup"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+		
 		It("missing required flag --cluster", func() {
-			cmd := newMockCmd( "nodegroup")
+			cmd := newMockDefaultGetCmd("nodegroup")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--cluster must be set"))
 		})
 
 		It("setting --name and argument at the same time", func() {
-			cmd := newMockCmd("nodegroup", "ng", "--cluster", "dummy", "--name", "ng")
+			cmd := newMockDefaultGetCmd("nodegroup", "ng", "--cluster", "dummy", "--name", "ng")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--name=ng and argument ng cannot be used at the same time"))
 		})
 
 		It("invalid flag", func() {
-			cmd := newMockCmd( "nodegroup", "--invalid", "dummy")
+			cmd := newMockDefaultGetCmd("nodegroup", "--invalid", "dummy")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown flag: --invalid"))

--- a/pkg/ctl/get/nodegroup_test.go
+++ b/pkg/ctl/get/nodegroup_test.go
@@ -11,7 +11,7 @@ var _ = Describe("get", func() {
 	Describe("nodegroup", func() {
 		It("with cluster name as flag", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd("nodegroup", "--cluster", "clusterName")
+			cmd := newMockEmptyCmd("nodegroup", "--cluster", "clusterName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *v1alpha5.NodeGroup, params *getCmdParams) error {
 					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
@@ -26,7 +26,7 @@ var _ = Describe("get", func() {
 
 		It("with cluster name and node group flags", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd("nodegroup", "--cluster", "clusterName", "--name", "nodeGroup")
+			cmd := newMockEmptyCmd("nodegroup", "--cluster", "clusterName", "--name", "nodeGroup")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				getNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *v1alpha5.NodeGroup, params *getCmdParams) error {
 					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
@@ -39,23 +39,23 @@ var _ = Describe("get", func() {
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(count).To(Equal(1))
 		})
-		
+
 		It("missing required flag --cluster", func() {
-			cmd := newMockDefaultGetCmd("nodegroup")
+			cmd := newMockDefaultCmd("nodegroup")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--cluster must be set"))
 		})
 
 		It("setting --name and argument at the same time", func() {
-			cmd := newMockDefaultGetCmd("nodegroup", "ng", "--cluster", "dummy", "--name", "ng")
+			cmd := newMockDefaultCmd("nodegroup", "ng", "--cluster", "dummy", "--name", "ng")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--name=ng and argument ng cannot be used at the same time"))
 		})
 
 		It("invalid flag", func() {
-			cmd := newMockDefaultGetCmd("nodegroup", "--invalid", "dummy")
+			cmd := newMockDefaultCmd("nodegroup", "--invalid", "dummy")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown flag: --invalid"))

--- a/pkg/ctl/scale/nodegroup.go
+++ b/pkg/ctl/scale/nodegroup.go
@@ -16,7 +16,7 @@ func scaleNodeGroupCmd(cmd *cmdutils.Cmd) {
 	})
 }
 
-func scaleNodeGroupWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, ng *api.NodeGroup) error ) {
+func scaleNodeGroupWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, ng *api.NodeGroup) error) {
 	cfg := api.NewClusterConfig()
 	ng := cfg.NewNodeGroup()
 	cmd.ClusterConfig = cfg
@@ -66,6 +66,10 @@ func doScaleNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup) error {
 		return cmdutils.ErrMustBeSet("--name")
 	}
 
+	if ng.DesiredCapacity == nil || *ng.DesiredCapacity < 0 {
+		return fmt.Errorf("number of nodes must be 0 or greater. Use the --nodes/-N flag")
+	}
+
 	ctl, err := cmd.NewCtl()
 	if err != nil {
 		return err
@@ -73,10 +77,6 @@ func doScaleNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup) error {
 
 	if err := ctl.CheckAuth(); err != nil {
 		return err
-	}
-
-	if ng.DesiredCapacity == nil || *ng.DesiredCapacity < 0 {
-		return fmt.Errorf("number of nodes must be 0 or greater. Use the --nodes/-N flag")
 	}
 
 	stackManager := ctl.NewStackManager(cfg)

--- a/pkg/ctl/scale/nodegroup.go
+++ b/pkg/ctl/scale/nodegroup.go
@@ -11,6 +11,12 @@ import (
 )
 
 func scaleNodeGroupCmd(cmd *cmdutils.Cmd) {
+	scaleNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *api.NodeGroup) error {
+		return doScaleNodeGroup(cmd, ng)
+	})
+}
+
+func scaleNodeGroupWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, ng *api.NodeGroup) error ) {
 	cfg := api.NewClusterConfig()
 	ng := cfg.NewNodeGroup()
 	cmd.ClusterConfig = cfg
@@ -19,7 +25,7 @@ func scaleNodeGroupCmd(cmd *cmdutils.Cmd) {
 
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return doScaleNodeGroup(cmd, ng)
+		return runFunc(cmd, ng)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/scale/nodegroup_test.go
+++ b/pkg/ctl/scale/nodegroup_test.go
@@ -1,0 +1,57 @@
+package scale
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("scale", func() {
+	Describe("nodegroup", func() {
+		It("with valid details", func() {
+			count := 0
+			cmd := newMockEmptyCmd("nodegroup", "--cluster", "clusterName", "--name", "nodeGroup", "--nodes", "2")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				scaleNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *v1alpha5.NodeGroup) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(ng.Name).To(Equal("nodeGroup"))
+					Expect(*ng.DesiredCapacity).To(Equal(2))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("missing required flag --cluster", func() {
+			cmd := newMockDefaultCmd("nodegroup")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--cluster must be set"))
+		})
+
+		It("setting --name and argument at the same time", func() {
+			cmd := newMockDefaultCmd("nodegroup", "ng", "--cluster", "dummy", "--name", "ng")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--name=ng and argument ng cannot be used at the same time"))
+		})
+
+		It("missing required nodes flag --nodes", func() {
+			cmd := newMockDefaultCmd("nodegroup", "ng", "--cluster", "dummy")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("number of nodes must be 0 or greater. Use the --nodes/-N flag"))
+		})
+
+		It("invalid flag", func() {
+			cmd := newMockDefaultCmd("nodegroup", "--invalid", "dummy")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
+		})
+	})
+})

--- a/pkg/ctl/scale/scale_test.go
+++ b/pkg/ctl/scale/scale_test.go
@@ -11,21 +11,21 @@ import (
 var _ = Describe("generate", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockCmd("invalid-resource")
+			cmd := newMockDefaultCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"scale\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"scale\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockCmd("invalid-resource", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"scale\""))
@@ -34,9 +34,17 @@ var _ = Describe("generate", func() {
 	})
 })
 
-func newMockCmd(args ...string) *mockVerbCmd {
+func newMockDefaultCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
 	cmd := Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+func newMockEmptyCmd(args ...string) *mockVerbCmd {
+	cmd := cmdutils.NewVerbCmd("scale", "Scale resources(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/set/labels.go
+++ b/pkg/ctl/set/labels.go
@@ -17,6 +17,12 @@ type labelOptions struct {
 }
 
 func setLabelsCmd(cmd *cmdutils.Cmd) {
+	setLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options labelOptions) error {
+		return setLabels(cmd, options)
+	})
+}
+
+func setLabelsWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, options labelOptions) error) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
 
@@ -25,7 +31,7 @@ func setLabelsCmd(cmd *cmdutils.Cmd) {
 	var options labelOptions
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return setLabels(cmd, options)
+		return runFunc(cmd, options)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/set/labels_test.go
+++ b/pkg/ctl/set/labels_test.go
@@ -10,7 +10,7 @@ var _ = Describe("set", func() {
 	Describe("labels", func() {
 		It("with valid details", func() {
 			count := 0
-			cmd := newMockEmptySetCmd("labels", "--cluster", "clusterName", "--labels", "testLabel=testValue")
+			cmd := newMockEmptyCmd("labels", "--cluster", "clusterName", "--labels", "testLabel=testValue")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				setLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options labelOptions) error {
 					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
@@ -27,7 +27,7 @@ var _ = Describe("set", func() {
 		})
 
 		It("with invalid label format", func() {
-			cmd := newMockDefaultSetCmd("labels", "--cluster", "clusterName", "--labels", "testLabel")
+			cmd := newMockDefaultCmd("labels", "--cluster", "clusterName", "--labels", "testLabel")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid argument \"testLabel\" for \"-l, --labels\" flag: testLabel must be formatted as key=value"))
@@ -35,7 +35,7 @@ var _ = Describe("set", func() {
 
 		It("with cluster name and node group flags", func() {
 			count := 0
-			cmd := newMockEmptySetCmd("labels", "--cluster", "clusterName", "--nodegroup", "nodeGroup", "--labels", "testLabel=testValue")
+			cmd := newMockEmptyCmd("labels", "--cluster", "clusterName", "--nodegroup", "nodeGroup", "--labels", "testLabel=testValue")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				setLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options labelOptions) error {
 					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
@@ -50,28 +50,28 @@ var _ = Describe("set", func() {
 		})
 
 		It("with one name argument", func() {
-			cmd := newMockDefaultSetCmd("labels", "clusterName", "--cluster", "dummyName", "--labels", "testLabel=testValue")
+			cmd := newMockDefaultCmd("labels", "clusterName", "--cluster", "dummyName", "--labels", "testLabel=testValue")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("name argument is not supported"))
 		})
 
 		It("missing required flag --labels", func() {
-			cmd := newMockDefaultSetCmd("labels")
+			cmd := newMockDefaultCmd("labels")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("required flag(s) \"labels\" not set"))
 		})
 
 		It("missing required flag --labels", func() {
-			cmd := newMockDefaultSetCmd("labels", "--cluster", "dummyName")
+			cmd := newMockDefaultCmd("labels", "--cluster", "dummyName")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("required flag(s) \"labels\" not set"))
 		})
 
 		It("setting name argument", func() {
-			cmd := newMockDefaultSetCmd("labels", "--cluster", "dummy", "dummyName", "--labels", "testLabel=testValue")
+			cmd := newMockDefaultCmd("labels", "--cluster", "dummy", "dummyName", "--labels", "testLabel=testValue")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("name argument is not supported"))

--- a/pkg/ctl/set/labels_test.go
+++ b/pkg/ctl/set/labels_test.go
@@ -1,0 +1,80 @@
+package set
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("set", func() {
+	Describe("labels", func() {
+		It("with valid details", func() {
+			count := 0
+			cmd := newMockEmptySetCmd("labels", "--cluster", "clusterName", "--labels", "testLabel=testValue")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				setLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options labelOptions) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(options.labels).To(Equal(map[string]string{
+						"testLabel": "testValue",
+					}))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with invalid label format", func() {
+			cmd := newMockDefaultSetCmd("labels", "--cluster", "clusterName", "--labels", "testLabel")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid argument \"testLabel\" for \"-l, --labels\" flag: testLabel must be formatted as key=value"))
+		})
+
+		It("with cluster name and node group flags", func() {
+			count := 0
+			cmd := newMockEmptySetCmd("labels", "--cluster", "clusterName", "--nodegroup", "nodeGroup", "--labels", "testLabel=testValue")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				setLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options labelOptions) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(options.nodeGroupName).To(Equal("nodeGroup"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with one name argument", func() {
+			cmd := newMockDefaultSetCmd("labels", "clusterName", "--cluster", "dummyName", "--labels", "testLabel=testValue")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("name argument is not supported"))
+		})
+
+		It("missing required flag --labels", func() {
+			cmd := newMockDefaultSetCmd("labels")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("required flag(s) \"labels\" not set"))
+		})
+
+		It("missing required flag --labels", func() {
+			cmd := newMockDefaultSetCmd("labels", "--cluster", "dummyName")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("required flag(s) \"labels\" not set"))
+		})
+
+		It("setting name argument", func() {
+			cmd := newMockDefaultSetCmd("labels", "--cluster", "dummy", "dummyName", "--labels", "testLabel=testValue")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("name argument is not supported"))
+		})
+	})
+})

--- a/pkg/ctl/set/set_test.go
+++ b/pkg/ctl/set/set_test.go
@@ -11,21 +11,21 @@ import (
 var _ = Describe("set", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockDefaultSetCmd("invalid-resource")
+			cmd := newMockDefaultCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"set\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockDefaultSetCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"set\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockDefaultSetCmd("invalid-resource", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"set\""))
@@ -34,7 +34,7 @@ var _ = Describe("set", func() {
 	})
 })
 
-func newMockDefaultSetCmd(args ...string) *mockVerbCmd {
+func newMockDefaultCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
 	cmd := Command(flagGrouping)
 	cmd.SetArgs(args)
@@ -43,7 +43,7 @@ func newMockDefaultSetCmd(args ...string) *mockVerbCmd {
 	}
 }
 
-func newMockEmptySetCmd(args ...string) *mockVerbCmd {
+func newMockEmptyCmd(args ...string) *mockVerbCmd {
 	cmd := cmdutils.NewVerbCmd("set", "Set value(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{

--- a/pkg/ctl/set/set_test.go
+++ b/pkg/ctl/set/set_test.go
@@ -11,21 +11,21 @@ import (
 var _ = Describe("set", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockCmd("invalid-resource")
+			cmd := newMockDefaultSetCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"set\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newMockDefaultSetCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"set\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockCmd("invalid-resource", "foo")
+			cmd := newMockDefaultSetCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"set\""))
@@ -34,9 +34,17 @@ var _ = Describe("set", func() {
 	})
 })
 
-func newMockCmd(args ...string) *mockVerbCmd {
+func newMockDefaultSetCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
 	cmd := Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+func newMockEmptySetCmd(args ...string) *mockVerbCmd {
+	cmd := cmdutils.NewVerbCmd("set", "Set value(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/unset/labels.go
+++ b/pkg/ctl/unset/labels.go
@@ -12,10 +12,16 @@ import (
 )
 
 func unsetLabelsCmd(cmd *cmdutils.Cmd) {
+	unsetLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, nodeGroupName string, removeLabels []string) error {
+		return unsetLabels(cmd, nodeGroupName, removeLabels)
+	})
+}
+
+func unsetLabelsWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, nodeGroupName string, removeLabels []string) error) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
 
-	cmd.SetDescription("labels", "Create removeLabels", "")
+	cmd.SetDescription("labels", "Remove Labels", "")
 
 	var (
 		nodeGroupName string
@@ -23,7 +29,7 @@ func unsetLabelsCmd(cmd *cmdutils.Cmd) {
 	)
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return unsetLabels(cmd, nodeGroupName, removeLabels)
+		return runFunc(cmd, nodeGroupName, removeLabels)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/unset/labels_test.go
+++ b/pkg/ctl/unset/labels_test.go
@@ -10,7 +10,7 @@ var _ = Describe("unset", func() {
 	Describe("labels", func() {
 		It("with valid details", func() {
 			count := 0
-			cmd := newMockEmptyUnsetCmd("labels", "--cluster", "clusterName", "--labels", "testLabel")
+			cmd := newMockEmptyCmd("labels", "--cluster", "clusterName", "--labels", "testLabel")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				unsetLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, nodeGroupName string, removeLabels []string) error {
 					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
@@ -26,7 +26,7 @@ var _ = Describe("unset", func() {
 
 		It("with multiple labels", func() {
 			count := 0
-			cmd := newMockEmptyUnsetCmd("labels", "--cluster", "clusterName", "--labels", "testLabel,testAnotherLabel")
+			cmd := newMockEmptyCmd("labels", "--cluster", "clusterName", "--labels", "testLabel,testAnotherLabel")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				unsetLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, nodeGroupName string, removeLabels []string) error {
 					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
@@ -42,7 +42,7 @@ var _ = Describe("unset", func() {
 
 		It("with cluster name and node group flags", func() {
 			count := 0
-			cmd := newMockEmptyUnsetCmd("labels", "--cluster", "clusterName", "--nodegroup", "nodeGroup", "--labels", "testLabel")
+			cmd := newMockEmptyCmd("labels", "--cluster", "clusterName", "--nodegroup", "nodeGroup", "--labels", "testLabel")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				unsetLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, nodeGroupName string, removeLabels []string) error {
 					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
@@ -58,28 +58,28 @@ var _ = Describe("unset", func() {
 		})
 
 		It("with one name argument", func() {
-			cmd := newMockDefaultUnsetCmd("labels", "clusterName", "--cluster", "dummyName", "--labels", "testLabel")
+			cmd := newMockDefaultCmd("labels", "clusterName", "--cluster", "dummyName", "--labels", "testLabel")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("name argument is not supported"))
 		})
 
 		It("missing required flag --labels", func() {
-			cmd := newMockDefaultUnsetCmd("labels")
+			cmd := newMockDefaultCmd("labels")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("required flag(s) \"labels\" not set"))
 		})
 
 		It("missing required flag --labels", func() {
-			cmd := newMockDefaultUnsetCmd("labels", "--cluster", "dummyName")
+			cmd := newMockDefaultCmd("labels", "--cluster", "dummyName")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("required flag(s) \"labels\" not set"))
 		})
 
 		It("setting name argument", func() {
-			cmd := newMockDefaultUnsetCmd("labels", "--cluster", "dummy", "dummyName", "--labels", "testLabel")
+			cmd := newMockDefaultCmd("labels", "--cluster", "dummy", "dummyName", "--labels", "testLabel")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("name argument is not supported"))

--- a/pkg/ctl/unset/labels_test.go
+++ b/pkg/ctl/unset/labels_test.go
@@ -1,0 +1,88 @@
+package unset
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("unset", func() {
+	Describe("labels", func() {
+		It("with valid details", func() {
+			count := 0
+			cmd := newMockEmptyUnsetCmd("labels", "--cluster", "clusterName", "--labels", "testLabel")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				unsetLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, nodeGroupName string, removeLabels []string) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(removeLabels).To(ConsistOf("testLabel"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with multiple labels", func() {
+			count := 0
+			cmd := newMockEmptyUnsetCmd("labels", "--cluster", "clusterName", "--labels", "testLabel,testAnotherLabel")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				unsetLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, nodeGroupName string, removeLabels []string) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(removeLabels).To(ConsistOf("testLabel", "testAnotherLabel"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with cluster name and node group flags", func() {
+			count := 0
+			cmd := newMockEmptyUnsetCmd("labels", "--cluster", "clusterName", "--nodegroup", "nodeGroup", "--labels", "testLabel")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				unsetLabelsWithRunFunc(cmd, func(cmd *cmdutils.Cmd, nodeGroupName string, removeLabels []string) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(nodeGroupName).To(Equal("nodeGroup"))
+					Expect(removeLabels).To(ConsistOf("testLabel"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with one name argument", func() {
+			cmd := newMockDefaultUnsetCmd("labels", "clusterName", "--cluster", "dummyName", "--labels", "testLabel")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("name argument is not supported"))
+		})
+
+		It("missing required flag --labels", func() {
+			cmd := newMockDefaultUnsetCmd("labels")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("required flag(s) \"labels\" not set"))
+		})
+
+		It("missing required flag --labels", func() {
+			cmd := newMockDefaultUnsetCmd("labels", "--cluster", "dummyName")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("required flag(s) \"labels\" not set"))
+		})
+
+		It("setting name argument", func() {
+			cmd := newMockDefaultUnsetCmd("labels", "--cluster", "dummy", "dummyName", "--labels", "testLabel")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("name argument is not supported"))
+		})
+	})
+})

--- a/pkg/ctl/unset/unset_test.go
+++ b/pkg/ctl/unset/unset_test.go
@@ -11,21 +11,21 @@ import (
 var _ = Describe("unset", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockDefaultUnsetCmd("invalid-resource")
+			cmd := newMockDefaultCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"unset\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockDefaultUnsetCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"unset\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockDefaultUnsetCmd("invalid-resource", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"unset\""))
@@ -34,7 +34,7 @@ var _ = Describe("unset", func() {
 	})
 })
 
-func newMockDefaultUnsetCmd(args ...string) *mockVerbCmd {
+func newMockDefaultCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
 	cmd := Command(flagGrouping)
 	cmd.SetArgs(args)
@@ -43,7 +43,7 @@ func newMockDefaultUnsetCmd(args ...string) *mockVerbCmd {
 	}
 }
 
-func newMockEmptyUnsetCmd(args ...string) *mockVerbCmd {
+func newMockEmptyCmd(args ...string) *mockVerbCmd {
 	cmd := cmdutils.NewVerbCmd("unset", "Unset values", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{

--- a/pkg/ctl/unset/unset_test.go
+++ b/pkg/ctl/unset/unset_test.go
@@ -11,21 +11,21 @@ import (
 var _ = Describe("unset", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockCmd("invalid-resource")
+			cmd := newMockDefaultUnsetCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"unset\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newMockDefaultUnsetCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"unset\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockCmd("invalid-resource", "foo")
+			cmd := newMockDefaultUnsetCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"unset\""))
@@ -34,9 +34,17 @@ var _ = Describe("unset", func() {
 	})
 })
 
-func newMockCmd(args ...string) *mockVerbCmd {
+func newMockDefaultUnsetCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
 	cmd := Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+func newMockEmptyUnsetCmd(args ...string) *mockVerbCmd {
+	cmd := cmdutils.NewVerbCmd("unset", "Unset values", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/update/cluster_test.go
+++ b/pkg/ctl/update/cluster_test.go
@@ -1,4 +1,4 @@
-package get
+package update
 
 import (
 	"fmt"
@@ -7,13 +7,13 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-var _ = Describe("get", func() {
+var _ = Describe("update", func() {
 	Describe("cluster", func() {
 		It("without cluster name", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd("cluster")
+			cmd := newMockEmptyUpdateCmd("cluster")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
-				getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
+				updateClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
 					count++
 					return nil
 				})
@@ -25,9 +25,9 @@ var _ = Describe("get", func() {
 
 		It("with cluster name as flag", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd("cluster", "--name", "clusterName")
+			cmd := newMockEmptyUpdateCmd("cluster", "--name", "clusterName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
-				getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
+				updateClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
 					count++
 					return nil
 				})
@@ -39,9 +39,9 @@ var _ = Describe("get", func() {
 
 		It("with cluster name as argument", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd("cluster", "clusterName")
+			cmd := newMockEmptyUpdateCmd("cluster", "clusterName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
-				getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
+				updateClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
 					count++
 					return nil
 				})
@@ -52,17 +52,17 @@ var _ = Describe("get", func() {
 		})
 
 		It("with cluster name as argument and flag", func() {
-			cmd := newMockDefaultGetCmd("cluster", "clusterName", "--name", "clusterName")
+			cmd := newMockDefaultUpdateCmd("cluster", "clusterName", "--name", "clusterName")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--name=clusterName and argument clusterName cannot be used at the same time"))
 		})
 
-		It("with all-regions flags", func() {
+		It("with config file flag", func() {
 			count := 0
-			cmd := newMockEmptyGetCmd("cluster", "--all-regions")
+			cmd := newMockEmptyUpdateCmd("cluster", "--config-file", "../../../examples/01-simple-cluster.yaml")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
-				getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
+				updateClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
 					count++
 					return nil
 				})
@@ -72,31 +72,47 @@ var _ = Describe("get", func() {
 			Expect(count).To(Equal(1))
 		})
 
-		It("with both cluster name argument and --all-regions flag", func() {
-			cmd := newMockDefaultGetCmd("cluster", "clusterName", "--all-regions")
-			_, err := cmd.execute()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("--all-regions is for listing all clusters, it must be used without cluster name flag/argument"))
+		It("with cluster name and deprecated dry-run flag", func() {
+			count := 0
+			cmd := newMockEmptyUpdateCmd("cluster", "clusterName", "--dry-run")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				updateClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
+					count++
+					return nil
+				})
+			})
+			out, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+			Expect(out).To(ContainSubstring("Flag --dry-run has been deprecated, see --approve"))
 		})
 
-		It("with both cluster name and --all-regions flags", func() {
-			cmd := newMockDefaultGetCmd("cluster", "--name", "clusterName", "--all-regions")
-			_, err := cmd.execute()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("--all-regions is for listing all clusters, it must be used without cluster name flag/argument"))
+		It("with cluster name and deprecated wait flag", func() {
+			count := 0
+			cmd := newMockEmptyUpdateCmd("cluster", "clusterName", "--wait")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				updateClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
+					count++
+					return nil
+				})
+			})
+			out, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+			Expect(out).To(ContainSubstring("Flag --wait has been deprecated, --wait is no longer respected; the cluster update always waits to complete"))
 		})
 
 		It("with invalid flags", func() {
-			cmd := newMockDefaultGetCmd("cluster", "--invalid", "dummy")
+			cmd := newMockDefaultUpdateCmd("cluster", "--invalid", "dummy")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
 		})
 
 		It("failed due to any reason", func() {
-			cmd := newMockEmptyGetCmd("cluster")
+			cmd := newMockEmptyUpdateCmd("cluster")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
-				getClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
+				updateClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
 					return fmt.Errorf("unable to fetch the cluster")
 				})
 			})
@@ -106,3 +122,4 @@ var _ = Describe("get", func() {
 		})
 	})
 })
+

--- a/pkg/ctl/update/cluster_test.go
+++ b/pkg/ctl/update/cluster_test.go
@@ -11,7 +11,7 @@ var _ = Describe("update", func() {
 	Describe("cluster", func() {
 		It("without cluster name", func() {
 			count := 0
-			cmd := newMockEmptyUpdateCmd("cluster")
+			cmd := newMockEmptyCmd("cluster")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				updateClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
 					count++
@@ -25,7 +25,7 @@ var _ = Describe("update", func() {
 
 		It("with cluster name as flag", func() {
 			count := 0
-			cmd := newMockEmptyUpdateCmd("cluster", "--name", "clusterName")
+			cmd := newMockEmptyCmd("cluster", "--name", "clusterName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				updateClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
 					count++
@@ -39,7 +39,7 @@ var _ = Describe("update", func() {
 
 		It("with cluster name as argument", func() {
 			count := 0
-			cmd := newMockEmptyUpdateCmd("cluster", "clusterName")
+			cmd := newMockEmptyCmd("cluster", "clusterName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				updateClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
 					count++
@@ -52,7 +52,7 @@ var _ = Describe("update", func() {
 		})
 
 		It("with cluster name as argument and flag", func() {
-			cmd := newMockDefaultUpdateCmd("cluster", "clusterName", "--name", "clusterName")
+			cmd := newMockDefaultCmd("cluster", "clusterName", "--name", "clusterName")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--name=clusterName and argument clusterName cannot be used at the same time"))
@@ -60,7 +60,7 @@ var _ = Describe("update", func() {
 
 		It("with config file flag", func() {
 			count := 0
-			cmd := newMockEmptyUpdateCmd("cluster", "--config-file", "../../../examples/01-simple-cluster.yaml")
+			cmd := newMockEmptyCmd("cluster", "--config-file", "../../../examples/01-simple-cluster.yaml")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				updateClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
 					count++
@@ -74,7 +74,7 @@ var _ = Describe("update", func() {
 
 		It("with cluster name and deprecated dry-run flag", func() {
 			count := 0
-			cmd := newMockEmptyUpdateCmd("cluster", "clusterName", "--dry-run")
+			cmd := newMockEmptyCmd("cluster", "clusterName", "--dry-run")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				updateClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
 					count++
@@ -89,7 +89,7 @@ var _ = Describe("update", func() {
 
 		It("with cluster name and deprecated wait flag", func() {
 			count := 0
-			cmd := newMockEmptyUpdateCmd("cluster", "clusterName", "--wait")
+			cmd := newMockEmptyCmd("cluster", "clusterName", "--wait")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				updateClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
 					count++
@@ -103,14 +103,14 @@ var _ = Describe("update", func() {
 		})
 
 		It("with invalid flags", func() {
-			cmd := newMockDefaultUpdateCmd("cluster", "--invalid", "dummy")
+			cmd := newMockDefaultCmd("cluster", "--invalid", "dummy")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
 		})
 
 		It("failed due to any reason", func() {
-			cmd := newMockEmptyUpdateCmd("cluster")
+			cmd := newMockEmptyCmd("cluster")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				updateClusterWithRunFunc(cmd, func(cmd *cmdutils.Cmd) error {
 					return fmt.Errorf("unable to fetch the cluster")

--- a/pkg/ctl/update/update_test.go
+++ b/pkg/ctl/update/update_test.go
@@ -44,7 +44,7 @@ func newMockDefaultUpdateCmd(args ...string) *mockVerbCmd {
 	}
 }
 
-// newMockEmptyGetCmd instantiates mock GET command without any resource command
+// newMockEmptyUpdateCmd instantiates mock UPDATE command without any resource command
 func newMockEmptyUpdateCmd(args ...string) *mockVerbCmd {
 	cmd := cmdutils.NewVerbCmd("update", "Get resource(s)", "")
 	cmd.SetArgs(args)

--- a/pkg/ctl/update/update_test.go
+++ b/pkg/ctl/update/update_test.go
@@ -46,7 +46,7 @@ func newMockDefaultUpdateCmd(args ...string) *mockVerbCmd {
 
 // newMockEmptyUpdateCmd instantiates mock UPDATE command without any resource command
 func newMockEmptyUpdateCmd(args ...string) *mockVerbCmd {
-	cmd := cmdutils.NewVerbCmd("update", "Get resource(s)", "")
+	cmd := cmdutils.NewVerbCmd("update", "Update resource(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/update/update_test.go
+++ b/pkg/ctl/update/update_test.go
@@ -11,21 +11,21 @@ import (
 var _ = Describe("update", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockCmd("invalid-resource")
+			cmd := newMockDefaultUpdateCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"update\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newMockDefaultUpdateCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"update\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockCmd("invalid-resource", "foo")
+			cmd := newMockDefaultUpdateCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"update\""))
@@ -34,9 +34,19 @@ var _ = Describe("update", func() {
 	})
 })
 
-func newMockCmd(args ...string) *mockVerbCmd {
+// newMockDefaultUpdateCmd instantiates mock UPDATE command with all the resource commands
+func newMockDefaultUpdateCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
 	cmd := Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+// newMockEmptyGetCmd instantiates mock GET command without any resource command
+func newMockEmptyUpdateCmd(args ...string) *mockVerbCmd {
+	cmd := cmdutils.NewVerbCmd("update", "Get resource(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/update/update_test.go
+++ b/pkg/ctl/update/update_test.go
@@ -11,21 +11,21 @@ import (
 var _ = Describe("update", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockDefaultUpdateCmd("invalid-resource")
+			cmd := newMockDefaultCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"update\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockDefaultUpdateCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"update\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockDefaultUpdateCmd("invalid-resource", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"update\""))
@@ -34,8 +34,8 @@ var _ = Describe("update", func() {
 	})
 })
 
-// newMockDefaultUpdateCmd instantiates mock UPDATE command with all the resource commands
-func newMockDefaultUpdateCmd(args ...string) *mockVerbCmd {
+// newMockDefaultCmd instantiates mock UPDATE command with all the resource commands
+func newMockDefaultCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
 	cmd := Command(flagGrouping)
 	cmd.SetArgs(args)
@@ -44,8 +44,8 @@ func newMockDefaultUpdateCmd(args ...string) *mockVerbCmd {
 	}
 }
 
-// newMockEmptyUpdateCmd instantiates mock UPDATE command without any resource command
-func newMockEmptyUpdateCmd(args ...string) *mockVerbCmd {
+// newMockEmptyCmd instantiates mock UPDATE command without any resource command
+func newMockEmptyCmd(args ...string) *mockVerbCmd {
 	cmd := cmdutils.NewVerbCmd("update", "Update resource(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{

--- a/pkg/ctl/upgrade/nodegroup.go
+++ b/pkg/ctl/upgrade/nodegroup.go
@@ -17,6 +17,12 @@ type upgradeOptions struct {
 }
 
 func upgradeNodeGroupCmd(cmd *cmdutils.Cmd) {
+	upgradeNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options upgradeOptions) error {
+		return upgradeNodeGroup(cmd, options)
+	})
+}
+
+func upgradeNodeGroupWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, options upgradeOptions) error) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
 
@@ -25,7 +31,7 @@ func upgradeNodeGroupCmd(cmd *cmdutils.Cmd) {
 	var options upgradeOptions
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return upgradeNodeGroup(cmd, options)
+		return runFunc(cmd, options)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/upgrade/nodegroup_test.go
+++ b/pkg/ctl/upgrade/nodegroup_test.go
@@ -10,7 +10,7 @@ var _ = Describe("upgrade", func() {
 	Describe("nodegroup", func() {
 		It("with cluster name as flag", func() {
 			count := 0
-			cmd := newMockEmptyUpgradeCmd("nodegroup", "--cluster", "clusterName")
+			cmd := newMockEmptyCmd("nodegroup", "--cluster", "clusterName")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				upgradeNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options upgradeOptions) error {
 					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
@@ -25,7 +25,7 @@ var _ = Describe("upgrade", func() {
 
 		It("with cluster name and node group flags", func() {
 			count := 0
-			cmd := newMockEmptyUpgradeCmd("nodegroup", "--cluster", "clusterName", "--name", "nodeGroup")
+			cmd := newMockEmptyCmd("nodegroup", "--cluster", "clusterName", "--name", "nodeGroup")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				upgradeNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options upgradeOptions) error {
 					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
@@ -41,7 +41,7 @@ var _ = Describe("upgrade", func() {
 
 		It("with cluster name, node group and kube version flags", func() {
 			count := 0
-			cmd := newMockEmptyUpgradeCmd("nodegroup", "--cluster", "clusterName", "--name", "nodeGroup", "--kubernetes-version", "1.14")
+			cmd := newMockEmptyCmd("nodegroup", "--cluster", "clusterName", "--name", "nodeGroup", "--kubernetes-version", "1.14")
 			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
 				upgradeNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options upgradeOptions) error {
 					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
@@ -57,28 +57,28 @@ var _ = Describe("upgrade", func() {
 		})
 
 		It("missing required flag --cluster", func() {
-			cmd := newMockDefaultUpgradeCmd("nodegroup")
+			cmd := newMockDefaultCmd("nodegroup")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--cluster must be set"))
 		})
 
 		It("missing required node group name", func() {
-			cmd := newMockDefaultUpgradeCmd("nodegroup", "--cluster", "clusterName")
+			cmd := newMockDefaultCmd("nodegroup", "--cluster", "clusterName")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("name must be set"))
 		})
 
 		It("setting --name and argument at the same time", func() {
-			cmd := newMockDefaultUpgradeCmd("nodegroup", "ng", "--cluster", "dummy", "--name", "ng")
+			cmd := newMockDefaultCmd("nodegroup", "ng", "--cluster", "dummy", "--name", "ng")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("--name=ng and argument ng cannot be used at the same time"))
 		})
 
 		It("invalid flag", func() {
-			cmd := newMockDefaultUpgradeCmd("nodegroup", "--invalid", "dummy")
+			cmd := newMockDefaultCmd("nodegroup", "--invalid", "dummy")
 			_, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown flag: --invalid"))

--- a/pkg/ctl/upgrade/nodegroup_test.go
+++ b/pkg/ctl/upgrade/nodegroup_test.go
@@ -1,0 +1,87 @@
+package upgrade
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("upgrade", func() {
+	Describe("nodegroup", func() {
+		It("with cluster name as flag", func() {
+			count := 0
+			cmd := newMockEmptyUpgradeCmd("nodegroup", "--cluster", "clusterName")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				upgradeNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options upgradeOptions) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with cluster name and node group flags", func() {
+			count := 0
+			cmd := newMockEmptyUpgradeCmd("nodegroup", "--cluster", "clusterName", "--name", "nodeGroup")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				upgradeNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options upgradeOptions) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(options.nodeGroupName).To(Equal("nodeGroup"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("with cluster name, node group and kube version flags", func() {
+			count := 0
+			cmd := newMockEmptyUpgradeCmd("nodegroup", "--cluster", "clusterName", "--name", "nodeGroup", "--kubernetes-version", "1.14")
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				upgradeNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, options upgradeOptions) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(options.nodeGroupName).To(Equal("nodeGroup"))
+					Expect(options.kubernetesVersion).To(Equal("1.14"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		})
+
+		It("missing required flag --cluster", func() {
+			cmd := newMockDefaultUpgradeCmd("nodegroup")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--cluster must be set"))
+		})
+
+		It("missing required node group name", func() {
+			cmd := newMockDefaultUpgradeCmd("nodegroup", "--cluster", "clusterName")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("name must be set"))
+		})
+
+		It("setting --name and argument at the same time", func() {
+			cmd := newMockDefaultUpgradeCmd("nodegroup", "ng", "--cluster", "dummy", "--name", "ng")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--name=ng and argument ng cannot be used at the same time"))
+		})
+
+		It("invalid flag", func() {
+			cmd := newMockDefaultUpgradeCmd("nodegroup", "--invalid", "dummy")
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unknown flag: --invalid"))
+		})
+	})
+})

--- a/pkg/ctl/upgrade/upgrade.go
+++ b/pkg/ctl/upgrade/upgrade.go
@@ -6,7 +6,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-// Command will create the `create` commands
+// Command will create the `upgrade` commands
 func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 	verbCmd := cmdutils.NewVerbCmd("upgrade", "Upgrade resource(s)", "")
 

--- a/pkg/ctl/upgrade/upgrade_test.go
+++ b/pkg/ctl/upgrade/upgrade_test.go
@@ -46,7 +46,7 @@ func newMockDefaultUpgradeCmd(args ...string) *mockVerbCmd {
 
 // newMockEmptyUpgradeCmd instantiates mock UPGRADE command without any resource command
 func newMockEmptyUpgradeCmd(args ...string) *mockVerbCmd {
-	cmd := cmdutils.NewVerbCmd("update", "Get resource(s)", "")
+	cmd := cmdutils.NewVerbCmd("upgrade", "Upgrade resource(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/upgrade/upgrade_test.go
+++ b/pkg/ctl/upgrade/upgrade_test.go
@@ -11,21 +11,21 @@ import (
 var _ = Describe("upgrade", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockDefaultUpgradeCmd("invalid-resource")
+			cmd := newMockDefaultCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"upgrade\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockDefaultUpgradeCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"upgrade\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockDefaultUpgradeCmd("invalid-resource", "foo")
+			cmd := newMockDefaultCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"upgrade\""))
@@ -34,8 +34,8 @@ var _ = Describe("upgrade", func() {
 	})
 })
 
-// newMockDefaultUpgradeCmd instantiates mock UPGRADE command with all the resource commands
-func newMockDefaultUpgradeCmd(args ...string) *mockVerbCmd {
+// newMockDefaultCmd instantiates mock UPGRADE command with all the resource commands
+func newMockDefaultCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
 	cmd := Command(flagGrouping)
 	cmd.SetArgs(args)
@@ -44,8 +44,8 @@ func newMockDefaultUpgradeCmd(args ...string) *mockVerbCmd {
 	}
 }
 
-// newMockEmptyUpgradeCmd instantiates mock UPGRADE command without any resource command
-func newMockEmptyUpgradeCmd(args ...string) *mockVerbCmd {
+// newMockEmptyCmd instantiates mock UPGRADE command without any resource command
+func newMockEmptyCmd(args ...string) *mockVerbCmd {
 	cmd := cmdutils.NewVerbCmd("upgrade", "Upgrade resource(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{

--- a/pkg/ctl/upgrade/upgrade_test.go
+++ b/pkg/ctl/upgrade/upgrade_test.go
@@ -11,21 +11,21 @@ import (
 var _ = Describe("upgrade", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockCmd("invalid-resource")
+			cmd := newMockDefaultUpgradeCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"upgrade\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newMockDefaultUpgradeCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"upgrade\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockCmd("invalid-resource", "foo")
+			cmd := newMockDefaultUpgradeCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"upgrade\""))
@@ -34,7 +34,8 @@ var _ = Describe("upgrade", func() {
 	})
 })
 
-func newMockCmd(args ...string) *mockVerbCmd {
+// newMockDefaultUpgradeCmd instantiates mock UPGRADE command with all the resource commands
+func newMockDefaultUpgradeCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
 	cmd := Command(flagGrouping)
 	cmd.SetArgs(args)
@@ -42,6 +43,16 @@ func newMockCmd(args ...string) *mockVerbCmd {
 		parentCmd: cmd,
 	}
 }
+
+// newMockEmptyUpgradeCmd instantiates mock UPGRADE command without any resource command
+func newMockEmptyUpgradeCmd(args ...string) *mockVerbCmd {
+	cmd := cmdutils.NewVerbCmd("update", "Get resource(s)", "")
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
 
 type mockVerbCmd struct {
 	parentCmd *cobra.Command


### PR DESCRIPTION
### Description

Refactor the CLI commands for testability. Having dependency with https://github.com/weaveworks/eksctl/pull/1776

List of CLIs needs to be done:
- [ ] create
- [x] delete
- [x] drain
- [x] enable
- [x] generate
- [x] get
- [x] scale
- [x] set
- [x] unset
- [x] update
- [x] upgrade
- [ ] utils

Discovered one bug https://github.com/weaveworks/eksctl/issues/1782

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
