### PR TITLE
Revert "Temporarily disable scheduled integration tests"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,3 +241,13 @@ workflows:
               ignore: /.*/
             tags:
               only: /[0-9]+\.[0-9]+\.[0-9]+/
+  scheduled-integration-tests:
+    triggers:
+      - schedule:
+          cron: "0 3 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - integration-tests


### PR DESCRIPTION
Reverts weaveworks/eksctl#1828

Re-enable nightly integration tests now that they have been fixed.