### PR TITLE
Update kubernetes VERSION in CF in case of upgrade managed node group

### DIFF
--- a/pkg/managed/service.go
+++ b/pkg/managed/service.go
@@ -139,6 +139,8 @@ func (m *Service) UpgradeNodeGroup(nodeGroupName, kubernetesVersion string) erro
 		return errors.Wrap(err, "invalid Kubernetes version")
 	}
 
+	// Upgrade only Version for kubernetes, by default CF will use the latest working AMI for ReleaseVersion
+	// Docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-releaseversion
 	if kubernetesVersion != *nodeGroup.Version {
 		return m.updateNodeGroupVersion(nodeGroupName, kubernetesVersion)
 	}


### PR DESCRIPTION
### Description

Related to https://github.com/weaveworks/eksctl/issues/1962.

If the current kubernetes version is different with inputted, we just need to update `Version` in CF. By default, the lastest AMI will be used.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-version

> ReleaseVersion
> The AMI version of the Amazon EKS-optimized AMI to use with your node group (for example, 1.14.7-YYYYMMDD). By default, the latest available AMI version for the node group's current Kubernetes version is used. For more information, see Amazon EKS-Optimized Linux AMI Versions in the Amazon EKS User Guide.
> 
> Note
> Changing this value triggers an update of the node group if one is available. However, only the latest available AMI release version is valid as an input. You cannot roll back to a previous AMI release version.
> 
> Required: No
> 
> Type: String
> 
> Update requires: No interruption

<details>
<summary>Simulate with the same scenario</summary>

```
$ ./eksctl version            
0.15.0

$ ./eksctl upgrade nodegroup \   
    --name=${MANAGED_NODE_GROUP} \
    --cluster=$cluster \
    --kubernetes-version=1.15                      
[ℹ]  Update nodegroup stack
[✖]  unexpected status "UPDATE_ROLLBACK_IN_PROGRESS" while waiting for CloudFormation stack "eksctl-old-cluster-nodegroup-ng-76cd34bf"
[ℹ]  fetching stack events in attempt to troubleshoot the root cause of the failure
[ℹ]  AWS::CloudFormation::Stack/eksctl-old-cluster-nodegroup-ng-76cd34bf: UPDATE_ROLLBACK_IN_PROGRESS – "The following resource(s) failed to update: [ManagedNodeGroup]. "
[ℹ]  AWS::EKS::Nodegroup/ManagedNodeGroup: UPDATE_FAILED – "Requested Nodegroup release version 1.15.10-20200312 is invalid. Allowed release version is 1.15.10-20200228 (Service: AmazonEKS; Status Code: 400; Error Code: InvalidParameterException; Request ID: a48a9166-1231-45cd-ba74-0741c541610f)"
[ℹ]  AWS::EKS::Nodegroup/ManagedNodeGroup: UPDATE_IN_PROGRESS
[ℹ]  AWS::CloudFormation::Stack/eksctl-old-cluster-nodegroup-ng-76cd34bf: UPDATE_IN_PROGRESS – "User Initiated"
[ℹ]  AWS::CloudFormation::Stack/eksctl-old-cluster-nodegroup-ng-76cd34bf: CREATE_COMPLETE
[ℹ]  AWS::EKS::Nodegroup/ManagedNodeGroup: CREATE_COMPLETE
[ℹ]  AWS::EKS::Nodegroup/ManagedNodeGroup: CREATE_IN_PROGRESS – "Resource creation Initiated"
[ℹ]  AWS::EKS::Nodegroup/ManagedNodeGroup: CREATE_IN_PROGRESS
[ℹ]  AWS::IAM::Role/NodeInstanceRole: CREATE_COMPLETE
[ℹ]  AWS::IAM::Role/NodeInstanceRole: CREATE_IN_PROGRESS – "Resource creation Initiated"
[ℹ]  AWS::IAM::Role/NodeInstanceRole: CREATE_IN_PROGRESS
[ℹ]  AWS::CloudFormation::Stack/eksctl-old-cluster-nodegroup-ng-76cd34bf: CREATE_IN_PROGRESS – "User Initiated"
Error: waiting for CloudFormation stack "eksctl-old-cluster-nodegroup-ng-76cd34bf": ResourceNotReady: failed waiting for successful resource state

```

</details>


<details>
<summary>Upgrade with changes </summary>

```
./eksctl upgrade nodegroup \
    --name=${MANAGED_NODE_GROUP} \
    --cluster=$cluster \
    --kubernetes-version=1.15
[ℹ]  Update nodegroup stack

kgno
NAME                                           STATUS   ROLES    AGE   VERSION
ip-192-168-42-139.us-east-2.compute.internal   Ready    <none>   20m   v1.15.10-eks-bac369
ip-192-168-85-26.us-east-2.compute.internal    Ready    <none>   20m   v1.15.10-eks-bac369
```

</details>

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
