### PR TITLE
Fix Fargate on Kubernetes 1.16

### DIFF
--- a/pkg/fargate/coredns/deployment.go
+++ b/pkg/fargate/coredns/deployment.go
@@ -1,0 +1,69 @@
+package coredns
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kubeclient "k8s.io/client-go/kubernetes"
+)
+
+type betaDeployment struct {
+	*v1beta1.Deployment
+}
+
+func (d betaDeployment) PodAnnotations() map[string]string { return d.Spec.Template.Annotations }
+
+func (d betaDeployment) Replicas() *int32 { return d.Spec.Replicas }
+
+func (d betaDeployment) ReadyReplicas() int32 { return d.Status.ReadyReplicas }
+
+type appsDeployment struct {
+	*appsv1.Deployment
+}
+
+func (d appsDeployment) PodAnnotations() map[string]string { return d.Spec.Template.Annotations }
+
+func (d appsDeployment) Replicas() *int32 { return d.Spec.Replicas }
+
+func (d appsDeployment) ReadyReplicas() int32 { return d.Status.ReadyReplicas }
+
+type deployment interface {
+	runtime.Object
+	PodAnnotations() map[string]string
+	Replicas() *int32
+	ReadyReplicas() int32
+}
+
+func getDeployment(clientSet kubeclient.Interface, useBetaAPIGroup bool) (deployment, error) {
+	if useBetaAPIGroup {
+		deployment, err := clientSet.ExtensionsV1beta1().Deployments(Namespace).Get(Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return betaDeployment{deployment}, nil
+	}
+
+	deployment, err := clientSet.AppsV1().Deployments(Namespace).Get(Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return appsDeployment{deployment}, nil
+}
+
+func patchDeployment(clientSet kubeclient.Interface, useBetaAPIGroup bool, bytes []byte) (deployment, error) {
+	if useBetaAPIGroup {
+		patchedDeployment, err := clientSet.ExtensionsV1beta1().Deployments(Namespace).Patch(Name, types.MergePatchType, bytes)
+		if err != nil {
+			return nil, err
+		}
+		return betaDeployment{patchedDeployment}, nil
+	}
+
+	patchedDeployment, err := clientSet.AppsV1().Deployments(Namespace).Patch(Name, types.MergePatchType, bytes)
+	if err != nil {
+		return nil, err
+	}
+	return appsDeployment{patchedDeployment}, nil
+}


### PR DESCRIPTION
### Description

`Deployment` is no longer served from extensions/v1beta1. This change migrates to use the apps/v1 API version for Kubernetes 1.16 and above.

Fixes #2169 

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

