### PR TITLE
Fix fargate profile tag input

### DIFF
--- a/pkg/fargate/client.go
+++ b/pkg/fargate/client.go
@@ -187,7 +187,7 @@ func createRequest(clusterName string, profile *api.FargateProfile) *eks.CreateF
 		Selectors:           toSelectorPointers(profile.Selectors),
 		PodExecutionRoleArn: strings.NilIfEmpty(profile.PodExecutionRoleARN),
 		Subnets:             strings.NilPointersArrayIfEmpty(strings.ToPointersArray(profile.Subnets)),
-		Tags:                strings.ToPointersMap(profile.Tags),
+		Tags:                strings.NilPointersMapIfEmpty(strings.ToPointersMap(profile.Tags)),
 	}
 	logger.Debug("Fargate profile: create request: sending: %#v", request)
 	return request

--- a/pkg/fargate/client_test.go
+++ b/pkg/fargate/client_test.go
@@ -28,6 +28,13 @@ var _ = Describe("fargate", func() {
 				Expect(err.Error()).To(Equal("invalid Fargate profile: nil"))
 			})
 
+			It("creates the provided profile without tag", func() {
+				client := fargate.NewClient(clusterName, mockForCreateFargateProfileWithoutTag())
+				waitForCreation := false
+				err := client.CreateProfile(testFargateProfileWithoutTag(), waitForCreation)
+				Expect(err).To(Not(HaveOccurred()))
+			})
+
 			It("creates the provided profile", func() {
 				client := fargate.NewClient(clusterName, mockForCreateFargateProfile())
 				waitForCreation := false
@@ -176,6 +183,12 @@ func mockForCreateFargateProfile() *mocks.EKSAPI {
 	return &mockClient
 }
 
+func mockForCreateFargateProfileWithoutTag() *mocks.EKSAPI {
+	mockClient := mocks.EKSAPI{}
+	mockCreateFargateProfileWithoutTag(&mockClient)
+	return &mockClient
+}
+
 func mockForCreateFargateProfileWithWait(numRetries int) *mocks.EKSAPI {
 	mockClient := mocks.EKSAPI{}
 	mockCreateFargateProfile(&mockClient)
@@ -192,11 +205,31 @@ func mockCreateFargateProfile(mockClient *mocks.EKSAPI) {
 		Return(&eks.CreateFargateProfileOutput{}, nil)
 }
 
+func mockCreateFargateProfileWithoutTag(mockClient *mocks.EKSAPI) {
+	mockClient.Mock.On("CreateFargateProfile", testCreateFargateProfileInputWithoutTag()).
+		Return(&eks.CreateFargateProfileOutput{}, nil)
+}
+
 func mockForFailureOnCreateFargateProfile() *mocks.EKSAPI {
 	mockClient := mocks.EKSAPI{}
 	mockClient.Mock.On("CreateFargateProfile", testCreateFargateProfileInput()).
 		Return(nil, errors.New("the Internet broke down!"))
 	return &mockClient
+}
+
+func testFargateProfileWithoutTag() *api.FargateProfile {
+	return &api.FargateProfile{
+		Name: "default",
+		Selectors: []api.FargateProfileSelector{
+			{
+				Namespace: "kube-system",
+				Labels: map[string]string{
+					"app": "my-app",
+					"env": "test",
+				},
+			},
+		},
+	}
 }
 
 func testFargateProfile() *api.FargateProfile {
@@ -232,6 +265,22 @@ func testCreateFargateProfileInput() *eks.CreateFargateProfileInput {
 		},
 		Tags: map[string]*string{
 			"env": strings.Pointer("test"),
+		},
+	}
+}
+
+func testCreateFargateProfileInputWithoutTag() *eks.CreateFargateProfileInput {
+	return &eks.CreateFargateProfileInput{
+		ClusterName:        strings.Pointer(clusterName),
+		FargateProfileName: strings.Pointer("default"),
+		Selectors: []*eks.FargateProfileSelector{
+			{
+				Namespace: strings.Pointer("kube-system"),
+				Labels: map[string]*string{
+					"app": strings.Pointer("my-app"),
+					"env": strings.Pointer("test"),
+				},
+			},
 		},
 	}
 }

--- a/pkg/fargate/client_test.go
+++ b/pkg/fargate/client_test.go
@@ -31,7 +31,7 @@ var _ = Describe("fargate", func() {
 			It("creates the provided profile without tag", func() {
 				client := fargate.NewClient(clusterName, mockForCreateFargateProfileWithoutTag())
 				waitForCreation := false
-				err := client.CreateProfile(testFargateProfileWithoutTag(), waitForCreation)
+				err := client.CreateProfile(createProfileWithoutTag(), waitForCreation)
 				Expect(err).To(Not(HaveOccurred()))
 			})
 
@@ -206,7 +206,7 @@ func mockCreateFargateProfile(mockClient *mocks.EKSAPI) {
 }
 
 func mockCreateFargateProfileWithoutTag(mockClient *mocks.EKSAPI) {
-	mockClient.Mock.On("CreateFargateProfile", testCreateFargateProfileInputWithoutTag()).
+	mockClient.Mock.On("CreateFargateProfile", createEksProfileWithoutTag()).
 		Return(&eks.CreateFargateProfileOutput{}, nil)
 }
 
@@ -217,7 +217,7 @@ func mockForFailureOnCreateFargateProfile() *mocks.EKSAPI {
 	return &mockClient
 }
 
-func testFargateProfileWithoutTag() *api.FargateProfile {
+func createProfileWithoutTag() *api.FargateProfile {
 	return &api.FargateProfile{
 		Name: "default",
 		Selectors: []api.FargateProfileSelector{
@@ -269,7 +269,7 @@ func testCreateFargateProfileInput() *eks.CreateFargateProfileInput {
 	}
 }
 
-func testCreateFargateProfileInputWithoutTag() *eks.CreateFargateProfileInput {
+func createEksProfileWithoutTag() *eks.CreateFargateProfileInput {
 	return &eks.CreateFargateProfileInput{
 		ClusterName:        strings.Pointer(clusterName),
 		FargateProfileName: strings.Pointer("default"),


### PR DESCRIPTION
### Description

Fixes https://github.com/weaveworks/eksctl/issues/1952. This will fix two failures for daily integration test as well.

In [CreateFargateProfileInput](https://godoc.org/github.com/aws/aws-sdk-go/service/eks#CreateFargateProfileInput) struct, Tags map is expecting at least 1 item.
Hence, empty map will cause issue. We need to convert to nil if it's empty.

<details>
<summary>Create cluster with --fargate</summary>

```
 ./eksctl create cluster --fargate
[ℹ]  eksctl version 0.16.0-dev+197bbaab.2020-03-19T08:06:21Z
[ℹ]  using region us-east-2
[ℹ]  setting availability zones to [us-east-2c us-east-2a us-east-2b]
[ℹ]  subnets for us-east-2c - public:192.168.0.0/19 private:192.168.96.0/19
[ℹ]  subnets for us-east-2a - public:192.168.32.0/19 private:192.168.128.0/19
[ℹ]  subnets for us-east-2b - public:192.168.64.0/19 private:192.168.160.0/19
[ℹ]  using Kubernetes version 1.14
[ℹ]  creating EKS cluster "floral-creature-1584566628" in "us-east-2" region with Fargate profile
[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-east-2 --cluster=floral-creature-1584566628'
[ℹ]  CloudWatch logging will not be enabled for cluster "floral-creature-1584566628" in "us-east-2"
[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --region=us-east-2 --cluster=floral-creature-1584566628'
[ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "floral-creature-1584566628" in "us-east-2"
[ℹ]  1 task: { create cluster control plane "floral-creature-1584566628" }
[ℹ]  building cluster stack "eksctl-floral-creature-1584566628-cluster"
[ℹ]  deploying stack "eksctl-floral-creature-1584566628-cluster"
[✔]  all EKS cluster resources for "floral-creature-1584566628" have been created
[✔]  saved kubeconfig as "/Users/tammach/.kube/config"
[ℹ]  creating Fargate profile "fp-default" on EKS cluster "floral-creature-1584566628"
[ℹ]  created Fargate profile "fp-default" on EKS cluster "floral-creature-1584566628"
[ℹ]  "coredns" is now schedulable onto Fargate
[ℹ]  "coredns" pods are now scheduled onto Fargate
[ℹ]  "coredns" is now scheduled onto Fargate
[ℹ]  "coredns" pods are now scheduled onto Fargate
[ℹ]  kubectl command should work with "/Users/tammach/.kube/config", try 'kubectl get nodes'
[✔]  EKS cluster "floral-creature-1584566628" in "us-east-2" region is ready

```

</details>

<details>
<summary>Create cluster with config file with 2 fargate profiles (one with tag, one without tag)</summary>

```
$ cat test_fargate.yaml
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig
metadata:
  name: test-fargate-tags
  region: us-east-2

fargateProfiles:
  - name: fp-default
    selectors:
      - namespace: default
      - namespace: kube-system
  - name: fp-dev
    selectors:
      - namespace: dev
        labels:
          env: dev
          checks: passed
    tags:
      namespace: dev
      env: dev

./eksctl create cluster -f test_fargate.yaml
[ℹ]  eksctl version 0.16.0-dev+197bbaab.2020-03-19T08:06:21Z
[ℹ]  using region us-east-2
[ℹ]  setting availability zones to [us-east-2a us-east-2b us-east-2c]
[ℹ]  subnets for us-east-2a - public:192.168.0.0/19 private:192.168.96.0/19
[ℹ]  subnets for us-east-2b - public:192.168.32.0/19 private:192.168.128.0/19
[ℹ]  subnets for us-east-2c - public:192.168.64.0/19 private:192.168.160.0/19
[ℹ]  using Kubernetes version 1.14
[ℹ]  creating EKS cluster "test-fargate-tags" in "us-east-2" region with Fargate profile
[ℹ]  will create a CloudFormation stack for cluster itself and 0 nodegroup stack(s)
[ℹ]  will create a CloudFormation stack for cluster itself and 0 managed nodegroup stack(s)
[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-east-2 --cluster=test-fargate-tags'
[ℹ]  CloudWatch logging will not be enabled for cluster "test-fargate-tags" in "us-east-2"
[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --region=us-east-2 --cluster=test-fargate-tags'
[ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "test-fargate-tags" in "us-east-2"
[ℹ]  1 task: { create cluster control plane "test-fargate-tags" }
[ℹ]  building cluster stack "eksctl-test-fargate-tags-cluster"
[ℹ]  deploying stack "eksctl-test-fargate-tags-cluster"
[✔]  all EKS cluster resources for "test-fargate-tags" have been created
[✔]  saved kubeconfig as "/Users/tammach/.kube/config"
[ℹ]  creating Fargate profile "fp-default" on EKS cluster "test-fargate-tags"
[ℹ]  created Fargate profile "fp-default" on EKS cluster "test-fargate-tags"
[ℹ]  creating Fargate profile "fp-dev" on EKS cluster "test-fargate-tags"
[ℹ]  created Fargate profile "fp-dev" on EKS cluster "test-fargate-tags"
[ℹ]  "coredns" is now schedulable onto Fargate
[ℹ]  "coredns" is now scheduled onto Fargate
[ℹ]  "coredns" pods are now scheduled onto Fargate
[ℹ]  kubectl command should work with "/Users/tammach/.kube/config", try 'kubectl get nodes'
[✔]  EKS cluster "test-fargate-tags" in "us-east-2" region is ready
```

</details>

<details>
<summary>Create fargate profiles from CLI (with and without tag)</summary>

```
$./eksctl create fargateprofile --name fg-profile-cli-with-tag --namespace dev -l env=dev -t env=dev --cluster  test-fargate-tags
[ℹ]  creating Fargate profile "fg-profile-cli-with-tag" on EKS cluster "test-fargate-tags"
[ℹ]  created Fargate profile "fg-profile-cli-with-tag" on EKS cluster "test-fargate-tags"

$./eksctl create fargateprofile --name fg-profile-cli-without-tag --namespace dev -l env=dev --cluster test-fargate-tags
[ℹ]  creating Fargate profile "fg-profile-cli-without-tag" on EKS cluster "test-fargate-tags"
[ℹ]  created Fargate profile "fg-profile-cli-without-tag" on EKS cluster "test-fargate-tags"

$./eksctl get fargateprofile --cluster test-fargate-tags
NAME				SELECTOR_NAMESPACE	SELECTOR_LABELS		POD_EXECUTION_ROLE_ARN										SUBNETS										TAGS
fg-profile-cli-with-tag		dev			env=dev			arn:aws:iam::363193625107:role/eksctl-test-fargate-tags-c-FargatePodExecutionRole-1HICVI400R5SU	subnet-035bf067a565aba5f,subnet-070acb4783ef8aecb,subnet-09f38c5394d032e2e	env=dev
fg-profile-cli-without-tag	dev			env=dev			arn:aws:iam::363193625107:role/eksctl-test-fargate-tags-c-FargatePodExecutionRole-1HICVI400R5SU	subnet-035bf067a565aba5f,subnet-070acb4783ef8aecb,subnet-09f38c5394d032e2e	<none>
fp-default			default			<none>			arn:aws:iam::363193625107:role/eksctl-test-fargate-tags-c-FargatePodExecutionRole-1HICVI400R5SU	subnet-035bf067a565aba5f,subnet-070acb4783ef8aecb,subnet-09f38c5394d032e2e	<none>
fp-default			kube-system		<none>			arn:aws:iam::363193625107:role/eksctl-test-fargate-tags-c-FargatePodExecutionRole-1HICVI400R5SU	subnet-035bf067a565aba5f,subnet-070acb4783ef8aecb,subnet-09f38c5394d032e2e	<none>
fp-dev				dev			checks=passed,env=dev	arn:aws:iam::363193625107:role/eksctl-test-fargate-tags-c-FargatePodExecutionRole-1HICVI400R5SU	subnet-035bf067a565aba5f,subnet-070acb4783ef8aecb,subnet-09f38c5394d032e2e	env=dev,namespace=dev
```

</details>


### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
