### PR TITLE
Adjust length of sub command path in -h/--help

### DIFF
--- a/pkg/ctl/cmdutils/group.go
+++ b/pkg/ctl/cmdutils/group.go
@@ -75,7 +75,7 @@ func (g *FlagGrouping) Usage(cmd *cobra.Command) error {
 	if cmd.HasAvailableSubCommands() {
 		usage = append(usage, "\nCommands:")
 		for _, subCommand := range cmd.Commands() {
-			usage = append(usage, fmt.Sprintf("  %s %-22s  %s", cmd.CommandPath(), subCommand.Name(), subCommand.Short))
+			usage = append(usage, fmt.Sprintf("  %s %-30s  %s", cmd.CommandPath(), subCommand.Name(), subCommand.Short))
 		}
 	}
 


### PR DESCRIPTION
### Description

Help output alignment for _utils_ is a little bit off.

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/9019229/84766903-eff70800-b014-11ea-877c-28fd40e947b6.png)


</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/9019229/84766941-fbe2ca00-b014-11ea-9e55-9119d3d80d10.png)

</details>

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

