### PR TITLE
Set kubeReserved defaults according to instance type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,10 @@ $(generated_code_aws_sdk_mocks): $(call godeps,pkg/eks/mocks/mocks.go)
 	ln -sfn "$(gopath)/pkg/mod/github.com/weaveworks/aws-sdk-go@v1.25.14-0.20191218135223-757eeed07291" vendor/github.com/aws/aws-sdk-go
 	time env GOBIN=$(GOBIN) go generate ./pkg/eks/mocks
 
+.PHONY: generate-kube-reserved
+generate-kube-reserved: ## Update instance list with respective specs
+	@cd ./pkg/nodebootstrap/ && go run reserved_generate.go
+
 ##@ Release
 .PHONY: prepare-release
 prepare-release:

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -272,6 +272,17 @@ func newStackWithOutputs(outputs map[string]string) cfn.Stack {
 	return s
 }
 
+// completeKubeletConfig amends changes that nodebootstrap.makeKubeletConfigYAML() would do.
+func completeKubeletConfig(kubeletConfigAssetContent []byte, clusterDNS string) string {
+	return string(kubeletConfigAssetContent) +
+		"\n" +
+		"clusterDNS: [" + clusterDNS + "]\n" +
+		"kubeReserved:\n" +
+		"  cpu: 70m\n" +
+		"  ephemeral-storage: 1Gi\n" +
+		"  memory: 1843Mi\n"
+}
+
 var _ = Describe("CloudFormation template builder API", func() {
 	var (
 		cc   *cloudconfig.CloudConfig
@@ -1717,10 +1728,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 
 			kubeletConfigAssetContent, err := nodebootstrap.Asset("kubelet.yaml")
 			Expect(err).ToNot(HaveOccurred())
-
-			kubeletConfigAssetContentString := string(kubeletConfigAssetContent) +
-				"\n" +
-				"clusterDNS: [10.100.0.10]\n"
+			kubeletConfigAssetContentString := completeKubeletConfig(kubeletConfigAssetContent, "10.100.0.10")
 
 			kubeletConfig := getFile(cc, "/etc/eksctl/kubelet.yaml")
 			Expect(kubeletConfig).ToNot(BeNil())
@@ -1959,10 +1967,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 
 			kubeletConfigAssetContent, err := nodebootstrap.Asset("kubelet.yaml")
 			Expect(err).ToNot(HaveOccurred())
-
-			kubeletConfigAssetContentString := string(kubeletConfigAssetContent) +
-				"\n" +
-				"clusterDNS: [172.20.0.10]\n"
+			kubeletConfigAssetContentString := completeKubeletConfig(kubeletConfigAssetContent, "172.20.0.10")
 
 			kubeletConfig := getFile(cc, "/etc/eksctl/kubelet.yaml")
 			Expect(kubeletConfig).ToNot(BeNil())

--- a/pkg/nodebootstrap/reserved.go
+++ b/pkg/nodebootstrap/reserved.go
@@ -1,0 +1,122 @@
+package nodebootstrap
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+const (
+	minimumMemoryToReserve = 255
+)
+
+// progression allows to define a progressive approach to take
+// fractions of values.
+type progression []struct {
+	upper    int64
+	fraction float64
+}
+
+var (
+	memProgression = progression{
+		{upper: 4096, fraction: 0.25},
+		{upper: 8192, fraction: 0.20},
+		{upper: 16384, fraction: 0.10},
+		{upper: 131072, fraction: 0.06},
+		{upper: math.MaxInt64, fraction: 0.02},
+	}
+	cpuProgression = progression{
+		{upper: 1000, fraction: 0.06},
+		{upper: 2000, fraction: 0.01},
+		{upper: 4000, fraction: 0.005},
+		{upper: math.MaxInt64, fraction: 0.0025},
+	}
+)
+
+func (p progression) calculate(value, min int64) int64 {
+	var lower, reserve int64
+	for _, f := range p {
+		if value <= f.upper {
+			reserve += int64(float64(value-lower) * f.fraction)
+			break
+		}
+		reserve += int64(float64(f.upper-lower) * f.fraction)
+		lower = f.upper
+	}
+	if reserve < min {
+		return min
+	}
+	return reserve
+
+}
+
+// InstanceTypeInfo holds minimal instance info required to
+// calculate resources to reserve.
+type InstanceTypeInfo struct {
+	// Storage (ephemeral) available (GiB).
+	// Is 0 if not supported or none available.
+	Storage int64
+	// Memory available (MiB).
+	Memory int64
+	// CPU count.
+	CPU int64
+}
+
+// NewInstanceTypeInfo creates a simple version of ec2.InstanceTypeInfo
+// that provides functions to calculate defaults.
+func NewInstanceTypeInfo(ec2info *ec2.InstanceTypeInfo) InstanceTypeInfo {
+	i := InstanceTypeInfo{}
+	if ec2info == nil {
+		return i
+	}
+	if aws.BoolValue(ec2info.InstanceStorageSupported) && ec2info.InstanceStorageInfo != nil {
+		i.Storage = aws.Int64Value(ec2info.InstanceStorageInfo.TotalSizeInGB)
+	}
+	if ec2info.MemoryInfo != nil {
+		i.Memory = aws.Int64Value(ec2info.MemoryInfo.SizeInMiB)
+	}
+	if ec2info.VCpuInfo != nil {
+		i.CPU = aws.Int64Value(ec2info.VCpuInfo.DefaultVCpus)
+	}
+	return i
+}
+
+// DefaultStorageToReserve returns how much storage to reserve.
+//
+// See https://github.com/awslabs/amazon-eks-ami/blob/ff690788dfaf399e6919eebb59371ee923617df4/files/bootstrap.sh#L306
+// This is always 1GiB
+func (i InstanceTypeInfo) DefaultStorageToReserve() string {
+	return "1Gi"
+}
+
+// DefaultMemoryToReserve returns how much memory to reserve.
+//
+// See https://github.com/awslabs/amazon-eks-ami/blob/ff690788dfaf399e6919eebb59371ee923617df4/files/bootstrap.sh#L150-L181
+// which takes it form https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture#node_allocatable
+//
+// 255 Mi of memory for machines with less than 1024Mi of memory
+// 25% of the first 4096Mi of memory
+// 20% of the next 4096Mi of memory (up to 8192Mi)
+// 10% of the next 8192Mi of memory (up to 16384Mi)
+// 6% of the next 114688Mi of memory (up to 131072Mi)
+// 2% of any memory above 131072Mi
+func (i InstanceTypeInfo) DefaultMemoryToReserve() string {
+	mib := memProgression.calculate(i.Memory, minimumMemoryToReserve)
+	return fmt.Sprintf("%dMi", mib)
+}
+
+// DefaultCPUToReserve returns the millicores to reserve.
+//
+// See https://github.com/awslabs/amazon-eks-ami/blob/ff690788dfaf399e6919eebb59371ee923617df4/files/bootstrap.sh#L183-L208
+// which takes it form https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture#node_allocatable
+//
+// 6% of the first core
+// 1% of the next core (up to 2 cores)
+// 0.5% of the next 2 cores (up to 4 cores)
+// 0.25% of any cores above 4 cores
+func (i InstanceTypeInfo) DefaultCPUToReserve() string {
+	millicores := cpuProgression.calculate(i.CPU*1000, 0)
+	return fmt.Sprintf("%dm", millicores)
+}

--- a/pkg/nodebootstrap/reserved_data.go
+++ b/pkg/nodebootstrap/reserved_data.go
@@ -1,0 +1,1322 @@
+package nodebootstrap
+
+// This file was generated 2020-03-26T16:18:43-07:00 by reserved_generate.go; DO NOT EDIT.
+
+// Data downloaded through the API.
+var instanceTypeInfos = map[string]InstanceTypeInfo{
+	"a1.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(16384),
+		Storage: int64(0),
+	},
+	"a1.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(32768),
+		Storage: int64(0),
+	},
+	"a1.large": {
+		CPU:     int64(2),
+		Memory:  int64(4096),
+		Storage: int64(0),
+	},
+	"a1.medium": {
+		CPU:     int64(1),
+		Memory:  int64(2048),
+		Storage: int64(0),
+	},
+	"a1.metal": {
+		CPU:     int64(16),
+		Memory:  int64(32768),
+		Storage: int64(0),
+	},
+	"a1.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(8192),
+		Storage: int64(0),
+	},
+	"c1.medium": {
+		CPU:     int64(2),
+		Memory:  int64(1740),
+		Storage: int64(350),
+	},
+	"c1.xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(7168),
+		Storage: int64(1680),
+	},
+	"c3.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(15360),
+		Storage: int64(160),
+	},
+	"c3.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(30720),
+		Storage: int64(320),
+	},
+	"c3.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(61440),
+		Storage: int64(640),
+	},
+	"c3.large": {
+		CPU:     int64(2),
+		Memory:  int64(3840),
+		Storage: int64(32),
+	},
+	"c3.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(7680),
+		Storage: int64(80),
+	},
+	"c4.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(15360),
+		Storage: int64(0),
+	},
+	"c4.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(30720),
+		Storage: int64(0),
+	},
+	"c4.8xlarge": {
+		CPU:     int64(36),
+		Memory:  int64(61440),
+		Storage: int64(0),
+	},
+	"c4.large": {
+		CPU:     int64(2),
+		Memory:  int64(3840),
+		Storage: int64(0),
+	},
+	"c4.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(7680),
+		Storage: int64(0),
+	},
+	"c5.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(98304),
+		Storage: int64(0),
+	},
+	"c5.18xlarge": {
+		CPU:     int64(72),
+		Memory:  int64(147456),
+		Storage: int64(0),
+	},
+	"c5.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(196608),
+		Storage: int64(0),
+	},
+	"c5.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(16384),
+		Storage: int64(0),
+	},
+	"c5.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(32768),
+		Storage: int64(0),
+	},
+	"c5.9xlarge": {
+		CPU:     int64(36),
+		Memory:  int64(73728),
+		Storage: int64(0),
+	},
+	"c5.large": {
+		CPU:     int64(2),
+		Memory:  int64(4096),
+		Storage: int64(0),
+	},
+	"c5.metal": {
+		CPU:     int64(96),
+		Memory:  int64(196608),
+		Storage: int64(0),
+	},
+	"c5.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(8192),
+		Storage: int64(0),
+	},
+	"c5d.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(98304),
+		Storage: int64(1800),
+	},
+	"c5d.18xlarge": {
+		CPU:     int64(72),
+		Memory:  int64(147456),
+		Storage: int64(1800),
+	},
+	"c5d.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(196608),
+		Storage: int64(3600),
+	},
+	"c5d.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(16384),
+		Storage: int64(200),
+	},
+	"c5d.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(32768),
+		Storage: int64(400),
+	},
+	"c5d.9xlarge": {
+		CPU:     int64(36),
+		Memory:  int64(73728),
+		Storage: int64(900),
+	},
+	"c5d.large": {
+		CPU:     int64(2),
+		Memory:  int64(4096),
+		Storage: int64(50),
+	},
+	"c5d.metal": {
+		CPU:     int64(96),
+		Memory:  int64(196608),
+		Storage: int64(3600),
+	},
+	"c5d.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(8192),
+		Storage: int64(100),
+	},
+	"c5n.18xlarge": {
+		CPU:     int64(72),
+		Memory:  int64(196608),
+		Storage: int64(0),
+	},
+	"c5n.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(21504),
+		Storage: int64(0),
+	},
+	"c5n.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(43008),
+		Storage: int64(0),
+	},
+	"c5n.9xlarge": {
+		CPU:     int64(36),
+		Memory:  int64(98304),
+		Storage: int64(0),
+	},
+	"c5n.large": {
+		CPU:     int64(2),
+		Memory:  int64(5376),
+		Storage: int64(0),
+	},
+	"c5n.metal": {
+		CPU:     int64(72),
+		Memory:  int64(196608),
+		Storage: int64(0),
+	},
+	"c5n.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(10752),
+		Storage: int64(0),
+	},
+	"cc2.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(61952),
+		Storage: int64(3360),
+	},
+	"d2.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(62464),
+		Storage: int64(12288),
+	},
+	"d2.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(124928),
+		Storage: int64(24576),
+	},
+	"d2.8xlarge": {
+		CPU:     int64(36),
+		Memory:  int64(249856),
+		Storage: int64(49152),
+	},
+	"d2.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(31232),
+		Storage: int64(6144),
+	},
+	"f1.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(999424),
+		Storage: int64(3760),
+	},
+	"f1.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(124928),
+		Storage: int64(470),
+	},
+	"f1.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(249856),
+		Storage: int64(940),
+	},
+	"g2.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(15360),
+		Storage: int64(60),
+	},
+	"g2.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(61440),
+		Storage: int64(240),
+	},
+	"g3.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(499712),
+		Storage: int64(0),
+	},
+	"g3.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(124928),
+		Storage: int64(0),
+	},
+	"g3.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(249856),
+		Storage: int64(0),
+	},
+	"g3s.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(31232),
+		Storage: int64(0),
+	},
+	"g4dn.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(196608),
+		Storage: int64(900),
+	},
+	"g4dn.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(262144),
+		Storage: int64(900),
+	},
+	"g4dn.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(32768),
+		Storage: int64(225),
+	},
+	"g4dn.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(65536),
+		Storage: int64(225),
+	},
+	"g4dn.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(131072),
+		Storage: int64(900),
+	},
+	"g4dn.metal": {
+		CPU:     int64(96),
+		Memory:  int64(393216),
+		Storage: int64(1800),
+	},
+	"g4dn.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(16384),
+		Storage: int64(125),
+	},
+	"h1.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(262144),
+		Storage: int64(16000),
+	},
+	"h1.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(32768),
+		Storage: int64(2000),
+	},
+	"h1.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(65536),
+		Storage: int64(4000),
+	},
+	"h1.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(131072),
+		Storage: int64(8000),
+	},
+	"i2.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(62464),
+		Storage: int64(1600),
+	},
+	"i2.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(124928),
+		Storage: int64(3200),
+	},
+	"i2.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(249856),
+		Storage: int64(6400),
+	},
+	"i2.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(31232),
+		Storage: int64(800),
+	},
+	"i3.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(499712),
+		Storage: int64(15200),
+	},
+	"i3.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(62464),
+		Storage: int64(1900),
+	},
+	"i3.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(124928),
+		Storage: int64(3800),
+	},
+	"i3.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(249856),
+		Storage: int64(7600),
+	},
+	"i3.large": {
+		CPU:     int64(2),
+		Memory:  int64(15616),
+		Storage: int64(475),
+	},
+	"i3.metal": {
+		CPU:     int64(72),
+		Memory:  int64(524288),
+		Storage: int64(15200),
+	},
+	"i3.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(31232),
+		Storage: int64(950),
+	},
+	"i3en.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(393216),
+		Storage: int64(30000),
+	},
+	"i3en.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(786432),
+		Storage: int64(60000),
+	},
+	"i3en.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(65536),
+		Storage: int64(5000),
+	},
+	"i3en.3xlarge": {
+		CPU:     int64(12),
+		Memory:  int64(98304),
+		Storage: int64(7500),
+	},
+	"i3en.6xlarge": {
+		CPU:     int64(24),
+		Memory:  int64(196608),
+		Storage: int64(15000),
+	},
+	"i3en.large": {
+		CPU:     int64(2),
+		Memory:  int64(16384),
+		Storage: int64(1250),
+	},
+	"i3en.metal": {
+		CPU:     int64(96),
+		Memory:  int64(786432),
+		Storage: int64(60000),
+	},
+	"i3en.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(32768),
+		Storage: int64(2500),
+	},
+	"inf1.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(196608),
+		Storage: int64(0),
+	},
+	"inf1.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(16384),
+		Storage: int64(0),
+	},
+	"inf1.6xlarge": {
+		CPU:     int64(24),
+		Memory:  int64(49152),
+		Storage: int64(0),
+	},
+	"inf1.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(8192),
+		Storage: int64(0),
+	},
+	"m1.large": {
+		CPU:     int64(2),
+		Memory:  int64(7680),
+		Storage: int64(840),
+	},
+	"m1.medium": {
+		CPU:     int64(1),
+		Memory:  int64(3788),
+		Storage: int64(410),
+	},
+	"m1.small": {
+		CPU:     int64(1),
+		Memory:  int64(1740),
+		Storage: int64(160),
+	},
+	"m1.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(15360),
+		Storage: int64(1680),
+	},
+	"m2.2xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(35020),
+		Storage: int64(850),
+	},
+	"m2.4xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(70041),
+		Storage: int64(1680),
+	},
+	"m2.xlarge": {
+		CPU:     int64(2),
+		Memory:  int64(17510),
+		Storage: int64(420),
+	},
+	"m3.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(30720),
+		Storage: int64(160),
+	},
+	"m3.large": {
+		CPU:     int64(2),
+		Memory:  int64(7680),
+		Storage: int64(32),
+	},
+	"m3.medium": {
+		CPU:     int64(1),
+		Memory:  int64(3840),
+		Storage: int64(4),
+	},
+	"m3.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(15360),
+		Storage: int64(80),
+	},
+	"m4.10xlarge": {
+		CPU:     int64(40),
+		Memory:  int64(163840),
+		Storage: int64(0),
+	},
+	"m4.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(262144),
+		Storage: int64(0),
+	},
+	"m4.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(32768),
+		Storage: int64(0),
+	},
+	"m4.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(65536),
+		Storage: int64(0),
+	},
+	"m4.large": {
+		CPU:     int64(2),
+		Memory:  int64(8192),
+		Storage: int64(0),
+	},
+	"m4.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(16384),
+		Storage: int64(0),
+	},
+	"m5.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(196608),
+		Storage: int64(0),
+	},
+	"m5.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(262144),
+		Storage: int64(0),
+	},
+	"m5.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(393216),
+		Storage: int64(0),
+	},
+	"m5.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(32768),
+		Storage: int64(0),
+	},
+	"m5.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(65536),
+		Storage: int64(0),
+	},
+	"m5.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(131072),
+		Storage: int64(0),
+	},
+	"m5.large": {
+		CPU:     int64(2),
+		Memory:  int64(8192),
+		Storage: int64(0),
+	},
+	"m5.metal": {
+		CPU:     int64(96),
+		Memory:  int64(393216),
+		Storage: int64(0),
+	},
+	"m5.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(16384),
+		Storage: int64(0),
+	},
+	"m5a.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(196608),
+		Storage: int64(0),
+	},
+	"m5a.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(262144),
+		Storage: int64(0),
+	},
+	"m5a.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(393216),
+		Storage: int64(0),
+	},
+	"m5a.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(32768),
+		Storage: int64(0),
+	},
+	"m5a.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(65536),
+		Storage: int64(0),
+	},
+	"m5a.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(131072),
+		Storage: int64(0),
+	},
+	"m5a.large": {
+		CPU:     int64(2),
+		Memory:  int64(8192),
+		Storage: int64(0),
+	},
+	"m5a.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(16384),
+		Storage: int64(0),
+	},
+	"m5ad.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(196608),
+		Storage: int64(1800),
+	},
+	"m5ad.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(262144),
+		Storage: int64(2400),
+	},
+	"m5ad.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(393216),
+		Storage: int64(3600),
+	},
+	"m5ad.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(32768),
+		Storage: int64(300),
+	},
+	"m5ad.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(65536),
+		Storage: int64(600),
+	},
+	"m5ad.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(131072),
+		Storage: int64(1200),
+	},
+	"m5ad.large": {
+		CPU:     int64(2),
+		Memory:  int64(8192),
+		Storage: int64(75),
+	},
+	"m5ad.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(16384),
+		Storage: int64(150),
+	},
+	"m5d.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(196608),
+		Storage: int64(1800),
+	},
+	"m5d.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(262144),
+		Storage: int64(2400),
+	},
+	"m5d.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(393216),
+		Storage: int64(3600),
+	},
+	"m5d.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(32768),
+		Storage: int64(300),
+	},
+	"m5d.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(65536),
+		Storage: int64(600),
+	},
+	"m5d.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(131072),
+		Storage: int64(1200),
+	},
+	"m5d.large": {
+		CPU:     int64(2),
+		Memory:  int64(8192),
+		Storage: int64(75),
+	},
+	"m5d.metal": {
+		CPU:     int64(96),
+		Memory:  int64(393216),
+		Storage: int64(3600),
+	},
+	"m5d.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(16384),
+		Storage: int64(150),
+	},
+	"m5dn.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(196608),
+		Storage: int64(1800),
+	},
+	"m5dn.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(262144),
+		Storage: int64(2400),
+	},
+	"m5dn.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(393216),
+		Storage: int64(3600),
+	},
+	"m5dn.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(32768),
+		Storage: int64(300),
+	},
+	"m5dn.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(65536),
+		Storage: int64(600),
+	},
+	"m5dn.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(131072),
+		Storage: int64(1200),
+	},
+	"m5dn.large": {
+		CPU:     int64(2),
+		Memory:  int64(8192),
+		Storage: int64(75),
+	},
+	"m5dn.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(16384),
+		Storage: int64(150),
+	},
+	"m5n.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(196608),
+		Storage: int64(0),
+	},
+	"m5n.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(262144),
+		Storage: int64(0),
+	},
+	"m5n.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(393216),
+		Storage: int64(0),
+	},
+	"m5n.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(32768),
+		Storage: int64(0),
+	},
+	"m5n.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(65536),
+		Storage: int64(0),
+	},
+	"m5n.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(131072),
+		Storage: int64(0),
+	},
+	"m5n.large": {
+		CPU:     int64(2),
+		Memory:  int64(8192),
+		Storage: int64(0),
+	},
+	"m5n.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(16384),
+		Storage: int64(0),
+	},
+	"p2.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(749568),
+		Storage: int64(0),
+	},
+	"p2.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(499712),
+		Storage: int64(0),
+	},
+	"p2.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(62464),
+		Storage: int64(0),
+	},
+	"p3.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(499712),
+		Storage: int64(0),
+	},
+	"p3.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(62464),
+		Storage: int64(0),
+	},
+	"p3.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(249856),
+		Storage: int64(0),
+	},
+	"p3dn.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(786432),
+		Storage: int64(1800),
+	},
+	"r3.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(62464),
+		Storage: int64(160),
+	},
+	"r3.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(124928),
+		Storage: int64(320),
+	},
+	"r3.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(249856),
+		Storage: int64(640),
+	},
+	"r3.large": {
+		CPU:     int64(2),
+		Memory:  int64(15360),
+		Storage: int64(32),
+	},
+	"r3.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(31232),
+		Storage: int64(80),
+	},
+	"r4.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(499712),
+		Storage: int64(0),
+	},
+	"r4.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(62464),
+		Storage: int64(0),
+	},
+	"r4.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(124928),
+		Storage: int64(0),
+	},
+	"r4.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(249856),
+		Storage: int64(0),
+	},
+	"r4.large": {
+		CPU:     int64(2),
+		Memory:  int64(15616),
+		Storage: int64(0),
+	},
+	"r4.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(31232),
+		Storage: int64(0),
+	},
+	"r5.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(393216),
+		Storage: int64(0),
+	},
+	"r5.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(524288),
+		Storage: int64(0),
+	},
+	"r5.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(786432),
+		Storage: int64(0),
+	},
+	"r5.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(65536),
+		Storage: int64(0),
+	},
+	"r5.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(131072),
+		Storage: int64(0),
+	},
+	"r5.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(262144),
+		Storage: int64(0),
+	},
+	"r5.large": {
+		CPU:     int64(2),
+		Memory:  int64(16384),
+		Storage: int64(0),
+	},
+	"r5.metal": {
+		CPU:     int64(96),
+		Memory:  int64(786432),
+		Storage: int64(0),
+	},
+	"r5.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(32768),
+		Storage: int64(0),
+	},
+	"r5a.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(393216),
+		Storage: int64(0),
+	},
+	"r5a.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(524288),
+		Storage: int64(0),
+	},
+	"r5a.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(786432),
+		Storage: int64(0),
+	},
+	"r5a.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(65536),
+		Storage: int64(0),
+	},
+	"r5a.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(131072),
+		Storage: int64(0),
+	},
+	"r5a.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(262144),
+		Storage: int64(0),
+	},
+	"r5a.large": {
+		CPU:     int64(2),
+		Memory:  int64(16384),
+		Storage: int64(0),
+	},
+	"r5a.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(32768),
+		Storage: int64(0),
+	},
+	"r5ad.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(393216),
+		Storage: int64(1800),
+	},
+	"r5ad.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(524288),
+		Storage: int64(2400),
+	},
+	"r5ad.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(786432),
+		Storage: int64(3600),
+	},
+	"r5ad.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(65536),
+		Storage: int64(300),
+	},
+	"r5ad.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(131072),
+		Storage: int64(600),
+	},
+	"r5ad.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(262144),
+		Storage: int64(1200),
+	},
+	"r5ad.large": {
+		CPU:     int64(2),
+		Memory:  int64(16384),
+		Storage: int64(75),
+	},
+	"r5ad.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(32768),
+		Storage: int64(150),
+	},
+	"r5d.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(393216),
+		Storage: int64(1800),
+	},
+	"r5d.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(524288),
+		Storage: int64(2400),
+	},
+	"r5d.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(786432),
+		Storage: int64(3600),
+	},
+	"r5d.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(65536),
+		Storage: int64(300),
+	},
+	"r5d.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(131072),
+		Storage: int64(600),
+	},
+	"r5d.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(262144),
+		Storage: int64(1200),
+	},
+	"r5d.large": {
+		CPU:     int64(2),
+		Memory:  int64(16384),
+		Storage: int64(75),
+	},
+	"r5d.metal": {
+		CPU:     int64(96),
+		Memory:  int64(786432),
+		Storage: int64(3600),
+	},
+	"r5d.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(32768),
+		Storage: int64(150),
+	},
+	"r5dn.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(393216),
+		Storage: int64(1800),
+	},
+	"r5dn.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(524288),
+		Storage: int64(2400),
+	},
+	"r5dn.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(786432),
+		Storage: int64(3600),
+	},
+	"r5dn.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(65536),
+		Storage: int64(300),
+	},
+	"r5dn.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(131072),
+		Storage: int64(600),
+	},
+	"r5dn.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(262144),
+		Storage: int64(1200),
+	},
+	"r5dn.large": {
+		CPU:     int64(2),
+		Memory:  int64(16384),
+		Storage: int64(75),
+	},
+	"r5dn.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(32768),
+		Storage: int64(150),
+	},
+	"r5n.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(393216),
+		Storage: int64(0),
+	},
+	"r5n.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(524288),
+		Storage: int64(0),
+	},
+	"r5n.24xlarge": {
+		CPU:     int64(96),
+		Memory:  int64(786432),
+		Storage: int64(0),
+	},
+	"r5n.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(65536),
+		Storage: int64(0),
+	},
+	"r5n.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(131072),
+		Storage: int64(0),
+	},
+	"r5n.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(262144),
+		Storage: int64(0),
+	},
+	"r5n.large": {
+		CPU:     int64(2),
+		Memory:  int64(16384),
+		Storage: int64(0),
+	},
+	"r5n.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(32768),
+		Storage: int64(0),
+	},
+	"t1.micro": {
+		CPU:     int64(1),
+		Memory:  int64(627),
+		Storage: int64(0),
+	},
+	"t2.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(32768),
+		Storage: int64(0),
+	},
+	"t2.large": {
+		CPU:     int64(2),
+		Memory:  int64(8192),
+		Storage: int64(0),
+	},
+	"t2.medium": {
+		CPU:     int64(2),
+		Memory:  int64(4096),
+		Storage: int64(0),
+	},
+	"t2.micro": {
+		CPU:     int64(1),
+		Memory:  int64(1024),
+		Storage: int64(0),
+	},
+	"t2.nano": {
+		CPU:     int64(1),
+		Memory:  int64(512),
+		Storage: int64(0),
+	},
+	"t2.small": {
+		CPU:     int64(1),
+		Memory:  int64(2048),
+		Storage: int64(0),
+	},
+	"t2.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(16384),
+		Storage: int64(0),
+	},
+	"t3.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(32768),
+		Storage: int64(0),
+	},
+	"t3.large": {
+		CPU:     int64(2),
+		Memory:  int64(8192),
+		Storage: int64(0),
+	},
+	"t3.medium": {
+		CPU:     int64(2),
+		Memory:  int64(4096),
+		Storage: int64(0),
+	},
+	"t3.micro": {
+		CPU:     int64(2),
+		Memory:  int64(1024),
+		Storage: int64(0),
+	},
+	"t3.nano": {
+		CPU:     int64(2),
+		Memory:  int64(512),
+		Storage: int64(0),
+	},
+	"t3.small": {
+		CPU:     int64(2),
+		Memory:  int64(2048),
+		Storage: int64(0),
+	},
+	"t3.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(16384),
+		Storage: int64(0),
+	},
+	"t3a.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(32768),
+		Storage: int64(0),
+	},
+	"t3a.large": {
+		CPU:     int64(2),
+		Memory:  int64(8192),
+		Storage: int64(0),
+	},
+	"t3a.medium": {
+		CPU:     int64(2),
+		Memory:  int64(4096),
+		Storage: int64(0),
+	},
+	"t3a.micro": {
+		CPU:     int64(2),
+		Memory:  int64(1024),
+		Storage: int64(0),
+	},
+	"t3a.nano": {
+		CPU:     int64(2),
+		Memory:  int64(512),
+		Storage: int64(0),
+	},
+	"t3a.small": {
+		CPU:     int64(2),
+		Memory:  int64(2048),
+		Storage: int64(0),
+	},
+	"t3a.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(16384),
+		Storage: int64(0),
+	},
+	"x1.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(999424),
+		Storage: int64(1920),
+	},
+	"x1.32xlarge": {
+		CPU:     int64(128),
+		Memory:  int64(1998848),
+		Storage: int64(3840),
+	},
+	"x1e.16xlarge": {
+		CPU:     int64(64),
+		Memory:  int64(1998848),
+		Storage: int64(1920),
+	},
+	"x1e.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(249856),
+		Storage: int64(240),
+	},
+	"x1e.32xlarge": {
+		CPU:     int64(128),
+		Memory:  int64(3997696),
+		Storage: int64(3840),
+	},
+	"x1e.4xlarge": {
+		CPU:     int64(16),
+		Memory:  int64(499712),
+		Storage: int64(480),
+	},
+	"x1e.8xlarge": {
+		CPU:     int64(32),
+		Memory:  int64(999424),
+		Storage: int64(960),
+	},
+	"x1e.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(124928),
+		Storage: int64(120),
+	},
+	"z1d.12xlarge": {
+		CPU:     int64(48),
+		Memory:  int64(393216),
+		Storage: int64(1800),
+	},
+	"z1d.2xlarge": {
+		CPU:     int64(8),
+		Memory:  int64(65536),
+		Storage: int64(300),
+	},
+	"z1d.3xlarge": {
+		CPU:     int64(12),
+		Memory:  int64(98304),
+		Storage: int64(450),
+	},
+	"z1d.6xlarge": {
+		CPU:     int64(24),
+		Memory:  int64(196608),
+		Storage: int64(900),
+	},
+	"z1d.large": {
+		CPU:     int64(2),
+		Memory:  int64(16384),
+		Storage: int64(75),
+	},
+	"z1d.metal": {
+		CPU:     int64(48),
+		Memory:  int64(393216),
+		Storage: int64(1800),
+	},
+	"z1d.xlarge": {
+		CPU:     int64(4),
+		Memory:  int64(32768),
+		Storage: int64(150),
+	},
+}

