### PR TITLE
Added `kubeReserved` calculation support for mixed instance NodeGroups

### DIFF
--- a/userdocs/src/usage/customizing-the-kubelet.md
+++ b/userdocs/src/usage/customizing-the-kubelet.md
@@ -2,18 +2,18 @@
 
 ## Customizing kubelet configuration
 
-System resources can be reserved through the configuration of the kubelet. This is recommended, because in the case 
+System resources can be reserved through the configuration of the kubelet. This is recommended, because in the case
 of resource starvation the kubelet might not be able to evict pods and eventually make the node become `NotReady`. To
- do this, config files can include the `kubeletExtraConfig` field which accepts a free form yaml that will be embedded 
+ do this, config files can include the `kubeletExtraConfig` field which accepts a free form yaml that will be embedded
  into the `kubelet.yaml`.
 
- 
-Some fields in the `kubelet.yaml` are set by eksctl and therefore are not overwritable, such as the `address`, 
+
+Some fields in the `kubelet.yaml` are set by eksctl and therefore are not overwritable, such as the `address`,
 `clusterDomain`, `authentication`, `authorization`, or `serverTLSBootstrap`.
 
-The following example config file creates a nodegroup that reserves `300m` vCPU, `300Mi` of memory and `1Gi` of 
-ephemeral-storage for the kubelet; `300m` vCPU, `300Mi` of memory and `1Gi`of ephemeral storage for OS system 
-daemons; and kicks in eviction of pods when there is less than `200Mi` of memory available or less than  10% of the 
+The following example config file creates a nodegroup that reserves `300m` vCPU, `300Mi` of memory and `1Gi` of
+ephemeral-storage for the kubelet; `300m` vCPU, `300Mi` of memory and `1Gi`of ephemeral storage for OS system
+daemons; and kicks in eviction of pods when there is less than `200Mi` of memory available or less than  10% of the
 root filesystem.
 
 ```yaml
@@ -48,12 +48,21 @@ nodeGroups:
 
 In this example, given instances of type `m5a.xlarge` which have 4 vCPUs and 16GiB of memory, the `Allocatable` amount
 of CPUs would be 3.4 and 15.4 GiB of memory. In addition, the `DynamicKubeletConfig` feature gate is also enabled. It is
-important to know that the values specified in the config file for the the fields in `kubeletExtraconfig` will 
+important to know that the values specified in the config file for the the fields in `kubeletExtraconfig` will
 completely overwrite the default values specified by eksctl. However, omitting one or more `kubeReserved` parameters
 will cause the missing parameters to be defaulted to sane values based on the aws instance type being used.
 
-!!!warning
-    By default `eksctl` sets `featureGates.RotateKubeletServerCertificate=true`, but when custom `featureGates` are provided, it will be unset. You should always include 
-    `featureGates.RotateKubeletServerCertificate=true`, unless you have to disable it.
- 
+### A note on the `kubeReserved` calculation for NodeGroups with mixed instances
+
+While it is generally recommended to configure a mixed instance NodeGroup to use instances with the same CPU and RAM
+configuration; that's not a strict requirement. Therefore the `kubeReserved` calculation uses the _smallest instance_ in
+the `InstanceDistribution.InstanceTypes` field. This way NodeGroups with disparate instance types will not reserve too
+many resources on the smallest instance. However, this could lead to a reservation that is too small for the largest
+instance type.
+
+### Warning
+By default `eksctl` sets `featureGates.RotateKubeletServerCertificate=true`, but when custom `featureGates` are
+provided, it will be unset. You should always include `featureGates.RotateKubeletServerCertificate=true`, unless
+you have to disable it.
+
 

--- a/userdocs/src/usage/customizing-the-kubelet.md
+++ b/userdocs/src/usage/customizing-the-kubelet.md
@@ -60,9 +60,8 @@ the `InstanceDistribution.InstanceTypes` field. This way NodeGroups with dispara
 many resources on the smallest instance. However, this could lead to a reservation that is too small for the largest
 instance type.
 
-### Warning
-By default `eksctl` sets `featureGates.RotateKubeletServerCertificate=true`, but when custom `featureGates` are
-provided, it will be unset. You should always include `featureGates.RotateKubeletServerCertificate=true`, unless
-you have to disable it.
-
+!!! Warning
+    By default `eksctl` sets `featureGates.RotateKubeletServerCertificate=true`, but when custom `featureGates` are
+    provided, it will be unset. You should always include `featureGates.RotateKubeletServerCertificate=true`, unless
+    you have to disable it.
 


### PR DESCRIPTION
### Description
Support for calculating CPU, RAM, and Storage reservations via
`kubeReserved` was added to `eksctl` in `v0.16`. However, it only supported
NodeGroups with a single instance type. ASGs can have multiple
instance types and were not included in the calculation.

This change enables calculation of `kubeReserved` for mixed instances too.
Since multiple instance types are supported it calculates the reservation
based on the smallest instance type in the distribution.

Additional `kubeReserved` tests covering unknown innstance types. The new tests
ensure that unknown instance types are properly ignored during calculation
of `kubeReserved`.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes