### PR TITLE
Fix upgrading nodegroups with old template format

### DIFF
--- a/pkg/managed/service.go
+++ b/pkg/managed/service.go
@@ -264,7 +264,7 @@ func (m *Service) requiresStackFormatUpdate(nodeGroupName string) (bool, error) 
 			Minor: 25,
 			Patch: 0,
 		}
-		return ver.Compare(newFormatVersion) < 0, nil
+		return ver.LT(newFormatVersion), nil
 	}
 	return true, nil
 }

--- a/pkg/managed/service.go
+++ b/pkg/managed/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"github.com/weaveworks/goformation/v4/cloudformation"
 
 	"github.com/weaveworks/eksctl/pkg/ami"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -172,6 +173,28 @@ func (m *Service) UpgradeNodeGroup(options UpgradeOptions) error {
 		return errors.New("unexpected error: failed to find nodegroup resource in nodegroup stack")
 	}
 
+	updateStack := func(stack *cloudformation.Template) error {
+		bytes, err := stack.JSON()
+		if err != nil {
+			return err
+		}
+		if err := m.stackCollection.UpdateNodeGroupStack(options.NodegroupName, string(bytes)); err != nil {
+			return errors.Wrap(err, "error updating nodegroup stack")
+		}
+		return nil
+	}
+
+	requiresUpdate, err := m.requiresStackFormatUpdate(options.NodegroupName)
+	if err != nil {
+		return err
+	}
+	if requiresUpdate {
+		logger.Info("updating nodegroup stack to a newer format before upgrading nodegroup version")
+		if err := updateStack(stack); err != nil {
+			return err
+		}
+	}
+
 	ltResources := stack.GetAllEC2LaunchTemplateResources()
 
 	if options.LaunchTemplateVersion != "" {
@@ -217,15 +240,33 @@ func (m *Service) UpgradeNodeGroup(options UpgradeOptions) error {
 		ngResource.LaunchTemplate.Version = gfnt.NewString(options.LaunchTemplateVersion)
 	}
 
-	updatedTemplate, err := stack.JSON()
-	if err != nil {
+	logger.Info("upgrading nodegroup version")
+	if err := updateStack(stack); err != nil {
 		return err
-	}
-	if err := m.stackCollection.UpdateNodeGroupStack(options.NodegroupName, string(updatedTemplate)); err != nil {
-		return errors.Wrap(err, "error updating nodegroup stack")
 	}
 	logger.Info("nodegroup successfully upgraded")
 	return nil
+}
+
+func (m *Service) requiresStackFormatUpdate(nodeGroupName string) (bool, error) {
+	ngStack, err := m.stackCollection.DescribeNodeGroupStack(nodeGroupName)
+	if err != nil {
+		return false, err
+	}
+
+	ver, found, err := manager.GetEksctlVersion(ngStack.Tags)
+	if err != nil {
+		return false, err
+	}
+	if found {
+		newFormatVersion := semver.Version{
+			Major: 0,
+			Minor: 25,
+			Patch: 0,
+		}
+		return ver.Compare(newFormatVersion) < 0, nil
+	}
+	return true, nil
 }
 
 func (m *Service) getLatestReleaseVersion(kubernetesVersion string, nodeGroup *eks.Nodegroup) (string, error) {


### PR DESCRIPTION
goformation unmarshals an attribute reference as an array. For old templates, this was causing the reference to `"Fn::GetAtt": "NodeInstanceRole.Arn"` to be unmarshalled as `"Fn::GetAtt": ["NodeInstanceRole", "Arn"]`, which, in turn, was triggering an update on this resource. However, when upgrading a nodegroup, CloudFormation does not permit combining release version updates with other updates, and this resulted in an error.

Fixes #2565 

### Description

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

