### PR TITLE
Fix: Update kube-proxy using a documented version in AWS docs

### DIFF
--- a/pkg/addons/default/kube_proxy.go
+++ b/pkg/addons/default/kube_proxy.go
@@ -21,6 +21,15 @@ const (
 	KubeProxy = "kube-proxy"
 )
 
+// KubeProxyDocumentedVersions maps major and minor control plane version to latest documented AWS kube-proxy version
+// see https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html for latest supported versions
+var KubeProxyDocumentedVersions = map[string]string{
+	"1.17": "1.17.7",
+	"1.16": "1.16.12",
+	"1.15": "1.15.11",
+	"1.14": "1.14.9",
+}
+
 func IsKubeProxyUpToDate(clientSet kubernetes.Interface, controlPlaneVersion string) (bool, error) {
 	d, err := clientSet.AppsV1().DaemonSets(metav1.NamespaceSystem).Get(KubeProxy, metav1.GetOptions{})
 	if err != nil {
@@ -98,17 +107,9 @@ func UpdateKubeProxyImageTag(clientSet kubernetes.Interface, controlPlaneVersion
 }
 
 func kubeProxyImageTag(controlPlaneVersion string) string {
-	// See https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html for latest supported versions
-	documentedVersions := map[string]string{
-		"1.17": "1.17.7",
-		"1.16": "1.16.12",
-		"1.15": "1.15.11",
-		"1.14": "1.14.9",
-	}
 	parsedVersion, _ := semver.ParseTolerant(controlPlaneVersion)
 	lookupVersion := fmt.Sprintf("%d.%d", parsedVersion.Major, parsedVersion.Minor)
-
-	imageTagVersion := documentedVersions[lookupVersion]
+	imageTagVersion := KubeProxyDocumentedVersions[lookupVersion]
 
 	if imageTagVersion == "" {
 		imageTagVersion = controlPlaneVersion

--- a/pkg/addons/default/kube_proxy_test.go
+++ b/pkg/addons/default/kube_proxy_test.go
@@ -37,10 +37,10 @@ var _ = Describe("default addons - kube-proxy", func() {
 			check("v1.14.6")
 		})
 
-		It("can update to multi-architecture image based on control plane version", func() {
-			_, err := UpdateKubeProxyImageTag(clientSet, "1.15.0", false)
+		It("can update to multi-architecture image based on control plane version and AWS documentation", func() {
+			_, err := UpdateKubeProxyImageTag(clientSet, "1.16.13", false)
 			Expect(err).ToNot(HaveOccurred())
-			check("v1.15.0-eksbuild.1")
+			check("v1.16.12-eksbuild.1")
 		})
 
 		It("can dry-run update based on control plane version", func() {


### PR DESCRIPTION
Some kubernetes control plane versions don't have a corresponding kube-proxy image tag with the same version. This change uses major and minor version to lookup for a documented version if exists, otherwise it uses the control plane version to build the image tag. The only consideration is to make sure to update the mapping each time AWS releases a new documented version.

Fixes #2536

### Description

As described in issue #2536, using only the control plane version to determine the correct image tag for kube-proxy when updated may lead to non-existing image. This causes some issues issues like worker nodes not being ready because CNI is failing to load due daemonset not having pods in the new worker nodes.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

