### PR TITLE
Fix IT that truncates cluster name

### DIFF
--- a/integration/tests/crud/creategetdelete_test.go
+++ b/integration/tests/crud/creategetdelete_test.go
@@ -408,7 +408,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 
 						Expect(sa.Annotations).To(HaveLen(1))
 						Expect(sa.Annotations).To(HaveKey(api.AnnotationEKSRoleARN))
-						Expect(sa.Annotations[api.AnnotationEKSRoleARN]).To(MatchRegexp("^arn:aws:iam::.*:role/eksctl-" + params.ClusterName + ".*$"))
+						Expect(sa.Annotations[api.AnnotationEKSRoleARN]).To(MatchRegexp("^arn:aws:iam::.*:role/eksctl-" + truncate(params.ClusterName) + ".*$"))
 					}
 				})
 


### PR DESCRIPTION
<!-- If you haven't done so already, you can add your name to the humans.txt file -->

```
[3] • Failure [76.425 seconds]
[3] (Integration) Create, Get, Scale & Delete
[3] /src/integration/tests/crud/creategetdelete_test.go:47
[3]   when creating a cluster with 1 node
[3]   /src/integration/tests/crud/creategetdelete_test.go:75
[3]     and add the second nodegroup
[3]     /src/integration/tests/crud/creategetdelete_test.go:148
[3]       create and delete iamserviceaccounts
[3]       /src/integration/tests/crud/creategetdelete_test.go:323
[3]         should enable OIDC and create two iamserviceaccounts [It]
[3]         /src/integration/tests/crud/creategetdelete_test.go:345
[3] 
[3]         Expected
[3]             <string>: arn:aws:iam::083751696308:role/eksctl-it-crud-extravagant-mongoose-15856240-Role1-1P16AFOXO0BS2
[3]         to match regular expression
[3]             <string>: ^arn:aws:iam::.*:role/eksctl-it-crud-extravagant-mongoose-1585624056.*$
[3] 
[3]         /src/integration/tests/crud/creategetdelete_test.go:411
```