### PR TITLE
Fix missing tags in nodegroup after scaling (#1834)

### DIFF
--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -472,9 +472,6 @@ func (c *StackCollection) doCreateChangeSetRequest(i *Stack, changeSetName strin
 		StackName:     i.StackName,
 		ChangeSetName: &changeSetName,
 		Description:   &description,
-		Tags: []*cloudformation.Tag{
-			newTag(api.EksctlVersionTag, version.GetVersion()),
-		},
 	}
 
 	input.SetChangeSetType(cloudformation.ChangeSetTypeUpdate)


### PR DESCRIPTION
fixes #1834

When scaling a cluster eksctl was overwritting all the tags with the `eksctl-version` one


- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->