### PR TITLE
Allow `version: auto` in the config file when creating a cluster

### DIFF
--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -107,7 +107,7 @@ func doCreateCluster(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *cmdutils.Crea
 	}
 	cmdutils.LogRegionAndVersionInfo(meta)
 
-	if cfg.Metadata.Version == "" {
+	if cfg.Metadata.Version == "" || cfg.Metadata.Version == "auto" {
 		cfg.Metadata.Version = api.DefaultVersion
 	}
 	if cfg.Metadata.Version != api.DefaultVersion {

--- a/pkg/ctl/upgrade/cluster_test.go
+++ b/pkg/ctl/upgrade/cluster_test.go
@@ -197,6 +197,13 @@ var _ = Describe("upgrade cluster", func() {
 			expectedUpgrade:        true,
 		}),
 
+		Entry("upgrades by default when the version is auto", upgradeCase{
+			givenVersion:           "auto",
+			eksVersion:             "1.16",
+			expectedUpgradeVersion: "1.17",
+			expectedUpgrade:        true,
+		}),
+
 		Entry("does not upgrade or fail when the cluster is already in the last version", upgradeCase{
 			givenVersion:           "",
 			eksVersion:             "1.17",


### PR DESCRIPTION
This allows the version to have the value `auto` when creating a cluster. This value
was only supported when creating a nodegroup and upgrading a cluster. Now it can also
be used when creating a cluster. In this case, eksctl will use the default version.



<details>
<summary>eksctl create cluster</summary>

```
$ eksctl create cluster -f examples/01-simple-cluster.yaml 
[ℹ]  eksctl version 0.26.0-dev+307fe94b.2020-08-03T16:51:48Z
[ℹ]  using region eu-north-1
[ℹ]  setting availability zones to [eu-north-1b eu-north-1a eu-north-1c]
[ℹ]  subnets for eu-north-1b - public:192.168.0.0/19 private:192.168.96.0/19
[ℹ]  subnets for eu-north-1a - public:192.168.32.0/19 private:192.168.128.0/19
[ℹ]  subnets for eu-north-1c - public:192.168.64.0/19 private:192.168.160.0/19
[ℹ]  nodegroup "ng-1" will use "ami-043dbb11ff9b5a350" [AmazonLinux2/1.17]
[ℹ]  using Kubernetes version 1.17
...
[ℹ]  nodegroup "ng-1" has 1 node(s)
[ℹ]  node "ip-192-168-83-103.eu-north-1.compute.internal" is ready
[ℹ]  kubectl command should work with "/home/martina/.kube/config", try 'kubectl get nodes'
[✔]  EKS cluster "martina-test-auto-1" in "eu-north-1" region is ready

```

</details>


<details>
<summary>eksctl create nodegroup</summary>

```
$ cat test.yaml 
---
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: martina-1-13-2
  region: eu-north-1
  version: "auto"

nodeGroups:
  - name: ng-2
    instanceType: t3.medium
    desiredCapacity: 1

```

```
$ eksctl create nodegroup -f test.yaml --include ng-2
[ℹ]  eksctl version 0.26.0-dev+307fe94b.2020-08-03T16:51:48Z
[ℹ]  using region eu-north-1
[ℹ]  will use version 1.13 for new nodegroup(s) based on control plane version
[ℹ]  nodegroup "ng-2" present in the given config, but missing in the cluster
[ℹ]  nodegroup "ng-84dc9dc0" present in the cluster, but missing from the given config
[ℹ]  1 existing nodegroup(s) (ng-84dc9dc0) will be excluded
[ℹ]  nodegroup "ng-2" will use "ami-046b83e67325d4d1e" [AmazonLinux2/1.13]
[ℹ]  combined include rules: ng-2
[ℹ]  1 nodegroup (ng-2) was included (based on the include/exclude rules)
[ℹ]  will create a CloudFormation stack for each of 1 nodegroups in cluster "martina-1-13-2"
[ℹ]  1 task: { 1 task: { 1 task: { create nodegroup "ng-2" } } }
[ℹ]  building nodegroup stack "eksctl-martina-1-13-2-nodegroup-ng-2"
[ℹ]  --nodes-min=1 was set automatically for nodegroup ng-2
[ℹ]  --nodes-max=1 was set automatically for nodegroup ng-2
[ℹ]  deploying stack "eksctl-martina-1-13-2-nodegroup-ng-2"
[ℹ]  no tasks
[ℹ]  adding identity "arn:aws:iam::123:role/eksctl-martina-1-13-2-nodegroup-n-NodeInstanceRole-1U3IUW46A2KTN" to auth ConfigMap
[ℹ]  nodegroup "ng-2" has 0 node(s)
[ℹ]  waiting for at least 1 node(s) to become ready in "ng-2"
[ℹ]  nodegroup "ng-2" has 1 node(s)
[ℹ]  node "ip-192-168-53-160.eu-north-1.compute.internal" is ready
[✔]  created 1 nodegroup(s) in cluster "martina-1-13-2"
[✔]  created 0 managed nodegroup(s) in cluster "martina-1-13-2"
[ℹ]  checking security group configuration for all nodegroups
[ℹ]  all nodegroups have up-to-date configuration

```
</details>


<details>
<summary>eksctl upgrade cluster</summary>

```
$ cat test.yaml 
---
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: martina-1-13-2
  region: eu-north-1
  version: "auto"

nodeGroups:
  - name: ng-2
    instanceType: t3.medium
    desiredCapacity: 1

```

```
$ eksctl upgrade cluster -f test.yaml 
[ℹ]  eksctl version 0.26.0-dev+307fe94b.2020-08-03T16:51:48Z
[ℹ]  using region eu-north-1
[!]  NOTE: cluster VPC (subnets, routing & NAT Gateway) configuration changes are not yet implemented
[ℹ]  (plan) would upgrade cluster "martina-1-13-2" control plane from current version "1.13" to "1.14"
[ℹ]  re-building cluster stack "eksctl-martina-1-13-2-cluster"
[ℹ]  (plan) updating stack to add new resources [PolicyELBPermissions] and outputs []
[ℹ]  checking security group configuration for all nodegroups
[ℹ]  all nodegroups have up-to-date configuration
[!]  no changes were applied, run again with '--approve' to apply the changes
```

</details>

- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes