### PR TITLE
Switch to `aws eks get-token` as the authenticator for Amazon Linux 2

### DIFF
--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -1,16 +1,19 @@
 package builder_test
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/aws/aws-sdk-go/aws"
 	cfn "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	gfn "github.com/awslabs/goformation/cloudformation"
@@ -135,37 +138,74 @@ type Template struct {
 	Resources   map[string]struct{ Properties Properties }
 }
 
-func kubeconfigBody(authenticator string) string {
-	return `apiVersion: v1
+var kubeconfigTemplate = template.Must(template.New("kubeconfig").Parse(`apiVersion: v1
 clusters:
 - cluster:
     certificate-authority: /etc/eksctl/ca.crt
-    server: ` + endpoint + `
-  name: ` + clusterName + `.us-west-2.eksctl.io
+    server: {{.Endpoint}}
+  name: {{.ClusterDomain}}
 contexts:
 - context:
-    cluster: ` + clusterName + `.us-west-2.eksctl.io
-    user: kubelet@` + clusterName + `.us-west-2.eksctl.io
-  name: kubelet@` + clusterName + `.us-west-2.eksctl.io
-current-context: kubelet@` + clusterName + `.us-west-2.eksctl.io
+    cluster: {{.ClusterDomain}}
+    user: kubelet@{{.ClusterDomain}}
+  name: kubelet@{{.ClusterDomain}}
+current-context: kubelet@{{.ClusterDomain}}
 kind: Config
 preferences: {}
 users:
-- name: kubelet@` + clusterName + `.us-west-2.eksctl.io
+- name: kubelet@{{.ClusterDomain}}
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
+      {{if eq .Authenticator "aws"}}
+      args:
+      - eks
+      - get-token
+      - --cluster-name
+      - {{.Cluster}}
+      - --region
+      - {{.Region}}
+      command: {{.Authenticator}}
+      env:
+      - name: AWS_STS_REGIONAL_ENDPOINTS
+        value: regional
+     {{else}}
       args:
       - token
       - -i
-      - ` + clusterName + `
-      command: ` + authenticator + `
+      - {{.Cluster}}
+      command: {{.Authenticator}}
       env:
       - name: AWS_STS_REGIONAL_ENDPOINTS
         value: regional
       - name: AWS_DEFAULT_REGION
-        value: us-west-2
-`
+        value: {{.Region}}
+     {{end}}
+`))
+
+func kubeconfigBody(authenticator string) string {
+	var out bytes.Buffer
+	region := "us-west-2"
+
+	err := kubeconfigTemplate.Execute(&out, struct {
+		Cluster       string
+		ClusterDomain string
+		Authenticator string
+		Region        string
+		Endpoint      string
+	}{
+		Cluster:       clusterName,
+		ClusterDomain: fmt.Sprintf("%s.%s.eksctl.io", clusterName, region),
+		Authenticator: authenticator,
+		Region:        region,
+		Endpoint:      endpoint,
+	})
+
+	if err != nil {
+		panic(errors.Wrap(err, "unexpected error while executing kubeconfig template"))
+	}
+
+	return out.String()
 }
 
 func testVPC() *api.ClusterVPC {
@@ -1843,7 +1883,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			kubeconfig := getFile(cc, "/etc/eksctl/kubeconfig.yaml")
 			Expect(kubeconfig).ToNot(BeNil())
 			Expect(kubeconfig.Permissions).To(Equal("0644"))
-			Expect(kubeconfig.Content).To(MatchYAML(kubeconfigBody("aws-iam-authenticator")))
+			Expect(kubeconfig.Content).To(MatchYAML(kubeconfigBody("aws")))
 
 			kubeletConfigAssetContent, err := nodebootstrap.Asset("kubelet.yaml")
 			Expect(err).ToNot(HaveOccurred())
@@ -1906,7 +1946,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			kubeconfig := getFile(cc, "/etc/eksctl/kubeconfig.yaml")
 			Expect(kubeconfig).ToNot(BeNil())
 			Expect(kubeconfig.Permissions).To(Equal("0644"))
-			Expect(kubeconfig.Content).To(MatchYAML(kubeconfigBody("aws-iam-authenticator")))
+			Expect(kubeconfig.Content).To(MatchYAML(kubeconfigBody("aws")))
 
 			ca := getFile(cc, "/etc/eksctl/ca.crt")
 			Expect(ca).ToNot(BeNil())
@@ -1965,7 +2005,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			kubeconfig := getFile(cc, "/etc/eksctl/kubeconfig.yaml")
 			Expect(kubeconfig).ToNot(BeNil())
 			Expect(kubeconfig.Permissions).To(Equal("0644"))
-			Expect(kubeconfig.Content).To(MatchYAML(kubeconfigBody("aws-iam-authenticator")))
+			Expect(kubeconfig.Content).To(MatchYAML(kubeconfigBody("aws")))
 
 			ca := getFile(cc, "/etc/eksctl/ca.crt")
 			Expect(ca).ToNot(BeNil())
@@ -2022,7 +2062,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			kubeconfig := getFile(cc, "/etc/eksctl/kubeconfig.yaml")
 			Expect(kubeconfig).ToNot(BeNil())
 			Expect(kubeconfig.Permissions).To(Equal("0644"))
-			Expect(kubeconfig.Content).To(MatchYAML(kubeconfigBody("aws-iam-authenticator")))
+			Expect(kubeconfig.Content).To(MatchYAML(kubeconfigBody("aws")))
 
 			ca := getFile(cc, "/etc/eksctl/ca.crt")
 			Expect(ca).ToNot(BeNil())

--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -65,13 +65,9 @@ func addFilesAndScripts(config *cloudconfig.CloudConfig, files configFiles, scri
 	return nil
 }
 
-func makeClientConfigData(spec *api.ClusterConfig, ng *api.NodeGroup) ([]byte, error) {
+func makeClientConfigData(spec *api.ClusterConfig, ng *api.NodeGroup, authenticatorCMD string) ([]byte, error) {
 	clientConfig, _, _ := kubeconfig.New(spec, "kubelet", configDir+"ca.crt")
-	authenticator := kubeconfig.AWSIAMAuthenticator
-	if ng.AMIFamily == api.NodeImageFamilyUbuntu1804 {
-		authenticator = kubeconfig.HeptioAuthenticatorAWS
-	}
-	kubeconfig.AppendAuthenticator(clientConfig, spec, authenticator, "", "")
+	kubeconfig.AppendAuthenticator(clientConfig, spec, authenticatorCMD, "", "")
 	clientConfigData, err := clientcmd.Write(*clientConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "serialising kubeconfig for nodegroup")

--- a/pkg/nodebootstrap/userdata_al2.go
+++ b/pkg/nodebootstrap/userdata_al2.go
@@ -7,10 +7,11 @@ import (
 	"github.com/pkg/errors"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/cloudconfig"
+	"github.com/weaveworks/eksctl/pkg/utils/kubeconfig"
 )
 
 func makeAmazonLinux2Config(spec *api.ClusterConfig, ng *api.NodeGroup) (configFiles, error) {
-	clientConfigData, err := makeClientConfigData(spec, ng)
+	clientConfigData, err := makeClientConfigData(spec, ng, kubeconfig.AWSEKSAuthenticator)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/nodebootstrap/userdata_ubuntu.go
+++ b/pkg/nodebootstrap/userdata_ubuntu.go
@@ -8,10 +8,11 @@ import (
 	"github.com/pkg/errors"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/cloudconfig"
+	"github.com/weaveworks/eksctl/pkg/utils/kubeconfig"
 )
 
 func makeUbuntu1804Config(spec *api.ClusterConfig, ng *api.NodeGroup) (configFiles, error) {
-	clientConfigData, err := makeClientConfigData(spec, ng)
+	clientConfigData, err := makeClientConfigData(spec, ng, kubeconfig.HeptioAuthenticatorAWS)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -96,6 +96,12 @@ func AppendAuthenticator(config *clientcmdapi.Config, spec *api.ClusterConfig, a
 	execConfig := &clientcmdapi.ExecConfig{
 		APIVersion: "client.authentication.k8s.io/v1alpha1",
 		Command:    authenticatorCMD,
+		Env: []clientcmdapi.ExecEnvVar{
+			{
+				Name:  "AWS_STS_REGIONAL_ENDPOINTS",
+				Value: "regional",
+			},
+		},
 	}
 
 	switch authenticatorCMD {
@@ -104,9 +110,6 @@ func AppendAuthenticator(config *clientcmdapi.Config, spec *api.ClusterConfig, a
 		roleARNFlag = "-r"
 		if spec.Metadata.Region != "" {
 			execConfig.Env = append(execConfig.Env, clientcmdapi.ExecEnvVar{
-				Name:  "AWS_STS_REGIONAL_ENDPOINTS",
-				Value: "regional",
-			}, clientcmdapi.ExecEnvVar{
 				Name:  "AWS_DEFAULT_REGION",
 				Value: spec.Metadata.Region,
 			})


### PR DESCRIPTION
### Description

Closes #2063 

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
