### PR TITLE
Error fix for CloudWatch docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ endif
 
 .PHONY: lint
 lint: ## Run linter over the codebase
-	time "$(GOBIN)/golangci-lint" run
+	time "$(GOBIN)/golangci-lint" run --timeout 6m
 
 .PHONY: test
 test:

--- a/userdocs/src/usage/cloudwatch-cluster-logging.md
+++ b/userdocs/src/usage/cloudwatch-cluster-logging.md
@@ -19,7 +19,7 @@ If you have created a cluster already, you can use `eksctl utils update-cluster-
 If you are using a config file, run:
 
 ```
-eksctl utils update-cluster-logging --config-file=<path> --enable-types all
+eksctl utils update-cluster-logging --config-file=<path>
 ```
 
 Alternatively, you can use CLI flags.


### PR DESCRIPTION
### Description

This is to fix an error in CloudWatch documentation which offers the following (incorrect) command to update existing cluster using configuration file:

`eksctl utils update-cluster-logging --config-file=<path> --enable-types all`

This command responses with `Error: cannot use --enable-types when --config-file/-f is set`.

The correct command would be just

`eksctl utils update-cluster-logging --config-file=<path>`
