### PR TITLE
Remove --allow-privileged flag in docs

### DIFF
--- a/docs/current-001-node_bootstrap.md
+++ b/docs/current-001-node_bootstrap.md
@@ -145,7 +145,6 @@ systemctl reset-failed
     "node-ip=${NODE_IP}"
     "max-pods=${MAX_PODS}"
     "node-labels=${NODE_LABELS},alpha.eksctl.io/instance-id=${INSTANCE_ID}"
-    "allow-privileged=true"
     "pod-infra-container-image=${AWS_EKS_ECR_ACCOUNT}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/eks/pause-amd64:3.1"
     "cloud-provider=aws"
     "cni-bin-dir=/opt/cni/bin"
@@ -182,7 +181,6 @@ ExecStart=/usr/bin/kubelet \
   --node-labels=${NODE_LABELS},alpha.eksctl.io/instance-id=${INSTANCE_ID} \
   --max-pods=${MAX_PODS} \
   --register-node=true --register-with-taints=${NODE_TAINTS} \
-  --allow-privileged=true \
   --cloud-provider=aws \
   --container-runtime=docker \
   --network-plugin=cni \


### PR DESCRIPTION
### Description

As per https://github.com/awslabs/amazon-eks-ami/pull/428, the flag `--allow-privileged` is not required for all supported versions.

This flag also got removed in recent PR https://github.com/weaveworks/eksctl/pull/1917/files#diff-6955196fab7d3ecf801e80fe59c65f30L17. 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
