### PR TITLE
fix #1910 set China region correct audience

### DIFF
--- a/pkg/iam/oidc/api.go
+++ b/pkg/iam/oidc/api.go
@@ -16,10 +16,7 @@ import (
 	cft "github.com/weaveworks/eksctl/pkg/cfn/template"
 )
 
-var defaultAudienceByPartition = map[string]string{
-	"aws":    "sts.amazonaws.com",
-	"aws-cn": "sts.amazonaws.com.cn",
-}
+var defaultAudience = "sts.amazonaws.com"
 
 // OpenIDConnectManager hold information about IAM OIDC integration
 type OpenIDConnectManager struct {
@@ -48,10 +45,7 @@ func NewOpenIDConnectManager(iamapi iamiface.IAMAPI, accountID, issuer, partitio
 		return nil, fmt.Errorf("unsupported URL scheme %q", issuerURL.Scheme)
 	}
 
-	audience, ok := defaultAudienceByPartition[partition]
-	if !ok {
-		return nil, fmt.Errorf("failed to find an audience for partition: %s", partition)
-	}
+	audience := defaultAudience
 
 	if issuerURL.Port() == "" {
 		issuerURL.Host += ":443"

--- a/pkg/iam/oidc/api.go
+++ b/pkg/iam/oidc/api.go
@@ -16,7 +16,7 @@ import (
 	cft "github.com/weaveworks/eksctl/pkg/cfn/template"
 )
 
-var defaultAudience = "sts.amazonaws.com"
+const defaultAudience = "sts.amazonaws.com"
 
 // OpenIDConnectManager hold information about IAM OIDC integration
 type OpenIDConnectManager struct {
@@ -45,8 +45,6 @@ func NewOpenIDConnectManager(iamapi iamiface.IAMAPI, accountID, issuer, partitio
 		return nil, fmt.Errorf("unsupported URL scheme %q", issuerURL.Scheme)
 	}
 
-	audience := defaultAudience
-
 	if issuerURL.Port() == "" {
 		issuerURL.Host += ":443"
 	}
@@ -55,7 +53,7 @@ func NewOpenIDConnectManager(iamapi iamiface.IAMAPI, accountID, issuer, partitio
 		iam:       iamapi,
 		accountID: accountID,
 		partition: partition,
-		audience:  audience,
+		audience:  defaultAudience,
 		issuerURL: issuerURL,
 	}
 	return m, nil

--- a/pkg/iam/oidc/api_test.go
+++ b/pkg/iam/oidc/api_test.go
@@ -265,8 +265,7 @@ var _ = Describe("EKS/IAM API wrapper", func() {
 					return false
 				}
 				clientID := *input.ClientIDList[0]
-				expectedAudience := defaultAudienceByPartition[partition]
-				return clientID == expectedAudience
+				return clientID == defaultAudience
 			})).Return(&awsiam.CreateOpenIDConnectProviderOutput{
 				OpenIDConnectProviderArn: aws.String(fmt.Sprintf("arn:%s:iam::12345:oidc-provider/localhost/", partition)),
 			}, nil)

--- a/pkg/iam/oidc/api_test.go
+++ b/pkg/iam/oidc/api_test.go
@@ -300,7 +300,7 @@ var _ = Describe("EKS/IAM API wrapper", func() {
 			Expect(actual).To(MatchJSON(expected))
 		},
 			Entry("Default AWS partition", "aws", "sts.amazonaws.com"),
-			Entry("AWS China partition", "aws-cn", "sts.amazonaws.com.cn"),
+			Entry("AWS China partition", "aws-cn", "sts.amazonaws.com"),
 		)
 	})
 })


### PR DESCRIPTION
### Description

fix #1910 , set China region correct audience, OIDC provider and AssumeRolePolicy use "sts.amazonaws.com"

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
