### PR TITLE
Add condition for maxinum number of args in resource command

### DIFF
--- a/pkg/ctl/cmdutils/cmd.go
+++ b/pkg/ctl/cmdutils/cmd.go
@@ -70,7 +70,9 @@ func (c *Cmd) NewCtl() (*eks.ClusterProvider, error) {
 // AddResourceCmd create a registers a new command under the given verb command
 func AddResourceCmd(flagGrouping *FlagGrouping, parentVerbCmd *cobra.Command, newCmd func(*Cmd)) {
 	c := &Cmd{
-		CobraCommand:   &cobra.Command{},
+		CobraCommand: &cobra.Command{
+			Args: cobra.MaximumNArgs(1),
+		},
 		ProviderConfig: &api.ProviderConfig{},
 
 		Plan:     true,  // always on by default


### PR DESCRIPTION
### Description

Fixes https://github.com/weaveworks/eksctl/issues/1777

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

