### PR TITLE
Fix unit test for go 1.14

### DIFF
--- a/pkg/iam/oidc/api_test.go
+++ b/pkg/iam/oidc/api_test.go
@@ -60,7 +60,9 @@ var _ = Describe("EKS/IAM API wrapper", func() {
 
 			err = oidc.getIssuerCAThumbprint()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(HavePrefix("connecting to issuer OIDC: Get https://localhost:10020/"))
+			// Use regex to match URL as go 1.14 have extra double quotes for URL
+			// related commit : https://github.com/golang/go/commit/64cfe9fe22113cd6bc05a2c5d0cbe872b1b57860
+			Expect(err.Error()).To(MatchRegexp("connecting to issuer OIDC: Get \"?https://localhost:10020/\"?"))
 			Expect(err.Error()).To(HaveSuffix("connect: connection refused"))
 		})
 


### PR DESCRIPTION
### Description

As mentioned in slack https://weave-community.slack.com/archives/CAYBZBWGL/p1583779099266600, unit test is failing for go 1.14. Understand that moving to go 1.14 might take sometime, I just change the assertion to make it work for both 1.13 and 1.14.


Original message:


>• Failure [0.002 seconds]
>EKS/IAM API wrapper
>/Users/_/Development/eksctl/pkg/iam/oidc/api_test.go:21
>  parse OIDC issuer URL and host fingerprint
>  /Users/_/Development/eksctl/pkg/iam/oidc/api_test.go:27
>    should get cluster, and fail to connect to fake issue URL [It]
>    /Users/_/Development/eksctl/pkg/iam/oidc/api_test.go:57
>    Expected
>        <string>: connecting to issuer OIDC: Get "https://localhost:10020/": dial tcp [::1]:10020: >connect: connection refused
>    to have prefix
>        <string>: connecting to issuer OIDC: Get https://localhost:10020/
>    /Users/_/Development/eksctl/pkg/iam/oidc/api_test.go:63
>------------------------------
>••••••
>Summarizing 1 Failure:
>[Fail] EKS/IAM API wrapper parse OIDC issuer URL and host fingerprint [It] should get cluster, and >Fail to connect to fake issue URL 
>/Users/_/Development/eksctl/pkg/iam/oidc/api_test.go:63


>there is extra "  before https, I got the same issue after upgrading to go 1.14, so it’s not your issue :slightly_smiling_face:. The project is still under go 1.13. so either you can ignore this error, or run it with 1.13 (i.e. multiple go versions). 


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