--- a/pkg/nodebootstrap/reserved_generate.go
+++ b/pkg/nodebootstrap/reserved_generate.go
@@ -1,0 +1,101 @@
+//+build ignore
+
+// Fetches AWS instance type data such as memory, cpus, and
+// (ephemeral) storage. Writes it to a Go file to be included
+// by eksctl.
+//
+// Since each region may support different instance types we
+// need to query all regions. But the same instance type in
+// different regions has consistent specs.
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	. "github.com/dave/jennifer/jen"
+
+	"github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/nodebootstrap"
+)
+
+const outputFilename = "reserved_data.go"
+
+func main() {
+	infos := map[string]nodebootstrap.InstanceTypeInfo{}
+	for _, region := range v1alpha5.SupportedRegions() {
+		fmt.Printf("Fetching instance types in %q\n", region)
+		client := ec2.New(newSession(region))
+		if err := updateRegionInstanceTypes(client, infos); err != nil {
+			checkError(region, err)
+		}
+	}
+	if err := render(infos); err != nil {
+		panic(err)
+	}
+	fmt.Println("Done.")
+}
+
+func checkError(region string, err error) {
+	if err == nil {
+		return
+	}
+	// Allow failing for Chinese regions
+	if aerr, ok := err.(awserr.Error); ok {
+		if aerr.Code() == "AuthFailure" && strings.HasPrefix(region, "cn-") {
+			fmt.Println("  AuthFailure, skipping.")
+			return
+		}
+	}
+	fmt.Println("Make sure your environment provides credentials to run ec2:DescribeInstanceTypes in supported regions")
+	panic(err)
+}
+
+func updateRegionInstanceTypes(client *ec2.EC2, infos map[string]nodebootstrap.InstanceTypeInfo) error {
+	var token *string
+	for {
+		resp, err := client.DescribeInstanceTypes(&ec2.DescribeInstanceTypesInput{NextToken: token})
+		if err != nil {
+			return err
+		}
+		for _, t := range resp.InstanceTypes {
+			infos[aws.StringValue(t.InstanceType)] = nodebootstrap.NewInstanceTypeInfo(t)
+		}
+		if resp.NextToken == nil {
+			return nil
+		}
+		token = resp.NextToken
+	}
+}
+
+func newSession(region string) *session.Session {
+	config := aws.NewConfig().WithRegion(region)
+	opts := session.Options{Config: *config}
+	return session.Must(session.NewSessionWithOptions(opts))
+}
+
+func render(infos map[string]nodebootstrap.InstanceTypeInfo) error {
+	f := NewFile("nodebootstrap")
+
+	f.Commentf("This file was generated %s by reserved_generate.go; DO NOT EDIT.", time.Now().Format(time.RFC3339))
+	f.Line()
+	f.Comment("Data downloaded through the API.")
+
+	f.Var().Id("instanceTypeInfos").Op("=").
+		Map(String()).Id("InstanceTypeInfo").Values(DictFunc(func(d Dict) {
+		for k, info := range infos {
+			d[Lit(k)] = Values(Dict{
+				Id("Storage"): Lit(info.Storage),
+				Id("Memory"):  Lit(info.Memory),
+				Id("CPU"):     Lit(info.CPU),
+			})
+		}
+	}))
+
+	return f.Save(outputFilename)
+}

