### PR TITLE
Move Gitops guides below the Usage section in the site

### DIFF
--- a/userdocs/mkdocs.yml
+++ b/userdocs/mkdocs.yml
@@ -12,7 +12,6 @@ extra_css:
 
 nav:
     - Introduction: introduction.md
-    - 'GitOps Quickstart': gitops-quickstart.md
     - Usage:
         - usage/creating-and-managing-clusters.md
         - usage/managing-nodegroups.md
@@ -36,6 +35,7 @@ nav:
         - usage/troubleshooting.md
         - FAQ: usage/faq.md
         - Experimental: usage/experimental/gitops.md
+    - 'GitOps Quickstart': gitops-quickstart.md
     - Examples:
         - examples/reusing-iam-and-vpc.md
     - Community: community.md


### PR DESCRIPTION
I think the usage section is more important and now that the usage submenu is collapsed it should be bumped up compared to the gitops guide.

@kalbir what do you think?

### Description


### Checklist

- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

