### PR TITLE
Add support for GovCloud regions

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -83,6 +83,12 @@ const (
 	// RegionCNNorth1 represents the China region Beijing
 	RegionCNNorth1 = "cn-north-1"
 
+	// RegionUSGovWest1 represents the region GovCloud (US-West)
+	RegionUSGovWest1 = "us-gov-west-1"
+
+	// RegionUSGovEast1 represents the region GovCloud (US-East)
+	RegionUSGovEast1 = "us-gov-east-1"
+
 	// DefaultRegion defines the default region, where to deploy the EKS cluster
 	DefaultRegion = RegionUSWest2
 
@@ -211,6 +217,12 @@ const (
 
 	// eksResourceAccountCNNorth1 defines the AWS EKS account ID that provides node resources in cn-north-1
 	eksResourceAccountCNNorth1 = "918309763551"
+
+	// eksResourceAccountUSGovWest1 defines the AWS EKS account ID that provides node resources in us-gov-west-1
+	eksResourceAccountUSGovWest1 = "013241004608"
+
+	// eksResourceAccountUSGovEast1 defines the AWS EKS account ID that provides node resources in us-gov-east-1
+	eksResourceAccountUSGovEast1 = "151742754352"
 )
 
 // NodeGroupType defines the nodegroup type
@@ -283,6 +295,8 @@ func SupportedRegions() []string {
 		RegionSAEast1,
 		RegionCNNorthwest1,
 		RegionCNNorth1,
+		RegionUSGovWest1,
+		RegionUSGovEast1,
 	}
 }
 
@@ -342,6 +356,10 @@ func EKSResourceAccountID(region string) string {
 		return eksResourceAccountCNNorthWest1
 	case RegionCNNorth1:
 		return eksResourceAccountCNNorth1
+	case RegionUSGovWest1:
+		return eksResourceAccountUSGovWest1
+	case RegionUSGovEast1:
+		return eksResourceAccountUSGovEast1
 	default:
 		return eksResourceAccountStandard
 	}

--- a/pkg/cfn/builder/partition.go
+++ b/pkg/cfn/builder/partition.go
@@ -12,6 +12,11 @@ var servicePrincipalPartitionMappings = map[string]map[string]string{
 		"EKS":            "eks.amazonaws.com",
 		"EKSFargatePods": "eks-fargate-pods.amazonaws.com",
 	},
+	"aws-us-gov": {
+		"EC2":            "ec2.amazonaws.com",
+		"EKS":            "eks.amazonaws.com",
+		"EKSFargatePods": "eks-fargate-pods.amazonaws.com",
+	},
 	"aws-cn": {
 		"EC2":            "ec2.amazonaws.com.cn",
 		"EKS":            "eks.amazonaws.com",

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -252,7 +252,7 @@ func (c *ClusterProvider) NewOpenIDConnectManager(spec *api.ClusterConfig) (*iam
 		return nil, errors.Wrapf(err, "unexpected invalid ARN: %q", spec.Status.ARN)
 	}
 	switch parsedARN.Partition {
-	case "aws", "aws-cn":
+	case "aws", "aws-cn", "aws-us-gov":
 	default:
 		return nil, fmt.Errorf("unknown EKS ARN: %q", spec.Status.ARN)
 	}


### PR DESCRIPTION
### Description

Adds support for GovCloud regions: us-gov-west-1 and us-gov-east-1

Closes #2189 

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

