### PR TITLE
Support aws2 as kubeconfig authenticator

### DIFF
--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -25,7 +25,10 @@ const (
 	HeptioAuthenticatorAWS = "heptio-authenticator-aws"
 	// AWSEKSAuthenticator defines the recently added `aws eks get-token` command
 	AWSEKSAuthenticator = "aws"
-	// Shadowing the default kubeconfig path environment variable
+	// AWS2EKSAuthenticator defines the name of the AWS CLI v2 command, in case
+	// it isn't available as `aws`
+	AWS2EKSAuthenticator = "aws2"
+	// RecommendedConfigPathEnvVar shadows the default kubeconfig path environment variable
 	RecommendedConfigPathEnvVar = clientcmd.RecommendedConfigPathEnvVar
 )
 
@@ -43,6 +46,7 @@ func AuthenticatorCommands() []string {
 		AWSIAMAuthenticator,
 		HeptioAuthenticatorAWS,
 		AWSEKSAuthenticator,
+		AWS2EKSAuthenticator,
 	}
 }
 
@@ -155,7 +159,7 @@ func AppendAuthenticator(config *clientcmdapi.Config, clusterMeta *api.ClusterMe
 				Value: clusterMeta.Region,
 			})
 		}
-	case AWSEKSAuthenticator:
+	case AWSEKSAuthenticator, AWS2EKSAuthenticator:
 		args = []string{"eks", "get-token", "--cluster-name", clusterMeta.Name}
 		roleARNFlag = "--role-arn"
 		if clusterMeta.Region != "" {


### PR DESCRIPTION
### Description
I see conflicting information on whether aws v2 is supposed to be named `aws` or `aws2` but seems [some users definitely only have `aws2` available](https://github.com/weaveworks/eksctl/issues/1562#issuecomment-555168784). So I think adding this makes sense.
<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

