### PR TITLE
Log warning in cluster update command when in plan mode

### DIFF
--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -181,7 +181,7 @@ func (c *StackCollection) AppendNewClusterStackResource(plan, supportsManagedNod
 	describeUpdate := fmt.Sprintf("updating stack to add new resources %v and outputs %v", addResources, addOutputs)
 	if plan {
 		logger.Info("(plan) %s", describeUpdate)
-		return false, nil
+		return true, nil
 	}
 	return true, c.UpdateStack(name, c.MakeChangeSetName("update-cluster"), describeUpdate, []byte(currentTemplate), nil)
 }


### PR DESCRIPTION
Make sure the plan warning is logged when running `eksctl update cluster`.

fixes #1643
supersedes #1795

- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->