### PR TITLE
Remove all dangling network intefaces during cluster deletion

### DIFF
--- a/pkg/vpc/cleanup.go
+++ b/pkg/vpc/cleanup.go
@@ -75,9 +75,6 @@ func CleanupNetworkInterfaces(ec2API ec2iface.EC2API, spec *api.ClusterConfig) e
 			return errors.Wrapf(err, "unable to delete network interface %q", eniID)
 		}
 		logger.Debug("deleted network interface %q", eniID)
-		// why we are removing only the first eni id https://github.com/weaveworks/eksctl/issues/1806
-		// nolint:staticcheck
-		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
### Description
Fixes https://github.com/weaveworks/eksctl/issues/1806

### Approach
The original changes were introduced in https://github.com/weaveworks/eksctl/pull/941. 

I have went through the comments to try to understand the rationale behind. Basically, there was a refractor done to address https://github.com/weaveworks/eksctl/pull/941#discussion_r298563702. However, the commit https://github.com/weaveworks/eksctl/pull/941/commits/77fe9b529b31ea0da382977a2327ad8c9e828c1a was still having return nil after deleted ENI.

So I believe that the `return nil` statement was un-intentional.

@cPu1 @martina-if @marccarre feel free to clarify if my understanding is wrong.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
