### PR TITLE
Fix timeout error when updating from 1.15 to 1.16

### DIFF
--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
@@ -38,7 +39,8 @@ func updateClusterCmd(cmd *cmdutils.Cmd) {
 
 		cmdutils.AddWaitFlag(fs, &cmd.Wait, "all update operations to complete")
 		_ = fs.MarkDeprecated("wait", "--wait is no longer respected; the cluster update always waits to complete")
-		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
+		// updating from 1.15 to 1.16 has been observed to take longer than the default value of 25 minutes
+		cmdutils.AddTimeoutFlagWithValue(fs, &cmd.ProviderConfig.WaitTimeout, 35*time.Minute)
 	})
 
 	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)


### PR DESCRIPTION
Clone pr of #2151 to branch `release-0.19`

