### PR TITLE
Increase IT timeout to 4.5h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ build-integration-test: $(all_generated_code) ## Build integration test binary
 
 .PHONY: integration-test
 integration-test: build build-integration-test ## Run the integration tests (with cluster creation and cleanup)
-	cd integration; ../eksctl-integration-test -test.timeout 150m $(INTEGRATION_TEST_ARGS)
+	cd integration; ../eksctl-integration-test -test.timeout 210m $(INTEGRATION_TEST_ARGS)
 
 .PHONY: integration-test-container
 integration-test-container: eksctl-image ## Run the integration tests inside a Docker container


### PR DESCRIPTION
The tests are timing out every time so we need to increase the timeout.



- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->