### PR TITLE
Increase timeout of operations for managed nodegroup tests to 20m

### DIFF
--- a/integration/managed_nodegroup_test.go
+++ b/integration/managed_nodegroup_test.go
@@ -25,7 +25,7 @@ var _ = Describe("(Integration) Create Managed Nodegroups", func() {
 		newNodeGroup     = "ng-1"
 	)
 
-	defaultTimeout := 15 * time.Minute
+	defaultTimeout := 20 * time.Minute
 
 	Describe("when creating a cluster with 1 managed nodegroup", func() {
 		// always generate a unique name


### PR DESCRIPTION
This is to fix the timeouts of integration tests:

```
• Failure [900.003 seconds]
(Integration) Create Managed Nodegroups
/src/integration/managed_nodegroup_test.go:21
  when creating a cluster with 1 managed nodegroup
  /src/integration/managed_nodegroup_test.go:30
    and deleting the cluster
    /src/integration/managed_nodegroup_test.go:181
      should not return an error [It]
      /src/integration/managed_nodegroup_test.go:182

      Timed out after 900.000s.
      Expected process to exit.  It did not.

      /src/integration/runner/runner.go:113
```


<!-- If you haven't done so already, you can add your name to the humans.txt file -->