### PR TITLE
Fix flaky unit test due to random data

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -1,7 +1,6 @@
 package v1alpha5
 
 import (
-	"github.com/bxcodec/faker"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -653,11 +652,19 @@ var _ = Describe("ClusterConfig validation", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("passes on randomly generated fields", func() {
-				profile := FargateProfile{}
-				err := faker.FakeData(&profile)
-				Expect(err).ToNot(HaveOccurred())
-				err = profile.Validate()
+			It("passes when a name and multiple selectors with a namespace is defined", func() {
+				profile := FargateProfile{
+					Name: "default",
+					Selectors: []FargateProfileSelector{
+						{
+							Namespace: "default",
+						},
+						{
+							Namespace: "dev",
+						},
+					},
+				}
+				err := profile.Validate()
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})


### PR DESCRIPTION
### Description

Fixes https://github.com/weaveworks/eksctl/issues/2105

### Approach

Underlying issue is due to https://github.com/bxcodec/faker/blob/1c6d6edb0123edda0348adc3ccb7e3480b9aaf07/faker.go#L488, which might cause the slice length as zero. I can enforce the length of slice with tag e.g. `faker:"len=1"`, but it's not looking good in struct. 

The default value https://github.com/bxcodec/faker/blob/1c6d6edb0123edda0348adc3ccb7e3480b9aaf07/faker.go#L29 is 100, so this test case will probably fail one in hundred times. We can also increase default values to reduce the odds, but it still fails some time :)

In short, I just add the check in case generated slice is empty.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

