### PR TITLE
Remove note about privateNetworking being unsupported

### DIFF
--- a/userdocs/src/usage/eks-managed-nodes.md
+++ b/userdocs/src/usage/eks-managed-nodes.md
@@ -97,6 +97,7 @@ managedNodeGroups:
 
   - name: managed-ng-2
     instanceType: t2.large
+    privateNetworking: true
     minSize: 2
     maxSize: 3
 ```
@@ -169,7 +170,6 @@ eksctl scale nodegroup --name=managed-ng-1 --cluster=managed-cluster --nodes=4
 EKS Managed Nodegroups are managed by AWS EKS and do not offer the same level of configuration as unmanaged nodegroups.
 The unsupported options are noted below.
 
-- No support for private networking (`nodeGroups[*].privateNetworking`).
 - Tags (`managedNodeGroups[*].tags`) in managed nodegroups apply to the EKS Nodegroup resource and do not propagate to
 the provisioned Autoscaling Group like in unmanaged nodegroups.
 - `iam.instanceProfileARN` is not supported for managed nodegroups.


### PR DESCRIPTION
### Description

Private networking is now supported for managed nodegroups. This change removes that note.

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
