### PR TITLE
Fix route validation for subnets with an explicit main route table association

### DIFF
--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -319,6 +319,9 @@ func importRouteTables(ec2API ec2iface.EC2API, subnets map[string]api.Network) (
 	subnetRoutes := make(map[string]string)
 	for _, rt := range routeTables {
 		for _, rta := range rt.Associations {
+			if rta.Main != nil && *rta.Main {
+				return nil, errors.New("subnets must be associated with a non-main route table; eksctl does not modify the main route table")
+			}
 			subnetRoutes[*rta.SubnetId] = *rt.RouteTableId
 		}
 	}


### PR DESCRIPTION
### Description

Fixes #2500 

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

