### PR TITLE
Docs: update the hyper link for latest release in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -319,6 +319,6 @@ You want to keep an eye on Circle CI for the progress of the release ([0.3.1 exa
 
 ### Latest release
 
-To get the latest release you can use the link [https://github.com/weaveworks/eksctl/releases/latest]().
+To get the latest release you can use the link <https://github.com/weaveworks/eksctl/releases/latest>.
 
 **Note** Previously, eksctl used a floating tag called `latest_release`. This is _deprecated_ and it will stop working after release `0.14.0`.


### PR DESCRIPTION
### Description

As per below screen shot, the link is pointing to master, upon clicking it returns 404.

![image](https://user-images.githubusercontent.com/9019229/79755819-08bca780-835d-11ea-9ee2-7fbc9bbc16c9.png)


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `site/content` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
