### PR TITLE
Make 1.16 as default

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -114,7 +114,7 @@ const (
 	Version1_16 = "1.16"
 
 	// DefaultVersion represents default Kubernetes version supported by EKS
-	DefaultVersion = Version1_15
+	DefaultVersion = Version1_16
 
 	// LatestVersion represents latest Kubernetes version supported by EKS
 	LatestVersion = Version1_16

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -449,7 +449,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Metadata: &api.ClusterMeta{
 				Region:  "us-west-2",
 				Name:    clusterName,
-				Version: "1.15",
+				Version: "1.16",
 			},
 			Status: &api.ClusterStatus{
 				Endpoint:                 endpoint,

--- a/pkg/ctl/cmdutils/nodegroup_filter_test.go
+++ b/pkg/ctl/cmdutils/nodegroup_filter_test.go
@@ -340,7 +340,7 @@ const expected = `
 		"metadata": {
 		  "name": "test-3x3-ngs",
 		  "region": "eu-central-1",
-		  "version": "1.15"
+		  "version": "1.16"
 		},
 		"iam": {},
 		"vpc": {

--- a/userdocs/src/introduction.md
+++ b/userdocs/src/introduction.md
@@ -19,12 +19,12 @@ eksctl create cluster --name=cluster-1 --nodes=4
 
 ```
 
-EKS supports versions `1.13`, `1.14`, `1.15` (default) and `1.16`
+EKS supports versions `1.13`, `1.14`, `1.15` and `1.16` (default)
 With `eksctl` you can deploy any of the supported versions by passing `--version`.
 
 ```
 
-eksctl create cluster --version=1.15
+eksctl create cluster --version=1.16
 
 ```
 
@@ -245,7 +245,7 @@ The features that are currently implemented are:
 - Update a cluster
 - Use custom AMIs
 - Configure VPC Networking
-- Configure accesss to API endpoints
+- Configure access to API endpoints
 - Support for GPU nodegroups
 - Spot instances and mixed instances
 - IAM Management and Add-on Policies


### PR DESCRIPTION
### Description

Fixes https://github.com/weaveworks/eksctl/issues/2175

### Testing
<details>
<summary>create new cluster</summary>

```shell scripts
$ ./eksctl create cluster --managed --node-private-networking               
[ℹ]  eksctl version 0.21.0-dev+f17aff04.2020-05-16T14:42:34Z
[ℹ]  using region us-east-2
[ℹ]  setting availability zones to [us-east-2a us-east-2b us-east-2c]
[ℹ]  subnets for us-east-2a - public:192.168.0.0/19 private:192.168.96.0/19
[ℹ]  subnets for us-east-2b - public:192.168.32.0/19 private:192.168.128.0/19
[ℹ]  subnets for us-east-2c - public:192.168.64.0/19 private:192.168.160.0/19
[ℹ]  using Kubernetes version 1.16
[ℹ]  creating EKS cluster "exciting-outfit-1589604182" in "us-east-2" region with managed nodes
[ℹ]  will create 2 separate CloudFormation stacks for cluster itself and the initial managed nodegroup
[ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-east-2 --cluster=exciting-outfit-1589604182'
[ℹ]  CloudWatch logging will not be enabled for cluster "exciting-outfit-1589604182" in "us-east-2"
[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --region=us-east-2 --cluster=exciting-outfit-1589604182'
[ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "exciting-outfit-1589604182" in "us-east-2"
[ℹ]  2 sequential tasks: { create cluster control plane "exciting-outfit-1589604182", 2 parallel sub-tasks: { no tasks, create managed nodegroup "ng-2844eacf" } }
[ℹ]  building cluster stack "eksctl-exciting-outfit-1589604182-cluster"
[ℹ]  deploying stack "eksctl-exciting-outfit-1589604182-cluster"
[ℹ]  building managed nodegroup stack "eksctl-exciting-outfit-1589604182-nodegroup-ng-2844eacf"
[ℹ]  deploying stack "eksctl-exciting-outfit-1589604182-nodegroup-ng-2844eacf"
[ℹ]  waiting for the control plane availability...
[✔]  saved kubeconfig as "/home/tammach/.kube/config"
[ℹ]  no tasks
[✔]  all EKS cluster resources for "exciting-outfit-1589604182" have been created
[ℹ]  nodegroup "ng-2844eacf" has 2 node(s)
[ℹ]  node "ip-192-168-185-172.us-east-2.compute.internal" is ready
[ℹ]  node "ip-192-168-96-62.us-east-2.compute.internal" is ready
[ℹ]  waiting for at least 2 node(s) to become ready in "ng-2844eacf"
[ℹ]  nodegroup "ng-2844eacf" has 2 node(s)
[ℹ]  node "ip-192-168-185-172.us-east-2.compute.internal" is ready
[ℹ]  node "ip-192-168-96-62.us-east-2.compute.internal" is ready
[ℹ]  kubectl command should work with "/home/tammach/.kube/config", try 'kubectl get nodes'
[✔]  EKS cluster "exciting-outfit-1589604182" in "us-east-2" region is ready

$ kgno
NAME                                            STATUS   ROLES    AGE   VERSION
ip-192-168-185-172.us-east-2.compute.internal   Ready    <none>   24m   v1.16.8-eks-e16311
ip-192-168-96-62.us-east-2.compute.internal     Ready    <none>   24m   v1.16.8-eks-e16311


```

</details>

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

