### PR TITLE
Cross-platform multi process support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/fluxcd/flux/pkg/install v0.0.0-20200402142123-873fb9300996 // flux 1.19.0
 	github.com/fluxcd/helm-operator/pkg/install v0.0.0-20200407140510-8d71b0072a3e // helm-operator 1.0.0
 	github.com/gobwas/glob v0.2.3
+	github.com/gofrs/flock v0.7.1
 	github.com/golangci/golangci-lint v1.27.0
 	github.com/goreleaser/goreleaser v0.110.0
 	github.com/instrumenta/kubeval v0.0.0-20190918223246-8d013ec9fc56

--- a/go.sum
+++ b/go.sum
@@ -404,6 +404,8 @@ github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZ
 github.com/gofrs/flock v0.0.0-20190320160742-5135e617513b/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/flock v0.7.0 h1:pGFUjl501gafK9HBt1VGL1KCOd/YhIooID+xgyJCf3g=
 github.com/gofrs/flock v0.7.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
+github.com/gofrs/flock v0.7.1 h1:DP+LD/t0njgoPBvT5MJLeliUIVQR03hiKR6vezdwHlc=
+github.com/gofrs/flock v0.7.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -5,14 +5,14 @@ import (
 	"os"
 	"path"
 	"strings"
-
-	"github.com/weaveworks/eksctl/pkg/utils/file"
+	"syscall"
 
 	"os/exec"
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/utils/file"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -139,12 +139,50 @@ func AppendAuthenticator(config *clientcmdapi.Config, spec *api.ClusterConfig, a
 	}
 }
 
+func lockConfigFile(configFileName string) (*os.File, error) {
+	f, err := os.Open(configFileName)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to open existing kubeconfig file")
+	}
+
+	err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+	if err != nil {
+		return nil, errors.Wrap(err, "flock: failed to obtain exclusive lock existing kubeconfig file")
+	}
+
+	return f, nil
+}
+
+func unlockConfigFile(file *os.File) error {
+	var e error
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_UN); err != nil {
+		e = errors.Wrap(err, "flock: failed to release exclusive lock on existing kubeconfig file")
+	}
+
+	if err := file.Close(); err != nil {
+		return errors.Wrap(e, "failed to close file")
+	}
+
+	return nil
+}
+
 // Write will write Kubernetes client configuration to a file.
 // If path isn't specified then the path will be determined by client-go.
 // If file pointed to by path doesn't exist it will be created.
 // If the file already exists then the configuration will be merged with the existing file.
 func Write(path string, newConfig clientcmdapi.Config, setContext bool) (string, error) {
 	configAccess := getConfigAccess(path)
+	configFileName := configAccess.GetDefaultFilename()
+	fd, err := lockConfigFile(configFileName)
+	if err != nil {
+		return "", err
+	}
+
+	defer func() {
+		if err := unlockConfigFile(fd); err != nil {
+			logger.Critical(err.Error())
+		}
+	}()
 
 	config, err := configAccess.GetStartingConfig()
 	if err != nil {
@@ -163,7 +201,7 @@ func Write(path string, newConfig clientcmdapi.Config, setContext bool) (string,
 		return "", errors.Wrapf(err, "unable to modify kubeconfig %s", path)
 	}
 
-	return configAccess.GetDefaultFilename(), nil
+	return configFileName, nil
 }
 
 func getConfigAccess(explicitPath string) clientcmd.ConfigAccess {
@@ -223,6 +261,16 @@ func MaybeDeleteConfig(meta *api.ClusterMeta) {
 	p := AutoPath(meta.Name)
 
 	if file.Exists(p) {
+		fd, err := lockConfigFile(p)
+		if err != nil {
+			logger.Critical(err.Error())
+		}
+
+		defer func() {
+			if err := unlockConfigFile(fd); err != nil {
+				logger.Critical(err.Error())
+			}
+		}()
 		if err := isValidConfig(p, meta.Name); err != nil {
 			logger.Debug(err.Error())
 			return
@@ -234,6 +282,17 @@ func MaybeDeleteConfig(meta *api.ClusterMeta) {
 	}
 
 	configAccess := getConfigAccess(DefaultPath)
+	fd, err := lockConfigFile(configAccess.GetDefaultFilename())
+	if err != nil {
+		logger.Critical(err.Error())
+	}
+
+	defer func() {
+		if err := unlockConfigFile(fd); err != nil {
+			logger.Critical(err.Error())
+		}
+	}()
+
 	config, err := configAccess.GetStartingConfig()
 	if err != nil {
 		logger.Debug("error reading kubeconfig file %q: %s", DefaultPath, err.Error())


### PR DESCRIPTION
### Description

This allows for safe concurrent reads/writes to the kubeconfig file. We have some use cases where we run many `eksctl` processes in parallel. Because of this we need some guarantees that any read-modify-write actions taken on this file are safe against n processes.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

This now works cross-platform instead of only on *nix. 