### PR TITLE
Use legacy ng tags to find ng type

### DIFF
--- a/pkg/cfn/manager/nodegroup_test.go
+++ b/pkg/cfn/manager/nodegroup_test.go
@@ -6,8 +6,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	cfn "github.com/aws/aws-sdk-go/service/cloudformation"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
+
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
 )
@@ -267,5 +269,102 @@ var _ = Describe("StackCollection NodeGroup", func() {
 				})
 			})
 		})
+	})
+
+	Describe("GetNodeGroupType", func() {
+
+		createTags := func(tags map[string]string) []*cfn.Tag {
+			cfnTags := make([]*cfn.Tag, 0)
+			for k, v := range tags {
+				cfnTags = append(cfnTags, &cfn.Tag{
+					Key:   aws.String(k),
+					Value: aws.String(v),
+				})
+			}
+			return cfnTags
+		}
+
+		DescribeTable("with tag for the nodegroup type", func(inputTags map[string]string, expectedType api.NodeGroupType) {
+			ngType, err := GetNodeGroupType(createTags(inputTags))
+
+			if expectedType == "" {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ngType).To(Equal(expectedType))
+			}
+		},
+
+			Entry("finds the type of a managed nodegroup",
+				map[string]string{
+					api.NodeGroupNameTag: "mng-1",
+					api.NodeGroupTypeTag: "managed",
+				},
+				api.NodeGroupTypeManaged),
+
+			Entry("finds the type of an un-managed nodegroup",
+				map[string]string{
+					api.NodeGroupNameTag: "ng-1",
+					api.NodeGroupTypeTag: "unmanaged",
+				},
+				api.NodeGroupTypeUnmanaged),
+
+			Entry("finds the type of an legacy un-managed nodegroup",
+				map[string]string{
+					api.OldNodeGroupNameTag: "ng-1",
+					api.NodeGroupTypeTag:    "unmanaged",
+				},
+				api.NodeGroupTypeUnmanaged),
+
+			Entry("finds the type of a legacy un-managed nodegroup",
+				map[string]string{
+					api.OldNodeGroupIDTag: "ng-1",
+					api.NodeGroupTypeTag:  "unmanaged",
+				},
+				api.NodeGroupTypeUnmanaged),
+
+			Entry("doesn't return the type if the stack tags don't contain any ng name tag",
+				map[string]string{
+					"some-other-tag": "ng-1",
+					"name":           "ng-1",
+				},
+				api.NodeGroupType("")),
+		)
+		DescribeTable("for legacy ngs without tag for the type", func(inputTags map[string]string, expectedType api.NodeGroupType) {
+			ngType, err := GetNodeGroupType(createTags(inputTags))
+
+			if expectedType == "" {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ngType).To(Equal(expectedType))
+			}
+		},
+
+			Entry("legacy ngs with old name tags are un-managed by default",
+				map[string]string{
+					api.NodeGroupNameTag: "ng-1",
+				},
+				api.NodeGroupTypeUnmanaged),
+
+			Entry("legacy ngs with old name tags are un-managed by default",
+				map[string]string{
+					api.OldNodeGroupNameTag: "ng-1",
+				},
+				api.NodeGroupTypeUnmanaged),
+
+			Entry("legacy ngs with old name tag group-id are un-managed by default",
+				map[string]string{
+					api.OldNodeGroupIDTag: "ng-1",
+				},
+				api.NodeGroupTypeUnmanaged),
+
+			Entry("doesn't return the type if the stack tags don't contain any ng name tag",
+				map[string]string{
+					"some-other-tag": "ng-1",
+					"name":           "ng-1",
+				},
+				api.NodeGroupType("")),
+		)
 	})
 })


### PR DESCRIPTION
possibly fixes #2148

When finding the type of a nodegroup the legacy tags used for identifying a nodegroup where not considered. But these
need to be taken into account because a cluster may have been created with an older version of eksctl.


- [x] Added tests that cover your change (if possible)
- [ ] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes