### PR TITLE
Generate nightly builds on Circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,3 +255,13 @@ workflows:
                 - master
     jobs:
       - integration-tests
+  nightly-build:
+    triggers:
+      - schedule:
+          cron: "0 4 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build-all-distros


### PR DESCRIPTION
This triggers a nightly build at 4am UTC in CircleCi



<!-- If you haven't done so already, you can add your name to the humans.txt file -->