### PR TITLE
Publish RCs to the homebrew tap

### DIFF
--- a/.goreleaser.brew.yml
+++ b/.goreleaser.brew.yml
@@ -18,3 +18,6 @@ brew:
   dependencies:
     - kubernetes-cli
     - aws-iam-authenticator
+
+  custom_block: |
+    head "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_Darwin_amd64.tar.gz"

--- a/do-release-candidate.sh
+++ b/do-release-candidate.sh
@@ -11,6 +11,20 @@ if [ -z "${CIRCLE_PULL_REQUEST}" ] && [ -n "${CIRCLE_TAG}" ] && [ "${CIRCLE_PROJ
 
   goreleaser release --skip-validate --config=./.goreleaser.yml --release-notes="${RELEASE_NOTES_FILE}"
 
+  # By moving the latest_release tag to the latest release candidate we ensure the rc is accessible through
+  # the `head` statement in the brew tap formula
+  sleep 90 # GitHub API resolves the time to the nearest minute, so in order to control the sorting oder we need this
+
+  git tag --delete "${CIRCLE_TAG}"
+  git tag --force latest_release
+
+  if github-release info --user weaveworks --repo "${CIRCLE_PROJECT_REPONAME}" --tag latest_release > /dev/null 2>&1 ; then
+    github-release delete --user weaveworks --repo "${CIRCLE_PROJECT_REPONAME}" --tag latest_release
+  fi
+
+  export RELEASE_DESCRIPTION="${CIRCLE_TAG}"
+  goreleaser release --skip-validate --rm-dist --config=./.goreleaser.yml --release-notes="${RELEASE_NOTES_FILE}"
+
 else
   echo "Not a tag release, skip publish"
 fi

--- a/tag-release-candidate.sh
+++ b/tag-release-candidate.sh
@@ -55,7 +55,7 @@ git add "${RELEASE_NOTES_FILE}"
 m="Tag ${full_version} release candidate"
 
 git commit --message "${m}"
-git push origin "${release_branch}"
+git tag --annotate --message "${m}" --force "latest_release"
 git tag --annotate --message "${m}" "${full_version}"
 git push origin "${full_version}"
 


### PR DESCRIPTION
With this change when we publich a release candidate it will also be published in Weaveworks homebrew tap.

closes #2010 

- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->