### PR TITLE
Make integration test assertions on nodegroups more robust

### DIFF
--- a/integration/matchers/json.go
+++ b/integration/matchers/json.go
@@ -1,0 +1,59 @@
+package matchers
+
+import (
+	"github.com/onsi/gomega/types"
+	"github.com/weaveworks/eksctl/pkg/cfn/manager"
+
+	"encoding/json"
+	"fmt"
+)
+
+// BeNodeGroupsWithNamesWhich helps match JSON-formatted nodegroups by
+// accepting matchers on an array of nodegroup names.
+func BeNodeGroupsWithNamesWhich(matchers ...types.GomegaMatcher) types.GomegaMatcher {
+	return &jsonNodeGroupMatcher{
+		matchers: matchers,
+	}
+}
+
+type jsonNodeGroupMatcher struct {
+	matchers              []types.GomegaMatcher
+	failureMessage        string
+	negatedFailureMessage string
+}
+
+func (matcher *jsonNodeGroupMatcher) Match(actual interface{}) (success bool, err error) {
+	rawJSON, ok := actual.(string)
+	if !ok {
+		return false, fmt.Errorf("BeNodeGroupsWithNamesWhich matcher expects a string")
+	}
+	ngSummaries := []manager.NodeGroupSummary{}
+	if err := json.Unmarshal([]byte(rawJSON), &ngSummaries); err != nil {
+		return false, fmt.Errorf("BeNodeGroupsWithNamesWhich matcher expects a NodeGroupSummary JSON array")
+	}
+	ngNames := extractNames(ngSummaries)
+	for _, m := range matcher.matchers {
+		if ok, err := m.Match(ngNames); !ok {
+			matcher.failureMessage = m.FailureMessage(ngNames)
+			matcher.negatedFailureMessage = m.NegatedFailureMessage(ngNames)
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+func extractNames(ngSummaries []manager.NodeGroupSummary) []string {
+	ngNames := make([]string, len(ngSummaries))
+	for i, ngSummary := range ngSummaries {
+		ngNames[i] = ngSummary.Name
+	}
+	return ngNames
+}
+
+func (matcher *jsonNodeGroupMatcher) FailureMessage(unusedActual interface{}) string {
+	return matcher.failureMessage
+}
+
+func (matcher *jsonNodeGroupMatcher) NegatedFailureMessage(unusedActual interface{}) string {
+	return matcher.negatedFailureMessage
+}

--- a/integration/matchers/json_test.go
+++ b/integration/matchers/json_test.go
@@ -1,0 +1,53 @@
+package matchers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/weaveworks/eksctl/integration/matchers"
+	"github.com/weaveworks/eksctl/pkg/testutils"
+)
+
+func TestSuite(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}
+
+var _ = Describe("BeNodeGroupsWithNamesWhich", func() {
+	It("can marshal the JSON representation of a nodegroup and match on its name", func() {
+		Expect(`[
+			{
+				"StackName": "eksctl-test-cluster-nodegroup-ng-0",
+				"Cluster": "test-cluster",
+				"Name": "ng-0",
+				"MaxSize": 4,
+				"MinSize": 4,
+				"DesiredCapacity": 4,
+				"InstanceType": "m5.xlarge",
+				"ImageID": "ami-036f46d54262b5179",
+				"CreationTime": "2020-03-10T10:53:05.106Z",
+				"NodeInstanceRoleARN": "arn:aws:iam::083751696308:role/eksctl-test-cluster-nodegroup-ng-0-NodeInstanceRole-1IYQ3JS8OKPX1"
+			}
+		]`).To(BeNodeGroupsWithNamesWhich(
+			HaveLen(1),
+			ContainElement("ng-0"),
+			Not(ContainElement("ng-1")),
+		))
+	})
+
+	It("can marshal the JSON representation of nodegroups and match on their names", func() {
+		Expect(`[
+			{
+				"Name": "ng-0"
+			},
+			{
+				"Name": "ng-1"
+			}
+		]`).To(BeNodeGroupsWithNamesWhich(
+			HaveLen(2),
+			ContainElement("ng-0"),
+			ContainElement("ng-1"),
+			Not(ContainElement("ng-2")),
+		))
+	})
+})

--- a/integration/tests/crud/creategetdelete_test.go
+++ b/integration/tests/crud/creategetdelete_test.go
@@ -161,34 +161,40 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				{
 					cmd := params.EksctlGetCmd.WithArgs(
 						"nodegroup",
+						"-o", "json",
 						"--cluster", params.ClusterName,
 						initNG,
 					)
-					Expect(cmd).To(RunSuccessfullyWithOutputStringLines(
-						ContainElement(ContainSubstring(initNG)),
-						Not(ContainElement(ContainSubstring(testNG))),
-					))
+					Expect(cmd).To(RunSuccessfullyWithOutputString(BeNodeGroupsWithNamesWhich(
+						HaveLen(1),
+						ContainElement(initNG),
+						Not(ContainElement(testNG)),
+					)))
 				}
 				{
 					cmd := params.EksctlGetCmd.WithArgs(
 						"nodegroup",
+						"-o", "json",
 						"--cluster", params.ClusterName,
 						testNG,
 					)
-					Expect(cmd).To(RunSuccessfullyWithOutputStringLines(
-						ContainElement(ContainSubstring(testNG)),
-						Not(ContainElement(ContainSubstring(initNG))),
-					))
+					Expect(cmd).To(RunSuccessfullyWithOutputString(BeNodeGroupsWithNamesWhich(
+						HaveLen(1),
+						ContainElement(testNG),
+						Not(ContainElement(initNG)),
+					)))
 				}
 				{
 					cmd := params.EksctlGetCmd.WithArgs(
 						"nodegroup",
+						"-o", "json",
 						"--cluster", params.ClusterName,
 					)
-					Expect(cmd).To(RunSuccessfullyWithOutputStringLines(
-						ContainElement(ContainSubstring(testNG)),
-						ContainElement(ContainSubstring(initNG)),
-					))
+					Expect(cmd).To(RunSuccessfullyWithOutputString(BeNodeGroupsWithNamesWhich(
+						HaveLen(2),
+						ContainElement(initNG),
+						ContainElement(testNG),
+					)))
 				}
 			})
 


### PR DESCRIPTION
### Description

Change "CRUD" integration tests to

- run `eksctl get nodegroups` commands with `-o json`,
- leverage a custom JSON matcher on `[]NodeGroupSummary`, instead of `string` matchers on raw `stdout` which could accidentally match on irrelevant output,

in order to make test assertions on nodegroups more robust.
Fixes #1914. 

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Manual test

```console
$ ginkgo -tags integration -v --progress integration/tests/crud/... -- -test.v -ginkgo.v
=== RUN   TestSuite
Running Suite: ${GOPATH}/src/github.com/weaveworks/eksctl/integration/tests/crud/creategetdelete_test.go
==============================================================================================================
Random Seed: 1584007358
Will run 35 of 35 specs

[...]

------------------------------
(Integration) Create, Get, Scale & Delete when creating a cluster with 1 node and add the second nodegroup 
  should be able to list nodegroups
  ${GOPATH}/src/github.com/weaveworks/eksctl/integration/tests/crud/creategetdelete_test.go:160
[It] should be able to list nodegroups
  ${GOPATH}/src/github.com/weaveworks/eksctl/integration/tests/crud/creategetdelete_test.go:160
starting '../../../eksctl "--region" "us-west-2" "get" "nodegroup" "-o" "json" "--cluster" "it-crud-fabulous-rainbow-1584007373" "ng-0"'
[
    {
        "StackName": "eksctl-it-crud-fabulous-rainbow-1584007373-nodegroup-ng-0",
        "Cluster": "it-crud-fabulous-rainbow-1584007373",
        "Name": "ng-0",
        "MaxSize": 4,
        "MinSize": 1,
        "DesiredCapacity": 4,
        "InstanceType": "m5.large",
        "ImageID": "ami-0907724389e8705d9",
        "CreationTime": "2020-03-12T10:15:17.954Z",
        "NodeInstanceRoleARN": "arn:aws:iam::083751696308:role/eksctl-it-crud-fabulous-rainbow-1-NodeInstanceRole-19K6WW16XLPI8"
    }
]starting '../../../eksctl "--region" "us-west-2" "get" "nodegroup" "-o" "json" "--cluster" "it-crud-fabulous-rainbow-1584007373" "ng-1"'
[
    {
        "StackName": "eksctl-it-crud-fabulous-rainbow-1584007373-nodegroup-ng-1",
        "Cluster": "it-crud-fabulous-rainbow-1584007373",
        "Name": "ng-1",
        "MaxSize": 4,
        "MinSize": 4,
        "DesiredCapacity": 4,
        "InstanceType": "m5.large",
        "ImageID": "ami-0907724389e8705d9",
        "CreationTime": "2020-03-12T10:22:05.489Z",
        "NodeInstanceRoleARN": "arn:aws:iam::083751696308:role/eksctl-it-crud-fabulous-rainbow-1-NodeInstanceRole-ODUIS405SSMX"
    }
]starting '../../../eksctl "--region" "us-west-2" "get" "nodegroup" "-o" "json" "--cluster" "it-crud-fabulous-rainbow-1584007373"'
[
    {
        "StackName": "eksctl-it-crud-fabulous-rainbow-1584007373-nodegroup-ng-1",
        "Cluster": "it-crud-fabulous-rainbow-1584007373",
        "Name": "ng-1",
        "MaxSize": 4,
        "MinSize": 4,
        "DesiredCapacity": 4,
        "InstanceType": "m5.large",
        "ImageID": "ami-0907724389e8705d9",
        "CreationTime": "2020-03-12T10:22:05.489Z",
        "NodeInstanceRoleARN": "arn:aws:iam::083751696308:role/eksctl-it-crud-fabulous-rainbow-1-NodeInstanceRole-ODUIS405SSMX"
    },
    {
        "StackName": "eksctl-it-crud-fabulous-rainbow-1584007373-nodegroup-ng-0",
        "Cluster": "it-crud-fabulous-rainbow-1584007373",
        "Name": "ng-0",
        "MaxSize": 4,
        "MinSize": 1,
        "DesiredCapacity": 4,
        "InstanceType": "m5.large",
        "ImageID": "ami-0907724389e8705d9",
        "CreationTime": "2020-03-12T10:15:17.954Z",
        "NodeInstanceRoleARN": "arn:aws:iam::083751696308:role/eksctl-it-crud-fabulous-rainbow-1-NodeInstanceRole-19K6WW16XLPI8"
    }
]
• [SLOW TEST:6.178 seconds]
(Integration) Create, Get, Scale & Delete
${GOPATH}/src/github.com/weaveworks/eksctl/integration/tests/crud/creategetdelete_test.go:47
  when creating a cluster with 1 node
  ${GOPATH}/src/github.com/weaveworks/eksctl/integration/tests/crud/creategetdelete_test.go:75
    and add the second nodegroup
    ${GOPATH}/src/github.com/weaveworks/eksctl/integration/tests/crud/creategetdelete_test.go:148
      should be able to list nodegroups
      ${GOPATH}/src/github.com/weaveworks/eksctl/integration/tests/crud/creategetdelete_test.go:160
------------------------------

[...]

Ran 35 of 35 Specs in 2185.157 seconds
SUCCESS! -- 35 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestSuite (2185.16s)
PASS

Ginkgo ran 1 suite in 36m40.915450376s
Test Suite Passed
```