### PR TITLE
Allow alpha.service-controller.kubernetes.io domain prefix in node labeling

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -258,7 +258,7 @@ func ValidateNodeGroupLabels(labels map[string]string) error {
 				}
 			}
 
-			for _, domain := range []string{"kubelet.kubernetes.io", "node.kubernetes.io", "node-role.kubernetes.io"} {
+			for _, domain := range []string{"kubelet.kubernetes.io", "node.kubernetes.io", "node-role.kubernetes.io", "alpha.service-controller.kubernetes.io"} {
 				if ns == domain || strings.HasSuffix(ns, "."+domain) {
 					allowedKubeletNamespace = true
 				}


### PR DESCRIPTION
### Description
We use `aws-alb-ingress-controller(target-type: instance)`  and we don't want to add specific instance(specific nodegroup) to alb, we need to give it a specific [label](https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/internal/ingress/annotations/class/main.go#L52).

FYI: https://github.com/weaveworks/eksctl/pull/582

This PR add domain prefix to allow node label.

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
