### PR TITLE
Increase cluster update timeout to 45 minutes

### DIFF
--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -40,7 +40,7 @@ func updateClusterCmd(cmd *cmdutils.Cmd) {
 		cmdutils.AddWaitFlag(fs, &cmd.Wait, "all update operations to complete")
 		_ = fs.MarkDeprecated("wait", "--wait is no longer respected; the cluster update always waits to complete")
 		// updating from 1.15 to 1.16 has been observed to take longer than the default value of 25 minutes
-		cmdutils.AddTimeoutFlagWithValue(fs, &cmd.ProviderConfig.WaitTimeout, 35*time.Minute)
+		cmdutils.AddTimeoutFlagWithValue(fs, &cmd.ProviderConfig.WaitTimeout, 45*time.Minute)
 	})
 
 	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

