### PR TITLE
WIP Leverage EKS service linked role

### DIFF
--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -2256,7 +2256,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Expect(clusterTemplate.Resources["ServiceRole"].Properties).ToNot(BeNil())
 
 			Expect(clusterTemplate.Resources["ServiceRole"].Properties.ManagedPolicyArns).To(Equal(makePolicyARNRef(
-				"AmazonEKSServicePolicy", "AmazonEKSClusterPolicy",
+				"AmazonEKSClusterPolicy",
 			)))
 
 			checkARPD([]string{"EKS", "EKSFargatePods"}, clusterTemplate.Resources["ServiceRole"].Properties.AssumeRolePolicyDocument)

--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -14,7 +14,6 @@ import (
 )
 
 const (
-	iamPolicyAmazonEKSServicePolicy = "AmazonEKSServicePolicy"
 	iamPolicyAmazonEKSClusterPolicy = "AmazonEKSClusterPolicy"
 
 	iamPolicyAmazonEKSWorkerNodePolicy           = "AmazonEKSWorkerNodePolicy"
@@ -79,7 +78,6 @@ func (c *ClusterResourceSet) addResourcesForIAM() {
 			MakeServiceRef("EKSFargatePods"),
 		),
 		ManagedPolicyArns: makePolicyARNs(
-			iamPolicyAmazonEKSServicePolicy,
 			iamPolicyAmazonEKSClusterPolicy,
 		),
 	}


### PR DESCRIPTION
Remove AmazonEKSServicePolicy policy for service role

### Description

<!-- Please explain the changes you made here. -->

<details>
<summary>Before</summary>

```
$ ./eksctl create cluster                                  
[ℹ]  eksctl version 0.17.0-dev+27dfa8de.2020-04-07T22:31:32Z
[ℹ]  using region us-east-2
[ℹ]  setting availability zones to [us-east-2a us-east-2c us-east-2b]
[ℹ]  subnets for us-east-2a - public:192.168.0.0/19 private:192.168.96.0/19
[ℹ]  subnets for us-east-2c - public:192.168.32.0/19 private:192.168.128.0/19
[ℹ]  subnets for us-east-2b - public:192.168.64.0/19 private:192.168.160.0/19
[ℹ]  nodegroup "ng-983654dc" will use "ami-0da2b71057dfd9557" [AmazonLinux2/1.15]
[ℹ]  using Kubernetes version 1.15
[ℹ]  creating EKS cluster "extravagant-painting-1586262707" in "us-east-2" region with un-managed nodes
[ℹ]  will create 2 separate CloudFormation stacks for cluster itself and the initial nodegroup
[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-east-2 --cluster=extravagant-painting-1586262707'
[ℹ]  CloudWatch logging will not be enabled for cluster "extravagant-painting-1586262707" in "us-east-2"
[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --region=us-east-2 --cluster=extravagant-painting-1586262707'
[ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "extravagant-painting-1586262707" in "us-east-2"
[ℹ]  2 sequential tasks: { create cluster control plane "extravagant-painting-1586262707", create nodegroup "ng-983654dc" }
[ℹ]  building cluster stack "eksctl-extravagant-painting-1586262707-cluster"
[ℹ]  deploying stack "eksctl-extravagant-painting-1586262707-cluster"
[✖]  unexpected status "ROLLBACK_IN_PROGRESS" while waiting for CloudFormation stack "eksctl-extravagant-painting-1586262707-cluster"
[ℹ]  fetching stack events in attempt to troubleshoot the root cause of the failure
[✖]  AWS::EC2::SubnetRouteTableAssociation/RouteTableAssociationPrivateUSEAST2C: CREATE_FAILED – "Resource creation cancelled"
[✖]  AWS::EC2::SubnetRouteTableAssociation/RouteTableAssociationPublicUSEAST2B: CREATE_FAILED – "Resource creation cancelled"
[✖]  AWS::EC2::SubnetRouteTableAssociation/RouteTableAssociationPublicUSEAST2A: CREATE_FAILED – "Resource creation cancelled"
[✖]  AWS::EC2::NatGateway/NATGateway: CREATE_FAILED – "Resource creation cancelled"
[✖]  AWS::EC2::SubnetRouteTableAssociation/RouteTableAssociationPrivateUSEAST2A: CREATE_FAILED – "Resource creation cancelled"
[✖]  AWS::EC2::SubnetRouteTableAssociation/RouteTableAssociationPublicUSEAST2C: CREATE_FAILED – "Resource creation cancelled"
[✖]  AWS::EC2::SubnetRouteTableAssociation/RouteTableAssociationPrivateUSEAST2B: CREATE_FAILED – "Resource creation cancelled"
[✖]  AWS::EKS::Cluster/ControlPlane: CREATE_FAILED – "Role with arn: arn:aws:iam::363193625107:role/eksctl-extravagant-painting-1586262707-ServiceRole-74T1LFHBO801, could not be assumed because it does not exist or the trusted entity is not correct (Service: AmazonEKS; Status Code: 400; Error Code: InvalidParameterException; Request ID: 3112b6f3-7a5a-4feb-b044-c63c19b59260)"
[ℹ]  1 error(s) occurred and cluster hasn't been created properly, you may wish to check CloudFormation console
[ℹ]  to cleanup resources, run 'eksctl delete cluster --region=us-east-2 --name=extravagant-painting-1586262707'
[✖]  waiting for CloudFormation stack "eksctl-extravagant-painting-1586262707-cluster": ResourceNotReady: failed waiting for successful resource state
Error: failed to create cluster "extravagant-painting-1586262707"
```

</details>

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
