### PR TITLE
Fix unknown revisions, update old versions in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,9 +58,9 @@ require (
 	k8s.io/cloud-provider v0.16.8
 	k8s.io/code-generator v0.16.8
 	k8s.io/kops v1.15.2
-	k8s.io/kubelet v0.0.0
+	k8s.io/kubelet v0.16.8
 	k8s.io/kubernetes v1.15.3
-	k8s.io/legacy-cloud-providers v0.0.0
+	k8s.io/legacy-cloud-providers v0.16.8
 	sigs.k8s.io/aws-iam-authenticator v0.5.0
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	k8s.io/code-generator v0.16.8
 	k8s.io/kops v1.15.2
 	k8s.io/kubelet v0.16.8
-	k8s.io/kubernetes v1.15.3
+	k8s.io/kubernetes v1.16.8
 	k8s.io/legacy-cloud-providers v0.16.8
 	sigs.k8s.io/aws-iam-authenticator v0.5.0
 	sigs.k8s.io/yaml v1.2.0


### PR DESCRIPTION
### Description
It's replaced in the end anyway, but I don't think there's a reason to have a nonsensical version specifier in `require`. It's also one error along the way to [having `go get` work](https://github.com/weaveworks/eksctl/issues/1538).

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

