### PR TITLE
Update the output-base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,9 +173,7 @@ site/content/usage/20-schema.md: $(call godeps,cmd/schema/generate.go)
 
 deep_copy_helper_input = $(shell $(call godeps_cmd,./pkg/apis/...) | sed 's|$(generated_code_deep_copy_helper)||' )
 $(generated_code_deep_copy_helper): $(deep_copy_helper_input) .license-header ## Generate Kubernetes API helpers
-	time env GOPATH="$(gopath)" bash "$(gopath)/pkg/mod/k8s.io/code-generator@v0.15.10/generate-groups.sh" \
-	  deepcopy,defaulter _ ./pkg/apis eksctl.io:v1alpha5 --go-header-file .license-header --output-base="$(git_toplevel)" \
-	  || (cat .license-header ; cat $(generated_code_deep_copy_helper); exit 1)
+	./hack/update-codegen.sh
 
 $(generated_code_aws_sdk_mocks): $(call godeps,pkg/eks/mocks/mocks.go)
 	mkdir -p vendor/github.com/aws/

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -o errexit
+#set -o nounset
+#set -o pipefail
+
+
+SCRIPT_ROOT=$(git rev-parse --show-toplevel)
+
+# Grab code-generator version from go.sum.
+CODEGEN_VERSION=$(grep 'k8s.io/code-generator' go.sum | awk '{print $2}' | head -1)
+CODEGEN_PKG=$(echo `go env GOPATH`"/pkg/mod/k8s.io/code-generator@${CODEGEN_VERSION}")
+
+echo ">> Using ${CODEGEN_PKG}"
+
+# code-generator does work with go.mod but makes assumptions about
+# the project living in `$GOPATH/src`. To work around this and support
+# any location; create a temporary directory, use this as an output
+# base, and copy everything back once generated.
+TEMP_DIR=$(mktemp -d)
+cleanup() {
+    echo ">> Removing ${TEMP_DIR}"
+    rm -rf ${TEMP_DIR}
+}
+trap "cleanup" EXIT SIGINT
+
+echo ">> Temporary output directory ${TEMP_DIR}"
+
+# Ensure we can execute.
+chmod +x ${CODEGEN_PKG}/generate-groups.sh
+
+GOPATH=$(go env GOPATH) ${CODEGEN_PKG}/generate-groups.sh deepcopy,defaulter \
+    _ github.com/weaveworks/eksctl/pkg/apis \
+    eksctl.io:v1alpha5 \
+    --go-header-file .license-header \
+    --output-base "${TEMP_DIR}"
+
+# Copy everything back.
+cp -r "${TEMP_DIR}/github.com/weaveworks/eksctl/." "${SCRIPT_ROOT}/"


### PR DESCRIPTION
### Description

Fixes https://github.com/weaveworks/eksctl/issues/1462. This issue is kind of annoying me, as with `github.com` directory generated, `make lint` will just failed.

code-gen usage is as below, so with the GOPATH env set up, output base will be $GOPATH/src, and 

```bash
  -o, --output-base string               Output base; defaults to $GOPATH/src/ or ./ if $GOPATH is not set. (default "/home/tammach/go/src")
```

```bash
 uname -a
Linux ubuntu 5.3.0-26-generic #28-Ubuntu SMP Wed Dec 18 05:37:46 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
```

#### Before (from master branch)
<details>
<summary>Output.</summary>
<p>

```bash
$ make generate-all
go-bindata version 3.15.0
env GOBIN=/home/tammach/go/bin time go generate ./pkg/nodebootstrap ./pkg/addons/default ./pkg/addons
1.32user 0.48system 0:01.85elapsed 97%CPU (0avgtext+0avgdata 132780maxresident)k
0inputs+22008outputs (1major+52293minor)pagefaults 0swaps
printf "/*\n%s\n*/\n" "$(cat LICENSE)" > .license-header
time env GOPATH="/home/tammach/go" bash "/home/tammach/go/pkg/mod/k8s.io/code-generator@v0.0.0-20190831074504-732c9ca86353/generate-groups.sh" \
  deepcopy,defaulter _ ./pkg/apis eksctl.io:v1alpha5 --go-header-file .license-header --output-base="/home/tammach/go/src/github.com/weaveworks/eksctl" \
  || (cat .license-header ; cat pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go; exit 1)
Generating deepcopy funcs
58.03user 14.04system 0:17.10elapsed 421%CPU (0avgtext+0avgdata 359956maxresident)k
0inputs+96outputs (0major+617726minor)pagefaults 0swaps
 ⎈ gitops  22:57:43  0.63  ~  go  …  github.com  weaveworks  eksctl  master  1+   
$ ls -lrt github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go 
-rw-r--r-- 1 tammach tammach 26379 Feb 13 22:57 github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
```

</p>
</details>  

#### After the changes:
<details>
<summary>Output.</summary>
<p>

```bash
$ ls -lrt pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
-rw-r--r-- 1 tammach tammach 26379 Feb 13 22:44 pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
 ⎈ gitops  22:59:09  0.52  ~  go  …  github.com  weaveworks  eksctl  bugfix/codegen-path  1+   
$ make generate-all
go-bindata version 3.15.0
env GOBIN=/home/tammach/go/bin time go generate ./pkg/nodebootstrap ./pkg/addons/default ./pkg/addons
1.38user 0.32system 0:01.36elapsed 125%CPU (0avgtext+0avgdata 132696maxresident)k
0inputs+22008outputs (1major+52488minor)pagefaults 0swaps
printf "/*\n%s\n*/\n" "$(cat LICENSE)" > .license-header
time bash "/home/tammach/go/pkg/mod/k8s.io/code-generator@v0.0.0-20190831074504-732c9ca86353/generate-groups.sh" \
  deepcopy,defaulter _ ./pkg/apis eksctl.io:v1alpha5 --go-header-file .license-header \
  || (cat .license-header ; cat pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go; exit 1)
Generating deepcopy funcs
58.81user 13.41system 0:17.07elapsed 423%CPU (0avgtext+0avgdata 342120maxresident)k
0inputs+96outputs (0major+617742minor)pagefaults 0swaps
time go run ./cmd/schema/generate.go site/content/usage/20-schema.md
2.37user 0.26system 0:01.41elapsed 186%CPU (0avgtext+0avgdata 524484maxresident)k
0inputs+79936outputs (1major+103967minor)pagefaults 0swaps
 ⎈ gitops  22:59:34  0.75  ~  go  …  github.com  weaveworks  eksctl  bugfix/codegen-path  1+   
$ ls -lrt pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
-rw-r--r-- 1 tammach tammach 26379 Feb 13 22:59 pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
 ⎈ gitops  22:59:41  0.74  ~  go  …  github.com  weaveworks  eksctl  bugfix/codegen-path  1+   
$ ls -lrt github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
ls: cannot access 'github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go': No such file or directory
```
</p>
</details>  

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, and `examples` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`) and target version (e.g. `version/0.12.0`)
- [ ] Added note in `docs/release_notes/draft.md` (or relevant release note)

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
<!-- If you need the attention of the maintainers ping @weaveworks/eksctl -->
