### PR TITLE
Don't use generic helper functions from kops

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -14,9 +14,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+	"github.com/weaveworks/eksctl/pkg/utils/slice"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/kops/util/pkg/slice"
 )
 
 const (

--- a/pkg/utils/file/file.go
+++ b/pkg/utils/file/file.go
@@ -2,8 +2,9 @@ package file
 
 import (
 	"os"
+	"strings"
 
-	kopsutils "k8s.io/kops/upup/pkg/fi/utils"
+	"k8s.io/client-go/util/homedir"
 )
 
 // Exists checks to see if a file exists.
@@ -14,4 +15,10 @@ func Exists(path string) bool {
 }
 
 // ExpandPath expands path with ~ notation
-func ExpandPath(p string) string { return kopsutils.ExpandPath(p) }
+func ExpandPath(p string) string {
+	if strings.HasPrefix(p, "~/") {
+		p = homedir.HomeDir() + p[1:]
+	}
+
+	return p
+}

--- a/pkg/utils/slice/slice.go
+++ b/pkg/utils/slice/slice.go
@@ -1,0 +1,12 @@
+package slice
+
+// Contains checks if a slice contains an element
+func Contains(list []string, e string) bool {
+	for _, x := range list {
+		if x == e {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/vpc/vpc.go
+++ b/pkg/vpc/vpc.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/kops/util/pkg/slice"
 
 	"github.com/kris-nova/logger"
 
@@ -18,6 +17,7 @@ import (
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/cfn/outputs"
 	"github.com/weaveworks/eksctl/pkg/utils/ipnet"
+	"github.com/weaveworks/eksctl/pkg/utils/slice"
 
 	"k8s.io/kops/pkg/util/subnet"
 )


### PR DESCRIPTION
### Description
IMO, no reason to use these functions from `kops` of all places. What do you think?

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

