### PR TITLE
Enable success notifications for integration test runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
     steps:
       - run: exit 0
       - slack/status:
-          fail_only: true
+          fail_only: false
           mentions: 'team-aws'
           only_for_branches: master
 


### PR DESCRIPTION
This enables notifications for successful runs of the IT every night.



<!-- If you haven't done so already, you can add your name to the humans.txt file -->