### PR TITLE
Don't run extra cluster tasks and nodegroup creation in parallel

### DIFF
--- a/pkg/cfn/manager/create_tasks.go
+++ b/pkg/cfn/manager/create_tasks.go
@@ -39,7 +39,7 @@ func (c *StackCollection) NewTasksToCreateClusterWithNodeGroups(nodeGroups []*ap
 
 	if len(postClusterCreationTasks) > 0 {
 		postClusterCreationTaskTree := TaskTree{
-			Parallel:  true,
+			Parallel:  false,
 			IsSubTask: true,
 		}
 		postClusterCreationTaskTree.Append(postClusterCreationTasks...)

--- a/pkg/cfn/manager/tasks_test.go
+++ b/pkg/cfn/manager/tasks_test.go
@@ -707,7 +707,7 @@ var _ = Describe("StackCollection Tasks", func() {
 				}
 				{
 					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar"), nil, false, &task{id: 1})
-					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 2 parallel sub-tasks: { task 1, create nodegroup "bar" } }`))
+					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 2 sequential sub-tasks: { task 1, create nodegroup "bar" } }`))
 				}
 			})
 		})


### PR DESCRIPTION
Fixes #2244

https://github.com/weaveworks/eksctl/pull/2129 was a little too aggressive, the cluster update tasks cause the status of the cluster to be `Updating` intermittently, causing nodegroup creation to fail.
Important for https://github.com/weaveworks/eksctl/issues/2125 is that they happen before the nodegroup creation.
### Description

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