--- a/pkg/nodebootstrap/reserved_test.go
+++ b/pkg/nodebootstrap/reserved_test.go
@@ -1,0 +1,84 @@
+package nodebootstrap
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Reservations defaults", func() {
+	type storageCase struct {
+		gib int64
+		exp string
+	}
+	DescribeTable("calculate storage", func(c storageCase) {
+		Expect(InstanceTypeInfo{Storage: c.gib}.DefaultStorageToReserve()).To(Equal(c.exp))
+	},
+		Entry("0GiB", storageCase{0, "1Gi"}),
+		Entry("1GiB", storageCase{1, "1Gi"}),
+		Entry("100GiB", storageCase{100, "1Gi"}),
+		Entry("1000GiB", storageCase{1000, "1Gi"}),
+	)
+
+	type memoryCase struct {
+		mib int64
+		exp string
+	}
+	DescribeTable("calculate memory", func(c memoryCase) {
+		Expect(InstanceTypeInfo{Memory: c.mib}.DefaultMemoryToReserve()).To(Equal(c.exp))
+	},
+		Entry("0MiB", memoryCase{0, "255Mi"}),
+		Entry("512MiB", memoryCase{512, "255Mi"}),
+		Entry("2GiB", memoryCase{2048, "512Mi"}),
+		Entry("4GiB", memoryCase{4096, "1024Mi"}),
+		Entry("6GiB", memoryCase{6144, "1433Mi"}),
+		Entry("8GiB", memoryCase{8192, "1843Mi"}),
+		Entry("12GiB", memoryCase{12288, "2252Mi"}),
+		Entry("64GiB", memoryCase{1 << 16, "5611Mi"}),
+	)
+
+	type cpuCase struct {
+		cpu int64
+		exp string
+	}
+	DescribeTable("calculate cpu", func(c cpuCase) {
+		Expect(InstanceTypeInfo{CPU: c.cpu}.DefaultCPUToReserve()).To(Equal(c.exp))
+	},
+		Entry("0 cpu", cpuCase{0, "0m"}),
+		Entry("1 cpu", cpuCase{1, "60m"}),
+		Entry("2 cpu", cpuCase{2, "70m"}),
+		Entry("4 cpu", cpuCase{4, "80m"}),
+		Entry("8 cpu", cpuCase{8, "90m"}),
+		Entry("16 cpu", cpuCase{16, "110m"}),
+		Entry("32 cpu", cpuCase{32, "150m"}),
+		Entry("48 cpu", cpuCase{48, "190m"}),
+		Entry("64 cpu", cpuCase{64, "230m"}),
+		Entry("80 cpu", cpuCase{80, "270m"}),
+		Entry("96 cpu", cpuCase{96, "310m"}),
+	)
+
+	type instanceCase struct {
+		instance   string
+		expMemory  string
+		expCPU     string
+		expStorage string
+	}
+	DescribeTable("calculate by instance type", func(c instanceCase) {
+		Expect(instanceTypeInfos[c.instance].DefaultStorageToReserve()).To(Equal(c.expStorage))
+		Expect(instanceTypeInfos[c.instance].DefaultMemoryToReserve()).To(Equal(c.expMemory))
+		Expect(instanceTypeInfos[c.instance].DefaultCPUToReserve()).To(Equal(c.expCPU))
+	},
+		Entry("a1.2xlarge", instanceCase{"a1.2xlarge", "2662Mi", "90m", "1Gi"}),
+		Entry("t3.nano", instanceCase{"t3.nano", "255Mi", "70m", "1Gi"}),
+		Entry("t3a.micro", instanceCase{"t3a.micro", "256Mi", "70m", "1Gi"}),
+		Entry("t2.small", instanceCase{"t2.small", "512Mi", "60m", "1Gi"}),
+		Entry("t2.medium", instanceCase{"t2.medium", "1024Mi", "70m", "1Gi"}),
+		Entry("m5ad.large", instanceCase{"m5ad.large", "1843Mi", "70m", "1Gi"}),
+		Entry("m5ad", instanceCase{"m5ad.xlarge", "2662Mi", "80m", "1Gi"}),
+		Entry("m5ad.2xlarge", instanceCase{"m5ad.2xlarge", "3645Mi", "90m", "1Gi"}),
+		Entry("m5ad.8xlarge", instanceCase{"m5ad.8xlarge", "9543Mi", "150m", "1Gi"}),
+		Entry("m5ad.12xlarge", instanceCase{"m5ad.12xlarge", "10853Mi", "190m", "1Gi"}),
+		Entry("m5ad.16xlarge", instanceCase{"m5ad.16xlarge", "12164Mi", "230m", "1Gi"}),
+		Entry("m5ad.24xlarge", instanceCase{"m5ad.24xlarge", "14785Mi", "310m", "1Gi"}),
+	)
+})

