### PR TITLE
docs: replace remaining quote blocks with styled notations

### DIFF
--- a/userdocs/src/index.md
+++ b/userdocs/src/index.md
@@ -96,8 +96,7 @@ To learn more about how to create clusters and other features continue reading t
 [![Circle CI](https://circleci.com/gh/weaveworks/eksctl/tree/master.svg?style=shield)](https://circleci.com/gh/weaveworks/eksctl/tree/master) [![Coverage Status](https://coveralls.io/repos/github/weaveworks/eksctl/badge.svg?branch=master)](https://coveralls.io/github/weaveworks/eksctl?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/weaveworks/eksctl)](https://goreportcard.com/report/github.com/weaveworks/eksctl)
 ![Gophers: E, K, S, C, T, & L](img/eksctl.png)
 
-> **_Credits_**
->
-> _Original Gophers drawn by [Ashley McNamara](https://twitter.com/ashleymcnamara), unique E, K, S, C, T & L Gopher identities had been produced with [Gopherize.me](https://gopherize.me/)._
->
-> Site powered by [Netlify ©](https://netlify.com)
+!!! credits
+    _Original Gophers drawn by [Ashley McNamara](https://twitter.com/ashleymcnamara), unique E, K, S, C, T & L Gopher identities had been produced with [Gopherize.me](https://gopherize.me/)._
+
+    Site powered by [Netlify ©](https://netlify.com)

--- a/userdocs/src/usage/vpc-networking.md
+++ b/userdocs/src/usage/vpc-networking.md
@@ -9,11 +9,13 @@ not insecure in principle, but some compromised workload could risk an access vi
 
 If that functionality doesn't suit you, the following options are currently available.
 
->**_IMPORTANT_**: From `eksctl` version `0.17.0` and onwards public subnets will have the property `MapPublicIpOnLaunch` enabled, and the property `AssociatePublicIpAddress` disabled in the Auto Scaling Group for the nodegroups.
-> This means that for clusters created with previous versions of eksctl when a new nodegroup is created it must either
->be a private nodegroup or have `MapPublicIpOnLaunch` enabled in its public subnets. Otherwise, the new nodes won't have
->access to the internet and won't be able to download the basic add-ons (CNI plugin, kube-proxy, etc).
->To help setting up subnets correctly for old clusters you can use the new command `eksctl utils update-legacy-subnet-settings`.
+!!! important
+    From `eksctl` version `0.17.0` and onwards public subnets will have the property `MapPublicIpOnLaunch` enabled, and
+    the property `AssociatePublicIpAddress` disabled in the Auto Scaling Group for the nodegroups. This means that for
+    clusters created with previous versions of eksctl when a new nodegroup is created it must either be a private
+    nodegroup or have `MapPublicIpOnLaunch` enabled in its public subnets. Otherwise, the new nodes won't have access to
+    the internet and won't be able to download the basic add-ons (CNI plugin, kube-proxy, etc). To help setting up
+    subnets correctly for old clusters you can use the new command `eksctl utils update-legacy-subnet-settings`.
 
 
 ## Change VPC CIDR


### PR DESCRIPTION
### Description

Replaced the two remaining "quote notation blocks" with properly styled "notation blocks".

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

