### PR TITLE
Improve linting rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -152,14 +152,20 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - gofmt
-    - unused
-    - govet
-    - golint
-    - errcheck
     - deadcode
-    - misspell
+    - errcheck
+    - gofmt
     - goimports
+    - golint
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
     # TODO: enable the below linter in the future
 #    - maligned
 #    - prealloc

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -707,15 +707,15 @@ type (
 	// NodeGroupInstancesDistribution holds the configuration for spot instances
 	NodeGroupInstancesDistribution struct {
 		//+required
-		InstanceTypes []string `json:"instanceTypes,omitEmpty"`
+		InstanceTypes []string `json:"instanceTypes,omitempty"`
 		// +optional
 		MaxPrice *float64 `json:"maxPrice,omitempty"`
 		//+optional
-		OnDemandBaseCapacity *int `json:"onDemandBaseCapacity,omitEmpty"`
+		OnDemandBaseCapacity *int `json:"onDemandBaseCapacity,omitempty"`
 		//+optional
-		OnDemandPercentageAboveBaseCapacity *int `json:"onDemandPercentageAboveBaseCapacity,omitEmpty"`
+		OnDemandPercentageAboveBaseCapacity *int `json:"onDemandPercentageAboveBaseCapacity,omitempty"`
 		//+optional
-		SpotInstancePools *int `json:"spotInstancePools,omitEmpty"`
+		SpotInstancePools *int `json:"spotInstancePools,omitempty"`
 	}
 )
 

