### PR TITLE
Add integration tests for Fargate

### DIFF
--- a/integration/fargate_test.go
+++ b/integration/fargate_test.go
@@ -137,6 +137,23 @@ var _ = Describe("(Integration) Fargate", func() {
 		})
 	})
 
+	Context("Creating a cluster with --fargate and --managed", func() {
+		ft := &fargateTest{}
+
+		BeforeEach(func() {
+			setup(ft, "--fargate", "--managed")
+		})
+
+		It("should support Fargate", func() {
+			assertFargateDefaultProfile(ft.clusterName, ft.kubeTest)
+			assertFargateNewProfile(ft.clusterName, ft.kubeTest)
+		})
+
+		AfterEach(func() {
+			deleteCluster(ft.clusterName)
+		})
+	})
+
 	Context("Creating a cluster without --fargate", func() {
 		ft := &fargateTest{}
 

--- a/integration/fargate_test.go
+++ b/integration/fargate_test.go
@@ -52,7 +52,7 @@ var _ = Describe("(Integration) Fargate", func() {
 		Expect(err).ToNot(HaveOccurred())
 	}
 
-	assertFargateDefaultProfile := func(clusterName string, kubeTest *harness.Test) {
+	testDefaultFargateProfile := func(clusterName string, kubeTest *harness.Test) {
 		By("having a default Fargate profile")
 		cmd := eksctlGetCmd.WithArgs(
 			"fargateprofile",
@@ -82,7 +82,7 @@ var _ = Describe("(Integration) Fargate", func() {
 		Expect(cmd).To(RunSuccessfully())
 	}
 
-	assertFargateNewProfile := func(clusterName string, kubeTest *harness.Test) {
+	testCreateFargateProfile := func(clusterName string, kubeTest *harness.Test) {
 		By("creating a new Fargate profile")
 		profileName := "profile-1"
 		cmd := eksctlCreateCmd.WithArgs(
@@ -128,8 +128,8 @@ var _ = Describe("(Integration) Fargate", func() {
 		})
 
 		It("should support Fargate", func() {
-			assertFargateDefaultProfile(ft.clusterName, ft.kubeTest)
-			assertFargateNewProfile(ft.clusterName, ft.kubeTest)
+			testDefaultFargateProfile(ft.clusterName, ft.kubeTest)
+			testCreateFargateProfile(ft.clusterName, ft.kubeTest)
 		})
 
 		AfterEach(func() {
@@ -145,8 +145,8 @@ var _ = Describe("(Integration) Fargate", func() {
 		})
 
 		It("should support Fargate", func() {
-			assertFargateDefaultProfile(ft.clusterName, ft.kubeTest)
-			assertFargateNewProfile(ft.clusterName, ft.kubeTest)
+			testDefaultFargateProfile(ft.clusterName, ft.kubeTest)
+			testCreateFargateProfile(ft.clusterName, ft.kubeTest)
 		})
 
 		AfterEach(func() {
@@ -162,7 +162,7 @@ var _ = Describe("(Integration) Fargate", func() {
 		})
 
 		It("should allow creation of new Fargate profiles", func() {
-			assertFargateNewProfile(ft.clusterName, ft.kubeTest)
+			testCreateFargateProfile(ft.clusterName, ft.kubeTest)
 		})
 
 		AfterEach(func() {

--- a/integration/fargate_test.go
+++ b/integration/fargate_test.go
@@ -1,0 +1,156 @@
+// +build integration
+
+package integration_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dlespiau/kube-test-harness"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/weaveworks/eksctl/integration/runner"
+	"github.com/weaveworks/eksctl/pkg/utils/names"
+)
+
+var _ = Describe("(Integration) Fargate", func() {
+
+	// Fargate is not supported in us-west-2 yet
+	const region = "ap-northeast-1"
+
+	deleteCluster := func(clusterName string) {
+		cmd := eksctlDeleteCmd.WithArgs(
+			"cluster", clusterName,
+			"--verbose", "4",
+			"--region", region,
+		)
+		Expect(cmd).To(RunSuccessfully())
+	}
+
+	type fargateTest struct {
+		clusterName string
+		kubeTest    *harness.Test
+	}
+
+	setup := func(ft *fargateTest, createArgs ...string) {
+		ft.clusterName = "fargate-" + names.ForCluster("", "")
+		args := []string{
+			"cluster",
+			"--name", ft.clusterName,
+			"--verbose", "4",
+			"--region", region,
+			"--kubeconfig", kubeconfigPath,
+		}
+
+		args = append(args, createArgs...)
+		cmd := eksctlCreateCmd.WithArgs(args...)
+		Expect(cmd).To(RunSuccessfully())
+
+		var err error
+		ft.kubeTest, err = newKubeTest()
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	assertFargateDefaultProfile := func(clusterName string, kubeTest *harness.Test) {
+		By("having a default Fargate profile")
+		cmd := eksctlGetCmd.WithArgs(
+			"fargateprofile",
+			"--cluster", clusterName,
+			"--verbose", "4",
+			"--region", region,
+		)
+		Expect(cmd).To(RunSuccessfullyWithOutputString(ContainSubstring("fp-default")))
+
+		By("scheduling pods matching the default profile onto Fargate")
+		d := kubeTest.CreateDeploymentFromFile("default", "podinfo.yaml")
+		kubeTest.WaitForDeploymentReady(d, 5*time.Minute)
+
+		pods := kubeTest.ListPodsFromDeployment(d)
+		Expect(len(pods.Items)).To(Equal(2))
+		for _, pod := range pods.Items {
+			Expect(pod.Spec.NodeName).To(HavePrefix("fargate-"))
+		}
+		cmd = eksctlDeleteCmd.WithArgs(
+			"fargateprofile",
+			"--cluster", clusterName,
+			"--name", "fp-default",
+			"--region", region,
+			"--wait",
+			"--verbose", "4",
+		)
+		Expect(cmd).To(RunSuccessfully())
+	}
+
+	assertFargateNewProfile := func(clusterName string, kubeTest *harness.Test) {
+		By("creating a new Fargate profile")
+		profileName := "profile-1"
+		cmd := eksctlCreateCmd.WithArgs(
+			"fargateprofile",
+			"--cluster", clusterName,
+			"--name", profileName,
+			"--namespace", kubeTest.Namespace,
+			"--labels", "run-on=fargate",
+			"--verbose", "4",
+			"--region", region,
+		)
+		Expect(cmd).To(RunSuccessfullyWithOutputString(ContainSubstring(profileName)))
+
+		By("scheduling pods matching the selector onto Fargate")
+		d := kubeTest.LoadDeployment("podinfo.yaml")
+		d.Spec.Template.Labels["run-on"] = "fargate"
+
+		kubeTest.CreateDeployment(kubeTest.Namespace, d)
+		kubeTest.WaitForDeploymentReady(d, 5*time.Minute)
+		pods := kubeTest.ListPodsFromDeployment(d)
+		Expect(len(pods.Items)).To(Equal(2))
+		for _, pod := range pods.Items {
+			Expect(pod.Spec.NodeName).To(HavePrefix("fargate-"))
+		}
+
+		By(fmt.Sprintf("deleting Fargate profile: %q", profileName))
+		cmd = eksctlDeleteCmd.WithArgs(
+			"fargateprofile",
+			"--cluster", clusterName,
+			"--name", profileName,
+			"--wait",
+			"--region", region,
+			"--verbose", "4",
+		)
+		Expect(cmd).To(RunSuccessfully())
+	}
+
+	Context("Creating a cluster with --fargate", func() {
+		ft := &fargateTest{}
+
+		BeforeEach(func() {
+			setup(ft, "--fargate")
+		})
+
+		It("should support Fargate", func() {
+			assertFargateDefaultProfile(ft.clusterName, ft.kubeTest)
+			assertFargateNewProfile(ft.clusterName, ft.kubeTest)
+		})
+
+		AfterEach(func() {
+			deleteCluster(ft.clusterName)
+		})
+	})
+
+	Context("Creating a cluster without --fargate", func() {
+		ft := &fargateTest{}
+
+		BeforeEach(func() {
+			setup(ft)
+		})
+
+		It("should allow creation of new Fargate profiles", func() {
+			assertFargateNewProfile(ft.clusterName, ft.kubeTest)
+		})
+
+		AfterEach(func() {
+			deleteCluster(ft.clusterName)
+		})
+	})
+
+})

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -51,7 +51,7 @@ func init() {
 	flag.StringVar(&clusterName, "eksctl.cluster", "", "Cluster name (default: generate one)")
 	flag.BoolVar(&doCreate, "eksctl.create", true, "Skip the creation tests. Useful for debugging the tests")
 	flag.BoolVar(&doDelete, "eksctl.delete", true, "Skip the cleanup after the tests have run")
-	flag.StringVar(&kubeconfigPath, "eksctl.kubeconfig", "", "Path to kubeconfig (default: create it a temporary file)")
+	flag.StringVar(&kubeconfigPath, "eksctl.kubeconfig", "", "Path to kubeconfig (default: create a temporary file)")
 	flag.StringVar(&privateSSHKeyPath, "eksctl.git.sshkeypath", defaultPrivateSSHKeyPath, fmt.Sprintf("Path to the SSH key to use for Git operations (default: %s)", defaultPrivateSSHKeyPath))
 }
 

--- a/integration/runner/runner.go
+++ b/integration/runner/runner.go
@@ -130,7 +130,7 @@ func (m *runCmdMatcher) run(cmd Cmd) bool {
 	return false
 }
 
-// RunSuccessfully matches successful excution of a command
+// RunSuccessfully matches successful execution of a command
 func RunSuccessfully() types.GomegaMatcher {
 	return &runCmdMatcher{}
 }

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -802,7 +802,7 @@ func HasMixedInstances(ng *NodeGroup) bool {
 	return ng.InstancesDistribution != nil && len(ng.InstancesDistribution.InstanceTypes) > 0
 }
 
-// IsAMI returns true if the argument is an AMI id
+// IsAMI returns true if the argument is an AMI ID
 func IsAMI(amiFlag string) bool {
 	return strings.HasPrefix(amiFlag, "ami-")
 }


### PR DESCRIPTION
### Description

Adds integration tests for Fargate. 

Closes #1736 

The tests follow this sequence:
- Create a new cluster, with each test using a different set of flags
- Create a new Fargate profile
- Deploy pods matching the Fargate profile selector
- Assert that the pods run on Fargate

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
