### PR TITLE
[release-0.18] Switch to `aws eks get-token` as the authenticator for AL2

### DIFF
--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -66,13 +66,9 @@ func addFilesAndScripts(config *cloudconfig.CloudConfig, files configFiles, scri
 	return nil
 }
 
-func makeClientConfigData(spec *api.ClusterConfig, ng *api.NodeGroup) ([]byte, error) {
+func makeClientConfigData(spec *api.ClusterConfig, ng *api.NodeGroup, authenticatorCMD string) ([]byte, error) {
 	clientConfig, _, _ := kubeconfig.New(spec, "kubelet", configDir+"ca.crt")
-	authenticator := kubeconfig.AWSIAMAuthenticator
-	if ng.AMIFamily == api.NodeImageFamilyUbuntu1804 {
-		authenticator = kubeconfig.HeptioAuthenticatorAWS
-	}
-	kubeconfig.AppendAuthenticator(clientConfig, spec, authenticator, "", "")
+	kubeconfig.AppendAuthenticator(clientConfig, spec, authenticatorCMD, "", "")
 	clientConfigData, err := clientcmd.Write(*clientConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "serialising kubeconfig for nodegroup")

--- a/pkg/nodebootstrap/userdata_al2.go
+++ b/pkg/nodebootstrap/userdata_al2.go
@@ -7,10 +7,11 @@ import (
 	"github.com/pkg/errors"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/cloudconfig"
+	"github.com/weaveworks/eksctl/pkg/utils/kubeconfig"
 )
 
 func makeAmazonLinux2Config(spec *api.ClusterConfig, ng *api.NodeGroup) (configFiles, error) {
-	clientConfigData, err := makeClientConfigData(spec, ng)
+	clientConfigData, err := makeClientConfigData(spec, ng, kubeconfig.AWSEKSAuthenticator)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/nodebootstrap/userdata_ubuntu.go
+++ b/pkg/nodebootstrap/userdata_ubuntu.go
@@ -8,10 +8,11 @@ import (
 	"github.com/pkg/errors"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/cloudconfig"
+	"github.com/weaveworks/eksctl/pkg/utils/kubeconfig"
 )
 
 func makeUbuntu1804Config(spec *api.ClusterConfig, ng *api.NodeGroup) (configFiles, error) {
-	clientConfigData, err := makeClientConfigData(spec, ng)
+	clientConfigData, err := makeClientConfigData(spec, ng, kubeconfig.HeptioAuthenticatorAWS)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -96,6 +96,12 @@ func AppendAuthenticator(config *clientcmdapi.Config, spec *api.ClusterConfig, a
 	execConfig := &clientcmdapi.ExecConfig{
 		APIVersion: "client.authentication.k8s.io/v1alpha1",
 		Command:    authenticatorCMD,
+		Env: []clientcmdapi.ExecEnvVar{
+			{
+				Name:  "AWS_STS_REGIONAL_ENDPOINTS",
+				Value: "regional",
+			},
+		},
 	}
 
 	switch authenticatorCMD {
@@ -104,9 +110,6 @@ func AppendAuthenticator(config *clientcmdapi.Config, spec *api.ClusterConfig, a
 		roleARNFlag = "-r"
 		if spec.Metadata.Region != "" {
 			execConfig.Env = append(execConfig.Env, clientcmdapi.ExecEnvVar{
-				Name:  "AWS_STS_REGIONAL_ENDPOINTS",
-				Value: "regional",
-			}, clientcmdapi.ExecEnvVar{
 				Name:  "AWS_DEFAULT_REGION",
 				Value: spec.Metadata.Region,
 			})


### PR DESCRIPTION
### Description

Clone of #2078 for the `release-0.18` branch

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
