### PR TITLE
fix kubeletExtraConfig phrasing

### DIFF
--- a/userdocs/src/usage/vpc-networking.md
+++ b/userdocs/src/usage/vpc-networking.md
@@ -132,7 +132,7 @@ nodeGroups:
 ```
 
 Note that this configuration only accepts one IP address. To specify more than one address, use the
-[`extraKubeletConfig` parameter](../customizing-the-kubelet):
+[`kubeletExtraConfig` parameter](../customizing-the-kubelet):
 
 ```yaml
 apiVersion: eksctl.io/v1alpha5


### PR DESCRIPTION
### Description

changed the word from `extraKubeletConfig` to `kubeletExtraConfig`

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

