### PR TITLE
fix the wrong message printed about how to enable logging for the clu…

### DIFF
--- a/pkg/eks/tasks.go
+++ b/pkg/eks/tasks.go
@@ -117,7 +117,7 @@ func (c *ClusterProvider) CreateExtraClusterConfigTasks(cfg *api.ClusterConfig, 
 	}
 	if !cfg.HasClusterCloudWatchLogging() {
 		logger.Info("CloudWatch logging will not be enabled for cluster %q in %q", cfg.Metadata.Name, cfg.Metadata.Region)
-		logger.Info("you can enable it with 'eksctl utils update-cluster-logging --region=%s --cluster=%s'", cfg.Metadata.Region, cfg.Metadata.Name)
+		logger.Info("you can enable it with 'eksctl utils update-cluster-logging --enable-types=all --region=%s --cluster=%s'", cfg.Metadata.Region, cfg.Metadata.Name)
 
 	} else {
 		newTasks.Append(&clusterConfigTask{

--- a/userdocs/src/usage/fargate-support.md
+++ b/userdocs/src/usage/fargate-support.md
@@ -24,7 +24,7 @@ $ eksctl create cluster --fargate
 [ℹ]  will create 2 separate CloudFormation stacks for cluster itself and the initial nodegroup
 [ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=ap-northeast-1 --cluster=ridiculous-painting-1574859263'
 [ℹ]  CloudWatch logging will not be enabled for cluster "ridiculous-painting-1574859263" in "ap-northeast-1"
-[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --region=ap-northeast-1 --cluster=ridiculous-painting-1574859263'
+[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --enable-types=all --region=ap-northeast-1 --cluster=ridiculous-painting-1574859263'
 [ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "ridiculous-painting-1574859263" in "ap-northeast-1"
 [ℹ]  2 sequential tasks: { create cluster control plane "ridiculous-painting-1574859263", create nodegroup "ng-dba9d731" }
 [ℹ]  building cluster stack "eksctl-ridiculous-painting-1574859263-cluster"
@@ -135,7 +135,7 @@ $ eksctl create cluster -f cluster-fargate.yaml
 [ℹ]  will create a CloudFormation stack for cluster itself and 0 managed nodegroup stack(s)
 [ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=ap-northeast-1 --cluster=fargate-cluster'
 [ℹ]  CloudWatch logging will not be enabled for cluster "fargate-cluster" in "ap-northeast-1"
-[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --region=ap-northeast-1 --cluster=fargate-cluster'
+[ℹ]  you can enable it with 'eksctl utils update-cluster-logging --enable-types=all --region=ap-northeast-1 --cluster=fargate-cluster'
 [ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "fargate-cluster" in "ap-northeast-1"
 [ℹ]  2 sequential tasks: { create cluster control plane "fargate-cluster", create nodegroup "ng-1" }
 [ℹ]  building cluster stack "eksctl-fargate-cluster-cluster"


### PR DESCRIPTION
…ster - type was not specified, therefore the command didn't work

### Description

I have fixed a wrong display message when creating a cluster with no logging.
The message was missing a flag for the command - the current message doesn't work...

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