--- a/pkg/nodebootstrap/userdata_test.go
+++ b/pkg/nodebootstrap/userdata_test.go
@@ -46,6 +46,20 @@ var _ = Describe("User data", func() {
 			Expect(errUnmarshal).ToNot(HaveOccurred())
 		})
 
+		It("contains default kube reservations", func() {
+			ng.InstanceType = "i3.metal"
+			data, err := makeKubeletConfigYAML(clusterConfig, ng)
+
+			kubelet := kubeletapi.KubeletConfiguration{}
+			err = yaml.UnmarshalStrict(data, &kubelet)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kubelet.KubeReserved).To(Equal(map[string]string{
+				"ephemeral-storage": "1Gi",
+				"cpu": "250m",
+				"memory": "17407Mi",
+			}))
+		})
+
 		It("the kubelet config contains the overwritten values", func() {
 
 			ng.KubeletExtraConfig = &api.InlineDocument{

--- a/site/content/usage/11-customizing-the-kubelet.md
+++ b/site/content/usage/11-customizing-the-kubelet.md
@@ -53,7 +53,8 @@ nodeGroups:
 In this example, given instances of type `m5a.xlarge` which have 4 vCPUs and 16GiB of memory, the `Allocatable` amount
 of CPUs would be 3.4 and 15.4 GiB of memory. In addition, the `DynamicKubeletConfig` feature gate is also enabled. It is
 important to know that the values specified in the config file for the the fields in `kubeletExtraconfig` will 
-completely overwrite the default values specified by eksctl.
+completely overwrite the default values specified by eksctl. However, omitting one or more `kubeReserved` parameters
+will cause the missing parameters to be defaulted to sane values based on the aws instance type being used.
 
 >**IMPORTANT**: by default `eksctl` sets  `featureGates.RotateKubeletServerCertificate=true`, but when custom 
 `featureGates` are provided, it will be unset. You should always include 


### PR DESCRIPTION
Replaces #1823
Closes #1981 

### Description

This change implements default values for `kube-reserved` the same way
as the [official AMIs] do which is dependent on the instance type.

Reserved memory and cpu are set according to a formula while the storage
is always set to 1GiB. See the source code for details.

Instance type information (such as available storage, memory, and cpu)
may not only change in the future but also new instances will be added.
There is a make target `generate-kube-reserved` which fetches all instance
types by querying the AWS API `ec2:DescribeInstanceTypes` in each
region. It then saves it to `pkg/nodebootstrap/reserved_data.go` ready
to be taken as input for computing appropriate default values.

[official AMIs]: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
