### PR TITLE
Add always() condition for all check steps

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -14,9 +14,9 @@ jobs:
         python-version: [3.8]
     steps:
       - uses: actions/checkout@v2
-      
       # Using markdown-link-check to check markdown docs
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        if: always()
         with:
           use-verbose-mode: 'yes'
           config-file: '.github/workflows/markdown-link-check-config.json'
@@ -24,16 +24,20 @@ jobs:
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
+        if: always()
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
+        if: always()
         run: |
           pip install -r userdocs/requirements.txt
       - name: Build docs for link check
+        if: always()
         run: make build-pages
         # Using liche action to check generated HTML site
       - name: Link Checker (generated site)
         id: lc
+        if: always()
         uses: peter-evans/link-checker@v1
         with:
           args: -d userdocs/site -r userdocs/site -x https://twitter.com/weaveworks

--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -1,6 +1,7 @@
 {
     "ignorePatterns": [
         { "pattern": "^https://github.com/\\S+/\\S+/(issues|pull)/[0-9]+" },
-        { "pattern": "^mailto:" }
+        { "pattern": "^mailto:" },
+        { "pattern": "^https://circleci.com/workflow-run/02d8b5fb-bc7f-404c-9051-68307c124649" }
     ]
 }

--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -1,7 +1,6 @@
 {
     "ignorePatterns": [
         { "pattern": "^https://github.com/\\S+/\\S+/(issues|pull)/[0-9]+" },
-        { "pattern": "^mailto:" },
-        { "pattern": "^https://circleci.com/workflow-run/02d8b5fb-bc7f-404c-9051-68307c124649" }
+        { "pattern": "^mailto:" }
     ]
 }


### PR DESCRIPTION
# Description

Currently, if md check failed due to any reason, other checks will not triggered.
In my opinion, it will be better if all the checks are run, then contributor can fix all in on shot insteawd of cyclying between push, check, fix multiple times

Please refer to the below screen shot as part of testing, I removed one of entry in markdown-link-check-config.json to force failure.

https://github.com/weaveworks/eksctl/pull/2066/checks?check_run_id=608215118

![image](https://user-images.githubusercontent.com/9019229/79973044-35e29480-84da-11ea-8405-dbc85cc95fed.png)

![image](https://user-images.githubusercontent.com/9019229/79973098-4dba1880-84da-11ea-8e87-a4fa5908030a.png)

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
