### PR TITLE
Fix timeouts in gitops operations on Fargate

### DIFF
--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -3,7 +3,6 @@ package create
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
@@ -425,7 +424,7 @@ func doCreateCluster(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *cmdutils.Crea
 			if err != nil {
 				return errors.Wrap(err, "cannot create Kubernetes client configuration")
 			}
-			err = gitops.Setup(k8sRestConfig, clientSet, cfg, time.Minute)
+			err = gitops.Setup(k8sRestConfig, clientSet, cfg, gitops.DefaultPodReadyTimeout)
 			if err != nil {
 				return err
 			}

--- a/pkg/ctl/enable/repo.go
+++ b/pkg/ctl/enable/repo.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/pflag"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/gitops"
 	"github.com/weaveworks/eksctl/pkg/gitops/flux"
 )
 
@@ -59,7 +60,7 @@ func configureRepositoryCmd(cmd *cmdutils.Cmd) *options {
 		fs.StringVar(&cmd.ClusterConfig.Metadata.Name, "cluster", "", "name of the EKS cluster to enable gitops on")
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
-		cmdutils.AddTimeoutFlagWithValue(fs, &opts.timeout, 20*time.Second)
+		cmdutils.AddTimeoutFlagWithValue(fs, &opts.timeout, gitops.DefaultPodReadyTimeout)
 	})
 	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, cmd.ProviderConfig, false)
 	return &opts

--- a/pkg/gitops/gitops.go
+++ b/pkg/gitops/gitops.go
@@ -16,6 +16,9 @@ import (
 	"github.com/weaveworks/eksctl/pkg/gitops/flux"
 )
 
+// DefaultPodReadyTimeout is the time it will wait for Flux and Helm Operator to become ready
+const DefaultPodReadyTimeout = 5 * time.Minute
+
 // Setup sets up gitops in a repository for a cluster. Installs flux, helm and a quickstart profile into the cluster
 func Setup(k8sRestConfig *rest.Config, k8sClientSet kubeclient.Interface, cfg *api.ClusterConfig, timeout time.Duration) error {
 	installer, err := flux.NewInstaller(k8sRestConfig, k8sClientSet, cfg, timeout)


### PR DESCRIPTION
fixes #1789
closes #1228

- Removes the use of port forwarding for checking helm-operator readiness
- Uses Deployments watch API to wait for flux and helm-operator pods to be ready
- Uses port forwarding to fetch the public key from flux only when the pod is ready

<details>
<summary> Before </summary>

```
[ℹ]  Writing Flux manifests
[ℹ]  created "Namespace/flux"
[ℹ]  Applying manifests
[ℹ]  created "flux:Deployment.apps/memcached"
[ℹ]  created "flux:ServiceAccount/flux"
[ℹ]  created "ClusterRole.rbac.authorization.k8s.io/flux"
[ℹ]  created "ClusterRoleBinding.rbac.authorization.k8s.io/flux"
[ℹ]  created "flux:Deployment.apps/flux"
[ℹ]  created "flux:Service/memcached"
[ℹ]  created "flux:Secret/flux-git-deploy"
[ℹ]  created "CustomResourceDefinition.apiextensions.k8s.io/helmreleases.helm.fluxcd.io"
[ℹ]  created "flux:Deployment.apps/helm-operator"
[ℹ]  created "flux:ServiceAccount/helm-operator"
[ℹ]  created "ClusterRole.rbac.authorization.k8s.io/helm-operator"
[ℹ]  created "ClusterRoleBinding.rbac.authorization.k8s.io/helm-operator"
[ℹ]  Waiting for Helm Operator to start
[!]  Helm Operator is not ready yet (Could not create port forward: error upgrading connection: pod helm-operator-6fd6b7fbfc-qzpxz does not have a host assigned), retrying ...
[!]  Helm Operator is not ready yet (Could not create port forward: error upgrading connection: pod helm-operator-6fd6b7fbfc-qzpxz does not have a host assigned), retrying ...
[!]  Helm Operator is not ready yet (Could not create port forward: error upgrading connection: pod helm-operator-6fd6b7fbfc-qzpxz does not have a host assigned), retrying ...
[!]  Helm Operator is not ready yet (Could not create port forward: error upgrading connection: pod helm-operator-6fd6b7fbfc-qzpxz does not have a host assigned), retrying ...
[!]  Helm Operator is not ready yet (Could not create port forward: error upgrading connection: pod helm-operator-6fd6b7fbfc-qzpxz does not have a host assigned), retrying ...
[!]  Helm Operator is not ready yet (Could not create port forward: error upgrading connection: pod helm-operator-6fd6b7fbfc-qzpxz does not have a host assigned), retrying ...
[!]  Helm Operator is not ready yet (Could not create port forward: error upgrading connection: pod helm-operator-6fd6b7fbfc-qzpxz does not have a host assigned), retrying ...
[!]  Helm Operator is not ready yet (Could not create port forward: error upgrading connection: pod helm-operator-6fd6b7fbfc-qzpxz does not have a host assigned), retrying ...
[!]  Helm Operator is not ready yet (Could not create port forward: error upgrading connection: pod helm-operator-6fd6b7fbfc-qzpxz does not have a host assigned), retrying ...
[!]  Helm Operator is not ready yet (Could not create port forward: error upgrading connection: pod helm-operator-6fd6b7fbfc-qzpxz does not have a host assigned), retrying ...
[!]  Helm Operator is not ready yet (Could not create port forward: error upgrading connection: pod helm-operator-6fd6b7fbfc-qzpxz does not have a host assigned), retrying ...
[!]  Helm Operator is not ready yet (Could not create port forward: error upgrading connection: error dialing backend: remote error: tls: internal error), retrying ...
E0525 10:48:09.642479    4762 portforward.go:400] an error occurred forwarding 35791 -> 3030: error forwarding port 3030 to pod cb2a7dc97efb6b7945e5de5be8d4fddafa0800522ec8e07f11ae3bcb0394b946, uid : failed to execute portforward in network namespace "/var/run/netns/cni-fda3a8c8-5384-7193-a6b5-61cd1588ad4d": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:09 socat[319] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Helm Operator is not ready yet (Get "http://127.0.0.1:35791/healthz": EOF), retrying ...
E0525 10:48:12.101888    4762 portforward.go:400] an error occurred forwarding 35791 -> 3030: error forwarding port 3030 to pod cb2a7dc97efb6b7945e5de5be8d4fddafa0800522ec8e07f11ae3bcb0394b946, uid : failed to execute portforward in network namespace "/var/run/netns/cni-fda3a8c8-5384-7193-a6b5-61cd1588ad4d": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:11 socat[355] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Helm Operator is not ready yet (Get "http://127.0.0.1:35791/healthz": EOF), retrying ...
E0525 10:48:14.560560    4762 portforward.go:400] an error occurred forwarding 35791 -> 3030: error forwarding port 3030 to pod cb2a7dc97efb6b7945e5de5be8d4fddafa0800522ec8e07f11ae3bcb0394b946, uid : failed to execute portforward in network namespace "/var/run/netns/cni-fda3a8c8-5384-7193-a6b5-61cd1588ad4d": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:14 socat[372] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Helm Operator is not ready yet (Get "http://127.0.0.1:35791/healthz": EOF), retrying ...
E0525 10:48:17.015846    4762 portforward.go:400] an error occurred forwarding 35791 -> 3030: error forwarding port 3030 to pod cb2a7dc97efb6b7945e5de5be8d4fddafa0800522ec8e07f11ae3bcb0394b946, uid : failed to execute portforward in network namespace "/var/run/netns/cni-fda3a8c8-5384-7193-a6b5-61cd1588ad4d": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:16 socat[429] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Helm Operator is not ready yet (Get "http://127.0.0.1:35791/healthz": EOF), retrying ...
E0525 10:48:19.375881    4762 portforward.go:400] an error occurred forwarding 35791 -> 3030: error forwarding port 3030 to pod cb2a7dc97efb6b7945e5de5be8d4fddafa0800522ec8e07f11ae3bcb0394b946, uid : failed to execute portforward in network namespace "/var/run/netns/cni-fda3a8c8-5384-7193-a6b5-61cd1588ad4d": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:19 socat[430] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Helm Operator is not ready yet (Get "http://127.0.0.1:35791/healthz": EOF), retrying ...
E0525 10:48:21.932336    4762 portforward.go:400] an error occurred forwarding 35791 -> 3030: error forwarding port 3030 to pod cb2a7dc97efb6b7945e5de5be8d4fddafa0800522ec8e07f11ae3bcb0394b946, uid : failed to execute portforward in network namespace "/var/run/netns/cni-fda3a8c8-5384-7193-a6b5-61cd1588ad4d": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:21 socat[431] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Helm Operator is not ready yet (Get "http://127.0.0.1:35791/healthz": EOF), retrying ...
E0525 10:48:24.498700    4762 portforward.go:400] an error occurred forwarding 35791 -> 3030: error forwarding port 3030 to pod cb2a7dc97efb6b7945e5de5be8d4fddafa0800522ec8e07f11ae3bcb0394b946, uid : failed to execute portforward in network namespace "/var/run/netns/cni-fda3a8c8-5384-7193-a6b5-61cd1588ad4d": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:24 socat[460] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Helm Operator is not ready yet (Get "http://127.0.0.1:35791/healthz": EOF), retrying ...
E0525 10:48:26.858159    4762 portforward.go:400] an error occurred forwarding 35791 -> 3030: error forwarding port 3030 to pod cb2a7dc97efb6b7945e5de5be8d4fddafa0800522ec8e07f11ae3bcb0394b946, uid : failed to execute portforward in network namespace "/var/run/netns/cni-fda3a8c8-5384-7193-a6b5-61cd1588ad4d": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:26 socat[464] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Helm Operator is not ready yet (Get "http://127.0.0.1:35791/healthz": EOF), retrying ...
E0525 10:48:29.216863    4762 portforward.go:400] an error occurred forwarding 35791 -> 3030: error forwarding port 3030 to pod cb2a7dc97efb6b7945e5de5be8d4fddafa0800522ec8e07f11ae3bcb0394b946, uid : failed to execute portforward in network namespace "/var/run/netns/cni-fda3a8c8-5384-7193-a6b5-61cd1588ad4d": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:29 socat[466] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Helm Operator is not ready yet (Get "http://127.0.0.1:35791/healthz": EOF), retrying ...
E0525 10:48:31.739101    4762 portforward.go:400] an error occurred forwarding 35791 -> 3030: error forwarding port 3030 to pod cb2a7dc97efb6b7945e5de5be8d4fddafa0800522ec8e07f11ae3bcb0394b946, uid : failed to execute portforward in network namespace "/var/run/netns/cni-fda3a8c8-5384-7193-a6b5-61cd1588ad4d": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:31 socat[468] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Helm Operator is not ready yet (Get "http://127.0.0.1:35791/healthz": EOF), retrying ...
E0525 10:48:34.194049    4762 portforward.go:400] an error occurred forwarding 35791 -> 3030: error forwarding port 3030 to pod cb2a7dc97efb6b7945e5de5be8d4fddafa0800522ec8e07f11ae3bcb0394b946, uid : failed to execute portforward in network namespace "/var/run/netns/cni-fda3a8c8-5384-7193-a6b5-61cd1588ad4d": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:34 socat[470] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Helm Operator is not ready yet (Get "http://127.0.0.1:35791/healthz": EOF), retrying ...
E0525 10:48:36.552609    4762 portforward.go:400] an error occurred forwarding 35791 -> 3030: error forwarding port 3030 to pod cb2a7dc97efb6b7945e5de5be8d4fddafa0800522ec8e07f11ae3bcb0394b946, uid : failed to execute portforward in network namespace "/var/run/netns/cni-fda3a8c8-5384-7193-a6b5-61cd1588ad4d": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:36 socat[478] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Helm Operator is not ready yet (Get "http://127.0.0.1:35791/healthz": EOF), retrying ...
E0525 10:48:38.931434    4762 portforward.go:400] an error occurred forwarding 35791 -> 3030: error forwarding port 3030 to pod cb2a7dc97efb6b7945e5de5be8d4fddafa0800522ec8e07f11ae3bcb0394b946, uid : failed to execute portforward in network namespace "/var/run/netns/cni-fda3a8c8-5384-7193-a6b5-61cd1588ad4d": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:38 socat[481] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Helm Operator is not ready yet (Get "http://127.0.0.1:35791/healthz": EOF), retrying ...
E0525 10:48:41.388921    4762 portforward.go:400] an error occurred forwarding 35791 -> 3030: error forwarding port 3030 to pod cb2a7dc97efb6b7945e5de5be8d4fddafa0800522ec8e07f11ae3bcb0394b946, uid : failed to execute portforward in network namespace "/var/run/netns/cni-fda3a8c8-5384-7193-a6b5-61cd1588ad4d": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:41 socat[483] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Helm Operator is not ready yet (Get "http://127.0.0.1:35791/healthz": EOF), retrying ...
E0525 10:48:43.748127    4762 portforward.go:400] an error occurred forwarding 35791 -> 3030: error forwarding port 3030 to pod cb2a7dc97efb6b7945e5de5be8d4fddafa0800522ec8e07f11ae3bcb0394b946, uid : failed to execute portforward in network namespace "/var/run/netns/cni-fda3a8c8-5384-7193-a6b5-61cd1588ad4d": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:43 socat[485] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Helm Operator is not ready yet (Get "http://127.0.0.1:35791/healthz": EOF), retrying ...
E0525 10:48:46.280953    4762 portforward.go:400] an error occurred forwarding 35791 -> 3030: error forwarding port 3030 to pod cb2a7dc97efb6b7945e5de5be8d4fddafa0800522ec8e07f11ae3bcb0394b946, uid : failed to execute portforward in network namespace "/var/run/netns/cni-fda3a8c8-5384-7193-a6b5-61cd1588ad4d": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:46 socat[487] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Helm Operator is not ready yet (Get "http://127.0.0.1:35791/healthz": EOF), retrying ...
[ℹ]  Helm Operator started successfully
[ℹ]  see https://docs.fluxcd.io/projects/helm-operator for details on how to use the Helm Operator
[ℹ]  Waiting for Flux to start
E0525 10:48:50.143945    4762 portforward.go:400] an error occurred forwarding 45289 -> 3030: error forwarding port 3030 to pod aeda71c0e54436877b84577ba9f595c35ded5af12f6dafe83fdb15525c908c17, uid : failed to execute portforward in network namespace "/var/run/netns/cni-f2bef114-8998-9b4e-c185-50b2ad59109c": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:50 socat[458] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Flux is not ready yet (failed to query Flux API: Get "http://127.0.0.1:45289/api/flux/v6/identity.pub": EOF), retrying ...
E0525 10:48:52.651580    4762 portforward.go:400] an error occurred forwarding 45289 -> 3030: error forwarding port 3030 to pod aeda71c0e54436877b84577ba9f595c35ded5af12f6dafe83fdb15525c908c17, uid : failed to execute portforward in network namespace "/var/run/netns/cni-f2bef114-8998-9b4e-c185-50b2ad59109c": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:52 socat[461] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Flux is not ready yet (failed to query Flux API: Get "http://127.0.0.1:45289/api/flux/v6/identity.pub": EOF), retrying ...
E0525 10:48:55.014734    4762 portforward.go:400] an error occurred forwarding 45289 -> 3030: error forwarding port 3030 to pod aeda71c0e54436877b84577ba9f595c35ded5af12f6dafe83fdb15525c908c17, uid : failed to execute portforward in network namespace "/var/run/netns/cni-f2bef114-8998-9b4e-c185-50b2ad59109c": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:54 socat[462] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Flux is not ready yet (failed to query Flux API: Get "http://127.0.0.1:45289/api/flux/v6/identity.pub": EOF), retrying ...
E0525 10:48:57.377344    4762 portforward.go:400] an error occurred forwarding 45289 -> 3030: error forwarding port 3030 to pod aeda71c0e54436877b84577ba9f595c35ded5af12f6dafe83fdb15525c908c17, uid : failed to execute portforward in network namespace "/var/run/netns/cni-f2bef114-8998-9b4e-c185-50b2ad59109c": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:57 socat[463] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Flux is not ready yet (failed to query Flux API: Get "http://127.0.0.1:45289/api/flux/v6/identity.pub": EOF), retrying ...
E0525 10:48:59.821469    4762 portforward.go:400] an error occurred forwarding 45289 -> 3030: error forwarding port 3030 to pod aeda71c0e54436877b84577ba9f595c35ded5af12f6dafe83fdb15525c908c17, uid : failed to execute portforward in network namespace "/var/run/netns/cni-f2bef114-8998-9b4e-c185-50b2ad59109c": socat command returns error: exit status 1, stderr: "2020/05/25 08:48:59 socat[465] E connect(5, AF=2 127.0.0.1:3030, 16): Connection refused\n"
[!]  Flux is not ready yet (failed to query Flux API: Get "http://127.0.0.1:45289/api/flux/v6/identity.pub": EOF), retrying ...
[ℹ]  Flux started successfully
[ℹ]  see https://docs.fluxcd.io/projects/flux for details on how to use Flux
[ℹ]  Committing and pushing manifests to git@github.com:martina-if/flux-test-3.git
[ℹ]  Nothing to commit (the repository contained identical files), moving on
Everything up-to-date
[ℹ]  Flux will only operate properly once it has write-access to the Git repository
Cloning into '/tmp/flux-test-3-701236396'...
remote: Enumerating objects: 32, done.        
remote: Counting objects: 100% (32/32), done.        
remote: Compressing objects: 100% (22/22), done.        
remote: Total 157 (delta 16), reused 23 (delta 10), pack-reused 125        
Receiving objects: 100% (157/157), 40.58 KiB | 500.00 KiB/s, done.
Resolving deltas: 100% (68/68), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
[ℹ]  cloning repository "https://github.com/weaveworks/eks-quickstart-app-dev":master
Cloning into '/tmp/quickstart-112792603'...
remote: Enumerating objects: 214, done.        
remote: Total 214 (delta 0), reused 0 (delta 0), pack-reused 214        
Receiving objects: 100% (214/214), 57.06 KiB | 452.00 KiB/s, done.
Resolving deltas: 100% (93/93), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
[ℹ]  processing template files in repository
[ℹ]  writing new manifests to "/tmp/flux-test-3-701236396/base"
[master 309a23a] Add app-dev quickstart components
 4 files changed, 7 insertions(+), 7 deletions(-)
Enumerating objects: 16, done.
Counting objects: 100% (16/16), done.
Delta compression using up to 4 threads
Compressing objects: 100% (9/9), done.
Writing objects: 100% (9/9), 1.22 KiB | 415.00 KiB/s, done.
Total 9 (delta 6), reused 0 (delta 0)
remote: Resolving deltas: 100% (6/6), completed with 6 local objects.        
To github.com:martina-if/flux-test-3.git
   b0cfff4..309a23a  master -> master
[ℹ]  please configure git@github.com:martina-if/flux-test-3.git so that the following Flux SSH public key has write access to it
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC+rtOxjI5...
```
</details>

<details>
<summary> After </summary>

```
$ eksctl enable repo -f examples/21-eks-quickstart-app-dev.yaml
[!]  flux deployment was not found
[ℹ]  Generating manifests
[ℹ]  Cloning git@github.com:martina-if/flux-test-3.git
Cloning into '/tmp/eksctl-install-flux-clone-067630557'...
remote: Enumerating objects: 50, done.        
remote: Counting objects: 100% (50/50), done.        
remote: Compressing objects: 100% (28/28), done.        
remote: Total 175 (delta 30), reused 39 (delta 22), pack-reused 125        
Receiving objects: 100% (175/175), 41.84 KiB | 504.00 KiB/s, done.
Resolving deltas: 100% (82/82), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
[ℹ]  Writing Flux manifests
[ℹ]  created "Namespace/flux"
[ℹ]  Applying manifests
[ℹ]  created "flux:Service/memcached"
[ℹ]  created "flux:ServiceAccount/flux"
[ℹ]  replaced "ClusterRole.rbac.authorization.k8s.io/flux"
[ℹ]  replaced "ClusterRoleBinding.rbac.authorization.k8s.io/flux"
[ℹ]  created "flux:Secret/flux-git-deploy"
[ℹ]  created "flux:Deployment.apps/memcached"
[ℹ]  created "flux:Deployment.apps/helm-operator"
[ℹ]  replaced "CustomResourceDefinition.apiextensions.k8s.io/helmreleases.helm.fluxcd.io"
[ℹ]  created "flux:ServiceAccount/helm-operator"
[ℹ]  replaced "ClusterRole.rbac.authorization.k8s.io/helm-operator"
[ℹ]  replaced "ClusterRoleBinding.rbac.authorization.k8s.io/helm-operator"
[ℹ]  created "flux:Deployment.apps/flux"
[ℹ]  Waiting for Helm Operator to start
[ℹ]  Helm Operator started successfully
[ℹ]  see https://docs.fluxcd.io/projects/helm-operator for details on how to use the Helm Operator
[ℹ]  Waiting for Flux to start
[ℹ]  Fetching public SSH key from Flux
[ℹ]  Flux started successfully
[ℹ]  see https://docs.fluxcd.io/projects/flux for details on how to use Flux
[ℹ]  Committing and pushing manifests to git@github.com:martina-if/flux-test-3.git
[ℹ]  Nothing to commit (the repository contained identical files), moving on
Everything up-to-date
[ℹ]  Flux will only operate properly once it has write-access to the Git repository
[ℹ]  please configure git@github.com:martina-if/flux-test-3.git so that the following Flux SSH public key has write access to it
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCvN1OoiW22MDgU0...

```
</details>



- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes