### PR TITLE
Fix bug in update-cluster-endpoint #1820

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -177,6 +177,21 @@ func DefaultClusterNAT() *ClusterNAT {
 	}
 }
 
+// SetClusterEndpointAccessDefaults sets the default values for cluster endpoint access
+func SetClusterEndpointAccessDefaults(endpoints *ClusterEndpoints) {
+	if endpoints == nil {
+		endpoints = ClusterEndpointAccessDefaults()
+	}
+
+	if endpoints.PublicAccess == nil {
+		endpoints.PublicAccess = Enabled()
+	}
+
+	if endpoints.PrivateAccess == nil {
+		endpoints.PrivateAccess = Disabled()
+	}
+}
+
 // ClusterEndpointAccessDefaults returns a ClusterEndpoints pointer with default values set.
 func ClusterEndpointAccessDefaults() *ClusterEndpoints {
 	return &ClusterEndpoints{

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -95,10 +95,6 @@ func ValidateClusterConfig(cfg *ClusterConfig) error {
 		}
 	}
 
-	if !cfg.HasClusterEndpointAccess() {
-		return ErrClusterEndpointNoAccess
-	}
-
 	if cfg.VPC != nil && len(cfg.VPC.PublicAccessCIDRs) > 0 {
 		cidrs, err := validateCIDRs(cfg.VPC.PublicAccessCIDRs)
 		if err != nil {
@@ -111,6 +107,9 @@ func ValidateClusterConfig(cfg *ClusterConfig) error {
 
 // ValidateClusterEndpointConfig checks the endpoint configuration for potential issues
 func (c *ClusterConfig) ValidateClusterEndpointConfig() error {
+	if !c.HasClusterEndpointAccess() {
+		return ErrClusterEndpointNoAccess
+	}
 	endpts := c.VPC.ClusterEndpoints
 	if NoAccess(endpts) {
 		return ErrClusterEndpointNoAccess

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -192,8 +192,10 @@ func NewCreateClusterLoader(cmd *Cmd, ngFilter *NodeGroupFilter, ng *api.NodeGro
 			*l.ClusterConfig.VPC.NAT.Gateway = api.ClusterSingleNAT
 		}
 
-		if l.ClusterConfig.VPC.ClusterEndpoints == nil {
-			l.ClusterConfig.VPC.ClusterEndpoints = api.ClusterEndpointAccessDefaults()
+		api.SetClusterEndpointAccessDefaults(l.ClusterConfig.VPC.ClusterEndpoints)
+
+		if !l.ClusterConfig.HasClusterEndpointAccess() {
+			return api.ErrClusterEndpointNoAccess
 		}
 
 		if l.ClusterConfig.HasAnySubnets() && len(l.ClusterConfig.AvailabilityZones) != 0 {
@@ -421,15 +423,32 @@ func NewUtilsEnableLoggingLoader(cmd *Cmd) ClusterConfigLoader {
 }
 
 // NewUtilsEnableEndpointAccessLoader will load config or use flags for 'eksctl utils vpc-cluster-api-access
-func NewUtilsEnableEndpointAccessLoader(cmd *Cmd) ClusterConfigLoader {
+func NewUtilsEnableEndpointAccessLoader(cmd *Cmd, privateAccess, publicAccess bool) ClusterConfigLoader {
 	l := newCommonClusterConfigLoader(cmd)
 
 	l.flagsIncompatibleWithConfigFile.Insert(
 		"private-access",
 		"public-access",
 	)
+	l.validateWithoutConfigFile = func() error {
+		if err := l.validateMetadataWithoutConfigFile(); err != nil {
+			return err
+		}
 
-	l.validateWithoutConfigFile = l.validateMetadataWithoutConfigFile
+		if flag := l.CobraCommand.Flag("private-access"); flag != nil && flag.Changed {
+			cmd.ClusterConfig.VPC.ClusterEndpoints.PrivateAccess = &privateAccess
+		} else {
+			cmd.ClusterConfig.VPC.ClusterEndpoints.PrivateAccess = nil
+		}
+
+		if flag := l.CobraCommand.Flag("public-access"); flag != nil && flag.Changed {
+			cmd.ClusterConfig.VPC.ClusterEndpoints.PublicAccess = &publicAccess
+		} else {
+			cmd.ClusterConfig.VPC.ClusterEndpoints.PublicAccess = nil
+		}
+
+		return nil
+	}
 
 	return l
 }


### PR DESCRIPTION
fixes #1820

- [x] Manually tested
- [x] Make sure Integration tests pass
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

## Integration tests passing

```
------------------------------

Ran 10 of 10 Specs in 3830.525 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestSuite (3830.53s)
PASS
```
