### PR TITLE
Correct --update-auth-configmap flag description for create nodegroup

### DIFF
--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -49,7 +49,7 @@ func createNodeGroupCmd(cmd *cmdutils.Cmd) {
 		cmdutils.AddVersionFlag(fs, cfg.Metadata, `for nodegroups "auto" and "latest" can be used to automatically inherit version from the control plane or force latest`)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 		cmdutils.AddNodeGroupFilterFlags(fs, &cmd.Include, &cmd.Exclude)
-		cmdutils.AddUpdateAuthConfigMap(fs, &params.updateAuthConfigMap, "Remove nodegroup IAM role from aws-auth configmap")
+		cmdutils.AddUpdateAuthConfigMap(fs, &params.updateAuthConfigMap, "Add nodegroup IAM role to aws-auth configmap")
 		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
 	})
 


### PR DESCRIPTION
### Description
To correct the typo/confusion in create nodegroup cli flag.

While creating node group, eksctl will add entry into auth-cm based on the flag --update-auth-configmap as per below implementation. However, the description of this flag was saying `Remove ...`

https://github.com/weaveworks/eksctl/blob/master/pkg/ctl/create/nodegroup.go#L209-L213

<details>
<summary>Before</summary>
<p>

```bash
./eksctl create nodegroup -h                                                                                         
Create a nodegroup

Usage: eksctl create nodegroup [flags]

Aliases: nodegroup, ng

General flags:
...
      --update-auth-configmap   Remove nodegroup IAM role from aws-auth configmap (default true)
      --timeout duration        maximum waiting time for any long-running operation (default 25m0s)
...

```

</p>
</details> 


<details>
<summary>After</summary>
<p>

```bash
./eksctl create nodegroup -h
Create a nodegroup

Usage: eksctl create nodegroup [flags]

Aliases: nodegroup, ng

General flags:
...
      --update-auth-configmap   Add nodegroup IAM role to aws-auth configmap (default true)
...

```

</p>
</details> 


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
