### PR TITLE
Support tags for Fargate profiles

### DIFF
--- a/examples/16-fargate-profile.yaml
+++ b/examples/16-fargate-profile.yaml
@@ -29,3 +29,6 @@ fargateProfiles:
         labels:
           env: dev
           checks: passed
+    tags:
+      env: dev
+      name: fp-dev

--- a/integration/tests/fargate/fargate_test.go
+++ b/integration/tests/fargate/fargate_test.go
@@ -103,6 +103,7 @@ var _ = Describe("(Integration) Fargate", func() {
 			"--name", profileName,
 			"--namespace", kubeTest.Namespace,
 			"--labels", "run-on=fargate",
+			"--tags", "env=integration",
 			"--verbose", "4",
 		)
 		Expect(cmd).To(RunSuccessfullyWithOutputString(ContainSubstring(profileName)))

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -883,6 +883,9 @@ type FargateProfile struct {
 	// Subnets which Fargate should use to do network placement of the selected workload.
 	// If none provided, all subnets for the cluster will be used.
 	Subnets []string `json:"subnets,omitempty"`
+
+	// +optional
+	Tags map[string]string `json:"tags,omitempty"`
 }
 
 // FargateProfileSelector defines rules to select workload to schedule onto Fargate.

--- a/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
@@ -482,6 +482,13 @@ func (in *FargateProfile) DeepCopyInto(out *FargateProfile) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/ctl/cmdutils/fargate.go
+++ b/pkg/ctl/cmdutils/fargate.go
@@ -13,6 +13,7 @@ const (
 	fargateProfileName              = "name"      // Fargate profile name.
 	fargateProfileSelectorNamespace = "namespace" // Fargate profile selector's namespace.
 	fargateProfileSelectorLabels    = "labels"    // Fargate profile selector's labels.
+	fargateProfileTags              = "tags"      // Fargate profile tags.
 )
 
 // AddFlagsForFargate configures the flags required to interact with Fargate.
@@ -30,6 +31,9 @@ func AddFlagsForFargateProfileCreation(fs *pflag.FlagSet, options *fargate.Creat
 
 	fs.StringToStringVarP(&options.ProfileSelectorLabels, fargateProfileSelectorLabels, "l", nil,
 		"Kubernetes selector labels of the workloads to schedule on Fargate, e.g. k1=v1,k2=v2")
+
+	fs.StringToStringVarP(&options.Tags, fargateProfileTags, "t", map[string]string{},
+		`A list of KV pairs used to tag the AWS resources (e.g. "Owner=John Doe,Team=Some Team")`)
 }
 
 func addFargateProfileName(fs *pflag.FlagSet, profileName *string) {

--- a/pkg/ctl/create/fargate_test.go
+++ b/pkg/ctl/create/fargate_test.go
@@ -71,6 +71,22 @@ var _ = Describe("create", func() {
 			Expect(selector.Namespace).To(Equal("default"))
 		})
 
+		It("the fargate profile with tags", func() {
+			cmd := newMockCreateFargateProfileCmd("fargateprofile", "--cluster", "foo", "--tags", "env=dev,name=fp-default", "--namespace", "default", "fp-default", )
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(cmd.cmd.ClusterConfig.Metadata.Name).To(Equal("foo"))
+			profiles := cmd.cmd.ClusterConfig.FargateProfiles
+			Expect(profiles).To(HaveLen(1))
+			profile := profiles[0]
+			Expect(profile.Name).To(Equal("fp-default"))
+			Expect(profile.Selectors).To(HaveLen(1))
+			selector := profile.Selectors[0]
+			Expect(selector.Namespace).To(Equal("default"))
+			Expect(profile.Tags).To(HaveKeyWithValue("env", "dev"))
+			Expect(profile.Tags).To(HaveKeyWithValue("name", "fp-default"))
+		})
+
 		It("supports all arguments to be provided by a ClusterConfig file", func() {
 			cmd := newMockCreateFargateProfileCmd("fargateprofile", "-f", "../../../examples/16-fargate-profile.yaml")
 			_, err := cmd.execute()
@@ -90,6 +106,8 @@ var _ = Describe("create", func() {
 			Expect(profiles[1].Selectors[0].Labels).To(HaveLen(2))
 			Expect(profiles[1].Selectors[0].Labels).To(HaveKeyWithValue("env", "dev"))
 			Expect(profiles[1].Selectors[0].Labels).To(HaveKeyWithValue("checks", "passed"))
+			Expect(profiles[1].Tags).To(HaveKeyWithValue("env", "dev"))
+			Expect(profiles[1].Tags).To(HaveKeyWithValue("name", "fp-dev"))
 		})
 	})
 })

