### PR TITLE
Add node-taints flag to add taints when registering the nodes in the nodegroup

### DIFF
--- a/pkg/ctl/cmdutils/nodegroup_flags.go
+++ b/pkg/ctl/cmdutils/nodegroup_flags.go
@@ -46,6 +46,7 @@ func AddCommonCreateNodeGroupFlags(fs *pflag.FlagSet, cmd *Cmd, ng *api.NodeGrou
 	fs.StringSliceVar(&ng.SecurityGroups.AttachIDs, "node-security-groups", []string{}, "Attach additional security groups to nodes, so that it can be used to allow extra ingress/egress access from/to pods")
 
 	fs.StringToStringVar(&ng.Labels, "node-labels", nil, `Extra labels to add when registering the nodes in the nodegroup, e.g. "partition=backend,nodeclass=hugememory"`)
+	fs.StringToStringVar(&ng.Taints, "node-taints", nil, `Taints to add when registering the nodes in the nodegroup, e.g. "key1=value1:NoSchedule,key1=value1:NoExecute"`)
 	fs.StringSliceVar(&ng.AvailabilityZones, "node-zones", nil, "(inherited from the cluster if unspecified)")
 }
 


### PR DESCRIPTION
### Description
Add --node-taints flag. To add taint fields when registering the nodes in the nodegroup

<!-- Please explain the changes you made here. -->
The field is already the in the Nodegroup struct but there is no command line flag
Only needed to add the flag and add to the Taints field

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [X] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [X] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
