### PR TITLE
Fix a typo in iamserviceaccount docs

### DIFF
--- a/userdocs/src/usage/iamserviceaccounts.md
+++ b/userdocs/src/usage/iamserviceaccounts.md
@@ -39,7 +39,7 @@ eksctl create iamserviceaccount --cluster=<clusterName> --name=<serviceAccountNa
 ```
 
 !!!note
-    You can specify `--attach-policy-arn` multiple times to use more then one policy.
+    You can specify `--attach-policy-arn` multiple times to use more than one policy.
 
 More specifically, you can create a service account with read-only access to S3 by running:
 


### PR DESCRIPTION
### Description

There is a trivial typo in https://eksctl.io/usage/iamserviceaccounts/. This PR addresses it.

### Checklist
- [ ] ~Added tests that cover your change (if possible)~
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

