### PR TITLE
Fix tag-release-candidate.sh script. Push release branch

### DIFF
--- a/tag-release-candidate.sh
+++ b/tag-release-candidate.sh
@@ -54,7 +54,11 @@ git add "${RELEASE_NOTES_FILE}"
 
 m="Tag ${full_version} release candidate"
 
+# Push branch
 git commit --message "${m}"
+git push origin "${release_branch}"
+
+# Push tags
 git tag --annotate --message "${m}" --force "latest_release"
 git tag --annotate --message "${m}" "${full_version}"
 git push origin "${full_version}"


### PR DESCRIPTION
The tag-release-candidate.sh script was not pushing the release branch (`release-0.X`) back to origin.


- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes