### PR TITLE
Enforce PR labels for release notes categorization

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -22,3 +22,5 @@ template: |
 replacers:
   - search: '/(@martina-if|@michaelbeaumont|@cPu1)(,)?/g'
     replace: ''
+exclude-labels:
+  - 'skip-release-notes'

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -1,0 +1,19 @@
+name: Check PR labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+
+jobs:
+  enforce-kind:
+    name: Enforce a valid PR category
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if a valid PR category is present
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          if ! jq --exit-status 'any(test("kind/feature") or test("kind/improvement") or test("kind/bug") or test("skip-release-notes"))' >/dev/null <<< $LABELS; then
+            echo "::error ::Please set either kind/feature, kind/improvement, kind/bug or skip-release-notes as label"
+            exit 1
+          fi


### PR DESCRIPTION
### Description
@martina-if @cPu1 This should make the release note drafts a little more reliable. WDYT?
Ideas about more `exclude-labels` or release note categories welcome.

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

