### PR TITLE
WIP Perform clean up regardless of stack status

### DIFF
--- a/pkg/cfn/manager/delete_tasks.go
+++ b/pkg/cfn/manager/delete_tasks.go
@@ -3,8 +3,6 @@ package manager
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/service/cloudformation"
-
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	iamoidc "github.com/weaveworks/eksctl/pkg/iam/oidc"
 	"github.com/weaveworks/eksctl/pkg/kubernetes"
@@ -76,7 +74,7 @@ func (c *StackCollection) NewTasksToDeleteNodeGroups(shouldDelete func(string) b
 		if !shouldDelete(name) {
 			continue
 		}
-		if *s.StackStatus == cloudformation.StackStatusDeleteFailed && cleanup != nil {
+		if cleanup != nil {
 			tasks.Append(&taskWithNameParam{
 				info: fmt.Sprintf("cleanup for nodegroup %q", name),
 				call: cleanup,


### PR DESCRIPTION
### Description
Fixes https://github.com/weaveworks/eksctl/issues/1856

Cleanup task is currently added into plan if and only if CF stack was failed to delete before. This requires to run `eksctl delete cluster` manually again.

I feel like we should run the cleanup task regardless of CF status, as deletion is idempotent anyway :)

<details>

```bash
/eksctl create cluster -f test_private.yaml
[ℹ]  eksctl version 0.16.0-dev+3ec2045c.2020-03-09T19:14:49Z
[ℹ]  using region ap-southeast-2
[ℹ]  setting availability zones to [ap-southeast-2a ap-southeast-2c ap-southeast-2b]
[ℹ]  subnets for ap-southeast-2a - public:192.168.0.0/19 private:192.168.96.0/19
[ℹ]  subnets for ap-southeast-2c - public:192.168.32.0/19 private:192.168.128.0/19
[ℹ]  subnets for ap-southeast-2b - public:192.168.64.0/19 private:192.168.160.0/19
[ℹ]  nodegroup "standard-workers" will use "ami-0cff399516eece2a9" [AmazonLinux2/1.14]
[ℹ]  nodegroup "private-workers" will use "ami-0cff399516eece2a9" [AmazonLinux2/1.14]
[ℹ]  using Kubernetes version 1.14
[ℹ]  creating EKS cluster "test-delete" in "ap-southeast-2" region with managed nodes and un-managed nodes
[ℹ]  3 nodegroups (managed-workers, private-workers, standard-workers) were included (based on the include/exclude rules)
[ℹ]  will create a CloudFormation stack for cluster itself and 2 nodegroup stack(s)
[ℹ]  will create a CloudFormation stack for cluster itself and 1 managed nodegroup stack(s)
[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=ap-southeast-2 --cluster=test-delete'
[ℹ]  CloudWatch logging will not be enabled for cluster "test-delete" in "ap-southeast-2"
[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --region=ap-southeast-2 --cluster=test-delete'
[ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "test-delete" in "ap-southeast-2"
[ℹ]  2 sequential tasks: { create cluster control plane "test-delete", 3 parallel sub-tasks: { create nodegroup "standard-workers", create nodegroup "private-workers", create managed nodegroup "managed-workers" } }
[ℹ]  building cluster stack "eksctl-test-delete-cluster"
[ℹ]  deploying stack "eksctl-test-delete-cluster"
[ℹ]  building nodegroup stack "eksctl-test-delete-nodegroup-private-workers"
[ℹ]  building managed nodegroup stack "eksctl-test-delete-nodegroup-managed-workers"
[ℹ]  building nodegroup stack "eksctl-test-delete-nodegroup-standard-workers"
[ℹ]  deploying stack "eksctl-test-delete-nodegroup-managed-workers"
[ℹ]  deploying stack "eksctl-test-delete-nodegroup-standard-workers"
[ℹ]  deploying stack "eksctl-test-delete-nodegroup-private-workers"
[✔]  all EKS cluster resources for "test-delete" have been created
[✔]  saved kubeconfig as "/home/tammach/.kube/config"
[ℹ]  adding identity "arn:aws:iam::363193625107:role/eksctl-test-delete-nodegroup-stan-NodeInstanceRole-EUDLASBDYR4L" to auth ConfigMap
[ℹ]  nodegroup "standard-workers" has 0 node(s)
[ℹ]  waiting for at least 1 node(s) to become ready in "standard-workers"
[ℹ]  nodegroup "standard-workers" has 1 node(s)
[ℹ]  node "ip-192-168-76-167.ap-southeast-2.compute.internal" is ready
[ℹ]  adding identity "arn:aws:iam::363193625107:role/eksctl-test-delete-nodegroup-priv-NodeInstanceRole-1EJXARIKOSEZ0" to auth ConfigMap
[ℹ]  nodegroup "private-workers" has 0 node(s)
[ℹ]  waiting for at least 1 node(s) to become ready in "private-workers"
[ℹ]  nodegroup "private-workers" has 1 node(s)
[ℹ]  node "ip-192-168-153-247.ap-southeast-2.compute.internal" is ready
[ℹ]  nodegroup "managed-workers" has 1 node(s)
[ℹ]  node "ip-192-168-23-22.ap-southeast-2.compute.internal" is ready
[ℹ]  waiting for at least 1 node(s) to become ready in "managed-workers"
[ℹ]  nodegroup "managed-workers" has 1 node(s)
[ℹ]  node "ip-192-168-23-22.ap-southeast-2.compute.internal" is ready
[ℹ]  kubectl command should work with "/home/tammach/.kube/config", try 'kubectl get nodes'
[✔]  EKS cluster "test-delete" in "ap-southeast-2" region is ready
```
</details>

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
