### PR TITLE
Support URLs as template data when creating stack

### DIFF
--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -37,6 +37,21 @@ type StackInfo struct {
 	Template  *string
 }
 
+// TemplateData is an union (sum type) to describe template data.
+type TemplateData interface {
+	isTemplateData()
+}
+
+// TemplateBody allows to pass the full template.
+type TemplateBody []byte
+
+func (b TemplateBody) isTemplateData() {}
+
+// TemplateURL allows to pass in a link to a template.
+type TemplateURL string
+
+func (u TemplateURL) isTemplateData() {}
+
 // ChangeSet represents a CloudFormation ChangeSet
 type ChangeSet = cloudformation.DescribeChangeSetOutput
 
@@ -69,7 +84,7 @@ func NewStackCollection(provider api.ClusterProvider, spec *api.ClusterConfig) *
 }
 
 // DoCreateStackRequest requests the creation of a CloudFormation stack
-func (c *StackCollection) DoCreateStackRequest(i *Stack, templateBody []byte, tags, parameters map[string]string, withIAM bool, withNamedIAM bool) error {
+func (c *StackCollection) DoCreateStackRequest(i *Stack, templateData TemplateData, tags, parameters map[string]string, withIAM bool, withNamedIAM bool) error {
 	input := &cloudformation.CreateStackInput{
 		StackName: i.StackName,
 	}
@@ -78,7 +93,14 @@ func (c *StackCollection) DoCreateStackRequest(i *Stack, templateBody []byte, ta
 		input.Tags = append(input.Tags, newTag(k, v))
 	}
 
-	input.SetTemplateBody(string(templateBody))
+	switch data := templateData.(type) {
+	case TemplateBody:
+		input.SetTemplateBody(string(data))
+	case TemplateURL:
+		input.SetTemplateURL(string(data))
+	default:
+		return fmt.Errorf("unknown template data type: %T", templateData)
+	}
 
 	if withIAM {
 		input.SetCapabilities(stackCapabilitiesIAM)
@@ -120,7 +142,7 @@ func (c *StackCollection) CreateStack(name string, stack builder.ResourceSet, ta
 		return errors.Wrapf(err, "rendering template for %q stack", *i.StackName)
 	}
 
-	if err := c.DoCreateStackRequest(i, templateBody, tags, parameters, stack.WithIAM(), stack.WithNamedIAM()); err != nil {
+	if err := c.DoCreateStackRequest(i, TemplateBody(templateBody), tags, parameters, stack.WithIAM(), stack.WithNamedIAM()); err != nil {
 		return err
 	}
 
@@ -132,10 +154,10 @@ func (c *StackCollection) CreateStack(name string, stack builder.ResourceSet, ta
 }
 
 // UpdateStack will update a CloudFormation stack by creating and executing a ChangeSet
-func (c *StackCollection) UpdateStack(stackName, changeSetName, description string, template []byte, parameters map[string]string) error {
+func (c *StackCollection) UpdateStack(stackName, changeSetName, description string, templateData TemplateData, parameters map[string]string) error {
 	logger.Info(description)
 	i := &Stack{StackName: &stackName}
-	if err := c.doCreateChangeSetRequest(i, changeSetName, description, template, parameters, true); err != nil {
+	if err := c.doCreateChangeSetRequest(i, changeSetName, description, templateData, parameters, true); err != nil {
 		return err
 	}
 	if err := c.doWaitUntilChangeSetIsCreated(i, changeSetName); err != nil {
@@ -194,7 +216,7 @@ func (c *StackCollection) GetManagedNodeGroupTemplate(nodeGroupName string) (str
 // UpdateNodeGroupStack updates the nodegroup stack with the specified template
 func (c *StackCollection) UpdateNodeGroupStack(nodeGroupName, template string) error {
 	stackName := c.makeNodeGroupStackName(nodeGroupName)
-	return c.UpdateStack(stackName, c.MakeChangeSetName("update-nodegroup"), "Update nodegroup stack", []byte(template), nil)
+	return c.UpdateStack(stackName, c.MakeChangeSetName("update-nodegroup"), "Update nodegroup stack", TemplateBody(template), nil)
 }
 
 // ListStacksMatching gets all of CloudFormation stacks with names matching nameRegex.
@@ -467,7 +489,7 @@ func (c *StackCollection) LookupCloudTrailEvents(i *Stack) ([]*cloudtrail.Event,
 	return events, nil
 }
 
-func (c *StackCollection) doCreateChangeSetRequest(i *Stack, changeSetName string, description string, templateBody []byte,
+func (c *StackCollection) doCreateChangeSetRequest(i *Stack, changeSetName string, description string, templateData TemplateData,
 	parameters map[string]string, withIAM bool) error {
 	input := &cloudformation.CreateChangeSetInput{
 		StackName:     i.StackName,
@@ -477,7 +499,14 @@ func (c *StackCollection) doCreateChangeSetRequest(i *Stack, changeSetName strin
 
 	input.SetChangeSetType(cloudformation.ChangeSetTypeUpdate)
 
-	input.SetTemplateBody(string(templateBody))
+	switch data := templateData.(type) {
+	case TemplateBody:
+		input.SetTemplateBody(string(data))
+	case TemplateURL:
+		input.SetTemplateURL(string(data))
+	default:
+		return fmt.Errorf("unknown template data type: %T", templateData)
+	}
 
 	if withIAM {
 		input.SetCapabilities(stackCapabilitiesIAM)

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -183,7 +183,7 @@ func (c *StackCollection) AppendNewClusterStackResource(plan, supportsManagedNod
 		logger.Info("(plan) %s", describeUpdate)
 		return true, nil
 	}
-	return true, c.UpdateStack(name, c.MakeChangeSetName("update-cluster"), describeUpdate, []byte(currentTemplate), nil)
+	return true, c.UpdateStack(name, c.MakeChangeSetName("update-cluster"), describeUpdate, TemplateBody(currentTemplate), nil)
 }
 
 func getClusterName(s *Stack) string {

--- a/pkg/cfn/manager/compat.go
+++ b/pkg/cfn/manager/compat.go
@@ -122,7 +122,7 @@ func (c *StackCollection) EnsureMapPublicIPOnLaunchEnabled() error {
 		}
 	}
 	description := fmt.Sprintf("update public subnets %q with property MapPublicIpOnLaunch enabled", publicSubnetsNames)
-	if err := c.UpdateStack(stackName, c.MakeChangeSetName("update-subnets"), description, []byte(currentTemplate), nil); err != nil {
+	if err := c.UpdateStack(stackName, c.MakeChangeSetName("update-subnets"), description, TemplateBody(currentTemplate), nil); err != nil {
 		return errors.Wrap(err, "unable to update subnets")
 	}
 	return nil

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -236,7 +236,7 @@ func (c *StackCollection) ScaleNodeGroup(ng *api.NodeGroup) error {
 	}
 	logger.Debug("stack template (post-scale change): %s", template)
 
-	return c.UpdateStack(name, c.MakeChangeSetName("scale-nodegroup"), descriptionBuffer.String(), []byte(template), nil)
+	return c.UpdateStack(name, c.MakeChangeSetName("scale-nodegroup"), descriptionBuffer.String(), TemplateBody(template), nil)
 }
 
 // GetNodeGroupSummaries returns a list of summaries for the nodegroups of a cluster


### PR DESCRIPTION
(This PR does not add any features to eksctl itself but extends stack manipulation functions to accept template data in various forms which expands applicability for other code using the stack manager.)


### Description

This allows `StackCollection.DoCreateStackRequest()` and
`StackCollection.UpdateStack()` to accept an URL instead of the template
body.
