### PR TITLE
WIP Change default value of update-config-map flag for ng deletion

### DIFF
--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -179,7 +179,7 @@ func AddWaitFlagWithFullDescription(fs *pflag.FlagSet, wait *bool, description s
 
 // AddUpdateAuthConfigMap adds common --update-auth-configmap flag
 func AddUpdateAuthConfigMap(fs *pflag.FlagSet, updateAuthConfigMap *bool, description string) {
-	fs.BoolVar(updateAuthConfigMap, "update-auth-configmap", true, description)
+	fs.BoolVar(updateAuthConfigMap, "update-auth-configmap", false, description)
 }
 
 // AddCommonFlagsForKubeconfig adds common flags for controlling how output kubeconfig is written


### PR DESCRIPTION
### Description
Fixes https://github.com/weaveworks/eksctl/issues/1703
Fixes https://github.com/weaveworks/eksctl/issues/1586

This flag is only used in `delete nodegroup` command.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
