### PR TITLE
Support github action for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,59 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    name: Build binaries on ${{ matrix.target_os }}_${{ matrix.target_arch }}
+    runs-on: ${{ matrix.os }}
+    container: weaveworks/eksctl-build:63bb98c9599ef0b0cc8bc08f64b6d572765e160e
+    env:
+      GOVER: 1.13.9
+      GOOS: ${{ matrix.target_os }}
+      GOARCH: ${{ matrix.target_arch }}
+      GOPROXY: https://proxy.golang.org,direct
+    strategy:
+      matrix:
+        #os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest]
+        target_arch: [amd64]
+        include:
+          - os: ubuntu-latest
+            target_os: linux
+#          - os: macOS-latest
+#            target_os: darwin
+#          - os: windows-latest
+#            target_os: darwin
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: Check all generated files
+        run: make check-all-generated-files-up-to-date
+      - name: Run make test
+        run: make test
+        env:
+          JUNIT_REPORT_DIR: ${{ github.workspace }}/test-results
+      - name: Run make build
+        run: make build
+      - name: Run make build integration test
+        run: make build-integration-test
+      - name: Upload test result artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: test-results
+          path: test-results
+      - name: Upload eksctl artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: eksctl
+          path: eksctl
+      - name: Upload eksctl-integration artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: eksctl-integration-test
+          path: eksctl-integration-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,10 @@ on:
       - master
 jobs:
   build:
-    name: Build binaries on ${{ matrix.target_os }}_${{ matrix.target_arch }}
+    name: test-and-build ${{ matrix.target_os }}_${{ matrix.target_arch }}
     runs-on: ${{ matrix.os }}
     container: weaveworks/eksctl-build:63bb98c9599ef0b0cc8bc08f64b6d572765e160e
     env:
-      GOVER: 1.13.9
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org,direct


### PR DESCRIPTION
### Description

Fixes https://github.com/weaveworks/eksctl/issues/2028

Seems like github action is slightly faster compared to circle CI

**First build:**
GH (~ 8m): https://github.com/weaveworks/eksctl/pull/2029/checks?check_run_id=580611619 
CircleCI (~14m): https://circleci.com/gh/weaveworks/eksctl/7286#build-parameters/containers/0

**Subsequent build (I didn't cache anything for github action):**
GH (~8m): https://github.com/weaveworks/eksctl/pull/2029/checks?check_run_id=580626486
CircleCI (~14m): https://circleci.com/gh/weaveworks/eksctl/7287#build-parameters/containers/0


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