--- a/pkg/fargate/client.go
+++ b/pkg/fargate/client.go
@@ -187,6 +187,7 @@ func createRequest(clusterName string, profile *api.FargateProfile) *eks.CreateF
 		Selectors:           toSelectorPointers(profile.Selectors),
 		PodExecutionRoleArn: strings.NilIfEmpty(profile.PodExecutionRoleARN),
 		Subnets:             strings.NilPointersArrayIfEmpty(strings.ToPointersArray(profile.Subnets)),
+		Tags:                strings.ToPointersMap(profile.Tags),
 	}
 	logger.Debug("Fargate profile: create request: sending: %#v", request)
 	return request
@@ -224,6 +225,7 @@ func toFargateProfile(in *eks.FargateProfile) *api.FargateProfile {
 		Selectors:           toSelectors(in.Selectors),
 		PodExecutionRoleARN: strings.EmptyIfNil(in.PodExecutionRoleArn),
 		Subnets:             strings.ToValuesArray(in.Subnets),
+		Tags:                strings.ToValuesMap(in.Tags),
 	}
 }
 

--- a/pkg/fargate/client_test.go
+++ b/pkg/fargate/client_test.go
@@ -211,6 +211,9 @@ func testFargateProfile() *api.FargateProfile {
 				},
 			},
 		},
+		Tags: map[string]string{
+			"env": "test",
+		},
 	}
 }
 
@@ -226,6 +229,9 @@ func testCreateFargateProfileInput() *eks.CreateFargateProfileInput {
 					"env": strings.Pointer("test"),
 				},
 			},
+		},
+		Tags: map[string]*string{
+			"env": strings.Pointer("test"),
 		},
 	}
 }
@@ -294,6 +300,7 @@ func apiFargateProfile(name string) *api.FargateProfile {
 			},
 		},
 		Subnets: []string{},
+		Tags:    map[string]string{},
 	}
 }
 

--- a/pkg/fargate/options.go
+++ b/pkg/fargate/options.go
@@ -28,6 +28,8 @@ type CreateOptions struct {
 	ProfileSelectorNamespace string
 	// +optional
 	ProfileSelectorLabels map[string]string
+	// +optional
+	Tags map[string]string
 }
 
 // Validate validates this Options object's fields.
@@ -51,5 +53,6 @@ func (o CreateOptions) ToFargateProfile() *api.FargateProfile {
 				Labels:    o.ProfileSelectorLabels,
 			},
 		},
+		Tags: o.Tags,
 	}
 }

--- a/pkg/fargate/print.go
+++ b/pkg/fargate/print.go
@@ -34,6 +34,7 @@ type row struct {
 	PodExecutionRoleARN string
 	Subnets             []string
 	Selector            api.FargateProfileSelector
+	Tags                map[string]string
 }
 
 func toTable(profiles []*api.FargateProfile) []*row {
@@ -45,6 +46,7 @@ func toTable(profiles []*api.FargateProfile) []*row {
 				PodExecutionRoleARN: profile.PodExecutionRoleARN,
 				Subnets:             profile.Subnets,
 				Selector:            selector,
+				Tags:                profile.Tags,
 			})
 		}
 	}
