### PR TITLE
Add nodes-min and nodes-max flags in ng scale

### DIFF
--- a/integration/tests/backwards_compat/backwards_compatibility_test.go
+++ b/integration/tests/backwards_compat/backwards_compatibility_test.go
@@ -109,7 +109,9 @@ var _ = Describe("(Integration) [Backwards compatibility test]", func() {
 		By("scaling the initial nodegroup")
 		cmd = params.EksctlScaleNodeGroupCmd.WithArgs(
 			"--cluster", params.ClusterName,
+			"--nodes-min", "2",
 			"--nodes", "3",
+			"--nodes-max", "4",
 			"--name", initialNgName,
 		)
 		Expect(cmd).To(RunSuccessfully())

--- a/integration/tests/crud/creategetdelete_test.go
+++ b/integration/tests/crud/creategetdelete_test.go
@@ -138,7 +138,9 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 			It("should not return an error", func() {
 				cmd := params.EksctlScaleNodeGroupCmd.WithArgs(
 					"--cluster", params.ClusterName,
+					"--nodes-min", "3",
 					"--nodes", "4",
+					"--nodes-max", "5",
 					"--name", initNG,
 				)
 				Expect(cmd).To(RunSuccessfully())
@@ -829,7 +831,9 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 			It("should not return an error", func() {
 				cmd := params.EksctlScaleNodeGroupCmd.WithArgs(
 					"--cluster", params.ClusterName,
+					"--nodes-min", "1",
 					"--nodes", "1",
+					"--nodes-max", "1",
 					"--name", initNG,
 				)
 				Expect(cmd).To(RunSuccessfully())

--- a/integration/tests/managed/managed_nodegroup_test.go
+++ b/integration/tests/managed/managed_nodegroup_test.go
@@ -103,7 +103,9 @@ var _ = Describe("(Integration) Create Managed Nodegroups", func() {
 			It("should not return an error", func() {
 				cmd := params.EksctlScaleNodeGroupCmd.WithArgs(
 					"--cluster", params.ClusterName,
+					"--nodes-min", "2",
 					"--nodes", "3",
+					"--nodes-max", "4",
 					"--name", initialNodeGroup,
 				)
 				Expect(cmd).To(RunSuccessfully())

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -211,7 +211,7 @@ func (c *StackCollection) ScaleNodeGroup(ng *api.NodeGroup) error {
 	}
 
 	// Set the new values
-	maybeUpdateField := func(path, fieldName string, newVal *int, oldVal gjson.Result) error {
+	updateField := func(path, fieldName string, newVal *int, oldVal gjson.Result) error {
 		if !hasChanged(newVal, oldVal) {
 			return nil
 		}
@@ -223,15 +223,15 @@ func (c *StackCollection) ScaleNodeGroup(ng *api.NodeGroup) error {
 		return nil
 	}
 
-	if err := maybeUpdateField(desiredCapacityPath, "desired capacity", ng.DesiredCapacity, currentCapacity); err != nil {
+	if err := updateField(desiredCapacityPath, "desired capacity", ng.DesiredCapacity, currentCapacity); err != nil {
 		return err
 	}
 
-	if err := maybeUpdateField(minSizePath, "min size", ng.MinSize, currentMinSize); err != nil {
+	if err := updateField(minSizePath, "min size", ng.MinSize, currentMinSize); err != nil {
 		return err
 	}
 
-	if err := maybeUpdateField(maxSizePath, "max size", ng.MaxSize, currentMaxSize); err != nil {
+	if err := updateField(maxSizePath, "max size", ng.MaxSize, currentMaxSize); err != nil {
 		return err
 	}
 	logger.Debug("stack template (post-scale change): %s", template)

--- a/pkg/cfn/manager/nodegroup_test.go
+++ b/pkg/cfn/manager/nodegroup_test.go
@@ -81,7 +81,7 @@ var _ = Describe("StackCollection NodeGroup", func() {
 								"Properties": {
 									"DesiredCapacity": 2,
 									"MinSize": 1,
-									"MaxSize: 3
+									"MaxSize": 3
 								}
 							}
 						}
@@ -93,10 +93,58 @@ var _ = Describe("StackCollection NodeGroup", func() {
 				ng.Name = "12345"
 				capacity := 2
 				ng.DesiredCapacity = &capacity
-
 				err := sc.ScaleNodeGroup(ng)
-
 				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should be a no-op if attempting to scale to the existing desired capacity, min size", func() {
+				ng.Name = "12345"
+				minSize := 1
+				capacity := 2
+				ng.MinSize = &minSize
+				ng.DesiredCapacity = &capacity
+				err := sc.ScaleNodeGroup(ng)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should be a no-op if attempting to scale to the existing desired capacity, max size", func() {
+				ng.Name = "12345"
+				capacity := 2
+				maxSize := 3
+				ng.DesiredCapacity = &capacity
+				ng.MaxSize = &maxSize
+				err := sc.ScaleNodeGroup(ng)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should be a no-op if attempting to scale to the existing desired capacity, min size and max size", func() {
+				ng.Name = "12345"
+				minSize := 1
+				capacity := 2
+				maxSize := 3
+				ng.MinSize = &minSize
+				ng.DesiredCapacity = &capacity
+				ng.MaxSize = &maxSize
+				err := sc.ScaleNodeGroup(ng)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should be a error if the desired capacity is greater than current CF maxSize", func() {
+				ng.Name = "12345"
+				capacity := 5
+				ng.DesiredCapacity = &capacity
+				err := sc.ScaleNodeGroup(ng)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("the desired nodes 5 is greater than current nodes-max/maxSize 3"))
+			})
+
+			It("should be a error if the desired capacity is less than current CF minSize", func() {
+				ng.Name = "12345"
+				capacity := 0
+				ng.DesiredCapacity = &capacity
+				err := sc.ScaleNodeGroup(ng)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("the desired nodes 0 is less than current nodes-min/minSize 1"))
 			})
 		})
 	})

--- a/pkg/ctl/scale/nodegroup.go
+++ b/pkg/ctl/scale/nodegroup.go
@@ -11,6 +11,12 @@ import (
 )
 
 func scaleNodeGroupCmd(cmd *cmdutils.Cmd) {
+	scaleNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *api.NodeGroup) error {
+		return doScaleNodeGroup(cmd, ng)
+	})
+}
+
+func scaleNodeGroupWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, ng *api.NodeGroup) error) {
 	cfg := api.NewClusterConfig()
 	ng := cfg.NewNodeGroup()
 	cmd.ClusterConfig = cfg
@@ -19,17 +25,26 @@ func scaleNodeGroupCmd(cmd *cmdutils.Cmd) {
 
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return doScaleNodeGroup(cmd, ng)
+		return runFunc(cmd, ng)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")
 		fs.StringVarP(&ng.Name, "name", "n", "", "Name of the nodegroup to scale")
 
-		desiredCapacity := fs.IntP("nodes", "N", -1, "total number of nodes (scale to this number)")
+		desiredCapacity := fs.IntP("nodes", "N", -1, "desired number of nodes (required)")
+		maxCapacity := fs.IntP("nodes-max", "M", -1, "maximum number of nodes")
+		minCapacity := fs.IntP("nodes-min", "m", -1, "minimum number of nodes")
+
 		cmdutils.AddPreRun(cmd.CobraCommand, func(cobraCmd *cobra.Command, args []string) {
 			if f := cobraCmd.Flag("nodes"); f.Changed {
 				ng.DesiredCapacity = desiredCapacity
+			}
+			if f := cobraCmd.Flag("nodes-max"); f.Changed {
+				ng.MaxSize = maxCapacity
+			}
+			if f := cobraCmd.Flag("nodes-min"); f.Changed {
+				ng.MinSize = minCapacity
 			}
 		})
 
@@ -60,6 +75,30 @@ func doScaleNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup) error {
 		return cmdutils.ErrMustBeSet("--name")
 	}
 
+	if ng.DesiredCapacity == nil || *ng.DesiredCapacity < 0 {
+		return fmt.Errorf("number of nodes must be 0 or greater. Use the --nodes/-N flag")
+	}
+
+	if ng.MaxSize != nil && *ng.MaxSize < 0 {
+		return fmt.Errorf("maximum number of nodes must be 0 or greater. Use the --nodes-max flag")
+	}
+
+	if ng.MaxSize != nil && ng.MinSize != nil && (*ng.MinSize > *ng.DesiredCapacity || *ng.MaxSize < *ng.DesiredCapacity) {
+		return fmt.Errorf("number of nodes must be within range of min nodes and max nodes")
+	}
+
+	if ng.MaxSize != nil && *ng.MaxSize < *ng.DesiredCapacity {
+		return fmt.Errorf("maximum number of nodes must be greater than or equal to number of nodes")
+	}
+
+	if ng.MinSize != nil && *ng.MinSize < 0 {
+		return fmt.Errorf("minimum number of nodes must be 0 or greater. Use the --nodes-min flag")
+	}
+
+	if ng.MinSize != nil && *ng.MinSize > *ng.DesiredCapacity {
+		return fmt.Errorf("minimum number of nodes must be less than or equal to number of nodes")
+	}
+
 	ctl, err := cmd.NewCtl()
 	if err != nil {
 		return err
@@ -67,10 +106,6 @@ func doScaleNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup) error {
 
 	if err := ctl.CheckAuth(); err != nil {
 		return err
-	}
-
-	if ng.DesiredCapacity == nil || *ng.DesiredCapacity < 0 {
-		return fmt.Errorf("number of nodes must be 0 or greater. Use the --nodes/-N flag")
 	}
 
 	stackManager := ctl.NewStackManager(cfg)

--- a/pkg/ctl/scale/nodegroup_test.go
+++ b/pkg/ctl/scale/nodegroup_test.go
@@ -1,0 +1,80 @@
+package scale
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/extensions/table"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+var _ = Describe("scale", func() {
+	Describe("nodegroup", func() {
+		DescribeTable("create cluster successfully",
+			func(args ...string) {
+				cmd := newMockEmptyCmd(args...)
+				count := 0
+				cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+					scaleNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *v1alpha5.NodeGroup) error {
+						Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+						Expect(ng.Name).To(Equal("nodeGroup"))
+						Expect(*ng.DesiredCapacity).To(Equal(2))
+						count++
+						return nil
+					})
+				})
+				_, err := cmd.execute()
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(count).To(Equal(1))
+			},
+			Entry("with all the valid flags", "nodegroup", "--cluster", "clusterName", "--name", "nodeGroup", "--nodes", "2", "--nodes-max", "3", "--nodes-min", "1"),
+			Entry("without --nodes-min flags", "nodegroup", "--cluster", "clusterName", "--name", "nodeGroup", "--nodes", "2", "--nodes-max", "3"),
+			Entry("without --nodes-max flags", "nodegroup", "--cluster", "clusterName", "--name", "nodeGroup", "--nodes", "2", "--nodes-min", "1"),
+		)
+
+		DescribeTable("invalid flags or arguments",
+			func(c invalidParamsCase) {
+				cmd := newDefaultCmd(c.args...)
+				_, err := cmd.execute()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal(c.error.Error()))
+			},
+			Entry("missing required flag --cluster", invalidParamsCase{
+				args:  []string{"nodegroup"},
+				error: fmt.Errorf("--cluster must be set"),
+			}),
+			Entry("setting --name and argument at the same time", invalidParamsCase{
+				args:  []string{"nodegroup", "ng", "--cluster", "dummy", "--name", "ng"},
+				error: fmt.Errorf("--name=ng and argument ng cannot be used at the same time"),
+			}),
+			Entry("missing required nodes flag --nodes", invalidParamsCase{
+				args:  []string{"nodegroup", "ng", "--cluster", "dummy"},
+				error: fmt.Errorf("number of nodes must be 0 or greater. Use the --nodes/-N flag"),
+			}),
+			Entry("invalid flag", invalidParamsCase{
+				args:  []string{"nodegroup", "--invalid", "dummy"},
+				error: fmt.Errorf("unknown flag: --invalid"),
+			}),
+			Entry("desired node less than min nodes", invalidParamsCase{
+				args:  []string{"nodegroup", "ng", "--cluster", "dummy", "--nodes", "2", "--nodes-min", "3"},
+				error: fmt.Errorf("minimum number of nodes must be less than or equal to number of nodes"),
+			}),
+
+			Entry("desired node greater than max nodes", invalidParamsCase{
+				args:  []string{"nodegroup", "ng", "--cluster", "dummy", "--nodes", "2", "--nodes-max", "1"},
+				error: fmt.Errorf("maximum number of nodes must be greater than or equal to number of nodes"),
+			}),
+			Entry("desired node less than min nodes", invalidParamsCase{
+				args:  []string{"nodegroup", "ng", "--cluster", "dummy", "--nodes", "2", "--nodes-min", "3"},
+				error: fmt.Errorf("minimum number of nodes must be less than or equal to number of nodes"),
+			}),
+			Entry("desired node outside the range [min, max]", invalidParamsCase{
+				args:  []string{"nodegroup", "ng", "--cluster", "dummy", "--nodes", "2", "--nodes-min", "1", "--nodes-max", "1"},
+				error: fmt.Errorf("number of nodes must be within range of min nodes and max nodes"),
+			}),
+		)
+	})
+})

