### PR TITLE
Fix helm-operator manifest names for integration tests

### DIFF
--- a/integration/matchers/flux.go
+++ b/integration/matchers/flux.go
@@ -96,11 +96,11 @@ func assertContainsFluxManifests(dir string) {
 		case "memcache-svc.yaml":
 			assertValidFluxMemcacheServiceManifest(filePath)
 		// Helm operator resources:
-		case "flux-helm-operator-account.yaml":
+		case "rbac.yaml":
 			assertValidFluxHelmOperatorAccount(filePath)
-		case "flux-helm-release-crd.yaml":
+		case "crds.yaml":
 			assertValidFluxHelmReleaseCRD(filePath)
-		case "helm-operator-deployment.yaml":
+		case "deployment.yaml":
 			assertValidHelmOperatorDeployment(filePath)
 		default:
 			Fail(fmt.Sprintf("Unrecognized file: %s", f.Name()))


### PR DESCRIPTION
### Description
See https://github.com/fluxcd/helm-operator/tree/master/pkg/install/templates
<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

