### PR TITLE
Revert "Merge pull request #1746 add ability to override kubeconfig cluster endpoint"

### DIFF
--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -63,12 +63,6 @@ func New(spec *api.ClusterConfig, username, certificateAuthorityPath string) (*c
 		CurrentContext: contextName,
 	}
 
-	clusterEndpoint, hasClusterEndpoint := os.LookupEnv("KUBECONFIG_CLUSTER_ENDPOINT")
-
-	if hasClusterEndpoint {
-		c.Clusters[clusterName].Server = clusterEndpoint
-	}
-
 	if certificateAuthorityPath == "" {
 		c.Clusters[clusterName].CertificateAuthorityData = spec.Status.CertificateAuthorityData
 	} else {

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -137,33 +137,6 @@ var _ = Describe("Kubeconfig", func() {
 		Expect(readConfig.CurrentContext).To(Equal("minikube"))
 	})
 
-	Context("KUBECONFIG_CLUSTER_ENDPOINT environment variable is set", func() {
-		var clusterConfig = eksctlapi.ClusterConfig{
-			Metadata: &eksctlapi.ClusterMeta{
-				Region: "us-west-2",
-				Name:   "foo",
-				Tags:   map[string]string{},
-			},
-			Status: &eksctlapi.ClusterStatus{
-				Endpoint: "https://eks-endpoint.com",
-			},
-		}
-
-		var expectedClusterName = "foo.us-west-2.eksctl.io"
-		var expectedContextName = "test-user@foo.us-west-2.eksctl.io"
-		var eksEndpoint = "http://my-eks-endpoint.com:8000"
-
-		os.Setenv("KUBECONFIG_CLUSTER_ENDPOINT", eksEndpoint)
-
-		It("sets the EKS Endpoint to be the value passed via the override", func() {
-			config, clusterName, contextName := kubeconfig.New(&clusterConfig, "test-user", "")
-
-			Expect(clusterName).To(Equal(expectedClusterName))
-			Expect(contextName).To(Equal(expectedContextName))
-			Expect(config.Clusters[expectedClusterName].Server).To(Equal(eksEndpoint))
-		})
-	})
-
 	Context("delete config", func() {
 		// Default cluster name is 'foo' and region is 'us-west-2'
 		var apiClusterConfigSample = eksctlapi.ClusterConfig{

--- a/site/content/usage/06-vpc-networking.md
+++ b/site/content/usage/06-vpc-networking.md
@@ -235,14 +235,3 @@ won't change, and you will still have the option to disable the public endpoint 
 the internet. (Source: https://github.com/aws/containers-roadmap/issues/108#issuecomment-552766489)
 
 Implementation notes: https://github.com/aws/containers-roadmap/issues/108#issuecomment-552698875
-
-**Note for using port forwarding with eksctl commands:**
-
-If you access your private cluster locally using port forwarding you'll need to
-override the cluster endpoint that's generated when running eksctl commands.
-
-This can be achieved by setting the following environment variable `KUBECONFIG_CLUSTER_ENDPOINT` when running eksctl commands:
-```
-export KUBECONFIG_CLUSTER_ENDPOINT=https://<local-url-for-cluster>:<port>
-eksctl get iamidentitymapping --cluster <cluster-name>
-```


### PR DESCRIPTION
### Description

After testing 0.14.0 this morning to create a new node group I noticed that the nodes were not coming up. After further investigation into the issue it turned out that the `KUBECONFIG_CLUSTER_ENDPOINT` was being used in the servers kubeconfig file as well.

We're using something along the lines of this as we're using SSH tunnelling:
```
export KUBECONFIG_CLUSTER_ENDPOINT=https://$KUBERNETES_API:8001
```

My initial assumption was that the kubeconfig file generated locally for performing eksctl commands was created separately from the one generated on the Kubernetes host but it turns out both of these are created from the same process.

Because of this, the change I've added causes the nodes not to be able to talk to the API as they're trying to access it on port 8001 instead of 443.

I clearly didn't test this change thoroughly enough with creating node groups and for that I'm sorry.
