### PR TITLE
Sort commands/subcommands by name in help

### DIFF
--- a/cmd/eksctl/main.go
+++ b/cmd/eksctl/main.go
@@ -42,8 +42,6 @@ func addCommands(rootCmd *cobra.Command, flagGrouping *cmdutils.FlagGrouping) {
 }
 
 func main() {
-	cobra.EnableCommandSorting = false
-
 	rootCmd := &cobra.Command{
 		Use:   "eksctl [command]",
 		Short: "The official CLI for Amazon EKS",


### PR DESCRIPTION
### Description
Personally, I like them sorted. It's what at least my brain expects. I don't want to think about where to place a specific command, e.g. in `eksctl utils`.
At most it might be helpful if they're grouped/ordered but then we can use groups to do that.

Some tools sort (kustomize, skaffold), some don't (kubectl, minikube) but both group.

Thoughts?

Fixes #1364
<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

