### PR TITLE
Add mappings as part of reconcilation

### DIFF
--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -19,6 +19,7 @@ import (
 const (
 	resourcesRootPath = "Resources"
 	outputsRootPath   = "Outputs"
+	mappingsRootPath  = "Mappings"
 )
 
 var (

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -108,7 +108,7 @@ func (c *StackCollection) AppendNewClusterStackResource(plan, supportsManagedNod
 	currentResources := gjson.Get(currentTemplate, resourcesRootPath)
 	currentOutputs := gjson.Get(currentTemplate, outputsRootPath)
 	currentMappings := gjson.Get(currentTemplate, mappingsRootPath)
-	if !currentResources.IsObject() || !currentOutputs.IsObject() || !currentMappings.IsObject() {
+	if !currentResources.IsObject() || !currentOutputs.IsObject() {
 		return false, fmt.Errorf("unexpected template format of the current stack ")
 	}
 

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -107,7 +107,8 @@ func (c *StackCollection) AppendNewClusterStackResource(plan, supportsManagedNod
 
 	currentResources := gjson.Get(currentTemplate, resourcesRootPath)
 	currentOutputs := gjson.Get(currentTemplate, outputsRootPath)
-	if !currentResources.IsObject() || !currentOutputs.IsObject() {
+	currentMappings := gjson.Get(currentTemplate, mappingsRootPath)
+	if !currentResources.IsObject() || !currentOutputs.IsObject() || !currentMappings.IsObject() {
 		return false, fmt.Errorf("unexpected template format of the current stack ")
 	}
 
@@ -125,7 +126,8 @@ func (c *StackCollection) AppendNewClusterStackResource(plan, supportsManagedNod
 
 	newResources := gjson.Get(string(newTemplate), resourcesRootPath)
 	newOutputs := gjson.Get(string(newTemplate), outputsRootPath)
-	if !newResources.IsObject() || !newOutputs.IsObject() {
+	newMappings := gjson.Get(string(newTemplate), mappingsRootPath)
+	if !newResources.IsObject() || !newOutputs.IsObject() || !newMappings.IsObject() {
 		return false, errors.New("unexpected template format of the new version of the stack")
 	}
 
@@ -146,6 +148,7 @@ func (c *StackCollection) AppendNewClusterStackResource(plan, supportsManagedNod
 	var (
 		addResources []string
 		addOutputs   []string
+		addMappings  []string
 	)
 
 	newResources.ForEach(func(k, v gjson.Result) bool {
@@ -161,7 +164,14 @@ func (c *StackCollection) AppendNewClusterStackResource(plan, supportsManagedNod
 		return false, errors.Wrap(iterErr, "adding outputs to current stack template")
 	}
 
-	if len(addResources) == 0 && len(addOutputs) == 0 {
+	newMappings.ForEach(func(k, v gjson.Result) bool {
+		return iterFunc(&addMappings, mappingsRootPath, currentMappings, k, v)
+	})
+	if iterErr != nil {
+		return false, errors.Wrap(iterErr, "adding mappings to current stack template")
+	}
+
+	if len(addResources) == 0 && len(addOutputs) == 0 && len(addMappings) == 0 {
 		logger.Success("all resources in cluster stack %q are up-to-date", name)
 		return false, nil
 	}


### PR DESCRIPTION
### Description

Fixes #1933 

Details can be found in slack discussion https://weave-community.slack.com/archives/CAYBZBWGL/p1584047570330400

<details>
<summary>Simulate issue</summary>

```bash
# Create cluster with old eksctl
./eksctl create cluster                                                     
[ℹ]  eksctl version 0.9.0
[ℹ]  using region us-east-2
[ℹ]  setting availability zones to [us-east-2c us-east-2b us-east-2a]
[ℹ]  subnets for us-east-2c - public:192.168.0.0/19 private:192.168.96.0/19
[ℹ]  subnets for us-east-2b - public:192.168.32.0/19 private:192.168.128.0/19
[ℹ]  subnets for us-east-2a - public:192.168.64.0/19 private:192.168.160.0/19
[ℹ]  nodegroup "ng-4b4860b6" will use "ami-082bb518441d3954c" [AmazonLinux2/1.14]
[ℹ]  using Kubernetes version 1.14
[ℹ]  creating EKS cluster "wonderful-hideout-1584077364" in "us-east-2" region
[ℹ]  will create 2 separate CloudFormation stacks for cluster itself and the initial nodegroup
[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-east-2 --cluster=wonderful-hideout-1584077364'
[ℹ]  CloudWatch logging will not be enabled for cluster "wonderful-hideout-1584077364" in "us-east-2"
[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --region=us-east-2 --cluster=wonderful-hideout-1584077364'
[ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "wonderful-hideout-1584077364" in "us-east-2"
[ℹ]  2 sequential tasks: { create cluster control plane "wonderful-hideout-1584077364", create nodegroup "ng-4b4860b6" }
[ℹ]  building cluster stack "eksctl-wonderful-hideout-1584077364-cluster"
[ℹ]  deploying stack "eksctl-wonderful-hideout-1584077364-cluster"
[ℹ]  building nodegroup stack "eksctl-wonderful-hideout-1584077364-nodegroup-ng-4b4860b6"
[ℹ]  --nodes-min=2 was set automatically for nodegroup ng-4b4860b6
[ℹ]  --nodes-max=2 was set automatically for nodegroup ng-4b4860b6
[ℹ]  deploying stack "eksctl-wonderful-hideout-1584077364-nodegroup-ng-4b4860b6"
[✔]  all EKS cluster resources for "wonderful-hideout-1584077364" have been created
[✔]  saved kubeconfig as "/home/tammach/.kube/config"
[ℹ]  adding identity "arn:aws:iam::363193625107:role/eksctl-wonderful-hideout-15840773-NodeInstanceRole-15C6ZS2ZCTVVJ" to auth ConfigMap
[ℹ]  nodegroup "ng-4b4860b6" has 0 node(s)
[ℹ]  waiting for at least 2 node(s) to become ready in "ng-4b4860b6"
[ℹ]  nodegroup "ng-4b4860b6" has 2 node(s)
[ℹ]  node "ip-192-168-58-122.us-east-2.compute.internal" is ready
[ℹ]  node "ip-192-168-87-190.us-east-2.compute.internal" is ready
[ℹ]  kubectl command should work with "/home/tammach/.kube/config", try 'kubectl get nodes'
[✔]  EKS cluster "wonderful-hideout-1584077364" in "us-east-2" region is ready


# Perform any actions required changes in cluster stack
./eksctl version                                                                     
0.15.0-rc.2
./eksctl create fargateprofile --cluster wonderful-hideout-1584077364 --namespace dev
[ℹ]  Fargate pod execution role is missing, fixing cluster stack to add Fargate resources
[ℹ]  checking cluster stack for missing resources
[ℹ]  cluster stack is missing resources for Managed Nodegroups
[ℹ]  cluster stack is missing resources for Fargate
[ℹ]  adding missing resources to cluster stack
[ℹ]  re-building cluster stack "eksctl-wonderful-hideout-1584077364-cluster"
[ℹ]  updating stack to add new resources [FargatePodExecutionRole IngressDefaultClusterToNodeSG IngressNodeToDefaultClusterSG] and outputs [ClusterSecurityGroupId FargatePodExecutionRoleARN]
Error: error fixing cluster compatibility: creating ChangeSet "eksctl-update-cluster-1584082933" for stack "eksctl-wonderful-hideout-1584077364-cluster": ValidationError: Template error: Mapping named 'ServicePrincipalPartitionMap' is not present in the 'Mappings' section of template.
	status code: 400, request id: 1721583e-cb97-4bfd-a525-673f34085a19

```
</details>

<details>
<summary>Testing the fix</summary>

```bash
  ./eksctl create fargateprofile --cluster wonderful-hideout-1584077364 --namespace dev
[ℹ]  Fargate pod execution role is missing, fixing cluster stack to add Fargate resources
[ℹ]  checking cluster stack for missing resources
[ℹ]  cluster stack is missing resources for Managed Nodegroups
[ℹ]  cluster stack is missing resources for Fargate
[ℹ]  adding missing resources to cluster stack
[ℹ]  re-building cluster stack "eksctl-wonderful-hideout-1584077364-cluster"
[ℹ]  updating stack to add new resources [FargatePodExecutionRole IngressDefaultClusterToNodeSG IngressNodeToDefaultClusterSG] and outputs [ClusterSecurityGroupId FargatePodExecutionRoleARN]
[ℹ]  creating Fargate profile "fp-fb4b0521" on EKS cluster "wonderful-hideout-1584077364"
[ℹ]  created Fargate profile "fp-fb4b0521" on EKS cluster "wonderful-hideout-1584077364"

./eksctl get fargateprofile --cluster wonderful-hideout-1584077364
NAME            SELECTOR_NAMESPACE      SELECTOR_LABELS POD_EXECUTION_ROLE_ARN                                                                          SUBNETS
fp-fb4b0521     dev                     <none>          arn:aws:iam::363193625107:role/eksctl-wonderful-hideout-1-FargatePodExecutionRole-WBGOQ3ZNB2I6  subnet-0e557b3586157c643,subnet-09179932cd38ee362,subnet-0143c875232f0d97f

```

</details>

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
