### PR TITLE
Make ITs more robust to long cluster names

### DIFF
--- a/integration/tests/crud/creategetdelete_test.go
+++ b/integration/tests/crud/creategetdelete_test.go
@@ -399,7 +399,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 
 						Expect(sa.Annotations).To(HaveLen(1))
 						Expect(sa.Annotations).To(HaveKey(api.AnnotationEKSRoleARN))
-						Expect(sa.Annotations[api.AnnotationEKSRoleARN]).To(MatchRegexp("^arn:aws:iam::.*:role/eksctl-" + params.ClusterName + ".*$"))
+						Expect(sa.Annotations[api.AnnotationEKSRoleARN]).To(MatchRegexp("^arn:aws:iam::.*:role/eksctl-" + truncate(params.ClusterName) + ".*$"))
 					}
 
 					{
@@ -567,7 +567,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 
 						Expect(so.AssumedRoleUser.AssumedRoleId).To(HaveSuffix(":integration-test"))
 
-						Expect(so.AssumedRoleUser.Arn).To(MatchRegexp("^arn:aws:sts::.*:assumed-role/eksctl-" + params.ClusterName + "-.*/integration-test$"))
+						Expect(so.AssumedRoleUser.Arn).To(MatchRegexp("^arn:aws:sts::.*:assumed-role/eksctl-" + truncate(params.ClusterName) + "-.*/integration-test$"))
 
 						Expect(so.Audience).To(Equal("sts.amazonaws.com"))
 
@@ -850,3 +850,11 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 		})
 	})
 })
+
+func truncate(clusterName string) string {
+	// CloudFormation seems to truncate long cluster names at 37 characters:
+	if len(clusterName) > 37 {
+		return clusterName[:37]
+	}
+	return clusterName
+}


### PR DESCRIPTION
### Description

CloudFormation seems to truncate long cluster names, hence
integration tests were failing on regex matching:

```
[3]         /src/integration/tests/crud/creategetdelete_test.go:345
[3]
[3]         Expected
[3]             <string>: arn:aws:iam::123:role/eksctl-it-crud-wonderful-sculpture-158493288-Role1-1GY15K7ZJLBWV
[3]         to match regular expression
[3]             <string>: ^arn:aws:iam::.*:role/eksctl-it-crud-wonderful-sculpture-1584932889.*$
[3]
[3]         /src/integration/tests/crud/creategetdelete_test.go:402
```

```
[3]         /src/integration/tests/crud/creategetdelete_test.go:519
[3]
[3]         Expected
[3]             <string>: arn:aws:sts::456:assumed-role/eksctl-it-crud-wonderful-sculpture-158493288-Role1-1D0SFXFEJQL5/integration-test
[3]         to match regular expression
[3]             <string>: ^arn:aws:sts::.*:assumed-role/eksctl-it-crud-wonderful-sculpture-1584932889-.*/integration-test$
[3]
[3]         /src/integration/tests/crud/creategetdelete_test.go:570
```

This change addresses that by also truncating long cluster names
for expected values.

### Checklist

- [x] Manually tested, see: https://play.golang.org/p/9n0Ud3wM9As
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes
