### PR TITLE
Fix notify-slack only_for_branches option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ commands:
         default: true
       only_for_branches:
         type: string
-        default: master
     steps:
       - run: exit 0
       - slack/status:
@@ -115,7 +114,8 @@ jobs:
           path: ./test-results
       - store_artifacts:
           path: ./bin
-      - notify-slack
+      - notify-slack:
+          only_for_branches: master
   build-all-distros:
     machine:
       image: ubuntu-1604:201903-01
@@ -133,7 +133,8 @@ jobs:
           cmd: make build-all
       - store_artifacts:
           path: dist/
-      - notify-slack
+      - notify-slack:
+          only_for_branches: master
   release-candidate:
     machine:
       image: ubuntu-1604:201903-01
@@ -222,6 +223,7 @@ jobs:
           path: ./test-results
       - notify-slack:
           fail_only: false
+          only_for_branches: master
 
 workflows:
   version: 2


### PR DESCRIPTION
### Description

I think there was an issue with the default being used when
passing `""`. Now, without a default, settings are more explicit.



<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

