### PR TITLE
Fix flags issue in version cli

### DIFF
--- a/cmd/eksctl/main.go
+++ b/cmd/eksctl/main.go
@@ -39,7 +39,8 @@ func addCommands(rootCmd *cobra.Command, flagGrouping *cmdutils.FlagGrouping) {
 	}
 	rootCmd.AddCommand(utils.Command(flagGrouping))
 	rootCmd.AddCommand(completion.Command(rootCmd))
-	rootCmd.AddCommand(versionCmd(flagGrouping))
+
+	cmdutils.AddResourceCmd(flagGrouping, rootCmd, versionCmd)
 }
 
 func main() {

--- a/cmd/eksctl/version.go
+++ b/cmd/eksctl/version.go
@@ -11,9 +11,9 @@ import (
 	"github.com/weaveworks/eksctl/pkg/version"
 )
 
-var output string
-
 func versionCmd(cmd *cmdutils.Cmd) {
+	var output string
+
 	cmd.SetDescription("version", "Output the version of eksctl", "")
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&output, "output", "o", "", "specifies the output format (valid option: json)")

--- a/cmd/eksctl/version.go
+++ b/cmd/eksctl/version.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 
+	"github.com/spf13/pflag"
+
 	"github.com/spf13/cobra"
 
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
@@ -11,22 +13,21 @@ import (
 
 var output string
 
-func versionCmd(_ *cmdutils.FlagGrouping) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "version",
-		Short: "Output the version of eksctl",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			switch output {
-			case "":
-				fmt.Printf("%s\n", version.GetVersion())
-			case "json":
-				fmt.Printf("%s\n", version.String())
-			default:
-				return fmt.Errorf("unknown output: %s", output)
-			}
-			return nil
-		},
+func versionCmd(cmd *cmdutils.Cmd) {
+	cmd.SetDescription("version", "Output the version of eksctl", "")
+	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
+		fs.StringVarP(&output, "output", "o", "", "specifies the output format (valid option: json)")
+	})
+	cmd.CobraCommand.Args = cobra.NoArgs
+	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
+		switch output {
+		case "":
+			fmt.Printf("%s\n", version.GetVersion())
+		case "json":
+			fmt.Printf("%s\n", version.String())
+		default:
+			return fmt.Errorf("unknown output: %s", output)
+		}
+		return nil
 	}
-	cmd.Flags().StringVarP(&output, "output", "o", "", "specifies the output format (valid option: json)")
-	return cmd
 }


### PR DESCRIPTION
### Description

Fixes https://github.com/weaveworks/eksctl/issues/2186

### Testing

<details>
<summary> Run eksctl version -h </summary>

```shell scripts
$ ./eksctl version -h
Output the version of eksctl

Usage: eksctl version [flags]

General flags:
  -o, --output string   specifies the output format (valid option: json)

Common flags:
  -C, --color string   toggle colorized logs (valid options: true, false, fabulous) (default "true")
  -h, --help           help for this command
  -v, --verbose int    set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging (default 3)

Use 'eksctl version [command] --help' for more information about a command.

$ ./eksctl -h        
The official CLI for Amazon EKS

Usage: eksctl [command] [flags]

Commands:
  eksctl create                  Create resource(s)
  eksctl get                     Get resource(s)
  eksctl update                  Update resource(s)
  eksctl upgrade                 Upgrade resource(s)
  eksctl delete                  Delete resource(s)
  eksctl set                     Set values
  eksctl unset                   Unset values
  eksctl scale                   Scale resources(s)
  eksctl drain                   Drain resource(s)
  eksctl utils                   Various utils
  eksctl completion              Generates shell completion scripts for bash, zsh or fish
  eksctl version                 Output the version of eksctl
  eksctl help                    Help about any command

Common flags:
  -C, --color string   toggle colorized logs (valid options: true, false, fabulous) (default "true")
  -h, --help           help for this command
  -v, --verbose int    set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging (default 3)

Use 'eksctl [command] --help' for more information about a command.

```

</details>

<details>
<summary> Make sure eksctl version didn't break </summary>

```shell scripts
$ ./eksctl version   
0.20.0-dev+480d13a2.2020-05-15T15:23:23Z

$ ./eksctl version -o json | jq
{
  "Version": "0.20.0",
  "PreReleaseID": "dev",
  "Metadata": {
    "BuildDate": "2020-05-15T15:23:23Z",
    "GitCommit": "480d13a2"
  },
  "EKSServerSupportedVersions": [
    "1.13",
    "1.14",
    "1.15",
    "1.16"
  ]
}

$ ./eksctl version 123123123   
Error: unknown command "123123123" for "eksctl version"

```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

