### PR TITLE
Temporarily disable scheduled integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,13 +241,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /[0-9]+\.[0-9]+\.[0-9]+/
-  scheduled-integration-tests:
-    triggers:
-      - schedule:
-          cron: "0 3 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - integration-tests


### PR DESCRIPTION
### Description

We may have a regression of cluster deletion, as many clusters created by our integration tests do not get deleted. This PR "stops the bleeding" for now, while we investigate the issue.
