### PR TITLE
Fix upgrading managed nodegroups

### DIFF
--- a/integration/tests/managed/managed_nodegroup_test.go
+++ b/integration/tests/managed/managed_nodegroup_test.go
@@ -7,17 +7,20 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/weaveworks/eksctl/integration/matchers"
-	. "github.com/weaveworks/eksctl/integration/runner"
-	"github.com/weaveworks/eksctl/integration/tests"
-	"github.com/weaveworks/eksctl/integration/utilities/kube"
-	"github.com/weaveworks/eksctl/pkg/testutils"
-
 	awseks "github.com/aws/aws-sdk-go/service/eks"
 	harness "github.com/dlespiau/kube-test-harness"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	. "github.com/weaveworks/eksctl/integration/matchers"
+	. "github.com/weaveworks/eksctl/integration/runner"
+	"github.com/weaveworks/eksctl/integration/tests"
+	"github.com/weaveworks/eksctl/integration/utilities/kube"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/testutils"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -27,6 +30,11 @@ func init() {
 	// Call testing.Init() prior to tests.NewParams(), as otherwise -test.* will not be recognised. See also: https://golang.org/doc/go1.13#testing
 	testing.Init()
 	params = tests.NewParams("managed")
+	supportedVersions := api.SupportedVersions()
+	if len(supportedVersions) < 2 {
+		panic("managed nodegroup tests require at least two supported Kubernetes versions to run")
+	}
+	params.Version = supportedVersions[len(supportedVersions)-2]
 }
 
 func TestSuite(t *testing.T) {
@@ -208,6 +216,48 @@ var _ = Describe("(Integration) Create Managed Nodegroups", func() {
 					)
 					Expect(cmd).To(RunSuccessfully())
 				})
+			})
+		})
+
+		Context("and upgrading a nodegroup", func() {
+			It("should upgrade to the next Kubernetes version", func() {
+				By("updating the control plane version")
+				cmd := params.EksctlUpdateCmd.
+					WithArgs(
+						"cluster",
+						"--verbose", "4",
+						"--name", params.ClusterName,
+						"--approve",
+					)
+				Expect(cmd).To(RunSuccessfully())
+
+				var nextVersion string
+				{
+					supportedVersions := api.SupportedVersions()
+					nextVersion = supportedVersions[len(supportedVersions)-1]
+				}
+				By(fmt.Sprintf("checking that control plane is updated to %v", nextVersion))
+				config, err := clientcmd.BuildConfigFromFlags("", params.KubeconfigPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				clientset, err := kubernetes.NewForConfig(config)
+				Expect(err).ToNot(HaveOccurred())
+
+				serverVersion, err := clientset.ServerVersion()
+				Expect(err).ToNot(HaveOccurred())
+
+				serverVersionStr := fmt.Sprintf("%s.%s", serverVersion.Major, serverVersion.Minor)
+				Expect(serverVersionStr).To(Equal(nextVersion))
+
+				By(fmt.Sprintf("upgrading nodegroup %s to Kubernetes version %s", initialNodeGroup, nextVersion))
+				cmd = params.EksctlUpgradeCmd.WithArgs(
+					"nodegroup",
+					"--verbose", "4",
+					"--cluster", params.ClusterName,
+					"--name", initialNodeGroup,
+					"--kubernetes-version", nextVersion,
+				)
+				Expect(cmd).To(RunSuccessfullyWithOutputString(ContainSubstring("nodegroup successfully upgraded")))
 			})
 		})
 

--- a/integration/tests/managed/managed_nodegroup_test.go
+++ b/integration/tests/managed/managed_nodegroup_test.go
@@ -4,6 +4,7 @@ package managed
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -60,6 +61,7 @@ var _ = Describe("(Integration) Create Managed Nodegroups", func() {
 				"--verbose", "4",
 				"--name", params.ClusterName,
 				"--tags", "alpha.eksctl.io/description=eksctl integration test",
+				"--managed",
 				"--nodegroup-name", initialNodeGroup,
 				"--node-labels", "ng-name="+initialNodeGroup,
 				"--nodes", "2",
@@ -246,7 +248,7 @@ var _ = Describe("(Integration) Create Managed Nodegroups", func() {
 				serverVersion, err := clientset.ServerVersion()
 				Expect(err).ToNot(HaveOccurred())
 
-				serverVersionStr := fmt.Sprintf("%s.%s", serverVersion.Major, serverVersion.Minor)
+				serverVersionStr := fmt.Sprintf("%s.%s", serverVersion.Major, strings.TrimSuffix(serverVersion.Minor, "+"))
 				Expect(serverVersionStr).To(Equal(nextVersion))
 
 				By(fmt.Sprintf("upgrading nodegroup %s to Kubernetes version %s", initialNodeGroup, nextVersion))

--- a/integration/tests/params.go
+++ b/integration/tests/params.go
@@ -32,6 +32,8 @@ type Params struct {
 	PrivateSSHKeyPath       string
 	EksctlCmd               runner.Cmd
 	EksctlCreateCmd         runner.Cmd
+	EksctlUpdateCmd         runner.Cmd
+	EksctlUpgradeCmd        runner.Cmd
 	EksctlGetCmd            runner.Cmd
 	EksctlDeleteCmd         runner.Cmd
 	EksctlDeleteClusterCmd  runner.Cmd
@@ -64,6 +66,13 @@ func (p *Params) GenerateCommands() {
 	p.EksctlCreateCmd = p.EksctlCmd.
 		WithArgs("create").
 		WithTimeout(25 * time.Minute)
+
+	p.EksctlUpdateCmd = p.EksctlCmd.
+		WithArgs("update").
+		WithTimeout(55 * time.Minute)
+
+	p.EksctlUpgradeCmd = p.EksctlCmd.
+		WithArgs("upgrade")
 
 	p.EksctlGetCmd = p.EksctlCmd.
 		WithArgs("get").

--- a/pkg/ctl/upgrade/nodegroup.go
+++ b/pkg/ctl/upgrade/nodegroup.go
@@ -1,6 +1,8 @@
 package upgrade
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
@@ -35,7 +37,7 @@ func upgradeNodeGroupCmd(cmd *cmdutils.Cmd) {
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 
-		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
+		cmdutils.AddTimeoutFlagWithValue(fs, &cmd.ProviderConfig.WaitTimeout, 35*time.Minute)
 	})
 
 	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)
@@ -68,5 +70,5 @@ func upgradeNodeGroup(cmd *cmdutils.Cmd, options upgradeOptions) error {
 
 	stackCollection := manager.NewStackCollection(ctl.Provider, cfg)
 	managedService := managed.NewService(ctl.Provider, stackCollection, cfg.Metadata.Name)
-	return managedService.UpgradeNodeGroup(options.nodeGroupName, options.kubernetesVersion)
+	return managedService.UpgradeNodeGroup(options.nodeGroupName, options.kubernetesVersion, cmd.ProviderConfig.WaitTimeout)
 }

--- a/pkg/managed/service.go
+++ b/pkg/managed/service.go
@@ -1,20 +1,21 @@
 package managed
 
 import (
+	"context"
 	"fmt"
 	"regexp"
+	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/eks"
-	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/blang/semver"
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
-	"github.com/weaveworks/eksctl/pkg/ami"
 	"github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 )
@@ -114,74 +115,115 @@ func (m *Service) GetLabels(nodeGroupName string) (map[string]string, error) {
 
 // UpgradeNodeGroup upgrades nodegroup to the latest AMI release for the specified Kubernetes version, or
 // the current Kubernetes version if the version isn't specified
-func (m *Service) UpgradeNodeGroup(nodeGroupName, kubernetesVersion string) error {
-	// Use the latest AMI release version
-	output, err := m.provider.EKS().DescribeNodegroup(&eks.DescribeNodegroupInput{
-		ClusterName:   &m.clusterName,
-		NodegroupName: &nodeGroupName,
+func (m *Service) UpgradeNodeGroup(nodeGroupName, kubernetesVersion string, waitTimeout time.Duration) error {
+	nodegroupOutput, err := m.provider.EKS().DescribeNodegroup(&eks.DescribeNodegroupInput{
+		ClusterName:   aws.String(m.clusterName),
+		NodegroupName: aws.String(nodeGroupName),
 	})
 
 	if err != nil {
-		if isNotFound(err) {
-			return fmt.Errorf("upgrade is only supported for managed nodegroups; could not find one with name %q",
-				nodeGroupName)
+		return errors.Wrap(err, "failed to describe nodegroup")
+	}
+
+	updateInput := &eks.UpdateNodegroupVersionInput{
+		ClusterName:   aws.String(m.clusterName),
+		NodegroupName: aws.String(nodeGroupName),
+	}
+
+	if kubernetesVersion != "" {
+		if _, err := semver.ParseTolerant(kubernetesVersion); err != nil {
+			return errors.Wrap(err, "error parsing Kubernetes version")
 		}
-		return err
+		updateInput.Version = aws.String(kubernetesVersion)
+	} else {
+		updateInput.Version = nodegroupOutput.Nodegroup.Version
 	}
 
-	nodeGroup := output.Nodegroup
-
-	if kubernetesVersion == "" {
-		// Use the current Kubernetes version
-		kubernetesVersion = *nodeGroup.Version
-	} else if _, err := semver.ParseTolerant(kubernetesVersion); err != nil {
-		return errors.Wrap(err, "invalid Kubernetes version")
-	}
-
-	instanceType := nodeGroup.InstanceTypes[0]
-	ssmParameterName, err := ami.MakeSSMParameterName(kubernetesVersion, *instanceType, v1alpha5.NodeImageFamilyAmazonLinux2)
+	nodegroupUpdate, err := m.provider.EKS().UpdateNodegroupVersion(updateInput)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error upgrading nodegroup")
 	}
 
-	ssmOutput, err := m.provider.SSM().GetParameter(&ssm.GetParameterInput{
-		Name: &ssmParameterName,
-	})
-	if err != nil {
-		return err
+	if updateErrors := nodegroupUpdate.Update.Errors; len(updateErrors) > 0 {
+		var allErrors []string
+		for _, updateError := range updateErrors {
+			allErrors = append(allErrors, updateError.String())
+		}
+		return errors.Errorf("failed to upgrade nodegroup:\n%v", strings.Join(allErrors, "\n"))
 	}
 
-	imageID := *ssmOutput.Parameter.Value
-
-	// To get the Kubernetes patch version, as it's not reported in the SSM GetParameter call
-	imagesOutput, err := m.provider.EC2().DescribeImages(&ec2.DescribeImagesInput{
-		ImageIds: aws.StringSlice([]string{imageID}),
-	})
-
-	if err != nil {
-		return err
+	for _, param := range nodegroupUpdate.Update.Params {
+		if *param.Type == eks.UpdateParamTypeReleaseVersion {
+			newReleaseVersion := *param.Value
+			if newReleaseVersion == *nodegroupOutput.Nodegroup.ReleaseVersion {
+				logger.Info("nodegroup %q is already up-to-date (release version: %v)", nodeGroupName, *nodegroupOutput.Nodegroup.ReleaseVersion)
+				return nil
+			}
+			logger.Info("upgrading nodegroup to release version %v", newReleaseVersion)
+		}
 	}
 
-	if len(imagesOutput.Images) != 1 {
-		return fmt.Errorf("expected to find exactly 1 image; got %d", len(imagesOutput.Images))
+	if waitTimeout > 0 {
+		ctx, cancelFunc := context.WithTimeout(context.Background(), waitTimeout)
+		defer cancelFunc()
+		return m.waitForUpdate(ctx, nodeGroupName, nodegroupUpdate.Update.Id)
 	}
+	return nil
+}
 
-	image := *imagesOutput.Images[0]
-	amiReleaseVersion, err := extractAMIReleaseVersion(*image.Name)
-	if err != nil {
-		return errors.Wrap(err, "error extracting AMI release version")
-	}
+func (m *Service) waitForUpdate(ctx context.Context, nodeGroupName string, updateID *string) error {
+	logger.Debug("waiting for nodegroup update to complete (updateID: %v)", *updateID)
 
-	kubernetesVersion, err = extractKubeVersion(*image.Description)
-	if err != nil {
-		return errors.Wrap(err, "error extracting Kubernetes version")
+	const retryAfter = 5 * time.Second
+
+	for {
+		describeOutput, err := m.provider.EKS().DescribeUpdate(&eks.DescribeUpdateInput{
+			Name:          aws.String(m.clusterName),
+			NodegroupName: aws.String(nodeGroupName),
+			UpdateId:      updateID,
+		})
+
+		if err != nil {
+			describeErr := errors.Wrap(err, "error describing nodegroup update")
+			if !request.IsErrorRetryable(err) {
+				return describeErr
+			}
+			logger.Warning(describeErr.Error())
+		}
+
+		logger.Debug("DescribeUpdate output: %v", describeOutput.Update.String())
+
+		switch status := *describeOutput.Update.Status; status {
+		case eks.UpdateStatusSuccessful:
+			logger.Debug("nodegroup successfully upgraded")
+			return nil
+
+		case eks.UpdateStatusCancelled:
+			return errors.New("nodegroup update cancelled")
+
+		case eks.UpdateStatusFailed:
+			var aggregatedErrors []string
+			for _, updateError := range describeOutput.Update.Errors {
+				aggregatedErrors = append(aggregatedErrors, updateError.String())
+			}
+			return errors.Errorf("nodegroup update failed: %v", strings.Join(aggregatedErrors, "\n"))
+
+		case eks.UpdateStatusInProgress:
+			logger.Debug("nodegroup update in progress")
+
+		default:
+			return errors.Errorf("unexpected nodegroup update status: %q", status)
+
+		}
+
+		timer := time.NewTimer(retryAfter)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return errors.Errorf("timed out waiting for nodegroup update to complete: %v", ctx.Err())
+		case <-timer.C:
+		}
 	}
-	releaseVersion := makeReleaseVersion(kubernetesVersion, amiReleaseVersion)
-	if releaseVersion == *nodeGroup.ReleaseVersion {
-		logger.Info("nodegroup %q is already up-to-date", nodeGroupName)
-		return nil
-	}
-	return m.updateNodeGroupVersion(nodeGroupName, releaseVersion)
 }
 
 func (m *Service) updateNodeGroupVersion(nodeGroupName, releaseVersion string) error {

--- a/pkg/managed/service.go
+++ b/pkg/managed/service.go
@@ -162,6 +162,7 @@ func (m *Service) UpgradeNodeGroup(nodeGroupName, kubernetesVersion string, wait
 		defer cancelFunc()
 		return m.waitForUpdate(ctx, nodeGroupName, nodegroupUpdate.Update.Id)
 	}
+	logger.Info("nodegroup upgrade request submitted")
 	return nil
 }
 


### PR DESCRIPTION
### Description

Currently, AMIs published for EKS worker nodes are not immediately available for use with managed nodegroups. To work around this, this change uses the AWS EKS Nodegroup API and leaves the ReleaseVersion unset to allow the default behaviour of the API choosing the latest available AMI version.

This change also switches from updating the CloudFormation stack to using the UpdateNodegroupVersion API call, because with the ReleaseVersion no longer being set to the latest AMI release obtained via SSM, some other field must be updated in order to trigger a stack update. Rather than use a hack like updating a label on the nodegroup, we simply use the UpdateNodegroupVersion API call which also gives more control over the update process.

Fixes #1962 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

