### PR TITLE
Config Kube client to use system certs when CA is not available

### DIFF
--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -69,8 +69,14 @@ func New(spec *api.ClusterConfig, username, certificateAuthorityPath string) (*c
 		c.Clusters[clusterName].Server = clusterEndpoint
 	}
 
+	// Some companies require you to use system CA certs.
+	// https://github.com/kubernetes/client-go/issues/416 - To use system CA's dont set the CertificateAuthorityData
+	_, useSystemCA := os.LookupEnv("KUBECONFIG_USE_SYSTEM_CA")
+
 	if certificateAuthorityPath == "" {
-		c.Clusters[clusterName].CertificateAuthorityData = spec.Status.CertificateAuthorityData
+		if !useSystemCA {
+			c.Clusters[clusterName].CertificateAuthorityData = spec.Status.CertificateAuthorityData
+		}
 	} else {
 		c.Clusters[clusterName].CertificateAuthority = certificateAuthorityPath
 	}


### PR DESCRIPTION
Fixes #895

### Description

Some companies require a CA cert to be installed in the system so that they can decrypt and re-encrypt the data before leaving the network. In these situations, and golang cli should rely on the system certs when ever there is not another option available.

I have update eksctl to look for an env variable, and if its found to use the system CAdata over using a hardcoded one within the cli.

KUBECONFIG_USE_SYSTEM_CA=true 

I want to make this the default behavior, but I am unsure as to why the CA data was set in the first place instead of opting for system data, so i am open for opinions

