### PR TITLE
fix #1871, add partion check(aws-cn,aws) for OpenIDConnectProviderArn

### DIFF
--- a/pkg/iam/oidc/api.go
+++ b/pkg/iam/oidc/api.go
@@ -72,8 +72,7 @@ func NewOpenIDConnectManager(iamapi iamiface.IAMAPI, accountID, issuer, partitio
 func (m *OpenIDConnectManager) CheckProviderExists() (bool, error) {
 	input := &awsiam.GetOpenIDConnectProviderInput{
 		OpenIDConnectProviderArn: aws.String(
-			fmt.Sprintf("arn:aws:iam::%s:oidc-provider/%s",
-				m.accountID, m.hostnameAndPath()),
+			fmt.Sprintf("arn:%s:iam::%s:oidc-provider/%s", m.partition, m.accountID, m.hostnameAndPath()),
 		),
 	}
 	_, err := m.iam.GetOpenIDConnectProvider(input)


### PR DESCRIPTION
### Description
Fix IAM Role for service account is not working in AWS China regions #1871

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
