### PR TITLE
Fix nameLabelValue when waiting for helm-operator

### DIFF
--- a/integration/matchers/flux.go
+++ b/integration/matchers/flux.go
@@ -275,20 +275,20 @@ func assertValidFluxHelmOperatorAccount(fileName string) {
 			Expect(ok).To(BeTrue(), "Failed to convert object of type %T to %s", item.Object, gvk.Kind)
 			Expect(sa.Kind).To(Equal("ServiceAccount"))
 			Expect(sa.Namespace).To(Equal(Namespace))
-			Expect(sa.Name).To(Equal("flux-helm-operator"))
-			Expect(sa.Labels["name"]).To(Equal("flux-helm-operator"))
+			Expect(sa.Name).To(Equal("helm-operator"))
+			Expect(sa.Labels["name"]).To(Equal("helm-operator"))
 		} else if gvk.Version == "v1beta1" && gvk.Kind == "ClusterRole" {
 			cr, ok := item.Object.(*rbacv1beta1.ClusterRole)
 			Expect(ok).To(BeTrue(), "Failed to convert object of type %T to %s", item.Object, gvk.Kind)
 			Expect(cr.Kind).To(Equal("ClusterRole"))
-			Expect(cr.Name).To(Equal("flux-helm-operator"))
-			Expect(cr.Labels["name"]).To(Equal("flux-helm-operator"))
+			Expect(cr.Name).To(Equal("helm-operator"))
+			Expect(cr.Labels["name"]).To(Equal("helm-operator"))
 		} else if gvk.Version == "v1beta1" && gvk.Kind == "ClusterRoleBinding" {
 			crb, ok := item.Object.(*rbacv1beta1.ClusterRoleBinding)
 			Expect(ok).To(BeTrue(), "Failed to convert object of type %T to %s", item.Object, gvk.Kind)
 			Expect(crb.Kind).To(Equal("ClusterRoleBinding"))
-			Expect(crb.Name).To(Equal("flux-helm-operator"))
-			Expect(crb.Labels["name"]).To(Equal("flux-helm-operator"))
+			Expect(crb.Name).To(Equal("helm-operator"))
+			Expect(crb.Labels["name"]).To(Equal("helm-operator"))
 		} else {
 			Fail(fmt.Sprintf("Unsupported Kubernetes object. Got %s object with version %s in: %s", gvk.Kind, gvk.Version, fileName))
 		}
@@ -329,12 +329,12 @@ func assertValidHelmOperatorDeployment(fileName string) {
 			Expect(ok).To(BeTrue(), "Failed to convert object of type %T to %s", item.Object, gvk.Kind)
 			Expect(deployment.Kind).To(Equal("Deployment"))
 			Expect(deployment.Namespace).To(Equal(Namespace))
-			Expect(deployment.Name).To(Equal("flux-helm-operator"))
+			Expect(deployment.Name).To(Equal("helm-operator"))
 			Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
-			Expect(deployment.Spec.Template.Labels["name"]).To(Equal("flux-helm-operator"))
+			Expect(deployment.Spec.Template.Labels["name"]).To(Equal("helm-operator"))
 			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 			container := deployment.Spec.Template.Spec.Containers[0]
-			Expect(container.Name).To(Equal("flux-helm-operator"))
+			Expect(container.Name).To(Equal("helm-operator"))
 			Expect(container.Image).To(Equal("docker.io/fluxcd/helm-operator:1.0.0"))
 		} else {
 			Fail(fmt.Sprintf("Unsupported Kubernetes object. Got %s object with version %s in: %s", gvk.Kind, gvk.Version, fileName))
@@ -351,7 +351,7 @@ func AssertFluxPodsPresentInKubernetes(kubeconfigPath string) {
 	pods := fluxPods(kubeconfigPath)
 	Expect(pods.Items).To(HaveLen(3))
 	Expect(pods.Items[0].Labels["name"]).To(Equal("flux"))
-	Expect(pods.Items[1].Labels["name"]).To(Equal("flux-helm-operator"))
+	Expect(pods.Items[1].Labels["name"]).To(Equal("helm-operator"))
 	Expect(pods.Items[2].Labels["name"]).To(Equal("memcached"))
 }
 

--- a/pkg/gitops/flux/wait.go
+++ b/pkg/gitops/flux/wait.go
@@ -68,7 +68,7 @@ func waitForHelmOpToStart(ctx context.Context, namespace string, timeout time.Du
 		_, err = http.DefaultClient.Do(req)
 		return err
 	}
-	return waitForPodToStart(namespace, "flux-helm-operator", 3030, "Helm Operator", restConfig, cs, try)
+	return waitForPodToStart(namespace, "helm-operator", 3030, "Helm Operator", restConfig, cs, try)
 }
 
 type tryFunc func(rootURL string) error