--- a/pkg/ctl/scale/scale_test.go
+++ b/pkg/ctl/scale/scale_test.go
@@ -2,42 +2,61 @@ package scale
 
 import (
 	"bytes"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
+type invalidParamsCase struct {
+	args   []string
+	error  error
+	output string
+}
+
 var _ = Describe("generate", func() {
 	Describe("invalid-resource", func() {
-		It("with no flag", func() {
-			cmd := newMockCmd("invalid-resource")
-			out, err := cmd.execute()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"scale\""))
-			Expect(out).To(ContainSubstring("usage"))
-		})
-		It("with invalid-resource and some flag", func() {
-			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
-			out, err := cmd.execute()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"scale\""))
-			Expect(out).To(ContainSubstring("usage"))
-		})
-		It("with invalid-resource and additional argument", func() {
-			cmd := newMockCmd("invalid-resource", "foo")
-			out, err := cmd.execute()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"scale\""))
-			Expect(out).To(ContainSubstring("usage"))
-		})
+		DescribeTable("invalid flags or arguments",
+			func(c invalidParamsCase) {
+				cmd := newDefaultCmd(c.args...)
+				out, err := cmd.execute()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal(c.error.Error()))
+				Expect(out).To(ContainSubstring(c.output))
+			},
+			Entry("missing required flag --cluster", invalidParamsCase{
+				args:   []string{"invalid-resource"},
+				error:  fmt.Errorf("unknown command \"invalid-resource\" for \"scale\""),
+				output: "usage",
+			}),
+			Entry("with invalid-resource and some flag", invalidParamsCase{
+				args:   []string{"invalid-resource", "--invalid-flag", "foo"},
+				error:  fmt.Errorf("unknown command \"invalid-resource\" for \"scale\""),
+				output: "usage",
+			}),
+			Entry("with invalid-resource and additional argument", invalidParamsCase{
+				args:   []string{"invalid-resource", "foo"},
+				error:  fmt.Errorf("unknown command \"invalid-resource\" for \"scale\""),
+				output: "usage",
+			}),
+		)
 	})
 })
 
