### PR TITLE
[release-0.20] Add IAM permissions required by AWS ALB Ingress to use WAFv2 and Shield

### DIFF
--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -1304,6 +1304,10 @@ var _ = Describe("CloudFormation template builder API", func() {
 				"tag:GetResources",
 				"tag:TagResources",
 				"waf:GetWebACL",
+				"wafv2:GetWebACL",
+				"wafv2:GetWebACLForResource",
+				"wafv2:AssociateWebACL",
+				"wafv2:DisassociateWebACL",
 			}))
 		})
 

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -1308,6 +1308,12 @@ var _ = Describe("CloudFormation template builder API", func() {
 				"wafv2:GetWebACLForResource",
 				"wafv2:AssociateWebACL",
 				"wafv2:DisassociateWebACL",
+				"shield:DescribeProtection",
+				"shield:GetSubscriptionState",
+				"shield:DeleteProtection",
+				"shield:CreateProtection",
+				"shield:DescribeSubscription",
+				"shield:ListProtections",
 			}))
 		})
 

--- a/pkg/cfn/builder/iam_helper.go
+++ b/pkg/cfn/builder/iam_helper.go
@@ -236,6 +236,12 @@ func createRole(cfnTemplate cfnTemplate, iamConfig *api.NodeGroupIAM, managed bo
 				"wafv2:GetWebACLForResource",
 				"wafv2:AssociateWebACL",
 				"wafv2:DisassociateWebACL",
+				"shield:DescribeProtection",
+				"shield:GetSubscriptionState",
+				"shield:DeleteProtection",
+				"shield:CreateProtection",
+				"shield:DescribeSubscription",
+				"shield:ListProtections",
 			},
 		)
 	}

--- a/pkg/cfn/builder/iam_helper.go
+++ b/pkg/cfn/builder/iam_helper.go
@@ -232,6 +232,10 @@ func createRole(cfnTemplate cfnTemplate, iamConfig *api.NodeGroupIAM, managed bo
 				"tag:GetResources",
 				"tag:TagResources",
 				"waf:GetWebACL",
+				"wafv2:GetWebACL",
+				"wafv2:GetWebACLForResource",
+				"wafv2:AssociateWebACL",
+				"wafv2:DisassociateWebACL",
 			},
 		)
 	}


### PR DESCRIPTION
### Description

Clone PR of https://github.com/weaveworks/eksctl/pull/2068

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

