### PR TITLE
Fix staticcheck Lint Failures in Tests

### DIFF
--- a/pkg/authconfigmap/authconfigmap_test.go
+++ b/pkg/authconfigmap/authconfigmap_test.go
@@ -343,22 +343,22 @@ var _ = Describe("AuthConfigMap{}", func() {
 		}
 
 		It("should add a role and a user", func() {
-			cm := addAndSave(roleA, RoleNodeGroupUsername, RoleNodeGroupGroups)
-			cm = addAndSave(userA, userAUsername, userAGroups)
+			_ = addAndSave(roleA, RoleNodeGroupUsername, RoleNodeGroupGroups)
+			cm := addAndSave(userA, userAUsername, userAGroups)
 			Expect(cm.Data["mapRoles"]).To(MatchYAML(expectedRoleA))
 			Expect(cm.Data["mapUsers"]).To(MatchYAML(expectedUserA))
 		})
 		It("should append a second role and user", func() {
-			cm := addAndSave(roleB, RoleNodeGroupUsername, []string{groupB})
-			cm = addAndSave(userB, userBUsername, userBGroups)
+			_ = addAndSave(roleB, RoleNodeGroupUsername, []string{groupB})
+			cm := addAndSave(userB, userBUsername, userBGroups)
 			Expect(cm.Data["mapRoles"]).To(MatchYAML(expectedRoleA + expectedRoleB))
 			Expect(cm.Data["mapUsers"]).To(MatchYAML(expectedUserA + expectedUserB))
 		})
 		It("should append a duplicate role", func() {
-			cm := addAndSave(roleA, RoleNodeGroupUsername, RoleNodeGroupGroups)
+			_ = addAndSave(roleA, RoleNodeGroupUsername, RoleNodeGroupGroups)
 			expectedRoles := expectedRoleA + expectedRoleB + expectedRoleA
 
-			cm = addAndSave(userA, userAUsername, userAGroups)
+			cm := addAndSave(userA, userAUsername, userAGroups)
 			expectedUsers := expectedUserA + expectedUserB + expectedUserA
 
 			Expect(cm.Data["mapRoles"]).To(MatchYAML(expectedRoles))

--- a/pkg/az/az_test.go
+++ b/pkg/az/az_test.go
@@ -23,7 +23,7 @@ var _ = Describe("AZ", func() {
 		)
 
 		BeforeEach(func() {
-			avoidedZones(ec2.AvailabilityZoneStateAvailable)
+			_ = avoidedZones(ec2.AvailabilityZoneStateAvailable)
 		})
 
 		Context("with a region that has no zones to avoid", func() {


### PR DESCRIPTION
This is part of an ongoing series of work to turn on linting in the tests. https://github.com/weaveworks/eksctl/issues/2026

This batch of commits fixes all of the `staticcheck` errors present when `golangci` is configured to lint the tests.