### PR DESCRIPTION
### Description

https://github.com/fluxcd/helm-operator/pull/322 updated the name of the
helm-operator deployment. This updates the nameLabelValue so deployment
is detected successfully.

Old name: `flux-helm-operator`
New name: `helm-operator`

Error when running `eksctl enable repo`

```sh
EKSCTL_EXPERIMENTAL=true eksctl enable repo --cluster=<redacted> --region=ap-southeast-2 --git-url=git@github.com:<redacted>.git --git-email=<redacted>
[ℹ]  Generating manifests
[ℹ]  Cloning git@github.com:<redacted>.git
Cloning into '<redacted>'...
remote: Enumerating objects: 3, done.
remote: Counting objects: 100% (3/3), done.
remote: Total 3 (delta 0), reused 0 (delta 0), pack-reused 0
Receiving objects: 100% (3/3), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
[ℹ]  Writing Flux manifests
[ℹ]  created "Namespace/flux"
[ℹ]  Applying manifests
[ℹ]  created "flux:Deployment.apps/flux"
[ℹ]  created "flux:Deployment.apps/helm-operator"
[ℹ]  created "flux:ServiceAccount/helm-operator"
[ℹ]  created "ClusterRole.rbac.authorization.k8s.io/helm-operator"
[ℹ]  created "ClusterRoleBinding.rbac.authorization.k8s.io/helm-operator"
[ℹ]  created "flux:ServiceAccount/flux"
[ℹ]  created "ClusterRole.rbac.authorization.k8s.io/flux"
[ℹ]  created "ClusterRoleBinding.rbac.authorization.k8s.io/flux"
[ℹ]  created "flux:Service/memcached"
[ℹ]  created "flux:Secret/flux-git-deploy"
[ℹ]  created "CustomResourceDefinition.apiextensions.k8s.io/helmreleases.helm.fluxcd.io"
[ℹ]  created "flux:Deployment.apps/memcached"
[ℹ]  Waiting for Helm Operator to start
[!]  Helm Operator is not ready yet (Could not create a dialer: Could not get pod name: Could not find pod for selector: labels "name in (flux-helm-operator)"), retrying ...
[!]  Helm Operator is not ready yet (Could not create a dialer: Could not get pod name: Could not find pod for selector: labels "name in (flux-helm-operator)"), retrying ...
[!]  Helm Operator is not ready yet (Could not create a dialer: Could not get pod name: Could not find pod for selector: labels "name in (flux-helm-operator)"), retrying ...
[!]  Helm Operator is not ready yet (Could not create a dialer: Could not get pod name: Could not find pod for selector: labels "name in (flux-helm-operator)"), retrying ...
[!]  Helm Operator is not ready yet (Could not create a dialer: Could not get pod name: Could not find pod for selector: labels "name in (flux-helm-operator)"), retrying ...
[!]  Helm Operator is not ready yet (Could not create a dialer: Could not get pod name: Could not find pod for selector: labels "name in (flux-helm-operator)"), retrying ...
[!]  Helm Operator is not ready yet (Could not create a dialer: Could not get pod name: Could not find pod for selector: labels "name in (flux-helm-operator)"), retrying ...
[!]  Helm Operator is not ready yet (Could not create a dialer: Could not get pod name: Could not find pod for selector: labels "name in (flux-helm-operator)"), retrying ...
[!]  Helm Operator is not ready yet (Could not create a dialer: Could not get pod name: Could not find pod for selector: labels "name in (flux-helm-operator)"), retrying ...
[!]  Helm Operator is not ready yet (Could not create a dialer: Could not get pod name: Could not find pod for selector: labels "name in (flux-helm-operator)"), retrying ...
[!]  Helm Operator is not ready yet (Could not create a dialer: Could not get pod name: Could not find pod for selector: labels "name in (flux-helm-operator)"), retrying ...
[!]  Helm Operator is not ready yet (Could not create a dialer: Could not get pod name: Could not find pod for selector: labels "name in (flux-helm-operator)"), retrying ...
[!]  Helm Operator is not ready yet (Could not create a dialer: Could not get pod name: Could not find pod for selector: labels "name in (flux-helm-operator)"), retrying ...
[!]  Helm Operator is not ready yet (Could not create a dialer: Could not get pod name: Could not find pod for selector: labels "name in (flux-helm-operator)"), retrying ...
[!]  Helm Operator is not ready yet (Could not create a dialer: Could not get pod name: Could not find pod for selector: labels "name in (flux-helm-operator)"), retrying ...
[✖]  You may find the local clone of git@github.com:<redacted>.git used by eksctl at <redacted>
[ℹ]
Error: timed out waiting for Helm Operator's pod to be created
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes
