### PR TITLE
Improve help of update cluster command

### DIFF
--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -17,7 +17,8 @@ func updateClusterCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
 
-	cmd.SetDescription("cluster", "Update cluster", "")
+	cmd.SetDescription("cluster", "Upgrade control plane to the next version",
+		"Upgrade control plane to the next Kubernetes version if available. Will also perform any updates needed in the cluster stack if resources are missing.")
 
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)


### PR DESCRIPTION
Fixes #1955

Improves the help message printed for the `eksctl update cluster` command.



```
eksctl update cluster --help
Update cluster

Usage: eksctl update cluster [flags]
...
```


```
eksctl update 
Update resource(s)

Usage: eksctl update [flags]

Commands:
  eksctl update cluster                 Update cluster
...
```




```
eksctl update cluster --help
Upgrade control plane to the next kubernetes version if available. Will also perform any updates needed in the cluster stack if resources are missing.

Usage: eksctl update cluster [flags]
...
```


```

eksctl update  --help
Update resource(s)

Usage: eksctl update [flags]

Commands:
  eksctl update cluster                 Update cluster
...
```



<!-- If you haven't done so already, you can add your name to the humans.txt file -->