### PR TITLE
Separate downloaded files from generated ones in Makefile

### DIFF
--- a/pkg/addons/default/aws_node_generate.go
+++ b/pkg/addons/default/aws_node_generate.go
@@ -1,0 +1,3 @@
+package defaultaddons
+
+//go:generate curl --silent --location https://github.com/aws/amazon-vpc-cni-k8s/blob/61c8d18c0e097c0b7e8477e1afc61d6f2601295d/config/v1.6/aws-k8s-cni.yaml?raw=1 --output assets/aws-node.yaml

--- a/pkg/addons/default/generate.go
+++ b/pkg/addons/default/generate.go
@@ -1,5 +1,3 @@
 package defaultaddons
 
-//go:generate curl --silent --location https://github.com/aws/amazon-vpc-cni-k8s/blob/61c8d18c0e097c0b7e8477e1afc61d6f2601295d/config/v1.6/aws-k8s-cni.yaml?raw=1 --output assets/aws-node.yaml
-
 //go:generate ${GOBIN}/go-bindata -pkg ${GOPACKAGE} -prefix assets -nometadata -o assets.go assets

--- a/pkg/nodebootstrap/maxpods_generate.go
+++ b/pkg/nodebootstrap/maxpods_generate.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"strconv"
@@ -16,6 +17,7 @@ import (
 const maxPodsPerNodeTypeSourceText = "https://raw.github.com/awslabs/amazon-eks-ami/master/files/eni-max-pods.txt"
 
 func main() {
+	fmt.Println("Generating maxpods.go file...")
 	maxPodsMap := generateMap()
 	renderGoMap(maxPodsMap)
 }

--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -16,7 +16,6 @@ import (
 )
 
 //go:generate ${GOBIN}/go-bindata -pkg ${GOPACKAGE} -prefix assets -nometadata -o assets.go assets
-//go:generate go run ./maxpods_generate.go
 
 const (
 	configDir            = "/etc/eksctl/"

--- a/tools/brew/update_formula.go
+++ b/tools/brew/update_formula.go
@@ -24,7 +24,6 @@ type formulaFile struct {
 	URL      string
 }
 
-// TODO move to tools/homebrew folder instead
 func main() {
 	var formula formula
 


### PR DESCRIPTION
This only forces generated files to be up to date before building. Files
that are downloaded should be updated consciously and not in every PR.
This makes sure that the build pipeline doesn't block PRs when new
instances are published (for maxpods), for example.

Triggered by https://github.com/weaveworks/eksctl/issues/2037
Possible fix for https://github.com/weaveworks/eksctl/issues/1608
Supersedes https://github.com/weaveworks/eksctl/pull/1819

- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes
- [ ] close #1819 if this is approved

<!-- If you haven't done so already, you can add your name to the humans.txt file -->