### PR TITLE
New default IP mapping settings for public subnets

### DIFF
--- a/integration/tests/backwards_compat/backwards_compatibility_test.go
+++ b/integration/tests/backwards_compat/backwards_compatibility_test.go
@@ -90,6 +90,13 @@ var _ = Describe("(Integration) [Backwards compatibility test]", func() {
 
 		Expect(cmd).To(RunSuccessfullyWithOutputString(ContainSubstring(params.ClusterName)))
 
+		By("updating the public subnets")
+		cmd = params.EksctlUtilsCmd.WithArgs(
+			"update-legacy-subnet-settings",
+			"--cluster", params.ClusterName,
+		)
+		Expect(cmd).To(RunSuccessfully())
+
 		By("adding a nodegroup")
 		cmd = params.EksctlCreateCmd.WithArgs(
 			"nodegroup",

--- a/pkg/apis/eksctl.io/v1alpha5/vpc.go
+++ b/pkg/apis/eksctl.io/v1alpha5/vpc.go
@@ -240,3 +240,10 @@ func (c *ClusterConfig) HasClusterEndpointAccess() bool {
 	}
 	return true
 }
+
+func (c *ClusterConfig) HasPrivateEndpointAccess() bool {
+	return c.VPC != nil &&
+		c.VPC.ClusterEndpoints != nil &&
+		c.VPC.ClusterEndpoints.PrivateAccess != nil &&
+		*c.VPC.ClusterEndpoints.PrivateAccess
+}

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -1520,7 +1520,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 
 			Expect(ltd.NetworkInterfaces).To(HaveLen(1))
 			Expect(ltd.NetworkInterfaces[0].DeviceIndex).To(Equal(0))
-			Expect(ltd.NetworkInterfaces[0].AssociatePublicIpAddress).To(BeTrue())
+			Expect(ltd.NetworkInterfaces[0].AssociatePublicIpAddress).To(BeFalse())
 
 			Expect(ngTemplate.Resources["SSHIPv4"].Properties.CidrIp).To(Equal("0.0.0.0/0"))
 			Expect(ngTemplate.Resources["SSHIPv4"].Properties.FromPort).To(Equal(22))
@@ -1607,7 +1607,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 
 			Expect(ltd.NetworkInterfaces).To(HaveLen(1))
 			Expect(ltd.NetworkInterfaces[0].DeviceIndex).To(Equal(0))
-			Expect(ltd.NetworkInterfaces[0].AssociatePublicIpAddress).To(BeTrue())
+			Expect(ltd.NetworkInterfaces[0].AssociatePublicIpAddress).To(BeFalse())
 
 			Expect(ngTemplate.Resources).ToNot(HaveKey("SSHIPv4"))
 

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -242,7 +242,8 @@ func newLaunchTemplateData(n *NodeGroupResourceSet) *gfn.AWSEC2LaunchTemplate_La
 		ImageId:  gfn.NewString(n.spec.AMI),
 		UserData: n.userData,
 		NetworkInterfaces: []gfn.AWSEC2LaunchTemplate_NetworkInterface{{
-			AssociatePublicIpAddress: gfn.NewBoolean(!n.spec.PrivateNetworking),
+			// Explicitly un-setting this so that it doesn't get defaulted to true
+			AssociatePublicIpAddress: nil,
 			DeviceIndex:              gfn.NewInteger(0),
 			Groups:                   n.securityGroups,
 		}},

--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -52,6 +52,7 @@ func (c *ClusterResourceSet) addSubnets(refRT *gfn.Value, topology api.SubnetTop
 				Key:   gfn.NewString("kubernetes.io/role/elb"),
 				Value: gfn.NewString("1"),
 			}}
+			subnet.MapPublicIpOnLaunch = gfn.True()
 		}
 		refSubnet := c.newResource("Subnet"+alias, subnet)
 		c.newResource("RouteTableAssociation"+alias, &gfn.AWSEC2SubnetRouteTableAssociation{

--- a/pkg/cfn/manager/compat.go
+++ b/pkg/cfn/manager/compat.go
@@ -1,11 +1,17 @@
 package manager
 
 import (
+	"fmt"
+
+	gfn "github.com/awslabs/goformation/cloudformation"
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
 	"github.com/weaveworks/eksctl/pkg/cfn/builder"
 	"github.com/weaveworks/eksctl/pkg/cfn/outputs"
+	"github.com/weaveworks/eksctl/pkg/vpc"
 )
 
 // FixClusterCompatibility adds any resources missing in the CloudFormation stack in order to support new features
@@ -60,6 +66,7 @@ func (c *StackCollection) FixClusterCompatibility() error {
 	if !stackSupportsFargate {
 		logger.Info("cluster stack is missing resources for Fargate")
 	}
+
 	logger.Info("adding missing resources to cluster stack")
 	_, err = c.AppendNewClusterStackResource(false, true)
 	return err
@@ -72,4 +79,70 @@ func (c *StackCollection) hasManagedToUnmanagedSG() (bool, error) {
 	}
 	stackResources := gjson.Get(stackTemplate, resourcesRootPath)
 	return builder.HasManagedNodesSG(&stackResources), nil
+}
+
+// EnsureMapPublicIPOnLaunchEnabled sets this subnet property to true when it is not set or is set to false
+func (c *StackCollection) EnsureMapPublicIPOnLaunchEnabled() error {
+	// First, make sure we enable the options in EC2. This is to make sure the settings are applied even
+	// if the stacks in Cloudformation have the setting enabled (since a stack update would produce "nothing to change"
+	// and therefore the setting would not be updated)
+	logger.Debug("enabling attribute MapPublicIpOnLaunch via EC2 on subnets %q", c.spec.PublicSubnetIDs())
+	err := vpc.EnsureMapPublicIPOnLaunchEnabled(c.provider, c.spec.PublicSubnetIDs())
+	if err != nil {
+		return err
+	}
+
+	// Get stack template
+	stackName := c.makeClusterStackName()
+	currentTemplate, err := c.GetStackTemplate(stackName)
+	if err != nil {
+		return errors.Wrapf(err, "unable to retrieve cluster stack %q", stackName)
+	}
+
+	// Find subnets in stack
+	outputTemplate := gjson.Get(currentTemplate, outputsRootPath)
+	publicSubnetsNames, err := getPublicSubnetResourceNames(outputTemplate.Raw)
+	if err != nil {
+		// Subnets do not appear in the stack because the VPC was imported
+		logger.Debug(err.Error())
+		return nil
+	}
+
+	// Modify the subnets' properties in the stack
+	logger.Debug("ensuring subnets have MapPublicIpOnLaunch enabled")
+	for _, subnet := range publicSubnetsNames {
+		path := subnetResourcePath(subnet)
+
+		currentValue := gjson.Get(currentTemplate, path)
+		if !currentValue.Exists() || !currentValue.Bool() {
+			currentTemplate, err = sjson.Set(currentTemplate, path, gfn.True())
+			if err != nil {
+				return errors.Wrapf(err, "unable to set MapPublicIpOnLaunch property on subnet %q", path)
+			}
+		}
+	}
+	description := fmt.Sprintf("update public subnets %q with property MapPublicIpOnLaunch enabled", publicSubnetsNames)
+	if err := c.UpdateStack(stackName, c.MakeChangeSetName("update-subnets"), description, []byte(currentTemplate), nil); err != nil {
+		return errors.Wrap(err, "unable to update subnets")
+	}
+	return nil
+}
+
+func subnetResourcePath(subnetName string) string {
+	return fmt.Sprintf("Resources.%s.Properties.MapPublicIpOnLaunch", subnetName)
+}
+
+// getPublicSubnetResourceNames returns the stack resource names for the public subnets, gotten from the stack
+// output "SubnetsPublic"
+func getPublicSubnetResourceNames(outputsTemplate string) ([]string, error) {
+	publicSubnets := gjson.Get(outputsTemplate, "SubnetsPublic.Value.Fn::Join.1.#.Ref")
+	if !publicSubnets.Exists() || len(publicSubnets.Array()) == 0 {
+		subnetsJSON := gjson.Get(outputsTemplate, "SubnetsPublic.Value")
+		return nil, fmt.Errorf("resource name for public subnets not found. Found %q", subnetsJSON.Raw)
+	}
+	subnetStackNames := make([]string, 0)
+	for _, subnet := range publicSubnets.Array() {
+		subnetStackNames = append(subnetStackNames, subnet.String())
+	}
+	return subnetStackNames, nil
 }

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/ssh"
 	"github.com/weaveworks/eksctl/pkg/utils/names"
+	"github.com/weaveworks/eksctl/pkg/vpc"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/authconfigmap"
@@ -154,6 +155,10 @@ func doCreateNodeGroups(cmd *cmdutils.Cmd, ng *api.NodeGroup, params createNodeG
 	// TODO
 	if err := ctl.ValidateClusterForCompatibility(cfg, stackManager); err != nil {
 		return errors.Wrap(err, "cluster compatibility check failed")
+	}
+
+	if err := vpc.ValidateLegacySubnetsForNodeGroups(cfg, ctl.Provider); err != nil {
+		return err
 	}
 
 	{

--- a/pkg/ctl/utils/update_legacy_subnet_settings.go
+++ b/pkg/ctl/utils/update_legacy_subnet_settings.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	"github.com/kris-nova/logger"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+func updateLegacySubnetSettings(cmd *cmdutils.Cmd) {
+	cfg := api.NewClusterConfig()
+	cmd.ClusterConfig = cfg
+
+	cmd.SetDescription("update-legacy-subnet-settings", "Update the configuration of the cluster's public subnets with MapPublicIpOnLaunch enabled",
+		"MapPublicIpOnLaunch is a new property for subnets that is required for creating new nodegroups in them")
+
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
+		return doUpdateLegacySubnetSettings(cmd)
+	}
+
+	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+		cmdutils.AddClusterFlagWithDeprecated(fs, cfg.Metadata)
+		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
+		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
+	})
+
+	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)
+}
+
+func doUpdateLegacySubnetSettings(cmd *cmdutils.Cmd) error {
+	cfg := cmd.ClusterConfig
+	meta := cmd.ClusterConfig.Metadata
+
+	ctl, err := cmd.NewCtl()
+	if err != nil {
+		return err
+	}
+	cmdutils.LogRegionAndVersionInfo(cfg.Metadata)
+
+	if err := ctl.CheckAuth(); err != nil {
+		return err
+	}
+
+	if meta.Name != "" && cmd.NameArg != "" {
+		return cmdutils.ErrFlagAndArg(cmdutils.ClusterNameFlag(cmd), meta.Name, cmd.NameArg)
+	}
+	if cmd.NameArg != "" {
+		meta.Name = cmd.NameArg
+	}
+
+	if meta.Name == "" {
+		return cmdutils.ErrMustBeSet(cmdutils.ClusterNameFlag(cmd))
+	}
+
+	if err := ctl.LoadClusterVPC(cfg); err != nil {
+		return errors.Wrapf(err, "getting VPC configuration for cluster %q", cfg.Metadata.Name)
+	}
+
+	stackManager := ctl.NewStackManager(cfg)
+
+	logger.Info("updating settings { MapPublicIpOnLaunch: enabled } for public subnets %q", cfg.PublicSubnetIDs())
+	err = stackManager.EnsureMapPublicIPOnLaunchEnabled()
+	if err != nil {
+		logger.Warning(err.Error())
+		return err
+	}
+
+	logger.Success("public subnets up to date")
+	return nil
+}

