### PR TITLE
Move doc make targets to separate file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 include Makefile.common
+include Makefile.docs
 
 version_pkg := github.com/weaveworks/eksctl/pkg/version
 
@@ -32,10 +33,6 @@ install-all-deps: install-build-deps install-site-deps ## Install all dependenci
 .PHONY: install-build-deps
 install-build-deps: ## Install dependencies (packages and tools)
 	./install-build-deps.sh
-
-.PHONY: install-site-deps
-install-site-deps: ## Install dependencies for user docs
-	pip3 install -r userdocs/requirements.txt
 
 ##@ Build
 
@@ -192,9 +189,6 @@ pkg/addons/default/assets/aws-node.yaml:
 update-aws-node: ## Re-download the aws-node manifests from AWS
 	time go generate ./pkg/addons/default/aws_node_generate.go
 
-userdocs/src/usage/schema.json:
-	cp ./pkg/apis/eksctl.io/v1alpha5/assets/schema.json ./userdocs/src/usage/schema.json
-
 deep_copy_helper_input = $(shell $(call godeps_cmd,./pkg/apis/...) | sed 's|$(generated_code_deep_copy_helper)||' )
 $(generated_code_deep_copy_helper): $(deep_copy_helper_input) .license-header ## Generate Kubernetes API helpers
 	./tools/update-codegen.sh
@@ -253,15 +247,6 @@ publish-homebrew:
 .PHONY: eksctl-image
 eksctl-image: ## Build the eksctl image that has release artefacts and no build dependencies
 	$(MAKE) -f Makefile.docker $@
-
-##@ Site
-.PHONY: serve-pages
-serve-pages: ## Serve the site locally
-	cd userdocs/ ; mkdocs serve
-
-.PHONY: build-pages
-build-pages: userdocs/src/usage/schema.json ## Generate the site
-	cd userdocs/ ; mkdocs build
 
 ##@ Utility
 

--- a/Makefile.docs
+++ b/Makefile.docs
@@ -1,0 +1,14 @@
+userdocs/src/usage/schema.json:
+	cp ./pkg/apis/eksctl.io/v1alpha5/assets/schema.json ./userdocs/src/usage/schema.json
+
+.PHONY: install-site-deps
+install-site-deps: ## Install dependencies for user docs
+	pip3 install -r userdocs/requirements.txt
+
+.PHONY: serve-pages
+serve-pages: ## Serve the site locally
+	cd userdocs/ && mkdocs serve
+
+.PHONY: build-pages
+build-pages: userdocs/src/usage/schema.json ## Generate the site
+	cd userdocs/ && mkdocs build


### PR DESCRIPTION
This way we can build docs with `make -f Makefile.docs build-pages`

### Description

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

