### PR TITLE
Add support for configfile and --version in upgrade cluster command

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -112,6 +112,9 @@ const (
 	// Version1_16 represents Kubernetes version 1.16.x
 	Version1_16 = "1.16"
 
+	// Version1_17 represents Kubernetes version 1.16.x
+	Version1_17 = "1.17"
+
 	// DefaultVersion represents default Kubernetes version supported by EKS
 	DefaultVersion = Version1_16
 
@@ -310,6 +313,16 @@ func DeprecatedVersions() []string {
 	}
 }
 
+// IsDeprecatedVersion returns true if the given Kubernetes version has been deprecated in EKS
+func IsDeprecatedVersion(version string) bool {
+	for _, v := range DeprecatedVersions() {
+		if version == v {
+			return true
+		}
+	}
+	return false
+}
+
 // SupportedVersions are the versions of Kubernetes that EKS supports
 func SupportedVersions() []string {
 	return []string{
@@ -318,6 +331,16 @@ func SupportedVersions() []string {
 		Version1_15,
 		Version1_16,
 	}
+}
+
+// IsSupportedVersion returns true if the given version is a Kubernetes supported by eksctl and EKS
+func IsSupportedVersion(version string) bool {
+	for _, v := range SupportedVersions() {
+		if version == v {
+			return true
+		}
+	}
+	return false
 }
 
 // SupportedNodeVolumeTypes are the volume types that can be used for a node root volume

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -111,8 +111,8 @@ func doCreateCluster(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *cmdutils.Crea
 		cfg.Metadata.Version = api.DefaultVersion
 	}
 	if cfg.Metadata.Version != api.DefaultVersion {
-		if !isValidVersion(cfg.Metadata.Version) {
-			if isDeprecatedVersion(cfg.Metadata.Version) {
+		if !api.IsSupportedVersion(cfg.Metadata.Version) {
+			if api.IsDeprecatedVersion(cfg.Metadata.Version) {
 				return fmt.Errorf("invalid version, %s is no longer supported, supported values: %s\nsee also: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html", cfg.Metadata.Version, strings.Join(api.SupportedVersions(), ", "))
 			}
 			return fmt.Errorf("invalid version, supported values: %s", strings.Join(api.SupportedVersions(), ", "))

--- a/pkg/ctl/create/utils.go
+++ b/pkg/ctl/create/utils.go
@@ -29,8 +29,8 @@ func checkVersion(cmd *cmdutils.Cmd, ctl *eks.ClusterProvider, meta *api.Cluster
 		meta.Version = api.LatestVersion
 		logger.Info("will use latest version (%s) for new nodegroup(s)", meta.Version)
 	default:
-		if !isValidVersion(meta.Version) {
-			if isDeprecatedVersion(meta.Version) {
+		if !api.IsSupportedVersion(meta.Version) {
+			if api.IsDeprecatedVersion(meta.Version) {
 				return fmt.Errorf("invalid version, %s is no longer supported, supported values: auto, default, latest, %s\nsee also: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html", meta.Version, strings.Join(api.SupportedVersions(), ", "))
 			}
 			return fmt.Errorf("invalid version %s, supported values: auto, default, latest, %s", meta.Version, strings.Join(api.SupportedVersions(), ", "))
@@ -68,22 +68,4 @@ func showDevicePluginMessageForNodeGroup(nodeGroup *api.NodeGroup, installNeuron
 		logger.Info("as you are using a GPU optimized instance type you will need to install NVIDIA Kubernetes device plugin.")
 		logger.Info("\t see the following page for instructions: https://github.com/NVIDIA/k8s-device-plugin")
 	}
-}
-
-func isValidVersion(version string) bool {
-	for _, v := range api.SupportedVersions() {
-		if version == v {
-			return true
-		}
-	}
-	return false
-}
-
-func isDeprecatedVersion(version string) bool {
-	for _, v := range api.DeprecatedVersions() {
-		if version == v {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -24,6 +24,7 @@ func updateClusterCmd(cmd *cmdutils.Cmd) {
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name")
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
+		cmdutils.AddVersionFlag(fs, cfg.Metadata, "")
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 
 		// cmdutils.AddVersionFlag(fs, cfg.Metadata, `"next" and "latest" can be used to automatically increment version by one, or force latest`)

--- a/pkg/ctl/upgrade/cluster.go
+++ b/pkg/ctl/upgrade/cluster.go
@@ -12,6 +12,7 @@ import (
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/printers"
+	"github.com/weaveworks/eksctl/pkg/utils"
 )
 
 func upgradeCluster(cmd *cmdutils.Cmd) {
@@ -30,6 +31,7 @@ func upgradeClusterWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name")
 		cmdutils.AddRegionFlag(fs, cmd.ProviderConfig)
+		cmdutils.AddVersionFlag(fs, cfg.Metadata, "")
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 
 		// cmdutils.AddVersionFlag(fs, cfg.Metadata, `"next" and "latest" can be used to automatically increment version by one, or force latest`)
@@ -73,30 +75,13 @@ func DoUpgradeCluster(cmd *cmdutils.Cmd) error {
 	}
 
 	if cmd.ClusterConfigFile != "" {
-		logger.Warning("NOTE: config file is used for finding cluster name and region")
 		logger.Warning("NOTE: cluster VPC (subnets, routing & NAT Gateway) configuration changes are not yet implemented")
 	}
-
 	currentVersion := ctl.ControlPlaneVersion()
-	// determine next version based on what's currently deployed
-	switch currentVersion {
-	case "":
-		return errors.New("unable to get control plane version")
-	case api.Version1_12:
-		cfg.Metadata.Version = api.Version1_13
-	case api.Version1_13:
-		cfg.Metadata.Version = api.Version1_14
-	case api.Version1_14:
-		cfg.Metadata.Version = api.Version1_15
-	case api.Version1_15:
-		cfg.Metadata.Version = api.Version1_16
-	case api.Version1_16:
-		cfg.Metadata.Version = api.Version1_16
-	default:
-		// version of control plane is not known to us, maybe we are just too old...
-		return fmt.Errorf("control plane version %q is not known to this version of eksctl, try to upgrade eksctl first", currentVersion)
+	versionUpdateRequired, err := requiresVersionUpgrade(cfg.Metadata, currentVersion)
+	if err != nil {
+		return err
 	}
-	versionUpdateRequired := cfg.Metadata.Version != currentVersion
 
 	if err := ctl.LoadClusterVPC(cfg); err != nil {
 		return errors.Wrapf(err, "getting VPC configuration for cluster %q", cfg.Metadata.Name)
@@ -141,4 +126,71 @@ func DoUpgradeCluster(cmd *cmdutils.Cmd) error {
 	cmdutils.LogPlanModeWarning(cmd.Plan && (stackUpdateRequired || versionUpdateRequired))
 
 	return nil
+}
+
+func requiresVersionUpgrade(clusterMeta *api.ClusterMeta, currentEKSVersion string) (bool, error) {
+	nextVersion, err := getNextVersion(currentEKSVersion)
+	if err != nil {
+		return false, err
+	}
+
+	// If the version was not specified default to the next Kubernetes version and assume the user intended to upgrade if possible
+	if clusterMeta.Version == "" {
+		if api.IsSupportedVersion(nextVersion) {
+			clusterMeta.Version = nextVersion
+			return true, nil
+		}
+
+		// There is no new version, stay in the current one
+		clusterMeta.Version = currentEKSVersion
+		return false, nil
+	}
+
+	if c, err := utils.CompareVersions(clusterMeta.Version, currentEKSVersion); err != nil {
+		return false, err
+	} else if c < 0 {
+		return false, fmt.Errorf("cannot upgrade to a lower version. Found given target version %q, current cluster version %q", clusterMeta.Version, currentEKSVersion)
+	}
+
+	if api.IsDeprecatedVersion(clusterMeta.Version) {
+		return false, fmt.Errorf("control plane version %q has been deprecated", clusterMeta.Version)
+	}
+
+	if !api.IsSupportedVersion(clusterMeta.Version) {
+		return false, fmt.Errorf("control plane version %q is not known to this version of eksctl, try to upgrade eksctl first", clusterMeta.Version)
+	}
+
+	if clusterMeta.Version == currentEKSVersion {
+		return false, nil
+	}
+
+	if clusterMeta.Version == nextVersion {
+		return true, nil
+	}
+
+	return false, fmt.Errorf(
+		"upgrading more than one version at a time is not supported. Found upgrade from %q to %q. Please upgrade to %q first",
+		currentEKSVersion,
+		clusterMeta.Version,
+		nextVersion)
+}
+
+func getNextVersion(currentVersion string) (string, error) {
+	switch currentVersion {
+	case "":
+		return "", errors.New("unable to get control plane version")
+	case api.Version1_12:
+		return api.Version1_13, nil
+	case api.Version1_13:
+		return api.Version1_14, nil
+	case api.Version1_14:
+		return api.Version1_15, nil
+	case api.Version1_15:
+		return api.Version1_16, nil
+	case api.Version1_16:
+		return api.Version1_17, nil
+	default:
+		// version of control plane is not known to us, maybe we are just too old...
+		return "", fmt.Errorf("control plane version %q is not known to this version of eksctl, try to upgrade eksctl first", currentVersion)
+	}
 }

--- a/pkg/ctl/upgrade/cluster_test.go
+++ b/pkg/ctl/upgrade/cluster_test.go
@@ -5,13 +5,14 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	. "github.com/weaveworks/eksctl/pkg/ctl/ctltest"
 )
 
-var _ = Describe("enable repo", func() {
+var _ = Describe("upgrade cluster", func() {
 
 	newMockUpgradeClusterCmd := func(args ...string) *MockCmd {
 		return NewMockCmd(upgradeClusterWithRunFunc, "upgrade", args...)
@@ -32,6 +33,12 @@ var _ = Describe("enable repo", func() {
 
 		It("should accept the --region flag", func() {
 			cmd := newMockUpgradeClusterCmd("cluster", "--name", "clus-1", "--region", "eu-north-1")
+			_, err := cmd.Execute()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should accept the --version flag", func() {
+			cmd := newMockUpgradeClusterCmd("cluster", "--name", "clus-1", "--region", "eu-north-1", "--version", "1.16")
 			_, err := cmd.Execute()
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -127,5 +134,95 @@ var _ = Describe("enable repo", func() {
 			Expect(out).To(ContainSubstring("Usage"))
 		})
 
+		It("loads the config file correctly", func() {
+			cfg.Metadata.Version = "1.16"
+			configFile = CreateConfigFile(cfg)
+
+			cmd := newMockUpgradeClusterCmd("cluster", "--config-file", configFile)
+			_, err := cmd.Execute()
+			Expect(err).To(Not(HaveOccurred()))
+
+			loadedCfg := cmd.Cmd.ClusterConfig.Metadata
+			Expect(loadedCfg.Name).To(Equal("cluster-1"))
+			Expect(loadedCfg.Region).To(Equal("us-west-2"))
+			Expect(loadedCfg.Version).To(Equal("1.16"))
+		})
 	})
+
+	type upgradeCase struct {
+		givenVersion           string
+		eksVersion             string
+		expectedUpgradeVersion string
+		expectedUpgrade        bool
+		expectedErrorText      string
+	}
+
+	DescribeTable("checks the specified version",
+		func(c upgradeCase) {
+			clusterMeta := api.ClusterMeta{
+				Version: c.givenVersion,
+			}
+			result, err := requiresVersionUpgrade(&clusterMeta, c.eksVersion)
+
+			if c.expectedErrorText != "" {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(c.expectedErrorText))
+			} else {
+				Expect(clusterMeta.Version).To(Equal(c.expectedUpgradeVersion))
+				Expect(result).To(Equal(c.expectedUpgrade))
+			}
+		},
+
+		Entry("upgrades by default when the version is not specified", upgradeCase{
+			givenVersion:           "",
+			eksVersion:             "1.15",
+			expectedUpgradeVersion: "1.16",
+			expectedUpgrade:        true,
+		}),
+
+		Entry("does not upgrade or fail when the cluster is already in the last version", upgradeCase{
+			givenVersion:           "",
+			eksVersion:             "1.16",
+			expectedUpgradeVersion: "1.16",
+			expectedUpgrade:        false,
+		}),
+
+		Entry("upgrades to the next version when specified", upgradeCase{
+			givenVersion:           "1.16",
+			eksVersion:             "1.15",
+			expectedUpgradeVersion: "1.16",
+			expectedUpgrade:        true,
+		}),
+
+		Entry("does not upgrade when the current version is specified", upgradeCase{
+			givenVersion:           "1.15",
+			eksVersion:             "1.15",
+			expectedUpgradeVersion: "1.15",
+			expectedUpgrade:        false,
+		}),
+
+		Entry("fails when the upgrade jumps more than one kubernetes version", upgradeCase{
+			givenVersion:      "1.16",
+			eksVersion:        "1.14",
+			expectedErrorText: "upgrading more than one version at a time is not supported",
+		}),
+
+		Entry("fails when the given version is lower than the current one", upgradeCase{
+			givenVersion:      "1.14",
+			eksVersion:        "1.15",
+			expectedErrorText: "cannot upgrade to a lower version. Found given target version \"1.14\", current cluster version \"1.15\"",
+		}),
+
+		Entry("fails when the version is deprecated", upgradeCase{
+			givenVersion:      "1.12",
+			eksVersion:        "1.12",
+			expectedErrorText: "control plane version \"1.12\" has been deprecated",
+		}),
+
+		Entry("fails when the version is still not supported", upgradeCase{
+			givenVersion:      "1.17",
+			eksVersion:        "1.16",
+			expectedErrorText: "control plane version \"1.17\" is not known to this version of eksctl",
+		}),
+	)
 })

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
+	"github.com/pkg/errors"
 )
 
 // IsGPUInstanceType returns true if the instance type is GPU optimised
@@ -39,4 +40,20 @@ func IsMinVersion(minimumVersion, version string) (bool, error) {
 		return false, fmt.Errorf("unable to parse version %s", version)
 	}
 	return targetVersion.GE(minVersion), nil
+}
+
+// CompareVersions compares two version strings with the usual conventions:
+// returns 0 if a == b
+// returns 1 if a > b
+// returns -1 if b < a
+func CompareVersions(a, b string) (int, error) {
+	aVersion, err := semver.ParseTolerant(a)
+	if err != nil {
+		return 0, errors.Wrapf(err, "unable to parse version %q", a)
+	}
+	bVersion, err := semver.ParseTolerant(b)
+	if err != nil {
+		return 0, errors.Wrapf(err, "unable to parse version %q", b)
+	}
+	return aVersion.Compare(bVersion), nil
 }

--- a/userdocs/src/usage/cluster-upgrade.md
+++ b/userdocs/src/usage/cluster-upgrade.md
@@ -2,7 +2,7 @@
 
 An _`eksctl`-managed_ cluster can be upgraded in 3 easy steps:
 
-1. update control plane version with `eksctl upgrade cluster`
+1. upgrade control plane version with `eksctl upgrade cluster`
 2. update default add-ons:
     - `kube-proxy`
     - `aws-node`
@@ -23,9 +23,9 @@ Please make sure to read this section in full before you proceed.
 
 ## Updating control plane version
 
-Control plane version updates must be done for one minor version at a time.
+Control plane version upgrades must be done for one minor version at a time.
 
-To update control plane to the next available version run:
+To upgrade control plane to the next available version run:
 
 ```
 eksctl upgrade cluster --name=<clusterName>
@@ -34,9 +34,36 @@ eksctl upgrade cluster --name=<clusterName>
 This command will not apply any changes right away, you will need to re-run it with
 `--approve` to apply the changes.
 
-## Updating nodegroups
+The target version for the cluster upgrade can be specified both with the CLI flag:
 
-You should update nodegroups only after you ran `eksctl upgrade cluster`.
+```
+eksctl upgrade cluster --name<clusterName> --version=1.16
+```
+
+or with the config file
+
+```
+cat cluster1.yaml
+---
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: cluster-1
+  region: eu-north-1
+  version: "1.16"
+
+eksctl upgrade cluster --config-file cluster1.yaml
+```
+
+!!!warning
+    The only values allowed for the `--version` and `metadata.version` arguments are the current version of the cluster
+    or one version higher. Upgrades of more than one Kubernetes version are not supported at the moment.
+
+
+## Upgrading nodegroups
+
+You should upgrading nodegroups only after you ran `eksctl upgrade cluster`.
 
 If you have a simple cluster with just an initial nodegroup (i.e. created with
 `eksctl create cluster`), the process is very simple.
@@ -93,7 +120,7 @@ eksctl delete nodegroup --cluster=<clusterName> --name=<oldNodeGroupName>
 If you are using config file, you will need to do the following.
 
 Edit config file to add new nodegroups, and remove old nodegroups.
-If you just want to update nodegroups and keep the same configuration,
+If you just want to upgrade nodegroups and keep the same configuration,
 you can just change nodegroup names, e.g. append `-v2` to the name.
 
 To create all of new nodegroups defined in the config file, run:


### PR DESCRIPTION
This PR adds support for reading the version and using that in the `upgrade cluster` and the legacy `update cluster` commands
both in the configfile and as a CLI flag (`--version`).

- If the version is not specified it will try to upgrade to the next K8s version by default if possible
- If it is specified it will only allow to upgrade to the next available version, otherwise it will error out


- [x] Added tests that cover your change (if possible)
- [x] **Added/modified documentation**
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes


# Manual testing

<details>
<summary> results from manual tests </summary>

```
eksctl upgrade cluster --name martina-test-1-14 --version  1.13
[ℹ]  eksctl version 0.22.0-dev+5cc9f0e1.2020-06-11T11:08:50Z
[ℹ]  using region eu-north-1
Error: cannot upgrade to a lower version. Found given target version "1.13", current cluster version "1.14"


$ eksctl upgrade cluster --name martina-test-1-14 --version  1.14
[ℹ]  eksctl version 0.22.0-dev+5cc9f0e1.2020-06-11T11:08:50Z
[ℹ]  using region eu-north-1
[ℹ]  re-building cluster stack "eksctl-martina-test-1-14-cluster"
[✔]  all resources in cluster stack "eksctl-martina-test-1-14-cluster" are up-to-date
[ℹ]  checking security group configuration for all nodegroups
[ℹ]  all nodegroups have up-to-date configuration



$ eksctl upgrade cluster --name martina-test-1-14 --version  1.15
[ℹ]  eksctl version 0.22.0-dev+5cc9f0e1.2020-06-11T11:08:50Z
[ℹ]  using region eu-north-1
[ℹ]  (plan) would upgrade cluster "martina-test-1-14" control plane from current version "1.14" to "1.15"
[ℹ]  re-building cluster stack "eksctl-martina-test-1-14-cluster"
[✔]  all resources in cluster stack "eksctl-martina-test-1-14-cluster" are up-to-date
[ℹ]  checking security group configuration for all nodegroups
[ℹ]  all nodegroups have up-to-date configuration
[!]  no changes were applied, run again with '--approve' to apply the changes


$ eksctl upgrade cluster --name martina-test-1-14 --version  1.16
[ℹ]  eksctl version 0.22.0-dev+5cc9f0e1.2020-06-11T11:08:50Z
[ℹ]  using region eu-north-1
Error: upgrading more than one version at a time is not supported. Found upgrade from "1.14" to "1.16". Please upgrade to "1.15" first



martina@wanderer:~/weaveworks/eksctl(upgrade-cluster-config-file *$)$ eksctl upgrade cluster --name martina-test-1-14 --version  1.17
[ℹ]  eksctl version 0.22.0-dev+5cc9f0e1.2020-06-11T11:08:50Z
[ℹ]  using region eu-north-1
Error: control plane version "1.17" is not known to this version of eksctl, try to upgrade eksctl first


# ============================================================================
$ cat examples/01-simple-cluster.yaml 
...
metadata:
  name: martina-test-1-14
  region: eu-north-1
  version: "1.13"
...

martina@wanderer:~/weaveworks/eksctl(upgrade-cluster-config-file *$)$ eksctl upgrade cluster -f examples/01-simple-cluster.yaml 
[ℹ]  eksctl version 0.22.0-dev+5cc9f0e1.2020-06-11T11:08:50Z
[ℹ]  using region eu-north-1
[!]  NOTE: cluster VPC (subnets, routing & NAT Gateway) configuration changes are not yet implemented
Error: cannot upgrade to a lower version. Found given target version "1.13", current cluster version "1.14"

# ============================================================================
martina@wanderer:~/weaveworks/eksctl(upgrade-cluster-config-file *$)$ cat examples/01-simple-cluster.yaml 
...
metadata:
  name: martina-test-1-14
  region: eu-north-1
  version: "1.14"
...


martina@wanderer:~/weaveworks/eksctl(upgrade-cluster-config-file *$)$ eksctl upgrade cluster -f examples/01-simple-cluster.yaml 
[ℹ]  eksctl version 0.22.0-dev+5cc9f0e1.2020-06-11T11:08:50Z
[ℹ]  using region eu-north-1
[!]  NOTE: cluster VPC (subnets, routing & NAT Gateway) configuration changes are not yet implemented
[ℹ]  re-building cluster stack "eksctl-martina-test-1-14-cluster"
[✔]  all resources in cluster stack "eksctl-martina-test-1-14-cluster" are up-to-date
[ℹ]  checking security group configuration for all nodegroups
[ℹ]  all nodegroups have up-to-date configuration



# ============================================================================
martina@wanderer:~/weaveworks/eksctl(upgrade-cluster-config-file *$)$ cat examples/01-simple-cluster.yaml 
...
metadata:
  name: martina-test-1-14
  region: eu-north-1
  version: "1.15"
...

martina@wanderer:~/weaveworks/eksctl(upgrade-cluster-config-file *$)$ eksctl upgrade cluster -f examples/01-simple-cluster.yaml 
[ℹ]  eksctl version 0.22.0-dev+5cc9f0e1.2020-06-11T11:08:50Z
[ℹ]  using region eu-north-1
[!]  NOTE: cluster VPC (subnets, routing & NAT Gateway) configuration changes are not yet implemented
[ℹ]  (plan) would upgrade cluster "martina-test-1-14" control plane from current version "1.14" to "1.15"
[ℹ]  re-building cluster stack "eksctl-martina-test-1-14-cluster"
[✔]  all resources in cluster stack "eksctl-martina-test-1-14-cluster" are up-to-date
[ℹ]  checking security group configuration for all nodegroups
[ℹ]  all nodegroups have up-to-date configuration
[!]  no changes were applied, run again with '--approve' to apply the changes

# ============================================================================

martina@wanderer:~/weaveworks/eksctl(upgrade-cluster-config-file *$)$ cat examples/01-simple-cluster.yaml 
...
metadata:
  name: martina-test-1-14
  region: eu-north-1
  version: "1.16"
...

martina@wanderer:~/weaveworks/eksctl(upgrade-cluster-config-file *$)$ eksctl upgrade cluster -f examples/01-simple-cluster.yaml 
[ℹ]  eksctl version 0.22.0-dev+5cc9f0e1.2020-06-11T11:08:50Z
[ℹ]  using region eu-north-1
[!]  NOTE: cluster VPC (subnets, routing & NAT Gateway) configuration changes are not yet implemented
Error: upgrading more than one version at a time is not supported. Found upgrade from "1.14" to "1.16". Please upgrade to "1.15" first


# ============================================================================
martina@wanderer:~/weaveworks/eksctl(upgrade-cluster-config-file *$)$ cat examples/01-simple-cluster.yaml 
...
metadata:
  name: martina-test-1-14
  region: eu-north-1
  version: "1.17"
...

martina@wanderer:~/weaveworks/eksctl(upgrade-cluster-config-file *$)$ eksctl upgrade cluster -f examples/01-simple-cluster.yaml 
[ℹ]  eksctl version 0.22.0-dev+5cc9f0e1.2020-06-11T11:08:50Z
[ℹ]  using region eu-north-1
[!]  NOTE: cluster VPC (subnets, routing & NAT Gateway) configuration changes are not yet implemented
Error: control plane version "1.17" is not known to this version of eksctl, try to upgrade eksctl first

# ============================================================================
$ cat examples/01-simple-cluster.yaml 
...
metadata:
  name: martina-test-1-13
  region: eu-north-1
  version: "1.16"
...

$ eksctl upgrade cluster -f examples/01-simple-cluster.yaml 
[ℹ]  eksctl version 0.22.0-dev+5cc9f0e1.2020-06-11T11:08:50Z
[ℹ]  using region eu-north-1
[!]  NOTE: cluster VPC (subnets, routing & NAT Gateway) configuration changes are not yet implemented
Error: upgrading more than one version at a time is not supported. Found upgrade from "1.13" to "1.16". Please upgrade to "1.14" first

```

</details>
