### PR TITLE
Correct error message for create/delete/drain nodegroup

### DIFF
--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -310,7 +310,7 @@ func NewCreateNodeGroupLoader(cmd *Cmd, ng *api.NodeGroup, ngFilter *NodeGroupFi
 			for _, ng := range l.ClusterConfig.ManagedNodeGroups {
 				ngName := names.ForNodeGroup(ng.Name, l.NameArg)
 				if ngName == "" {
-					return ErrClusterFlagAndArg(l.Cmd, ng.Name, l.NameArg)
+					return ErrFlagAndArg("--name", ng.Name, l.NameArg)
 				}
 				ng.Name = ngName
 			}
@@ -319,7 +319,7 @@ func NewCreateNodeGroupLoader(cmd *Cmd, ng *api.NodeGroup, ngFilter *NodeGroupFi
 				// generate nodegroup name or use either flag or argument
 				ngName := names.ForNodeGroup(ng.Name, l.NameArg)
 				if ngName == "" {
-					return ErrClusterFlagAndArg(l.Cmd, ng.Name, l.NameArg)
+					return ErrFlagAndArg("--name", ng.Name, l.NameArg)
 				}
 				ng.Name = ngName
 				if err := normalizeNodeGroup(ng, l); err != nil {

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -388,7 +388,7 @@ func NewDeleteNodeGroupLoader(cmd *Cmd, ng *api.NodeGroup, ngFilter *NodeGroupFi
 		}
 
 		if ng.Name != "" && l.NameArg != "" {
-			return ErrClusterFlagAndArg(l.Cmd, ng.Name, l.NameArg)
+			return ErrFlagAndArg("--name", ng.Name, l.NameArg)
 		}
 
 		if l.NameArg != "" {

--- a/pkg/ctl/create/nodegroup_test.go
+++ b/pkg/ctl/create/nodegroup_test.go
@@ -68,7 +68,7 @@ var _ = Describe("create nodegroup", func() {
 			}),
 			Entry("with nodegroup name as argument and flag", invalidParamsCase{
 				args:  []string{"nodegroupName", "--cluster", "clusterName", "--name", "nodegroupName"},
-				error: fmt.Errorf("--cluster=nodegroupName and argument nodegroupName cannot be used at the same time"),
+				error: fmt.Errorf("--name=nodegroupName and argument nodegroupName cannot be used at the same time"),
 			}),
 			Entry("with invalid flags", invalidParamsCase{
 				args:  []string{"nodegroup", "--invalid", "dummy"},
@@ -140,7 +140,7 @@ var _ = Describe("create nodegroup", func() {
 			},
 			Entry("with nodegroup name as argument and flag", invalidParamsCase{
 				args:  []string{"nodegroupName", "--name", "nodegroupName"},
-				error: fmt.Errorf("--cluster=nodegroupName and argument nodegroupName cannot be used at the same time"),
+				error: fmt.Errorf("--name=nodegroupName and argument nodegroupName cannot be used at the same time"),
 			}),
 			Entry("with invalid flags", invalidParamsCase{
 				args:  []string{"nodegroup", "--invalid", "dummy"},

--- a/pkg/ctl/delete/delete_suite_test.go
+++ b/pkg/ctl/delete/delete_suite_test.go
@@ -1,8 +1,9 @@
 package delete
 
 import (
-	"github.com/weaveworks/eksctl/pkg/testutils"
 	"testing"
+
+	"github.com/weaveworks/eksctl/pkg/testutils"
 )
 
 func TestSuite(t *testing.T) {

--- a/pkg/ctl/delete/delete_test.go
+++ b/pkg/ctl/delete/delete_test.go
@@ -2,6 +2,7 @@ package delete
 
 import (
 	"bytes"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
@@ -11,21 +12,21 @@ import (
 var _ = Describe("delete", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockVerbCmd("invalid-resource")
+			cmd := newDefaultCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"delete\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockVerbCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newDefaultCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"delete\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockVerbCmd("invalid-resource", "foo")
+			cmd := newDefaultCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"delete\""))
@@ -34,9 +35,17 @@ var _ = Describe("delete", func() {
 	})
 })
 
-func newMockVerbCmd(args ...string) *mockVerbCmd {
+func newDefaultCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
 	cmd := Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+func newMockEmptyCmd(args ...string) *mockVerbCmd {
+	cmd := cmdutils.NewVerbCmd("delete", "Delete resource(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/delete/fargate_test.go
+++ b/pkg/ctl/delete/fargate_test.go
@@ -2,6 +2,7 @@ package delete
 
 import (
 	"bytes"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -12,6 +12,12 @@ import (
 )
 
 func deleteNodeGroupCmd(cmd *cmdutils.Cmd) {
+	deleteNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *api.NodeGroup, updateAuthConfigMap, deleteNodeGroupDrain, onlyMissing bool) error {
+		return doDeleteNodeGroup(cmd, ng, updateAuthConfigMap, deleteNodeGroupDrain, onlyMissing)
+	})
+}
+
+func deleteNodeGroupWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, ng *api.NodeGroup, updateAuthConfigMap, deleteNodeGroupDrain, onlyMissing bool) error) {
 	cfg := api.NewClusterConfig()
 	ng := api.NewNodeGroup()
 	cmd.ClusterConfig = cfg
@@ -22,7 +28,7 @@ func deleteNodeGroupCmd(cmd *cmdutils.Cmd) {
 
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return doDeleteNodeGroup(cmd, ng, updateAuthConfigMap, deleteNodeGroupDrain, onlyMissing)
+		return runFunc(cmd, ng, updateAuthConfigMap, deleteNodeGroupDrain, onlyMissing)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/delete/nodegroup_test.go
+++ b/pkg/ctl/delete/nodegroup_test.go
@@ -2,6 +2,7 @@ package delete
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"

--- a/pkg/ctl/delete/nodegroupd_test.go
+++ b/pkg/ctl/delete/nodegroupd_test.go
@@ -1,0 +1,54 @@
+package delete
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+type invalidParamsCase struct {
+	args  []string
+	error error
+}
+
+var _ = Describe("delete", func() {
+	DescribeTable("drain node group successfully",
+		func(args ...string) {
+			cmd := newMockEmptyCmd(args...)
+			count := 0
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				deleteNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *v1alpha5.NodeGroup, updateAuthConfigMap, deleteNodeGroupDrain, onlyMissing bool) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(ng.Name).To(Equal("ng"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		},
+		Entry("with valid details", "nodegroup", "--cluster", "clusterName", "--name", "ng"),
+		Entry("with deprecated flag --only", "nodegroup", "--cluster", "clusterName", "--name", "ng", "--only", "ng"),
+	)
+
+	DescribeTable("invalid flags or arguments",
+		func(c invalidParamsCase) {
+			cmd := newDefaultCmd(c.args...)
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal(c.error.Error()))
+		},
+		Entry("missing required flag --cluster", invalidParamsCase{
+			args:  []string{"nodegroup"},
+			error: fmt.Errorf("--cluster must be set"),
+		}),
+		Entry("setting --name and argument at the same time", invalidParamsCase{
+			args:  []string{"nodegroup", "ng", "--cluster", "dummy", "--name", "ng"},
+			error: fmt.Errorf("--name=ng and argument ng cannot be used at the same time"),
+		}),
+	)
+})

--- a/pkg/ctl/drain/drain_suite_test.go
+++ b/pkg/ctl/drain/drain_suite_test.go
@@ -1,8 +1,9 @@
 package drain
 
 import (
-	"github.com/weaveworks/eksctl/pkg/testutils"
 	"testing"
+
+	"github.com/weaveworks/eksctl/pkg/testutils"
 )
 
 func TestSuite(t *testing.T) {

--- a/pkg/ctl/drain/drain_test.go
+++ b/pkg/ctl/drain/drain_test.go
@@ -2,6 +2,7 @@ package drain
 
 import (
 	"bytes"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
@@ -11,21 +12,21 @@ import (
 var _ = Describe("drain", func() {
 	Describe("invalid-resource", func() {
 		It("with no flag", func() {
-			cmd := newMockCmd("invalid-resource")
+			cmd := newDefaultCmd("invalid-resource")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"drain\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and some flag", func() {
-			cmd := newMockCmd("invalid-resource", "--invalid-flag", "foo")
+			cmd := newDefaultCmd("invalid-resource", "--invalid-flag", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"drain\""))
 			Expect(out).To(ContainSubstring("usage"))
 		})
 		It("with invalid-resource and additional argument", func() {
-			cmd := newMockCmd("invalid-resource", "foo")
+			cmd := newDefaultCmd("invalid-resource", "foo")
 			out, err := cmd.execute()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("unknown command \"invalid-resource\" for \"drain\""))
@@ -34,9 +35,17 @@ var _ = Describe("drain", func() {
 	})
 })
 
-func newMockCmd(args ...string) *mockVerbCmd {
+func newDefaultCmd(args ...string) *mockVerbCmd {
 	flagGrouping := cmdutils.NewGrouping()
 	cmd := Command(flagGrouping)
+	cmd.SetArgs(args)
+	return &mockVerbCmd{
+		parentCmd: cmd,
+	}
+}
+
+func newMockEmptyCmd(args ...string) *mockVerbCmd {
+	cmd := cmdutils.NewVerbCmd("get", "Get resource(s)", "")
 	cmd.SetArgs(args)
 	return &mockVerbCmd{
 		parentCmd: cmd,

--- a/pkg/ctl/drain/nodegroup.go
+++ b/pkg/ctl/drain/nodegroup.go
@@ -12,6 +12,12 @@ import (
 )
 
 func drainNodeGroupCmd(cmd *cmdutils.Cmd) {
+	drainNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *api.NodeGroup, undo, onlyMissing bool) error {
+		return doDrainNodeGroup(cmd, ng, undo, onlyMissing)
+	})
+}
+
+func drainNodeGroupWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, ng *api.NodeGroup, undo, onlyMissing bool) error) {
 	cfg := api.NewClusterConfig()
 	ng := cfg.NewNodeGroup()
 	cmd.ClusterConfig = cfg
@@ -22,7 +28,7 @@ func drainNodeGroupCmd(cmd *cmdutils.Cmd) {
 
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return doDrainNodeGroup(cmd, ng, undo, onlyMissing)
+		return runFunc(cmd, ng, undo, onlyMissing)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/drain/nodegroup_test.go
+++ b/pkg/ctl/drain/nodegroup_test.go
@@ -1,0 +1,57 @@
+package drain
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/onsi/ginkgo/extensions/table"
+
+	"github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+)
+
+type invalidParamsCase struct {
+	args  []string
+	error error
+}
+
+var _ = Describe("drain node group", func() {
+	DescribeTable("drain node group successfully",
+		func(args ...string) {
+			cmd := newMockEmptyCmd(args...)
+			count := 0
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				drainNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *v1alpha5.NodeGroup, undo, onlyMissing bool) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(ng.Name).To(Equal("ng"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		},
+		Entry("with valid details", "nodegroup", "--cluster", "clusterName", "--name", "ng"),
+		Entry("with deprecated flag --only", "nodegroup", "--cluster", "clusterName", "--name", "ng", "--only", "ng"),
+	)
+
+	DescribeTable("invalid flags or arguments",
+		func(c invalidParamsCase) {
+			cmd := newDefaultCmd(c.args...)
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal(c.error.Error()))
+		},
+		Entry("missing required flag --cluster", invalidParamsCase{
+			args:  []string{"nodegroup"},
+			error: fmt.Errorf("--cluster must be set"),
+		}),
+		Entry("setting --name and argument at the same time", invalidParamsCase{
+			args:  []string{"nodegroup", "ng", "--cluster", "dummy", "--name", "ng"},
+			error: fmt.Errorf("--name=ng and argument ng cannot be used at the same time"),
+		}),
+	)
+})


### PR DESCRIPTION
### Description

Fixes https://github.com/weaveworks/eksctl/issues/1782

<details>
<summary>before</summary>

```shell script
$ ./eksctl delete nodegroup --cluster dummyCluster --name ng ng --region us-east-2  
Error: --cluster=ng and argument ng cannot be used at the same time

$  ./eksctl drain nodegroup --cluster dummyCluster --name ng ng --region us-east-2
Error: --cluster=ng and argument ng cannot be used at the same time

$ ./eksctl create nodegroup --cluster dummy --name dummy dummy
Error: --cluster=dummy and argument dummy cannot be used at the same time

```
</details>

<details>
<summary>after</summary>

```shell script
$ ./eksctl delete nodegroup --cluster dummyCluster --name ng ng --region us-east-2       
Error: --name=ng and argument ng cannot be used at the same time

$ ./eksctl drain nodegroup --cluster dummyCluster --name ng ng --region us-east-2
Error: --name=ng and argument ng cannot be used at the same time

$ ./eksctl create nodegroup --cluster dummyCluster --name dummy dummy
Error: --name=dummy and argument dummy cannot be used at the same time

```
</details>



### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
