### PR TITLE
Enable bodyclose linter in golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -150,6 +150,7 @@ issues:
 linters:
   disable-all: true
   enable:
+    - bodyclose
     - deadcode
     - errcheck
     - gofmt

--- a/pkg/iam/oidc/api.go
+++ b/pkg/iam/oidc/api.go
@@ -132,7 +132,7 @@ func (m *OpenIDConnectManager) getIssuerCAThumbprint() error {
 	if err != nil {
 		return errors.Wrap(err, "connecting to issuer OIDC")
 	}
-
+	defer response.Body.Close()
 	if response.TLS != nil {
 		if numCerts := len(response.TLS.PeerCertificates); numCerts >= 1 {
 			root := response.TLS.PeerCertificates[numCerts-1]


### PR DESCRIPTION
### Description

As per godoc, the caller is responsible to close body.

	// The http Client and Transport guarantee that Body is always
	// non-nil, even on responses without a body or responses with
	// a zero-length body. It is the caller's responsibility to
	// close Body.

bodyclose lint is also added to avoid similar cases in future.

Signed-off-by: Tam Mach <sayboras@yahoo.com>

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

