### PR TITLE
Add example of using labels for forcing pods to run on desired node groups

### DIFF
--- a/examples/18-node-to-pod-label-matching.yaml
+++ b/examples/18-node-to-pod-label-matching.yaml
@@ -1,0 +1,33 @@
+# This example demonstrates how to force the spawning of 
+# certain pods to a desired node group.
+# 
+# Pre-requisites
+# In order for this sample to work, the pod's deployment file
+# should contain the following yaml property.
+# 
+# spec:
+#   containers:
+#     - ...omitted for brevity
+#   nodeSelector:
+#     node-class: "compute-intensive-node"
+#
+# Setting labels could be very useful as they allow you to
+# design an infrastructure that is suited for an app's use-case.
+--- 
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: cluster-18
+  region: ap-southeast-1
+
+nodeGroups:
+  - name: std-ng
+    instanceType: m5.xlarge
+    desiredCapacity: 8
+  - name: ci-ng
+    instanceType: c5.12xlarge
+    desiredCapacity: 8
+    labels:
+      node-class: "compute-intensive-node"
+

--- a/pkg/ctl/cmdutils/configfile_test.go
+++ b/pkg/ctl/cmdutils/configfile_test.go
@@ -81,7 +81,7 @@ var _ = Describe("cmdutils configfile", func() {
 			examples, err := filepath.Glob(examplesDir + "*.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(examples).To(HaveLen(17))
+			Expect(examples).To(HaveLen(18))
 			for _, example := range examples {
 				cmd := &Cmd{
 					CobraCommand:      newCmd(),


### PR DESCRIPTION
### Description

In order to match the underlying EC2's purpose to a pod's resource use-case, we can use the combination of a pod's `nodeSelector` and node group `labels` property. This pull request will help people that want to achieve this by providing a sample YAML file under the `examples/18-node-to-pod-label-matching.yaml`

### Checklist
- [ ] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)