--- a/pkg/ctl/utils/utils.go
+++ b/pkg/ctl/utils/utils.go
@@ -16,6 +16,7 @@ func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
 	cmdutils.AddResourceCmd(flagGrouping, verbCmd, updateKubeProxyCmd)
 	cmdutils.AddResourceCmd(flagGrouping, verbCmd, updateAWSNodeCmd)
 	cmdutils.AddResourceCmd(flagGrouping, verbCmd, updateCoreDNSCmd)
+	cmdutils.AddResourceCmd(flagGrouping, verbCmd, updateLegacySubnetSettings)
 	cmdutils.AddResourceCmd(flagGrouping, verbCmd, enableLoggingCmd)
 	cmdutils.AddResourceCmd(flagGrouping, verbCmd, associateIAMOIDCProviderCmd)
 	cmdutils.AddResourceCmd(flagGrouping, verbCmd, installWindowsVPCController)

--- a/site/content/usage/06-vpc-networking.md
+++ b/site/content/usage/06-vpc-networking.md
@@ -15,6 +15,13 @@ not insecure in principle, but some compromised workload could risk an access vi
 
 If that functionality doesn't suit you, the following options are currently available.
 
+>**_IMPORTANT_**: From `eksctl` version `0.17.0` and onwards public subnets will have the property `MapPublicIpOnLaunch` enabled, and the property `AssociatePublicIpAddress` disabled in the Auto Scaling Group for the nodegroups.
+> This means that for clusters created with previous versions of eksctl when a new nodegroup is created it must either
+>be a private nodegroup or have `MapPublicIpOnLaunch` enabled in its public subnets. Otherwise, the new nodes won't have
+>access to the internet and won't be able to download the basic add-ons (CNI plugin, kube-proxy, etc).
+>To help setting up subnets correctly for old clusters you can use the new command `eksctl utils update-legacy-subnet-settings`.
+
+
 ### Change VPC CIDR
 
 If you need to setup peering with another VPC, or simply need larger or smaller range of IPs, you can use `--vpc-cidr` flag to
@@ -71,6 +78,7 @@ recommended.
 - tagging of subnets
   - `kubernetes.io/cluster/<name>` tag set to either `shared` or `owned`
   - `kubernetes.io/role/internal-elb` tag set to `1` for private subnets
+- **NEW**: all public subnets should have the property `MapPublicIpOnLaunch` enabled (i.e. `Auto-assign public IPv4 address` in the AWS console)
 
 There maybe other requirements imposed by EKS or Kubernetes, and it is entirely up to you to stay up-to-date on any requirements and/or
 recommendations, and implement those as needed/possible.


### PR DESCRIPTION
### Description

This PR makes eksctl leverage the property `MapPublicIpOnLaunch` for subnets (Also known as "Assign IP v4 address") to assign ip addresses for nodes on public subnets.

At the same time we disable the property `AssociatePublicIpAddress` on the Network interface settings of the ASG.

To keep eksctl compatible with existing cluster the following functionality has changed:

- `eksctl create cluster` will enable `MapPublicIpOnLaunch` in public subnets and will unset `AssociatePublicIpAddress` on the ASG
- `eksctl create nodegroup` will check if the new nodes will be able to talk to the cluster endpoint by checking:
    - if the nodes are in a public subnet, and the subnets don't have `MapPublicIpOnLaunch` enabled, and the cluster doesn't have the access to the private endpoint enabled either -> it will throw an error because the nodes won't be able to join the cluster
- `eksctl update cluster` will not upgrade the subnets in the stack because this operation has to be done consciously by the user
- a new command `utils update-legacy-subnet-settings` has been added to update the subnet's settings with `MapPublicIpAddress` enabled either via CF if the VPC was created by eksctl or via the EC2 API if the VPC was imported.

 

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
