### PR TITLE
Fix root device mapping selection from AMI

### DIFF
--- a/pkg/ami/ami_test.go
+++ b/pkg/ami/ami_test.go
@@ -1,13 +1,14 @@
-package ami
+package ami_test
 
 import (
-	"strconv"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/mock"
+	"github.com/weaveworks/eksctl/pkg/ami"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
 )
@@ -16,8 +17,10 @@ func TestUseAMI(t *testing.T) {
 	amiTests := []struct {
 		blockDeviceMappings []*ec2.BlockDeviceMapping
 		rootDeviceName      string
+		description         string
 	}{
 		{
+			description:    "Root device mapping not at index 0 (Windows AMIs in some regions)",
 			rootDeviceName: "/dev/sda1",
 			blockDeviceMappings: []*ec2.BlockDeviceMapping{
 				{
@@ -36,12 +39,44 @@ func TestUseAMI(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:    "Only one device mapping (AL2 AMIs)",
+			rootDeviceName: "/dev/sda1",
+			blockDeviceMappings: []*ec2.BlockDeviceMapping{
+				{
+					DeviceName: aws.String("/dev/sda1"),
+					Ebs: &ec2.EbsBlockDevice{
+						Encrypted: aws.Bool(true),
+					},
+				},
+			},
+		},
+		{
+			description:    "Different root device name",
+			rootDeviceName: "/dev/xvda",
+			blockDeviceMappings: []*ec2.BlockDeviceMapping{
+				{
+					DeviceName:  aws.String("xvdca"),
+					VirtualName: aws.String("ephemeral0"),
+				},
+				{
+					DeviceName: aws.String("/dev/xvda"),
+					Ebs: &ec2.EbsBlockDevice{
+						Encrypted: aws.Bool(true),
+					},
+				},
+				{
+					DeviceName:  aws.String("xvdcb"),
+					VirtualName: aws.String("ephemeral1"),
+				},
+			},
+		},
 	}
 
 	for i, tt := range amiTests {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d: %s", i, tt.description), func(t *testing.T) {
 			mockProvider := mockDescribeImages(tt.blockDeviceMappings, tt.rootDeviceName)
-			err := Use(mockProvider.MockEC2(), &api.NodeGroup{
+			err := ami.Use(mockProvider.MockEC2(), &api.NodeGroup{
 				AMI: "ami-0121d8347f8191f90",
 			})
 

--- a/pkg/ami/ami_test.go
+++ b/pkg/ami/ami_test.go
@@ -1,0 +1,77 @@
+package ami
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/mock"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
+)
+
+func TestUseAMI(t *testing.T) {
+	amiTests := []struct {
+		blockDeviceMappings []*ec2.BlockDeviceMapping
+		rootDeviceName      string
+	}{
+		{
+			rootDeviceName: "/dev/sda1",
+			blockDeviceMappings: []*ec2.BlockDeviceMapping{
+				{
+					DeviceName:  aws.String("xvdca"),
+					VirtualName: aws.String("ephemeral0"),
+				},
+				{
+					DeviceName:  aws.String("xvdcb"),
+					VirtualName: aws.String("ephemeral1"),
+				},
+				{
+					DeviceName: aws.String("/dev/sda1"),
+					Ebs: &ec2.EbsBlockDevice{
+						Encrypted: aws.Bool(true),
+					},
+				},
+			},
+		},
+	}
+
+	for i, tt := range amiTests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			mockProvider := mockDescribeImages(tt.blockDeviceMappings, tt.rootDeviceName)
+			err := Use(mockProvider.MockEC2(), &api.NodeGroup{
+				AMI: "ami-0121d8347f8191f90",
+			})
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+
+}
+
+func mockDescribeImages(blockDeviceMappings []*ec2.BlockDeviceMapping, rootDeviceName string) *mockprovider.MockProvider {
+	mockProvider := mockprovider.NewMockProvider()
+
+	mockProvider.MockEC2().On("DescribeImages", mock.MatchedBy(func(input *ec2.DescribeImagesInput) bool {
+		return len(input.ImageIds) == 1 && strings.HasPrefix(*input.ImageIds[0], "ami-")
+	})).Return(func(input *ec2.DescribeImagesInput) *ec2.DescribeImagesOutput {
+		return &ec2.DescribeImagesOutput{
+			Images: []*ec2.Image{
+				{
+					ImageId:             input.ImageIds[0],
+					RootDeviceName:      aws.String(rootDeviceName),
+					RootDeviceType:      aws.String("ebs"),
+					BlockDeviceMappings: blockDeviceMappings,
+				},
+			},
+		}
+	}, func(*ec2.DescribeImagesInput) error {
+		return nil
+	})
+
+	return mockProvider
+}

--- a/pkg/eks/api_test.go
+++ b/pkg/eks/api_test.go
@@ -204,8 +204,10 @@ func mockDescribeImages(p *mockprovider.MockProvider, amiId string, matcher func
 					State:          aws.String("available"),
 					OwnerId:        aws.String("123"),
 					RootDeviceType: aws.String("ebs"),
+					RootDeviceName: aws.String("/dev/sda1"),
 					BlockDeviceMappings: []*ec2.BlockDeviceMapping{
 						{
+							DeviceName: aws.String("/dev/sda1"),
 							Ebs: &ec2.EbsBlockDevice{
 								Encrypted: aws.Bool(false),
 							},


### PR DESCRIPTION
### Description
The code was relying on the root device mapping to be present at the first index (`image.BlockDeviceMappings[0].Ebs.Encrypted`). This is, however, not a valid assumption as some AMIs (EKS 1.15 for Windows in us-east-1) have multiple block device mappings where the root device mapping is not at the first index.

This change uses the `RootDeviceName` field to find the root device block mapping.

Fixes #1944 

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