-func newMockCmd(args ...string) *mockVerbCmd {
+func newDefaultCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
 	cmd := Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+func newMockEmptyCmd(args ...string) *mockVerbCmd {
+	cmd := cmdutils.NewVerbCmd("scale", "Scale resources(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/userdocs/src/usage/eks-managed-nodes.md
+++ b/userdocs/src/usage/eks-managed-nodes.md
@@ -162,7 +162,7 @@ eksctl get labels --cluster managed-cluster --nodegroup managed-ng-1
 the same.
 
 ```console
-eksctl scale nodegroup --name=managed-ng-1 --cluster=managed-cluster --nodes=4
+eksctl scale nodegroup --name=managed-ng-1 --cluster=managed-cluster --nodes=4 --nodes-min=3 --nodes-max=5
 ```
 
 

--- a/userdocs/src/usage/managing-nodegroups.md
+++ b/userdocs/src/usage/managing-nodegroups.md
@@ -116,7 +116,7 @@ load and delete the old one. Check [Deleting and draining](#deleting-and-drainin
 A nodegroup can be scaled by using the `eksctl scale nodegroup` command:
 
 ```
-eksctl scale nodegroup --cluster=<clusterName> --nodes=<desiredCount> --name=<nodegroupName>
+eksctl scale nodegroup --cluster=<clusterName> --nodes=<desiredCount> --name=<nodegroupName> [ --nodes-min=<minSize> ] [ --nodes-max=<maxSize> ]
 ```
 
 For example, to scale nodegroup `ng-a345f4e1` in `cluster-1` to 5 nodes, run:
@@ -125,7 +125,8 @@ For example, to scale nodegroup `ng-a345f4e1` in `cluster-1` to 5 nodes, run:
 eksctl scale nodegroup --cluster=cluster-1 --nodes=5 ng-a345f4e1
 ```
 
-If the desired number of nodes is greater than the current maximum set on the ASG then the maximum value will be increased to match the number of requested nodes. And likewise for the minimum.
+If the desired number of nodes is `NOT` within the range of current minimum and current maximum nodes, one specific error will be shown.
+Kindly note that these values can also be passed with flags `--nodes-min` and `--nodes-max` respectively.
 
 Scaling a nodegroup works by modifying the nodegroup CloudFormation stack via a ChangeSet.
 


### PR DESCRIPTION
### Description

Fixes https://github.com/weaveworks/eksctl/issues/1893
Fixes https://github.com/weaveworks/eksctl/issues/809

### Approach

I am having below assumptions/scopes while implementing this feature.
- `--nodes` flag is mandatory flag
- following `fail fast` approach i.e. if there is anything wrong with input, just throw error instead of waiting for error from CF.
- supporting for configuration file will be done later in separate PR. I would like to hear your inputs if I am going with right direction firstly.

### Testing

<details>
<summary>invalid flag values</summary>

```shell script
$ ./eksctl scale ng --cluster amazing-sculpture-1586756685 ng-89ba46f7 --nodes 2 --nodes-max 1 --nodes-min 1
Error: number of nodes must be within range of min nodes and max nodes

$ ./eksctl scale ng --cluster amazing-sculpture-1586756685 ng-89ba46f7 --nodes 2 --nodes-max 1              
Error: maximum number of nodes must be greater than or equal to number of nodes

$ ./eksctl scale ng --cluster amazing-sculpture-1586756685 ng-89ba46f7 --nodes 2 --nodes-min 3
Error: minimum number of nodes must be less than or equal to number of nodes

```

</details>

<details>
<summary>no change in current value</summary>

```shell script
$ ./eksctl scale ng --cluster amazing-sculpture-1586756685 ng-89ba46f7 --nodes 2                            
[ℹ]  scaling nodegroup stack "eksctl-amazing-sculpture-1586756685-nodegroup-ng-89ba46f7" in cluster eksctl-amazing-sculpture-1586756685-cluster
[ℹ]  no change for nodegroup "ng-89ba46f7" in cluster "eksctl-amazing-sculpture-1586756685-cluster": nodes-min 2, desired 2, nodes-max 2

$ ./eksctl scale ng --cluster amazing-sculpture-1586756685 ng-89ba46f7 --nodes 2 --nodes-min 2              
[ℹ]  scaling nodegroup stack "eksctl-amazing-sculpture-1586756685-nodegroup-ng-89ba46f7" in cluster eksctl-amazing-sculpture-1586756685-cluster
[ℹ]  no change for nodegroup "ng-89ba46f7" in cluster "eksctl-amazing-sculpture-1586756685-cluster": nodes-min 2, desired 2, nodes-max 2

$ ./eksctl scale ng --cluster amazing-sculpture-1586756685 ng-89ba46f7 --nodes 2 --nodes-max 2
[ℹ]  scaling nodegroup stack "eksctl-amazing-sculpture-1586756685-nodegroup-ng-89ba46f7" in cluster eksctl-amazing-sculpture-1586756685-cluster
[ℹ]  no change for nodegroup "ng-89ba46f7" in cluster "eksctl-amazing-sculpture-1586756685-cluster": nodes-min 2, desired 2, nodes-max 2

$ ./eksctl scale ng --cluster amazing-sculpture-1586756685 ng-89ba46f7 --nodes 2 --nodes-min 2 --nodes-max 2
[ℹ]  scaling nodegroup stack "eksctl-amazing-sculpture-1586756685-nodegroup-ng-89ba46f7" in cluster eksctl-amazing-sculpture-1586756685-cluster
[ℹ]  no change for nodegroup "ng-89ba46f7" in cluster "eksctl-amazing-sculpture-1586756685-cluster": nodes-min 2, desired 2, nodes-max 2
```

</details>

<details>
<summary>some changes with desired node, min or max</summary>

```shell script
$ ./eksctl scale ng --cluster amazing-sculpture-1586756685 ng-89ba46f7 --nodes 2 --nodes-min 1
[ℹ]  scaling nodegroup stack "eksctl-amazing-sculpture-1586756685-nodegroup-ng-89ba46f7" in cluster eksctl-amazing-sculpture-1586756685-cluster
[ℹ]  scaling nodegroup, min size from 2 to 1

$ ./eksctl scale ng --cluster amazing-sculpture-1586756685 ng-89ba46f7 --nodes 2 --nodes-max 3
[ℹ]  scaling nodegroup stack "eksctl-amazing-sculpture-1586756685-nodegroup-ng-89ba46f7" in cluster eksctl-amazing-sculpture-1586756685-cluster
[ℹ]  scaling nodegroup, max size from 2 to 3

$ ./eksctl scale ng --cluster amazing-sculpture-1586756685 ng-89ba46f7 --nodes 2 --nodes-min 2 --nodes-max 2
[ℹ]  scaling nodegroup stack "eksctl-amazing-sculpture-1586756685-nodegroup-ng-89ba46f7" in cluster eksctl-amazing-sculpture-1586756685-cluster
[ℹ]  scaling nodegroup, min size from 1 to 2, max size from 3 to 2
```

</details>

<details>
<summary>desired node is not within current range from CF</summary>

```shell scripts
$ ./eksctl scale ng --cluster amazing-sculpture-1586756685 ng-89ba46f7 --nodes 1
[ℹ]  scaling nodegroup stack "eksctl-amazing-sculpture-1586756685-nodegroup-ng-89ba46f7" in cluster eksctl-amazing-sculpture-1586756685-cluster
[!]  the desired nodes 1 is less than current nodes-min/minSize 2
Error: failed to scale nodegroup for cluster "amazing-sculpture-1586756685", error the desired nodes 1 is less than current nodes-min/minSize 2

$ ./eksctl scale ng --cluster amazing-sculpture-1586756685 ng-89ba46f7 --nodes 4
[ℹ]  scaling nodegroup stack "eksctl-amazing-sculpture-1586756685-nodegroup-ng-89ba46f7" in cluster eksctl-amazing-sculpture-1586756685-cluster
[!]  the desired nodes 4 is greater than current nodes-max/maxSize 2
Error: failed to scale nodegroup for cluster "amazing-sculpture-1586756685", error the desired nodes 4 is greater than current nodes-max/maxSize 2
```
</details>

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