--- a/pkg/apis/eksctl.io/v1alpha5/vpc.go
+++ b/pkg/apis/eksctl.io/v1alpha5/vpc.go
@@ -55,8 +55,8 @@ type (
 
 	// ClusterEndpoints holds cluster api server endpoint access information
 	ClusterEndpoints struct {
-		PrivateAccess *bool `json:"privateAccess,omitempty,false"`
-		PublicAccess  *bool `json:"publicAccess,omitempty,true"`
+		PrivateAccess *bool `json:"privateAccess,omitempty"`
+		PublicAccess  *bool `json:"publicAccess,omitempty"`
 	}
 )
 

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -72,10 +72,7 @@ func (c *StackCollection) DoCreateStackRequest(i *Stack, templateBody []byte, ta
 	input := &cloudformation.CreateStackInput{
 		StackName: i.StackName,
 	}
-
-	for _, t := range c.sharedTags {
-		input.Tags = append(input.Tags, t)
-	}
+	input.Tags = append(input.Tags, c.sharedTags...)
 	for k, v := range tags {
 		input.Tags = append(input.Tags, newTag(k, v))
 	}

--- a/pkg/cfn/template/types.go
+++ b/pkg/cfn/template/types.go
@@ -74,18 +74,18 @@ func (v *Value) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	switch raw.(type) {
+	switch r := raw.(type) {
 	case string:
-		v.value = String(raw.(string))
+		v.value = String(r)
 		return nil
 	case float64:
-		v.value = Double(raw.(float64))
+		v.value = Double(r)
 	case bool:
-		v.value = Boolean(raw.(bool))
+		v.value = Boolean(r)
 	case map[string]interface{}:
-		v.value = AnythingMap(raw.(map[string]interface{}))
+		v.value = AnythingMap(r)
 	case []interface{}:
-		v.value = AnythingSlice(raw.([]interface{}))
+		v.value = AnythingSlice(r)
 	default:
 		return fmt.Errorf("cannot handle type %s", reflect.ValueOf(raw).Kind())
 	}

--- a/pkg/ctl/cmdutils/filter.go
+++ b/pkg/ctl/cmdutils/filter.go
@@ -59,7 +59,7 @@ func (f *Filter) hasIncludeRules() bool {
 
 func (f *Filter) describeIncludeRules() string {
 	rules := append(f.includeNames.List(), f.rawIncludeGlobs...)
-	return fmt.Sprintf("%s", strings.Join(rules, ","))
+	return strings.Join(rules, ",")
 }
 
 func (f *Filter) hasExcludeRules() bool {
@@ -68,7 +68,7 @@ func (f *Filter) hasExcludeRules() bool {
 
 func (f *Filter) describeExcludeRules() string {
 	rules := append(f.excludeNames.List(), f.rawExcludeGlobs...)
-	return fmt.Sprintf("%s", strings.Join(rules, ","))
+	return strings.Join(rules, ",")
 }
 
 // Match given name against the filter and returns

--- a/pkg/ctl/enable/profile.go
+++ b/pkg/ctl/enable/profile.go
@@ -94,6 +94,9 @@ func doEnableProfile(cmd *cmdutils.Cmd, opts *ProfileOptions) error {
 		return err
 	}
 	usersRepoDir, err := ioutil.TempDir("", usersRepoName+"-")
+	if err != nil {
+		return err
+	}
 	logger.Debug("Directory %s will be used to clone the configuration repository and install the profile", usersRepoDir)
 	profileOutputPath := filepath.Join(usersRepoDir, "base")
 

--- a/pkg/ctl/enable/profile.go
+++ b/pkg/ctl/enable/profile.go
@@ -95,7 +95,7 @@ func doEnableProfile(cmd *cmdutils.Cmd, opts *ProfileOptions) error {
 	}
 	usersRepoDir, err := ioutil.TempDir("", usersRepoName+"-")
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "unable to create temporary directory for %q", usersRepoName)
 	}
 	logger.Debug("Directory %s will be used to clone the configuration repository and install the profile", usersRepoDir)
 	profileOutputPath := filepath.Join(usersRepoDir, "base")

--- a/pkg/ctl/utils/update_cluster_logging.go
+++ b/pkg/ctl/utils/update_cluster_logging.go
@@ -157,8 +157,8 @@ func validateLoggingFlags(toEnable []string, toDisable []string) error {
 }
 
 func processTypesToEnable(existingEnabled, toEnable, toDisable []string) sets.String {
-	emptyToEnable := toEnable == nil || len(toEnable) == 0
-	emptyToDisable := toDisable == nil || len(toDisable) == 0
+	emptyToEnable := len(toEnable) == 0
+	emptyToDisable := len(toDisable) == 0
 
 	isEnableAll := !emptyToEnable && toEnable[0] == "all"
 	isDisableAll := !emptyToDisable && toDisable[0] == "all"

--- a/pkg/elb/cleanup.go
+++ b/pkg/elb/cleanup.go
@@ -114,7 +114,7 @@ func getServiceLoadBalancer(ctx context.Context, ec2API ec2iface.EC2API, elbAPI 
 	}
 	name := cloudprovider.DefaultLoadBalancerName(service)
 	kind := getLoadBalancerKind(service)
-	ctx, cleanup := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cleanup := context.WithTimeout(ctx, 30*time.Second)
 	securityGroupIDs, err := getSecurityGroupsOwnedByLoadBalancer(ctx, ec2API, elbAPI, clusterName, name, kind)
 	cleanup()
 	if err != nil {

--- a/pkg/gitops/flux/installer.go
+++ b/pkg/gitops/flux/installer.go
@@ -270,7 +270,7 @@ func runShell(workDir string) error {
 }
 
 func (fi *Installer) getManifests() (map[string][]byte, error) {
-	manifests := map[string][]byte{}
+	var manifests map[string][]byte
 
 	// Flux
 	var err error

--- a/pkg/kubernetes/manifests.go
+++ b/pkg/kubernetes/manifests.go
@@ -31,9 +31,7 @@ func NewRawExtensions(manifest []byte) ([]runtime.RawExtension, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, object := range list.Items {
-		objects = append(objects, object)
-	}
+	objects = append(objects, list.Items...)
 	return objects, nil
 }
 

--- a/pkg/ssh/loader.go
+++ b/pkg/ssh/loader.go
@@ -13,7 +13,7 @@ import (
 // or by its contents (in the config-file). It also assumes that if ssh is enabled (SSH.Allow
 // == true) then one key was specified
 func LoadKey(sshConfig *api.NodeGroupSSH, clusterName, nodeGroupName string, ec2API ec2iface.EC2API) (string, error) {
-	if sshConfig.Allow == nil || *sshConfig.Allow == false {
+	if sshConfig.Allow == nil || !*sshConfig.Allow {
 		return "", nil
 	}
 

--- a/pkg/utils/ipnet/ipnet.go
+++ b/pkg/utils/ipnet/ipnet.go
@@ -39,7 +39,6 @@ func (ipnet *IPNet) DeepCopyInto(out *IPNet) {
 	} else {
 		*out = *ipnet
 	}
-	return
 }
 
 // DeepCopy copies the receiver, creating a new IPNet.

--- a/pkg/vpc/cleanup.go
+++ b/pkg/vpc/cleanup.go
@@ -75,6 +75,8 @@ func CleanupNetworkInterfaces(ec2API ec2iface.EC2API, spec *api.ClusterConfig) e
 			return errors.Wrapf(err, "unable to delete network interface %q", eniID)
 		}
 		logger.Debug("deleted network interface %q", eniID)
+		// why we are removing only the first eni id
+		// nolint:staticcheck
 		return nil
 	}
 	return nil

--- a/pkg/vpc/cleanup.go
+++ b/pkg/vpc/cleanup.go
@@ -75,7 +75,7 @@ func CleanupNetworkInterfaces(ec2API ec2iface.EC2API, spec *api.ClusterConfig) e
 			return errors.Wrapf(err, "unable to delete network interface %q", eniID)
 		}
 		logger.Debug("deleted network interface %q", eniID)
-		// why we are removing only the first eni id
+		// why we are removing only the first eni id https://github.com/weaveworks/eksctl/issues/1806
 		// nolint:staticcheck
 		return nil
 	}

--- a/site/content/usage/20-schema.md
+++ b/site/content/usage/20-schema.md
@@ -491,11 +491,6 @@ NodeGroupInstancesDistribution:
       type: integer
     spotInstancePools:
       type: integer
-  required:
-  - instanceTypes
-  - onDemandBaseCapacity
-  - onDemandPercentageAboveBaseCapacity
-  - spotInstancePools
   type: object
 NodeGroupSGs:
   additionalProperties: false


### PR DESCRIPTION
### Description

Address comment https://github.com/weaveworks/eksctl/pull/1758#pullrequestreview-350002836

Enable few more linters:

- gosimple
- ineffassign
- staticcheck
- structcheck
- typecheck
- varcheck

Please find the below warning/issues by the golangci-lint for your reference:

```
pkg/gitops/flux/installer.go:383:2              ineffassign  ineffectual assignment to `manifests`
pkg/ctl/enable/profile.go:96:16                 ineffassign  ineffectual assignment to `err`
pkg/apis/eksctl.io/v1alpha5/types.go:707:26     staticcheck  SA5008: unknown JSON option "omitEmpty"
pkg/apis/eksctl.io/v1alpha5/types.go:711:29     staticcheck  SA5008: unknown JSON option "omitEmpty"
pkg/apis/eksctl.io/v1alpha5/types.go:713:44     staticcheck  SA5008: unknown JSON option "omitEmpty"
pkg/apis/eksctl.io/v1alpha5/vpc.go:58:23        staticcheck  SA5008: unknown JSON option "false"
pkg/apis/eksctl.io/v1alpha5/vpc.go:59:23        staticcheck  SA5008: unknown JSON option "true"
pkg/elb/cleanup.go:110:29                       staticcheck  SA4009: argument ctx is overwritten before first use
pkg/vpc/cleanup.go:78:3                         staticcheck  SA4004: the surrounding loop is unconditionally terminated
pkg/kubernetes/manifests.go:34:2                gosimple     S1011: should replace loop with `objects = append(objects, list.Items...)`
pkg/cfn/manager/api.go:73:2                     gosimple     S1011: should replace loop with `input.Tags = append(input.Tags, c.sharedTags...)`
pkg/ctl/cmdutils/filter.go:62:9                 gosimple     S1025: the argument is already a string, there's no need to use fmt.Sprintf
pkg/ctl/cmdutils/filter.go:71:9                 gosimple     S1025: the argument is already a string, there's no need to use fmt.Sprintf
pkg/ssh/loader.go:16:31                         gosimple     S1002: should omit comparison to bool constant, can be simplified to `!*sshConfig.Allow`
pkg/utils/ipnet/ipnet.go:42:2                   gosimple     S1023: redundant `return` statement
pkg/cfn/template/types.go:77:9                  gosimple     S1034: assigning the result of this type assertion to a variable (switch raw := raw.(type)) could eliminate the following type assertions:
                                                        pkg/cfn/template/types.go:79:20
                                                        pkg/cfn/template/types.go:82:20
                                                        pkg/cfn/template/types.go:84:21
                                                        pkg/cfn/template/types.go:86:25
                                                        pkg/cfn/template/types.go:88:27
pkg/ctl/utils/update_cluster_logging.go:160:19  gosimple  S1009: should omit nil check; len() for nil slices is defined as zero
pkg/ctl/utils/update_cluster_logging.go:161:20  gosimple  S1009: should omit nil check; len() for nil slices is defined as zero
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
