### PR TITLE
Fix incorrect IAM example

### DIFF
--- a/userdocs/src/examples/reusing-iam-and-vpc.md
+++ b/userdocs/src/examples/reusing-iam-and-vpc.md
@@ -1,5 +1,5 @@
 # Custom IAM and VPC config
-This example shows how to create a cluster reusing pre-existing IAM and VPC resources:
+This example shows how to create a cluster using pre-existing IAM and VPC resources:
 
 ```yaml
 apiVersion: eksctl.io/v1alpha5
@@ -57,9 +57,6 @@ managedNodeGroups:
       'environment:basedomain': 'example.org'
     iam:
       instanceRoleARN: "arn:aws:iam::1111:role/eks-nodes-base-role"
-      withAddonPolicies:
-        externalDNS: true
-        certManager: true
 
 ```
 


### PR DESCRIPTION
Specifying both `iam.instanceRoleARN` and `iam.withAddonPolicies.<policy>` is not supported

### Description

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

