### PR TITLE
Validate `secretsEncryption.keyARN` for nil

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -104,6 +104,10 @@ func ValidateClusterConfig(cfg *ClusterConfig) error {
 		cfg.VPC.PublicAccessCIDRs = cidrs
 	}
 
+	if cfg.SecretsEncryption != nil && cfg.SecretsEncryption.KeyARN == nil {
+		return errors.New("field secretsEncryption.keyARN is required for enabling secrets encryption")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
### Description

Fixes a panic by validating `secretsEncryption.keyARN` for nil-ness.

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

