### PR TITLE
Fix cluster upgrading to default version always

### DIFF
--- a/pkg/ctl/update/cluster.go
+++ b/pkg/ctl/update/cluster.go
@@ -14,6 +14,8 @@ import (
 
 func updateClusterCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()
+	// Reset version before loading
+	cfg.Metadata.Version = ""
 	cmd.ClusterConfig = cfg
 
 	cmd.SetDescription("cluster", "DEPRECATED: use 'upgrade cluster' instead. Upgrade control plane to the next version. ",

--- a/pkg/ctl/upgrade/cluster.go
+++ b/pkg/ctl/upgrade/cluster.go
@@ -21,6 +21,8 @@ func upgradeCluster(cmd *cmdutils.Cmd) {
 
 func upgradeClusterWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd) error) {
 	cfg := api.NewClusterConfig()
+	// Reset version
+	cfg.Metadata.Version = ""
 	cmd.ClusterConfig = cfg
 
 	cmd.SetDescription("cluster", "Upgrade control plane to the next version",

--- a/pkg/ctl/upgrade/cluster_test.go
+++ b/pkg/ctl/upgrade/cluster_test.go
@@ -61,8 +61,13 @@ var _ = Describe("upgrade cluster", func() {
 
 			cfg := cmd.Cmd.ClusterConfig
 			Expect(cfg.Metadata.Name).To(Equal("clus-1"))
+
+			// The version should be empty when not specified as a flag
+			Expect(cfg.Metadata.Version).To(Equal(""))
+
 			// I cannot test the region here because this flag is loaded into the cmd.ProviderConfig.Region
 			//Expect(cfg.Metadata.Region).To(Equal("us-west-2"))
+
 			Expect(cmd.Cmd.ProviderConfig.Region).To(Equal("us-west-2"))
 			Expect(cmd.Cmd.Plan).To(BeFalse())
 			Expect(cmd.Cmd.ProviderConfig.WaitTimeout).To(Equal(123 * time.Minute))
@@ -147,6 +152,18 @@ var _ = Describe("upgrade cluster", func() {
 			Expect(loadedCfg.Region).To(Equal("us-west-2"))
 			Expect(loadedCfg.Version).To(Equal("1.16"))
 		})
+
+		It("when not specified in the config file the version is empty", func() {
+			cfg.Metadata.Version = ""
+			configFile = CreateConfigFile(cfg)
+
+			cmd := newMockUpgradeClusterCmd("cluster", "--config-file", configFile)
+			_, err := cmd.Execute()
+			Expect(err).To(Not(HaveOccurred()))
+
+			loadedCfg := cmd.Cmd.ClusterConfig.Metadata
+			Expect(loadedCfg.Version).To(Equal(""))
+		})
 	})
 
 	type upgradeCase struct {
@@ -175,8 +192,8 @@ var _ = Describe("upgrade cluster", func() {
 
 		Entry("upgrades by default when the version is not specified", upgradeCase{
 			givenVersion:           "",
-			eksVersion:             "1.15",
-			expectedUpgradeVersion: "1.16",
+			eksVersion:             "1.16",
+			expectedUpgradeVersion: "1.17",
 			expectedUpgrade:        true,
 		}),
 


### PR DESCRIPTION
The upgrade/update cluster commands where always trying to upgrade to the default version when
one was not specified by the user.


```
eksctl upgrade cluster  martina-test-1-13
[ℹ]  eksctl version 0.24.0-dev+2c97a450.2020-07-10T08:09:08Z
[ℹ]  using region eu-north-1
Error: upgrading more than one version at a time is not supported. Found upgrade from "1.13" to "1.16". Please upgrade to "1.14" first
```


```
eksctl upgrade cluster martina-test-1-13
[ℹ]  eksctl version 0.24.0-dev+19f9b371.2020-07-10T09:30:41Z
[ℹ]  using region eu-north-1
[ℹ]  (plan) would upgrade cluster "martina-test-1-13" control plane from current version "1.13" to "1.14"
[ℹ]  re-building cluster stack "eksctl-martina-test-1-13-cluster"
[✔]  all resources in cluster stack "eksctl-martina-test-1-13-cluster" are up-to-date
[ℹ]  checking security group configuration for all nodegroups
[ℹ]  all nodegroups have up-to-date configuration
[!]  no changes were applied, run again with '--approve' to apply the changes
```

The problem is that when we create a new ClusterConfig object we set the version to the default version. Then this
value is used as a default for the `--version` flag.


- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes