### PR TITLE
Fix broken AllocationId syntax in VPC cloudformation

### DIFF
--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -369,7 +369,7 @@ func (c *ClusterResourceSet) haNAT() {
 		})
 		// Allocate a NAT gateway in the public subnet
 		refNG := c.newResource("NATGateway"+alphanumericUpperAZ, &gfn.AWSEC2NatGateway{
-			AllocationId: gfn.MakeFnGetAttString("NATIP" + alphanumericUpperAZ + ".AllocationID"),
+			AllocationId: gfn.MakeFnGetAttString("NATIP" + alphanumericUpperAZ + ".AllocationId"),
 			SubnetId:     gfn.MakeRef("SubnetPublic" + alphanumericUpperAZ),
 		})
 
@@ -401,7 +401,7 @@ func (c *ClusterResourceSet) singleNAT() {
 		Domain: gfn.NewString("vpc"),
 	})
 	refNG := c.newResource("NATGateway", &gfn.AWSEC2NatGateway{
-		AllocationId: gfn.MakeFnGetAttString("NATIP.AllocationID"),
+		AllocationId: gfn.MakeFnGetAttString("NATIP.AllocationId"),
 		SubnetId:     gfn.MakeRef("SubnetPublic" + firstUpperAZ),
 	})
 


### PR DESCRIPTION
### Description

Broken after merging https://github.com/weaveworks/eksctl/commit/5215e9fb917e6890f492a1e2ebb8cfff31ba6f43#diff-74bb78b98a963fd1fdfb709c48f1983eR372

Thanks @aaronjwood
https://github.com/weaveworks/eksctl/pull/2147#issuecomment-624949204
<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

