### PR TITLE
Remove old test for Cluster API endpoint only private access

### DIFF
--- a/integration/tests/cluster_api/cluster_api_endpoints_test.go
+++ b/integration/tests/cluster_api/cluster_api_endpoints_test.go
@@ -162,13 +162,6 @@ var _ = Describe("(Integration) Create and Update Cluster with Endpoint Configs"
 			Type:    createCluster,
 			Fails:   false,
 		}),
-		Entry("Create cluster2, Private=true, Public=false, should not succeed", endpointAccessCase{
-			Name:    "cluster2",
-			Private: true,
-			Public:  false,
-			Type:    createCluster,
-			Fails:   true,
-		}),
 		Entry("Create cluster3, Private=true, Public=true, should succeed", endpointAccessCase{
 			Name:    "cluster3",
 			Private: true,


### PR DESCRIPTION
This case is not easy to test in our infra. The cluster creation in this
case will just timeout unless it is done from inside the VPC (and we
don't have a good way to do that in IT).


- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes