### PR TITLE
Store artifacts created during release and rc jobs in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,8 @@ jobs:
               --volume=$HOME/go/pkg/mod/:/go/pkg/mod \
               weaveworks/eksctl-build:$(cat .docker/image_tag) ./do-release-candidate.sh
           no_output_timeout: 21m
+      - store_artifacts:
+          path: dist/
   release:
     machine:
       image: ubuntu-1604:201903-01
@@ -172,6 +174,8 @@ jobs:
               --volume=$HOME/go/pkg/mod/:/go/pkg/mod \
               weaveworks/eksctl-build:$(cat .docker/image_tag) ./do-release.sh
           no_output_timeout: 21m
+      - store_artifacts:
+          path: dist/
   integration-tests:
     machine:
       image: ubuntu-1604:201903-01


### PR DESCRIPTION
By storing the binaries as artifacts in circleci we can recover them if something goes wrong
during the publishing stage like it happened yesterday when GH had some issues.


<!-- If you haven't done so already, you can add your name to the humans.txt file -->