### PR TITLE
Add name argument for delete iamserviceaccount

### DIFF
--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -610,7 +610,7 @@ func NewDeleteIAMServiceAccountLoader(cmd *Cmd, sa *api.ClusterIAMServiceAccount
 		}
 
 		if sa.Name != "" && l.NameArg != "" {
-			return ErrClusterFlagAndArg(l.Cmd, sa.Name, l.NameArg)
+			return ErrFlagAndArg("--name", sa.Name, l.NameArg)
 		}
 
 		if l.NameArg != "" {

--- a/pkg/ctl/delete/iamserviceaccount.go
+++ b/pkg/ctl/delete/iamserviceaccount.go
@@ -14,6 +14,12 @@ import (
 )
 
 func deleteIAMServiceAccountCmd(cmd *cmdutils.Cmd) {
+	deleteIAMServiceAccountCmdWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, onlyMissing bool) error {
+		return doDeleteIAMServiceAccount(cmd, serviceAccount, onlyMissing)
+	})
+}
+
+func deleteIAMServiceAccountCmdWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, onlyMissing bool) error) {
 	cfg := api.NewClusterConfig()
 	cmd.ClusterConfig = cfg
 
@@ -27,7 +33,8 @@ func deleteIAMServiceAccountCmd(cmd *cmdutils.Cmd) {
 	cmd.SetDescription("iamserviceaccount", "Delete an IAM service account", "")
 
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
-		return doDeleteIAMServiceAccount(cmd, serviceAccount, onlyMissing)
+		cmd.NameArg = cmdutils.GetNameArg(args)
+		return runFunc(cmd, serviceAccount, onlyMissing)
 	}
 
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/delete/iamserviceaccount_test.go
+++ b/pkg/ctl/delete/iamserviceaccount_test.go
@@ -1,0 +1,63 @@
+package delete
+
+import (
+	"fmt"
+	"strings"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+
+	. "github.com/onsi/ginkgo/extensions/table"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("delete iamserviceaccount", func() {
+	DescribeTable("delete service account successfully",
+		func(args ...string) {
+			commandArgs := append([]string{"iamserviceaccount"}, args...)
+			cmd := newMockEmptyCmd(commandArgs...)
+			count := 0
+			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+				deleteIAMServiceAccountCmdWithRunFunc(cmd, func(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMServiceAccount, onlyMissing bool) error {
+					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+					Expect(cmd.ClusterConfig.IAM.ServiceAccounts[0].Name).To(Equal("serviceAccountName"))
+					Expect(onlyMissing).To(Equal(strings.Contains(strings.Join(commandArgs, " "), "only-missing")))
+					count++
+					return nil
+				})
+			})
+			_, err := cmd.execute()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(count).To(Equal(1))
+		},
+		Entry("with all required flags", "--cluster", "clusterName", "--name", "serviceAccountName"),
+		Entry("with namespace flag", "--cluster", "clusterName", "--name", "serviceAccountName", "--namespace", "dev"),
+		Entry("with only-missing flag", "--cluster", "clusterName", "--name", "serviceAccountName", "--only-missing"),
+		Entry("with approve flag", "--cluster", "clusterName", "--name", "serviceAccountName", "--approve"),
+	)
+
+	DescribeTable("invalid flags or arguments",
+		func(c invalidParamsCase) {
+			commandArgs := append([]string{"iamserviceaccount"}, c.args...)
+			cmd := newDefaultCmd(commandArgs...)
+			_, err := cmd.execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal(c.error.Error()))
+		},
+		Entry("without cluster name", invalidParamsCase{
+			args:  []string{"--name", "serviceAccountName"},
+			error: fmt.Errorf("--cluster must be set"),
+		}),
+		Entry("with iamserviceaccount name as argument and flag", invalidParamsCase{
+			args:  []string{"--cluster", "clusterName", "--name", "serviceAccountName", "serviceAccountName"},
+			error: fmt.Errorf("--name=serviceAccountName and argument serviceAccountName cannot be used at the same time"),
+		}),
+		Entry("with invalid flags", invalidParamsCase{
+			args:  []string{"iamserviceaccount", "--invalid", "dummy"},
+			error: fmt.Errorf("unknown flag: --invalid"),
+		}),
+	)
+})


### PR DESCRIPTION
### Description

To add name argument for delete iamserviceaccount CLI. This is also to
make the behavior consistent with create iamserviceaccount CLI.

While working on this, I also correct error message related to name args

Closes #2087 

### Testing

<details>
<summary>Before</summary>

```
$ ./eksctl delete iamserviceaccount --cluster dummy dummysa                                         
Error: --name must be set  
```

</details>

<details>
<summary>After</summary>

```
$ ./eksctl delete iamserviceaccount --cluster dummy dummysa
[ℹ]  eksctl version 0.20.0-dev+f63eea27.2020-05-11T21:45:32Z
[ℹ]  using region ap-southeast-2
Error: checking AWS STS access – cannot get role ARN for current session: ExpiredToken: The security token included in the request is expired
	status code: 403, request id: 7be241f2-640a-4050-a48b-a86f5092ba9a

```

</details>


### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

