### PR TITLE
Private-only clusters with an eksctl-created VPC are not supported

### DIFF
--- a/integration/tests/cluster_api/cluster_api_endpoints_test.go
+++ b/integration/tests/cluster_api/cluster_api_endpoints_test.go
@@ -162,12 +162,12 @@ var _ = Describe("(Integration) Create and Update Cluster with Endpoint Configs"
 			Type:    createCluster,
 			Fails:   false,
 		}),
-		Entry("Create cluster2, Private=true, Public=false, should succeed", endpointAccessCase{
+		Entry("Create cluster2, Private=true, Public=false, should not succeed", endpointAccessCase{
 			Name:    "cluster2",
 			Private: true,
 			Public:  false,
 			Type:    createCluster,
-			Fails:   false,
+			Fails:   true,
 		}),
 		Entry("Create cluster3, Private=true, Public=true, should succeed", endpointAccessCase{
 			Name:    "cluster3",


### PR DESCRIPTION
In order to create private-only clusters, the ClusterConfig should use a pre-existing VPC and eksctl must be run from that VPC (or a peered VPC).

https://github.com/weaveworks/eksctl/pull/2071 added support for creating private-only clusters, however, this is not supported when run from outside the cluster VPC (or a peered VPC).

This change marks this feature as failing in the integration tests.

### Description

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