@@ -69,5 +71,8 @@ func addFargateProfileColumns(printer *printers.TablePrinter) {
 			return "<none>"
 		}
 		return strings.Join(r.Subnets, ",")
+	})
+	printer.AddColumn("TAGS", func(r *row) string {
+		return labels.FormatLabels(r.Tags)
 	})
 }

--- a/pkg/fargate/print_test.go
+++ b/pkg/fargate/print_test.go
@@ -45,10 +45,10 @@ var _ = Describe("fargate", func() {
 	})
 })
 
-const expectedTable = `NAME	SELECTOR_NAMESPACE	SELECTOR_LABELS		POD_EXECUTION_ROLE_ARN		SUBNETS
-fp-prod	prod			env=prod		arn:aws:iam::123:role/root	subnet-prod,subnet-d34dc0w
-fp-test	default			<none>			arn:aws:iam::123:role/root	<none>
-fp-test	kube-system		app=my-app,env=test	arn:aws:iam::123:role/root	<none>
+const expectedTable = `NAME	SELECTOR_NAMESPACE	SELECTOR_LABELS		POD_EXECUTION_ROLE_ARN		SUBNETS				TAGS
+fp-prod	prod			env=prod		arn:aws:iam::123:role/root	subnet-prod,subnet-d34dc0w	<none>
+fp-test	default			<none>			arn:aws:iam::123:role/root	<none>				app=my-app,env=test
+fp-test	kube-system		app=my-app,env=test	arn:aws:iam::123:role/root	<none>				app=my-app,env=test
 `
 
 const expectedYAML = `- name: fp-test
@@ -59,6 +59,9 @@ const expectedYAML = `- name: fp-test
       env: test
     namespace: kube-system
   - namespace: default
+  tags:
+    app: my-app
+    env: test
 - name: fp-prod
   podExecutionRoleARN: arn:aws:iam::123:role/root
   selectors:
@@ -85,7 +88,11 @@ const expectedJSON = `[
             {
                 "namespace": "default"
             }
-        ]
+        ],
+        "tags": {
+            "app": "my-app",
+            "env": "test"
+        }
     },
     {
         "name": "fp-prod",
@@ -121,6 +128,10 @@ func sampleProfiles() []*api.FargateProfile {
 				{
 					Namespace: "default",
 				},
+			},
+			Tags: map[string]string{
+				"app": "my-app",
+				"env": "test",
 			},
 		},
 		{

--- a/site/content/usage/20-schema.md
+++ b/site/content/usage/20-schema.md
@@ -222,6 +222,11 @@ FargateProfile:
       items:
         type: string
       type: array
+    tags:
+      patternProperties:
+        .*:
+          type: string
+      type: object
   required:
   - name
   - selectors


### PR DESCRIPTION
### Description

Fixes https://github.com/weaveworks/eksctl/issues/1841

<details>
<summary>Create fargate cluster with config file</summary>

```shell script
$ cat test_fargate.yaml 
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig
metadata:
  name: test-fargate-tags
  region: us-east-2

fargateProfiles:
  - name: fp-default
    selectors:
      - namespace: default
      - namespace: kube-system
    tags:
      namespace: default
  - name: fp-dev
    selectors:
      - namespace: dev
        labels:
          env: dev
          checks: passed
    tags:
      namespace: dev
      env: dev

$ ./eksctl create cluster -f test_fargate.yaml
[ℹ]  eksctl version 0.16.0-dev+e938f361.2020-03-16T20:12:37Z
[ℹ]  using region us-east-2
[ℹ]  setting availability zones to [us-east-2b us-east-2a us-east-2c]
[ℹ]  subnets for us-east-2b - public:192.168.0.0/19 private:192.168.96.0/19
[ℹ]  subnets for us-east-2a - public:192.168.32.0/19 private:192.168.128.0/19
[ℹ]  subnets for us-east-2c - public:192.168.64.0/19 private:192.168.160.0/19
[ℹ]  using Kubernetes version 1.14
[ℹ]  creating EKS cluster "test-fargate-tags" in "us-east-2" region with Fargate profile
[ℹ]  will create a CloudFormation stack for cluster itself and 0 nodegroup stack(s)
[ℹ]  will create a CloudFormation stack for cluster itself and 0 managed nodegroup stack(s)
[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-east-2 --cluster=test-fargate-tags'
[ℹ]  CloudWatch logging will not be enabled for cluster "test-fargate-tags" in "us-east-2"
[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --region=us-east-2 --cluster=test-fargate-tags'
[ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "test-fargate-tags" in "us-east-2"
[ℹ]  1 task: { create cluster control plane "test-fargate-tags" }
[ℹ]  building cluster stack "eksctl-test-fargate-tags-cluster"
[ℹ]  deploying stack "eksctl-test-fargate-tags-cluster"
[✔]  all EKS cluster resources for "test-fargate-tags" have been created
[✔]  saved kubeconfig as "/home/tammach/.kube/config"
[ℹ]  creating Fargate profile "fp-default" on EKS cluster "test-fargate-tags"
[ℹ]  created Fargate profile "fp-default" on EKS cluster "test-fargate-tags"
[ℹ]  creating Fargate profile "fp-dev" on EKS cluster "test-fargate-tags"
[ℹ]  created Fargate profile "fp-dev" on EKS cluster "test-fargate-tags"
[ℹ]  "coredns" is now schedulable onto Fargate
[ℹ]  "coredns" is now scheduled onto Fargate
[ℹ]  "coredns" pods are now scheduled onto Fargate
[ℹ]  kubectl command should work with "/home/tammach/.kube/config", try 'kubectl get nodes'
[✔]  EKS cluster "test-fargate-tags" in "us-east-2" region is ready
```

</details>


<details>
<summary>Create fargate profile from CLI</summary>

```shell script
./eksctl create fargateprofile --name fg-profile-cli --namespace dev -l env=test -t env=test --cluster  test-fargate-tags
[ℹ]  creating Fargate profile "fg-profile-cli" on EKS cluster "test-fargate-tags"
[ℹ]  created Fargate profile "fg-profile-cli" on EKS cluster "test-fargate-tags"
```

</details>

<details>
<summary>List fargate profiles</summary>

```shell scripts
$ ./eksctl get fargateprofile --cluster test-fargate-tags                 
NAME            SELECTOR_NAMESPACE      SELECTOR_LABELS         POD_EXECUTION_ROLE_ARN                                                                          SUBNETS                                                                         TAGS
fg-profile-cli  dev                     env=test                arn:aws:iam::363193625107:role/eksctl-test-fargate-tags-c-FargatePodExecutionRole-1817J6HHCI8C9 subnet-01d563775722c729b,subnet-035cf5a04ff6f832c,subnet-09848eba0e966548d      env=test
fp-default      default                 <none>                  arn:aws:iam::363193625107:role/eksctl-test-fargate-tags-c-FargatePodExecutionRole-1817J6HHCI8C9 subnet-01d563775722c729b,subnet-035cf5a04ff6f832c,subnet-09848eba0e966548d      namespace=default
fp-default      kube-system             <none>                  arn:aws:iam::363193625107:role/eksctl-test-fargate-tags-c-FargatePodExecutionRole-1817J6HHCI8C9 subnet-01d563775722c729b,subnet-035cf5a04ff6f832c,subnet-09848eba0e966548d      namespace=default
fp-dev          dev                     checks=passed,env=dev   arn:aws:iam::363193625107:role/eksctl-test-fargate-tags-c-FargatePodExecutionRole-1817J6HHCI8C9 subnet-01d563775722c729b,subnet-035cf5a04ff6f832c,subnet-09848eba0e966548d      env=dev,namespace=dev

```

</details>

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
