### PR TITLE
Remove integration tests timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ build-integration-test: $(all_generated_code) ## Build integration test binary
 
 .PHONY: integration-test
 integration-test: build build-integration-test ## Run the integration tests (with cluster creation and cleanup)
-	cd integration; ../eksctl-integration-test -test.timeout 210m $(INTEGRATION_TEST_ARGS)
+	cd integration; ../eksctl-integration-test $(INTEGRATION_TEST_ARGS)
 
 .PHONY: integration-test-container
 integration-test-container: eksctl-image ## Run the integration tests inside a Docker container


### PR DESCRIPTION
Removing it since they still take a very long time to run and they timeout:

```
panic: test timed out after 3h30m0s.
```



<!-- If you haven't done so already, you can add your name to the humans.txt file -->