### PR TITLE
Skip MapPublicIpOnLaunch check for ManagedNodeGroups with privateNetwork flag

### DIFF
--- a/pkg/vpc/vpc.go
+++ b/pkg/vpc/vpc.go
@@ -256,6 +256,9 @@ func ValidateLegacySubnetsForNodeGroups(spec *api.ClusterConfig, provider api.Cl
 	}
 
 	for _, ng := range spec.ManagedNodeGroups {
+		if ng.PrivateNetworking {
+			continue
+		}
 		err := selectSubnets(ng.AvailabilityZones)
 		if err != nil {
 			return err


### PR DESCRIPTION
### Description

fixes #2374

Previously code was added to skip `MapPublicIpOnLaunch` check for `NodeGroups` with `privateNetworking` flag. The same check is necessary for ManagedNodeGroups, so users are able to utilize `eksctl create nodegroup` to create nodegroups on clusters that use private networking, but still also have public subnets. 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [X] Make sure the title of the PR is a good description that can go into the release notes


