### PR TITLE
Deprecate latest_release tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,11 +293,8 @@ When you run `make prepare-release` it will push a commit to master and a tag, w
 
 You want to keep an eye on Circle CI for the progress of the release ([0.3.1 example logs](https://circleci.com/workflow-run/02d8b5fb-bc7f-404c-9051-68307c124649)). It normally takes around 30 minutes.
 
-### Notes on Artifacts
+### Latest release
 
-We use `latest_release` floating tag, in order to enable static URLs for release artifacts, i.e. `latest_release` gets shifted on every release.
+To get the latest release you can use the link [https://github.com/weaveworks/eksctl/releases/latest]().
 
-That means you will see two entries on [the release page](https://github.com/weaveworks/eksctl/releases):
-
-- [**eksctl 0.4.0 (permalink)**](https://github.com/weaveworks/eksctl/releases/tag/0.4.0)
-- [**eksctl 0.4.0**](https://github.com/weaveworks/eksctl/releases/tag/latest_release)
+**Note** Previously, eksctl used a floating tag called `latest_release`. This is _deprecated_ and it will stop working after release `0.14.0`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _Need help? Join [Weave Community Slack][slackjoin]._
 To download the latest release, run:
 
 ```
-curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
 sudo mv /tmp/eksctl /usr/local/bin
 ```
 

--- a/site/content/introduction/02-installation.md
+++ b/site/content/introduction/02-installation.md
@@ -9,7 +9,7 @@ url: introduction/installation
 To download the latest release, run:
 
 ```
-curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
 sudo mv /tmp/eksctl /usr/local/bin
 ```
 


### PR DESCRIPTION
We had talked about deprecating the latest_release tag for a while but we never got to do it.

This change only adds a deprecation notice in the documentation. After we release 0.14.0 we should 
also implement it by removing the creation of the tag in our scripts (we can leave the tag pointing to 0.14.0
for some time and then delete it as well).

@marccarre do you think we should explain more about it?

- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [ ] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->

Related to https://github.com/weaveworks/eksctl/issues/903.