### PR TITLE
Support private networking for managed nodegroups

### DIFF
--- a/examples/15-managed-nodes.yaml
+++ b/examples/15-managed-nodes.yaml
@@ -8,7 +8,7 @@ metadata:
   region: us-west-2
 
 managedNodeGroups:
-  - name: managed-1
+  - name: managed-ng-public
     instanceType: m5.large
     minSize: 2
     desiredCapacity: 3
@@ -27,3 +27,8 @@ managedNodeGroups:
       withAddonPolicies:
         externalDNS: true
         certManager: true
+
+  - name: managed-ng-private
+    instanceType: m5.large
+    # launch nodegroup in private subnets
+    privateNetworking: true

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -819,6 +819,10 @@ type ManagedNodeGroup struct {
 	Labels map[string]string `json:"labels,omitempty"`
 	// +optional
 	Tags map[string]string `json:"tags,omitempty"`
+
+	// +optional
+	PrivateNetworking bool `json:"privateNetworking"`
+
 	// +optional
 	IAM *NodeGroupIAM `json:"iam,omitempty"`
 }

--- a/pkg/cfn/builder/managed_nodegroup.go
+++ b/pkg/cfn/builder/managed_nodegroup.go
@@ -92,7 +92,7 @@ func (m *ManagedNodeGroupResourceSet) AddAllResources() error {
 		nodeRole = gfn.NewString(m.nodeGroup.IAM.InstanceRoleARN)
 	}
 
-	subnets, err := AssignSubnets(m.nodeGroup.AvailabilityZones, m.clusterStackName, m.clusterConfig, false)
+	subnets, err := AssignSubnets(m.nodeGroup.AvailabilityZones, m.clusterStackName, m.clusterConfig, m.nodeGroup.PrivateNetworking)
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/cmdutils/configfile_test.go
+++ b/pkg/ctl/cmdutils/configfile_test.go
@@ -224,8 +224,8 @@ var _ = Describe("cmdutils configfile", func() {
 				{"05-advanced-nodegroups.yaml", 3, false, false},
 				{"07-ssh-keys.yaml", 6, true, false},
 				{"07-ssh-keys.yaml", 6, false, false},
-				{"15-managed-nodes.yaml", 1, true, true},
-				{"15-managed-nodes.yaml", 1, false, true},
+				{"15-managed-nodes.yaml", 2, true, true},
+				{"15-managed-nodes.yaml", 2, false, true},
 				{"20-bottlerocket.yaml", 2, false, false},
 			}
 

--- a/site/content/usage/20-schema.md
+++ b/site/content/usage/20-schema.md
@@ -341,6 +341,8 @@ ManagedNodeGroup:
       type: object
     name:
       type: string
+    privateNetworking:
+      type: boolean
     ssh:
       $ref: '#/definitions/NodeGroupSSH'
     tags:
@@ -353,6 +355,7 @@ ManagedNodeGroup:
   required:
   - name
   - ScalingConfig
+  - privateNetworking
   type: object
 Network:
   additionalProperties: false


### PR DESCRIPTION
### Description

Adds support for private networking for managed nodegroups. This needs to be released after https://aws.amazon.com/blogs/containers/upcoming-changes-to-ip-assignment-for-eks-managed-node-groups/ is out. Currently, this still lets you create managed nodegroups in private subnets but the ASG for the nodegroups still gets configured to assign a public IP to its instances. When the IP assignment changes for EKS are out, nodegroups launched in private subnets (e.g., with `managedNodeGroups[*].privateNetworking` set) will no longer be allocated a public IP and will mirror the `privateNetworking` feature for eksctl-managed nodegroups.

Closes #1575 

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
