### PR TITLE
Improve error message for Fargate support

### DIFF
--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -197,7 +197,8 @@ func deleteFargateProfiles(cmd *cmdutils.Cmd, ctl *eks.ClusterProvider) error {
 	if err != nil {
 		if fargate.IsUnauthorizedError(err) {
 			logger.Debug("Fargate: unauthorized error: %v", err)
-			logger.Info("account is not authorized to use Fargate. Ignoring error")
+			logger.Info("either account is not authorized to use Fargate or region %s is not supported. Ignoring error",
+				cmd.ClusterConfig.Metadata.Region)
 			return nil
 		}
 		return err


### PR DESCRIPTION
### Description

The AWS API throws an `AccessDeniedException` when a Fargate region is not supported. This PR adds that information to the error message.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
