### PR TITLE
Add name argument support for create iamserviceaccount cli

### DIFF
--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -531,8 +531,16 @@ func NewCreateIAMServiceAccountLoader(cmd *Cmd, saFilter *IAMServiceAccountFilte
 
 		serviceAccount := l.ClusterConfig.IAM.ServiceAccounts[0]
 
+		if serviceAccount.Name != "" && l.NameArg != "" {
+			return ErrFlagAndArg("--name", serviceAccount.Name, l.NameArg)
+		}
+
+		if l.NameArg != "" {
+			serviceAccount.Name = l.NameArg
+		}
+
 		if serviceAccount.Name == "" {
-			return ErrMustBeSet(ClusterNameFlag(cmd))
+			return ErrMustBeSet("--name")
 		}
 
 		if len(serviceAccount.AttachPolicyARNs) == 0 {

--- a/pkg/ctl/create/iamserviceaccount.go
+++ b/pkg/ctl/create/iamserviceaccount.go
@@ -15,6 +15,12 @@ import (
 )
 
 func createIAMServiceAccountCmd(cmd *cmdutils.Cmd) {
+	createIAMServiceAccountCmdWithRunFunc(cmd, func(cmd *cmdutils.Cmd, overrideExistingServiceAccounts bool) error {
+		return doCreateIAMServiceAccount(cmd, overrideExistingServiceAccounts)
+	})
+}
+
+func createIAMServiceAccountCmdWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, overrideExistingServiceAccounts bool) error) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
 
@@ -27,8 +33,9 @@ func createIAMServiceAccountCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("iamserviceaccount", "Create an iamserviceaccount - AWS IAM role bound to a Kubernetes service account", "")
 
-	cmd.CobraCommand.RunE = func(_ *cobra.Command, _ []string) error {
-		return doCreateIAMServiceAccount(cmd, overrideExistingServiceAccounts)
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		cmd.NameArg = cmdutils.GetNameArg(args)
+		return runFunc(cmd, overrideExistingServiceAccounts)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/create/iamserviceaccount_test.go
+++ b/pkg/ctl/create/iamserviceaccount_test.go
@@ -1,0 +1,61 @@
+package create
+
+import (
+	"fmt"
+
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+
+	. "github.com/onsi/ginkgo/extensions/table"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("create iamserviceaccount", func() {
+	DescribeTable("create service account successfully",
+		func(args ...string) {
+			commandArgs := append([]string{"iamserviceaccount"}, args...)
+			cmd := newMockEmptyCmd(commandArgs...)
+			count := 0
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				createIAMServiceAccountCmdWithRunFunc(cmd, func(cmd *cmdutils.Cmd, overrideExistingServiceAccounts bool) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(cmd.ClusterConfig.IAM.ServiceAccounts[0].Name).To(Equal("serviceAccountName"))
+					Expect(cmd.ClusterConfig.IAM.ServiceAccounts[0].AttachPolicyARNs).To(ContainElement("dummyPolicyArn"))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		},
+		Entry("with all required flags", "--cluster", "clusterName", "--name", "serviceAccountName", "--attach-policy-arn", "dummyPolicyArn"),
+		Entry("with override flags", "--cluster", "clusterName", "--name", "serviceAccountName", "--attach-policy-arn", "dummyPolicyArn", "--override-existing-serviceaccounts"),
+	)
+
+	DescribeTable("invalid flags or arguments",
+		func(c invalidParamsCase) {
+			cmd := newDefaultCmd(c.args...)
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal(c.error.Error()))
+		},
+		Entry("without cluster name", invalidParamsCase{
+			args:  []string{"iamserviceaccount", "--name", "serviceAccountName"},
+			error: fmt.Errorf("--cluster must be set"),
+		}),
+		Entry("with iamserviceaccount name as argument and flag", invalidParamsCase{
+			args:  []string{"iamserviceaccount", "--cluster", "clusterName", "--name", "serviceAccountName", "serviceAccountName"},
+			error: fmt.Errorf("--name=serviceAccountName and argument serviceAccountName cannot be used at the same time"),
+		}),
+		Entry("without required flag --attach-policy-arn", invalidParamsCase{
+			args:  []string{"iamserviceaccount", "--cluster", "clusterName", "serviceAccountName"},
+			error: fmt.Errorf("--attach-policy-arn must be set"),
+		}),
+		Entry("with invalid flags", invalidParamsCase{
+			args:  []string{"iamserviceaccount", "--invalid", "dummy"},
+			error: fmt.Errorf("unknown flag: --invalid"),
+		}),
+	)
+})


### PR DESCRIPTION
### Description

Fixes https://github.com/weaveworks/eksctl/issues/2081

### Testing

<details>
<summary>Before</summary>

```shell script
./eksctl create iamserviceaccount --cluster dummyCluster dummyName           
Error: --cluster must be set
```

</details>

<details>
<summary>After</summary>

```shell script
$ ./eksctl create iamserviceaccount --cluster dummyCluster dummyName           
Error: --attach-policy-arn must be set

$ ./eksctl create iamserviceaccount --cluster dummyCluster dummyName --attach-policy-arn dummyPolicy
[ℹ]  eksctl version 0.19.0-dev+2df5c1f2.2020-04-25T20:24:02Z
[ℹ]  using region ap-southeast-2

```

</details>

## Notes
I cross check for for other CLIs, and find out the similar issue for delete iamserviceaccount. This issue will be fixed in seperate PR, and currently tracked https://github.com/weaveworks/eksctl/issues/2087

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
