### PR TITLE
Fix Windows build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/weaveworks/github-release v0.6.3-0.20161024133933-73deea6af1e8
 	github.com/weaveworks/launcher v0.0.0-20180711153254-f1b2830d4f2d
 	github.com/whilp/git-urls v0.0.0-20160530060445-31bac0d230fa
+	golang.org/x/sys v0.0.0-20200428200454-593003d681fa // indirect
 	golang.org/x/tools v0.0.0-20200301222351-066e0c02454c
 	k8s.io/api v0.15.10
 	k8s.io/apiextensions-apiserver v0.15.10

--- a/go.sum
+++ b/go.sum
@@ -1231,6 +1231,8 @@ golang.org/x/sys v0.0.0-20190812172437-4e8604ab3aff/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69 h1:rOhMmluY6kLMhdnrivzec6lLgaVbMHMn2ISQXJeJ5EM=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200428200454-593003d681fa h1:yMbJOvnfYkO1dSAviTu/ZguZWLBTXx4xE3LYrxUCCiA=
+golang.org/x/sys v0.0.0-20200428200454-593003d681fa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20180810153555-6e3c4e7365dd/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
The windows build was broken in #2058 when some dependencies were updated.

```
$ make build-all
goreleaser --config=.goreleaser-local.yaml --snapshot --skip-publish --rm-dist
   • releasing using goreleaser dev...
   • loading config file       file=.goreleaser-local.yaml
.....
   • BUILDING BINARIES
      • building                  binary=dist/default_linux_amd64/eksctl
      • building                  binary=dist/default_windows_amd64/eksctl.exe
      • building                  binary=dist/default_darwin_amd64/eksctl
   ⨯ release failed after 166.79s error=failed to build for windows_amd64: # golang.org/x/crypto/ssh/terminal
../../goprojects/pkg/mod/golang.org/x/crypto@v0.0.0-20191206172530-e9b2fee46413/ssh/terminal/util_windows.go:97:7: assignment mismatch: 2 variables but "golang.org/x/sys/windows".GetCurrentProcess returns 1 values
../../goprojects/pkg/mod/github.com/prometheus/client_golang@v1.1.0/prometheus/process_collector_windows.go:78:9: assignment mismatch: 2 variables but "golang.org/x/sys/windows".GetCurrentProcess returns 1 values
make: *** [Makefile:46: build-all] Error 1
```

This was caused by https://github.com/golang/go/issues/34461 

To fix this issue I upgraded `golang.org/x/sys`.

```
go get -u  golang.org/x/sys
```


- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes