### PR TITLE
Implement make command to merge release branches back to master

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pkg/version/release.go merge=keep-release-file

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,17 @@ prepare-release-candidate:
 print-version:
 	@go run pkg/version/generate/release_generate.go print-version
 
+.PHONY: merge-release-branch-back
+merge-release-branch-back:
+ifeq ($(BRANCH),)
+	$(error BRANCH expected but not specified)
+endif
+	@git config --global merge.keep-release-file.name "keep master version of pkg/version/release.go and other files in .gitattributes during merge"
+	@git config --global merge.keep-release-file.driver "true"
+	@git pull --ff-only origin $(shell git rev-parse --abbrev-ref @)
+	@git merge $(BRANCH)
+	@echo "Release branch $(BRANCH) merged into current branch except files defined in .gitattributes. You can now push the changes to the repo or open a pull request"
+
 ##@ Docker
 
 .PHONY: eksctl-image


### PR DESCRIPTION
It will maintain the master version of the file pkg/version/release.go
which contains eksctl hardcoded version. This is done through the file
.gitattributes and configuring a dummy merge strategy for it.


- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes