### PR TITLE
Don't alter addons in plan mode

### DIFF
--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -310,9 +310,11 @@ func (r *RawResource) CreateOrReplace(plan bool) (string, error) {
 		return "", errors.Wrap(err, "unexpected non-404 error")
 	}
 	if !exists {
-		_, err := r.Helper.Create(r.Info.Namespace, !plan, r.Info.Object, &metav1.CreateOptions{})
-		if err != nil {
-			return "", err
+		if !plan {
+			_, err := r.Helper.Create(r.Info.Namespace, true, r.Info.Object, &metav1.CreateOptions{})
+			if err != nil {
+				return "", err
+			}
 		}
 		return r.LogAction(plan, "created"), nil
 	}
@@ -322,9 +324,10 @@ func (r *RawResource) CreateOrReplace(plan bool) (string, error) {
 		return "", errors.Wrapf(err, "converting object")
 	}
 	scheme.Scheme.Default(convertedObj)
-
-	if _, err := r.Helper.Replace(r.Info.Namespace, r.Info.Name, !plan, r.Info.Object); err != nil {
-		return "", err
+	if !plan {
+		if _, err := r.Helper.Replace(r.Info.Namespace, r.Info.Name, true, r.Info.Object); err != nil {
+			return "", err
+		}
 	}
 
 	return r.LogAction(plan, "replaced"), nil


### PR DESCRIPTION
The previous implementation misinterpreted the arguments for the helper
functions. The current implementation updates resources in plan mode
(see #1811 and #1801 ). I changed the implementation to log only in plan
mode.

Closes #1811
Closes #1801

### Description

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
