### PR TITLE
Update aws-sdk-go version tagging in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ $(generated_code_deep_copy_helper): $(deep_copy_helper_input) .license-header ##
 $(generated_code_aws_sdk_mocks): $(call godeps,pkg/eks/mocks/mocks.go)
 	mkdir -p vendor/github.com/aws/
 	@# Hack for Mockery to find the dependencies handled by `go mod`
-	ln -sfn "$(gopath)/pkg/mod/github.com/weaveworks/aws-sdk-go@v1.25.14-0.20191218135223-757eeed07291" vendor/github.com/aws/aws-sdk-go
+	ln -sfn "$(gopath)/pkg/mod/github.com/aws/aws-sdk-go@v1.30.11" vendor/github.com/aws/aws-sdk-go
 	time env GOBIN=$(GOBIN) go generate ./pkg/eks/mocks
 
 .PHONY: generate-kube-reserved


### PR DESCRIPTION
### Description

I de-fork aws-sdk-go in https://github.com/weaveworks/eksctl/pull/2067, but didn't update the version tagging in Makefile. My mistake :sob: 

This PR is to keep the aws-sdk-go consistent between Makefile and go.mod. I feel this one is tactical approach only. We should remove mockery hack sooner or later.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

<!-- If you haven't done so already, you can add your name to the humans.txt file -->
