### PR TITLE
Add github workflow to merge release branch to master

### DIFF
--- a/.github/workflows/release-merge.yaml
+++ b/.github/workflows/release-merge.yaml
@@ -1,0 +1,38 @@
+name: Merge release changes to master
+on:
+  push:
+    branches:
+      - release-*
+env:
+  VERSION_FILE: pkg/version/release.go
+  DEFAULT_BRANCH: master
+jobs:
+  merge_release:
+    name: Merge release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Merge release branch into ${{env.DEFAULT_BRANCH}}
+        run: |
+          git checkout $DEFAULT_BRANCH
+          git checkout -b merge-${{ github.sha }}
+          git config user.name "weaveworksbot"
+          git config user.email "weaveworksbot@users.noreply.github.com"
+          git merge --no-commit --no-ff ${{ github.ref }}
+          git checkout ORIG_HEAD -- $VERSION_FILE
+          git add $VERSION_FILE
+          EDITOR=true git merge --continue
+          git push --set-upstream origin HEAD
+      - uses: actions/github-script@v2.0.0
+        name: Open PR to ${{env.DEFAULT_BRANCH}}
+        with:
+          github-token: ${{ secrets.WEAVEWORKSBOT_TOKEN }}
+          script: |
+            await github.pulls.create({
+              ...context.repo,
+              title: `Merge ${context.ref} to ${{ env.DEFAULT_BRANCH }}`,
+              head: `merge-${context.sha}`,
+              base: "${{ env.DEFAULT_BRANCH }}",
+            });


### PR DESCRIPTION
### Description

closes #2336

[Tested this a bunch already](https://github.com/michaelbeaumont/eksctl/pull/5), it will automatically open a PR for every push to `release-*`. There was talk of a command (`/cherry` in a comment) in https://github.com/weaveworks/eksctl/issues/1284 but I don't think this is necessary.

This would make the workflow (the hotfix, git flow based method):
1. fix in a `release` branch
1. open and merge a PR to the `release` branch
1. wait for automatic PR to `master`
    - it's rather the exception that we _don't_ want to merge it to `master` and in that case, we just close the PR.

What this doesn't support is fixing something on `master` and merging it to one or more `release` branches (like the `/cherry 0.2.0 0.3.0 0.4.0` comment method would support)

Do you @martina-if @cPu1 think this makes sense?

Only thing left is that since the PR is opened by a github action, it [won't trigger the github actions usually run on a PR](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token). The way around this is to use a real account to open the PR. There doesn't seem to be a `secrets.GITHUB_TOKEN` on this repo atm. 
I think the best way would be to create a Github App for the repo and use it similarly to [how this action suggests doing it](https://github.com/peter-evans/create-pull-request/blob/master/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens).

This can use `make merge-release-branch-back` from #2383 as well.
<!-- Please explain the changes you made here. -->


### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

