### PR TITLE
Fix homebrew formula update tool

### DIFF
--- a/tools/brew/formula.tmpl
+++ b/tools/brew/formula.tmpl
@@ -5,10 +5,10 @@ class Eksctl < Formula
   version "{{ .Version }}"
 
   if OS.mac?
-    url "{{ .Mac.Url }}"
+    url "{{ .Mac.URL }}"
     sha256 "{{ .Mac.Checksum }}"
   elsif OS.linux?
-    url "{{ .Linux.Url }}"
+    url "{{ .Linux.URL }}"
     sha256 "{{ .Linux.Checksum}}"
   end
 

--- a/tools/brew/update_formula.go
+++ b/tools/brew/update_formula.go
@@ -16,10 +16,10 @@ import (
 
 type formula struct {
 	Version string
-	Mac     FormulaFile
-	Linux   FormulaFile
+	Mac     formulaFile
+	Linux   formulaFile
 }
-type FormulaFile struct {
+type formulaFile struct {
 	Checksum string
 	URL      string
 }
@@ -85,7 +85,9 @@ func main() {
 	if err = parsedTemplate.Execute(executedTemplate, formula); err != nil {
 		log.Fatalf("could not apply values to template: %s", err.Error())
 	}
+	log.Println("Successfully executed template")
 
+	log.Println("Writing file")
 	if err := ioutil.WriteFile(*outputPath, executedTemplate.Bytes(), 0644); err != nil {
 		log.Fatalf("error while writing executed template file %q: %s", *outputPath, err.Error())
 	}


### PR DESCRIPTION
It was not working due to having `.Url` instead of `.URL` in the template.


<!-- If you haven't done so already, you can add your name to the humans.txt file -->