### PR TITLE
Remove @michaelbeaumont from Acknowledgements list in release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -20,5 +20,5 @@ template: |
   Weaveworks would like to sincerely thank:
   $CONTRIBUTORS
 replacers:
-  - search: '/(@martina-if|@marccarre|@cPu1)(,)?/g'
+  - search: '/(@martina-if|@michaelbeaumont|@cPu1)(,)?/g'
     replace: ''


### PR DESCRIPTION
Since Michael is part of the maintainers team he should not be part of the
automatic list of Acknowledged contributors.