### PR TITLE
Update Flux and Helm Operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/dave/jennifer v1.3.0
 	github.com/dlespiau/kube-test-harness v0.0.0-20190930170435-ec3f93e1a754
 	github.com/evanphx/json-patch v4.5.0+incompatible
-	github.com/fluxcd/flux/pkg/install v0.0.0-20200206191601-8b676b003ab0 // flux 1.18.0
-	github.com/fluxcd/helm-operator/pkg/install v0.0.0-20200213151218-f7e487142b46 // helm-operator 1.0.0-rc9
+	github.com/fluxcd/flux/pkg/install v0.0.0-20200402142123-873fb9300996 // flux 1.19.0
+	github.com/fluxcd/helm-operator/pkg/install v0.0.0-20200407140510-8d71b0072a3e // helm-operator 1.0.0
 	github.com/gobuffalo/envy v1.9.0 // indirect
 	github.com/gobwas/glob v0.2.3
 	github.com/gohugoio/hugo v0.68.0

--- a/go.sum
+++ b/go.sum
@@ -332,10 +332,10 @@ github.com/fatih/camelcase v0.0.0-20160318181535-f6a740d52f96/go.mod h1:yN2Sb0lF
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
-github.com/fluxcd/flux/pkg/install v0.0.0-20200206191601-8b676b003ab0 h1:HPX8m+SWDfRJaReoMUaJegrkbkPGAsQRXDq4y06FbUI=
-github.com/fluxcd/flux/pkg/install v0.0.0-20200206191601-8b676b003ab0/go.mod h1:F19jvpuZunZPI7JJcqHxu8eBbUzEbbyUpR84Z0G08oo=
-github.com/fluxcd/helm-operator/pkg/install v0.0.0-20200213151218-f7e487142b46 h1:KXR87Z2/Heu64MRvBxzcpXFJenr50XY1qn6u7yChSOE=
-github.com/fluxcd/helm-operator/pkg/install v0.0.0-20200213151218-f7e487142b46/go.mod h1:sVoV/NqClg8zFoK5a4nfts0aBq0fLrQO+LoNkfOxx1U=
+github.com/fluxcd/flux/pkg/install v0.0.0-20200402142123-873fb9300996 h1:Fhxaa1iYgpAkoSJaIpNjn/nAFHSLg6dEFxNJSNl5S44=
+github.com/fluxcd/flux/pkg/install v0.0.0-20200402142123-873fb9300996/go.mod h1:F19jvpuZunZPI7JJcqHxu8eBbUzEbbyUpR84Z0G08oo=
+github.com/fluxcd/helm-operator/pkg/install v0.0.0-20200407140510-8d71b0072a3e h1:1Lye+YFYfaejOaZ4Uunl5APc/Sjtdj0yMv3/tXhMGcU=
+github.com/fluxcd/helm-operator/pkg/install v0.0.0-20200407140510-8d71b0072a3e/go.mod h1:sVoV/NqClg8zFoK5a4nfts0aBq0fLrQO+LoNkfOxx1U=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fortytw2/leaktest v1.2.0 h1:cj6GCiwJDH7l3tMHLjZDo0QqPtrXJiWSI9JgpeQKw+Q=
 github.com/fortytw2/leaktest v1.2.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=

--- a/integration/matchers/flux.go
+++ b/integration/matchers/flux.go
@@ -160,7 +160,7 @@ func assertValidFluxDeploymentManifest(fileName string) {
 			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 			container := deployment.Spec.Template.Spec.Containers[0]
 			Expect(container.Name).To(Equal("flux"))
-			Expect(container.Image).To(Equal("docker.io/fluxcd/flux:1.18.0"))
+			Expect(container.Image).To(Equal("docker.io/fluxcd/flux:1.19.0"))
 		} else {
 			Fail(fmt.Sprintf("Unsupported Kubernetes object. Got %s object with version %s in: %s", gvk.Kind, gvk.Version, fileName))
 		}
@@ -334,7 +334,7 @@ func assertValidHelmOperatorDeployment(fileName string) {
 			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 			container := deployment.Spec.Template.Spec.Containers[0]
 			Expect(container.Name).To(Equal("flux-helm-operator"))
-			Expect(container.Image).To(Equal("docker.io/fluxcd/helm-operator:1.0.0-rc9"))
+			Expect(container.Image).To(Equal("docker.io/fluxcd/helm-operator:1.0.0"))
 		} else {
 			Fail(fmt.Sprintf("Unsupported Kubernetes object. Got %s object with version %s in: %s", gvk.Kind, gvk.Version, fileName))
 		}


### PR DESCRIPTION
This PR updates the GitOps operators to latest GA releases:
- Flux v1.19.0 [changelog](https://github.com/fluxcd/flux/blob/master/CHANGELOG.md#1190-2020-04-02)
- Helm Operator v1.0.0 [changelog](https://github.com/fluxcd/helm-operator/blob/master/CHANGELOG.md#100-2020-04-07)

