### PR TITLE
Fix IDE build issue: add same build annotations to test file as prod file

### DIFF
--- a/pkg/version/generate/generate_suite_test.go
+++ b/pkg/version/generate/generate_suite_test.go
@@ -1,3 +1,5 @@
+// +build release
+
 package main
 
 import (

--- a/pkg/version/generate/release_generate_test.go
+++ b/pkg/version/generate/release_generate_test.go
@@ -1,3 +1,5 @@
+// +build release
+
 package main
 
 import (


### PR DESCRIPTION
### Description

Prior to this change, some IDEs were failing to build the project because methods from:

```
pkg/version/generate/release_generate.go
```

annotated with `// +build release` could NOT be found by its tests:

```
pkg/version/generate/release_generate_test.go
```

Indeed, both files were in the same `main` package so that tests should be able to call functions from `release_generate.go` directly but the fact the test file didn't have `// +build release` made the compiler fail to find these, leading to errors like:

```
undeclared name: prepareRelease
```

### Checklist

- [x] Manually tested: fixes build errors under VisualCode
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
