### PR TITLE
Fix titles of sections in release notes draft

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,13 +1,13 @@
 name-template: 'eksctl $NEXT_MINOR_VERSION'
 tag-template: '$NEXT_MINOR_VERSION'
 categories:
-  - title: '## Features'
+  - title: 'Features'
     labels:
       - 'kind/feature'
-  - title: '## Improvements'
+  - title: 'Improvements'
     labels:
       - 'kind/improvement'
-  - title: '## Bug Fixes'
+  - title: 'Bug Fixes'
     labels:
       - 'kind/bug'
 change-template: '- $TITLE (#$NUMBER)'


### PR DESCRIPTION
Removes the extra `##` in each title since it's added by the release-drafter tool already
<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->