### PR TITLE
Disallow setting node-role.kubernetes.io label 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	k8s.io/code-generator v0.16.8
 	k8s.io/kops v1.15.2
 	k8s.io/kubelet v0.0.0
+	k8s.io/kubernetes v1.15.3
 	k8s.io/legacy-cloud-providers v0.0.0
 	sigs.k8s.io/aws-iam-authenticator v0.5.0
 	sigs.k8s.io/yaml v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1480,6 +1480,7 @@ k8s.io/kube-scheduler v0.16.8/go.mod h1:Yq1uX8tvuzb/dxjx0nKQE88XBRDRyhW75drSDHLT
 k8s.io/kubectl v0.16.8/go.mod h1:s6lhPwTkZjHBVHH6BRVRUA1SAqqZF8osaWSYTvR1H1U=
 k8s.io/kubelet v0.16.8 h1:737GeCz3Bu4NxGivTj910vPaL6UYkxaXoOGuMarzCI0=
 k8s.io/kubelet v0.16.8/go.mod h1:mzDpnryQg2dlB6V3/WAgb1baIamiICtWpXMFrPOFh6I=
+k8s.io/kubernetes v1.16.8 h1:AQb20svioSN1foO9LOdZiUOM8zRmNua2PnYB8bvO48w=
 k8s.io/kubernetes v1.16.8/go.mod h1:bpUsy1qP0W6EtkxrPluP02p2+wyVN+95lkjPKnLQZtc=
 k8s.io/legacy-cloud-providers v0.16.8 h1:CtBX+VIKHfijcJzvNaIZJ/oRYQJCsZ5y57aN8cb8Xqs=
 k8s.io/legacy-cloud-providers v0.16.8/go.mod h1:8g5j8qDmqXvj1mQjyYOvSBv15CWbzV3D/CsRFrTGCJY=

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -274,7 +274,7 @@ func ValidateNodeGroupLabels(labels map[string]string) error {
 				}
 			}
 
-			for _, domain := range []string{"kubelet.kubernetes.io", "node.kubernetes.io", "node-role.kubernetes.io", "alpha.service-controller.kubernetes.io"} {
+			for _, domain := range []string{"kubelet.kubernetes.io", "node.kubernetes.io", "alpha.service-controller.kubernetes.io"} {
 				if ns == domain || strings.HasSuffix(ns, "."+domain) {
 					allowedKubeletNamespace = true
 				}

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	"k8s.io/apimachinery/pkg/util/validation"
+	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 )
 
 var (
@@ -249,54 +250,24 @@ func ValidateNodeGroupLabels(labels map[string]string) error {
 
 	unknownKubernetesLabels := []string{}
 
-	for l := range labels {
-		labelParts := strings.Split(l, "/")
+	for label := range labels {
+		labelParts := strings.Split(label, "/")
 
 		if len(labelParts) > 2 {
-			return fmt.Errorf("node label key %q is of invalid format, can only use one '/' separator", l)
+			return fmt.Errorf("node label key %q is of invalid format, can only use one '/' separator", label)
 		}
 
-		if errs := validation.IsQualifiedName(l); len(errs) > 0 {
-			return fmt.Errorf("label %q is invalid - %v", l, errs)
+		if errs := validation.IsQualifiedName(label); len(errs) > 0 {
+			return fmt.Errorf("label %q is invalid - %v", label, errs)
 		}
-		if errs := validation.IsValidLabelValue(labels[l]); len(errs) > 0 {
-			return fmt.Errorf("label %q has invalid value %q - %v", l, labels[l], errs)
+		if errs := validation.IsValidLabelValue(labels[label]); len(errs) > 0 {
+			return fmt.Errorf("label %q has invalid value %q - %v", label, labels[label], errs)
 		}
 
-		isKubernetesLabel := false
-		allowedKubeletNamespace := false
 		if len(labelParts) == 2 {
-			ns := labelParts[0]
-
-			for _, domain := range []string{"kubernetes.io", "k8s.io"} {
-				if ns == domain || strings.HasSuffix(ns, "."+domain) {
-					isKubernetesLabel = true
-				}
-			}
-
-			for _, domain := range []string{"kubelet.kubernetes.io", "node.kubernetes.io", "alpha.service-controller.kubernetes.io"} {
-				if ns == domain || strings.HasSuffix(ns, "."+domain) {
-					allowedKubeletNamespace = true
-				}
-			}
-
-			if isKubernetesLabel && !allowedKubeletNamespace {
-				switch l {
-				case
-					"kubernetes.io/hostname",
-					"kubernetes.io/instance-type",
-					"kubernetes.io/os",
-					"kubernetes.io/arch",
-					"beta.kubernetes.io/instance-type",
-					"beta.kubernetes.io/os",
-					"beta.kubernetes.io/arch",
-					"failure-domain.beta.kubernetes.io/zone",
-					"failure-domain.beta.kubernetes.io/region",
-					"failure-domain.kubernetes.io/zone",
-					"failure-domain.kubernetes.io/region":
-				default:
-					unknownKubernetesLabels = append(unknownKubernetesLabels, l)
-				}
+			namespace := labelParts[0]
+			if isKubernetesLabel(namespace) && !kubeletapis.IsKubeletLabel(label) {
+				unknownKubernetesLabels = append(unknownKubernetesLabels, label)
 			}
 		}
 	}
@@ -305,6 +276,15 @@ func ValidateNodeGroupLabels(labels map[string]string) error {
 		return fmt.Errorf("unknown 'kubernetes.io' or 'k8s.io' labels were specified: %v", unknownKubernetesLabels)
 	}
 	return nil
+}
+
+func isKubernetesLabel(namespace string) bool {
+	for _, domain := range []string{"kubernetes.io", "k8s.io"} {
+		if namespace == domain || strings.HasSuffix(namespace, "."+domain) {
+			return true
+		}
+	}
+	return false
 }
 
 func validateNodeGroupIAM(iam *NodeGroupIAM, value, fieldName, path string) error {

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -779,6 +779,31 @@ var _ = Describe("ClusterConfig validation", func() {
 			}
 		})
 	})
+
+	DescribeTable("Nodegroup label validation", func(labels map[string]string, valid bool) {
+		err := ValidateNodeGroupLabels(labels)
+		if valid {
+			Expect(err).ToNot(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+		}
+	},
+		Entry("Disallowed label", map[string]string{
+			"node-role.kubernetes.io/os": "linux",
+		}, false),
+
+		Entry("Disallowed label", map[string]string{
+			"alpha.service-controller.kubernetes.io/test": "value",
+		}, false),
+
+		Entry("No labels", map[string]string{}, true),
+
+		Entry("Allowed labels", map[string]string{
+			"kubernetes.io/hostname":           "supercomputer",
+			"beta.kubernetes.io/os":            "linux",
+			"kubelet.kubernetes.io/palindrome": "telebuk",
+		}, true),
+	)
 })
 
 func checkItDetectsError(SSHConfig *NodeGroupSSH) {


### PR DESCRIPTION
### Description

It's no longer permitted by the kubelet: kubernetes/kubernetes#85073

Fixes #2197 

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

