### PR TITLE
Fix helm-operator pod name for Flux

### DIFF
--- a/integration/matchers/flux.go
+++ b/integration/matchers/flux.go
@@ -275,20 +275,20 @@ func assertValidFluxHelmOperatorAccount(fileName string) {
 			Expect(ok).To(BeTrue(), "Failed to convert object of type %T to %s", item.Object, gvk.Kind)
 			Expect(sa.Kind).To(Equal("ServiceAccount"))
 			Expect(sa.Namespace).To(Equal(Namespace))
-			Expect(sa.Name).To(Equal("flux-helm-operator"))
-			Expect(sa.Labels["name"]).To(Equal("flux-helm-operator"))
+			Expect(sa.Name).To(Equal("helm-operator"))
+			Expect(sa.Labels["name"]).To(Equal("helm-operator"))
 		} else if gvk.Version == "v1beta1" && gvk.Kind == "ClusterRole" {
 			cr, ok := item.Object.(*rbacv1beta1.ClusterRole)
 			Expect(ok).To(BeTrue(), "Failed to convert object of type %T to %s", item.Object, gvk.Kind)
 			Expect(cr.Kind).To(Equal("ClusterRole"))
-			Expect(cr.Name).To(Equal("flux-helm-operator"))
-			Expect(cr.Labels["name"]).To(Equal("flux-helm-operator"))
+			Expect(cr.Name).To(Equal("helm-operator"))
+			Expect(cr.Labels["name"]).To(Equal("helm-operator"))
 		} else if gvk.Version == "v1beta1" && gvk.Kind == "ClusterRoleBinding" {
 			crb, ok := item.Object.(*rbacv1beta1.ClusterRoleBinding)
 			Expect(ok).To(BeTrue(), "Failed to convert object of type %T to %s", item.Object, gvk.Kind)
 			Expect(crb.Kind).To(Equal("ClusterRoleBinding"))
-			Expect(crb.Name).To(Equal("flux-helm-operator"))
-			Expect(crb.Labels["name"]).To(Equal("flux-helm-operator"))
+			Expect(crb.Name).To(Equal("helm-operator"))
+			Expect(crb.Labels["name"]).To(Equal("helm-operator"))
 		} else {
 			Fail(fmt.Sprintf("Unsupported Kubernetes object. Got %s object with version %s in: %s", gvk.Kind, gvk.Version, fileName))
 		}
@@ -329,12 +329,12 @@ func assertValidHelmOperatorDeployment(fileName string) {
 			Expect(ok).To(BeTrue(), "Failed to convert object of type %T to %s", item.Object, gvk.Kind)
 			Expect(deployment.Kind).To(Equal("Deployment"))
 			Expect(deployment.Namespace).To(Equal(Namespace))
-			Expect(deployment.Name).To(Equal("flux-helm-operator"))
+			Expect(deployment.Name).To(Equal("helm-operator"))
 			Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
-			Expect(deployment.Spec.Template.Labels["name"]).To(Equal("flux-helm-operator"))
+			Expect(deployment.Spec.Template.Labels["name"]).To(Equal("helm-operator"))
 			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 			container := deployment.Spec.Template.Spec.Containers[0]
-			Expect(container.Name).To(Equal("flux-helm-operator"))
+			Expect(container.Name).To(Equal("helm-operator"))
 			Expect(container.Image).To(Equal("docker.io/fluxcd/helm-operator:1.0.0"))
 		} else {
 			Fail(fmt.Sprintf("Unsupported Kubernetes object. Got %s object with version %s in: %s", gvk.Kind, gvk.Version, fileName))
@@ -351,7 +351,7 @@ func AssertFluxPodsPresentInKubernetes(kubeconfigPath string) {
 	pods := fluxPods(kubeconfigPath)
 	Expect(pods.Items).To(HaveLen(3))
 	Expect(pods.Items[0].Labels["name"]).To(Equal("flux"))
-	Expect(pods.Items[1].Labels["name"]).To(Equal("flux-helm-operator"))
+	Expect(pods.Items[1].Labels["name"]).To(Equal("helm-operator"))
 	Expect(pods.Items[2].Labels["name"]).To(Equal("memcached"))
 }
 

--- a/pkg/gitops/flux/wait.go
+++ b/pkg/gitops/flux/wait.go
@@ -68,7 +68,7 @@ func waitForHelmOpToStart(ctx context.Context, namespace string, timeout time.Du
 		_, err = http.DefaultClient.Do(req)
 		return err
 	}
-	return waitForPodToStart(namespace, "flux-helm-operator", 3030, "Helm Operator", restConfig, cs, try)
+	return waitForPodToStart(namespace, "helm-operator", 3030, "Helm Operator", restConfig, cs, try)
 }
 
 type tryFunc func(rootURL string) error


### PR DESCRIPTION
This replicates this PR #2117 for branch `release-0.19`.

Integration tests run:

```
ginkgo -tags integration -v --progress integration/tests/quickstart_profiles/... -- -test.v -ginkgo.v
...
...
Ran 1 of 1 Specs in 1069.957 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestSuite (1069.96s)
PASS

Ginkgo ran 1 suite in 18m8.417940884s
Test Suite Passed
```

- [x] Added tests that cover your change (if possible)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes