### PR TITLE
Intro improvements, volumeSize references, default volume size 80G.

### DIFF
--- a/userdocs/src/introduction.md
+++ b/userdocs/src/introduction.md
@@ -32,6 +32,26 @@ eksctl create cluster --version=1.16
 
 ```
 
+#### Config-based creation
+
+You can also create a cluster passing all configuration information in a file
+using `--config-file`:
+
+```
+
+eksctl create cluster --config-file=<path>
+
+```
+
+To create a cluster using a configuration file and skip creating
+nodegroups until later:
+
+```
+
+eksctl create cluster --config-file=<path> --without-nodegroup
+
+```
+
 #### Cluster credentials
 
 To write cluster credentials to a file other than default, run:
@@ -81,14 +101,6 @@ eksctl create cluster --name=cluster-5 --nodes-min=3 --nodes-max=5
     note that depending on your workloads you might need to use a separate nodegroup for each AZ. See [Zone-aware
     Auto Scaling](/usage/autoscaling/) for more info.
 
-To use 30 `c4.xlarge` nodes and prevent updating current context in `~/.kube/config`, run:
-
-```
-
-eksctl create cluster --name=cluster-6 --nodes=30 --node-type=c4.xlarge --set-kubeconfig-context=false
-
-```
-
 ### SSH access
 
 In order to allow SSH access to nodes, `eksctl` imports `~/.ssh/id_rsa.pub` by default, to use a different SSH public key, e.g. `my_eks_node_id.pub`, run:
@@ -124,29 +136,6 @@ To configure node root volume, use the `--node-volume-size` (and optionally `--n
 ```
 
 eksctl create cluster --node-volume-size=50 --node-volume-type=io1
-
-```
-
-!!! note
-    In `us-east-1` you are likely to get `UnsupportedAvailabilityZoneException`. If you do, copy the suggested zones and pass `--zones` flag, e.g. `eksctl create cluster --region=us-east-1 --zones=us-east-1a,us-east-1b,us-east-1d`. This may occur in other regions, but less likely. You shouldn't need to use `--zone` flag otherwise.
-
-### Config-based creation
-
-You can also create a cluster passing all configuration information in a file
-using `--config-file`:
-
-```
-
-eksctl create cluster --config-file=<path>
-
-```
-
-To create a cluster using a configuration file and skip creating
-nodegroups until later:
-
-```
-
-eksctl create cluster --config-file=<path> --without-nodegroup
 
 ```
 

--- a/userdocs/src/introduction.md
+++ b/userdocs/src/introduction.md
@@ -131,6 +131,9 @@ eksctl create cluster --tags environment=staging --region=us-east-1
 
 ### Volume size
 
+!!! note
+    The default volume size is 80G.
+
 To configure node root volume, use the `--node-volume-size` (and optionally `--node-volume-type`), e.g.:
 
 ```

--- a/userdocs/src/introduction.md
+++ b/userdocs/src/introduction.md
@@ -3,6 +3,8 @@
 _Need help? Join [Weave Community Slack][slackjoin]._
 [slackjoin]: https://slack.weave.works/
 
+### Listing clusters
+
 To list the details about a cluster or all of the clusters, use:
 
 ```
@@ -11,7 +13,9 @@ eksctl get cluster [--name=<name>][--region=<region>]
 
 ```
 
-To create the same kind of basic cluster, but with a different name, run:
+### Basic cluster creation
+
+To create a basic cluster, but with a different name, run:
 
 ```
 
@@ -27,6 +31,8 @@ With `eksctl` you can deploy any of the supported versions by passing `--version
 eksctl create cluster --version=1.16
 
 ```
+
+#### Cluster credentials
 
 To write cluster credentials to a file other than default, run:
 
@@ -60,6 +66,8 @@ eksctl utils write-kubeconfig --cluster=<name> [--kubeconfig=<path>][--set-kubec
 
 ```
 
+### Autoscaling
+
 To use a 3-5 node Auto Scaling Group, run:
 
 ```
@@ -81,6 +89,8 @@ eksctl create cluster --name=cluster-6 --nodes=30 --node-type=c4.xlarge --set-ku
 
 ```
 
+### SSH access
+
 In order to allow SSH access to nodes, `eksctl` imports `~/.ssh/id_rsa.pub` by default, to use a different SSH public key, e.g. `my_eks_node_id.pub`, run:
 
 ```
@@ -97,6 +107,8 @@ eksctl create cluster --ssh-access --ssh-public-key=my_kubernetes_key --region=u
 
 ```
 
+### Tagging
+
 To add custom tags for all resources, use `--tags`.
 
 ```
@@ -104,6 +116,8 @@ To add custom tags for all resources, use `--tags`.
 eksctl create cluster --tags environment=staging --region=us-east-1
 
 ```
+
+### Volume size
 
 To configure node root volume, use the `--node-volume-size` (and optionally `--node-volume-type`), e.g.:
 
@@ -115,6 +129,8 @@ eksctl create cluster --node-volume-size=50 --node-volume-type=io1
 
 !!! note
     In `us-east-1` you are likely to get `UnsupportedAvailabilityZoneException`. If you do, copy the suggested zones and pass `--zones` flag, e.g. `eksctl create cluster --region=us-east-1 --zones=us-east-1a,us-east-1b,us-east-1d`. This may occur in other regions, but less likely. You shouldn't need to use `--zone` flag otherwise.
+
+### Config-based creation
 
 You can also create a cluster passing all configuration information in a file
 using `--config-file`:
@@ -134,6 +150,8 @@ eksctl create cluster --config-file=<path> --without-nodegroup
 
 ```
 
+### Deletion
+
 To delete a cluster, run:
 
 ```
@@ -145,7 +163,7 @@ eksctl delete cluster --name=<name> [--region=<region>]
 !!! note
     Cluster info will be cleaned up in kubernetes config file. Please run `kubectl config get-contexts` to select right context.
 
-### Contributions
+## Contributions
 
 Code contributions are very welcome. If you are interested in helping make `eksctl` great then see our [contributing guide](https://github.com/weaveworks/eksctl/blob/master/CONTRIBUTING.md).
 

--- a/userdocs/src/usage/creating-and-managing-clusters.md
+++ b/userdocs/src/usage/creating-and-managing-clusters.md
@@ -42,11 +42,13 @@ nodeGroups:
   - name: ng-1
     instanceType: m5.large
     desiredCapacity: 10
+    volumeSize: 80
     ssh:
       allow: true # will use ~/.ssh/id_rsa.pub as the default ssh key
   - name: ng-2
     instanceType: m5.xlarge
     desiredCapacity: 2
+    volumeSize: 100
     ssh:
       publicKeyPath: ~/.ssh/ec2_id_rsa.pub
 ```

--- a/userdocs/src/usage/creating-and-managing-clusters.md
+++ b/userdocs/src/usage/creating-and-managing-clusters.md
@@ -11,6 +11,9 @@ eksctl create cluster
 That will create an EKS cluster in your default region (as specified by your AWS CLI configuration) with one
 nodegroup containing 2 m5.large nodes.
 
+!!! note
+    In `us-east-1` you are likely to get `UnsupportedAvailabilityZoneException`. If you do, copy the suggested zones and pass `--zones` flag, e.g. `eksctl create cluster --region=us-east-1 --zones=us-east-1a,us-east-1b,us-east-1d`. This may occur in other regions, but less likely. You shouldn't need to use `--zone` flag otherwise.
+
 After the cluster has been created, the appropriate kubernetes configuration will be added to your kubeconfig file.
 This is, the file that you have configured in the environment variable `KUBECONFIG` or `~/.kube/config` by default.
 The path to the kubeconfig file can be overridden using the `--kubeconfig` flag.

--- a/userdocs/src/usage/managing-nodegroups.md
+++ b/userdocs/src/usage/managing-nodegroups.md
@@ -43,11 +43,13 @@ nodeGroups:
     labels: { role: workers }
     instanceType: m5.xlarge
     desiredCapacity: 10
+    volumeSize: 80
     privateNetworking: true
   - name: ng-2-builders
     labels: { role: builders }
     instanceType: m5.2xlarge
     desiredCapacity: 2
+    volumeSize: 100
     privateNetworking: true
 ```
 


### PR DESCRIPTION
### Description
Was going through old issues, saw https://github.com/weaveworks/eksctl/issues/780 and also noticed the intro docs were a little unorganized. WDYT?
<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

