### PR TITLE
Use proper commit range in release-merge workflow check

### DIFF
--- a/.github/workflows/release-merge.yaml
+++ b/.github/workflows/release-merge.yaml
@@ -24,7 +24,7 @@ jobs:
           git checkout ORIG_HEAD -- $VERSION_FILE
           git add $VERSION_FILE
           EDITOR=true git merge --continue
-          ! git diff --exit-code $DEFAULT_BRANCH HEAD
+          ! git diff --exit-code $DEFAULT_BRANCH...HEAD
           git push --set-upstream origin HEAD
       - uses: actions/github-script@v2.0.0
         name: Open PR to ${{env.DEFAULT_BRANCH}}


### PR DESCRIPTION
### Description
This was causing spurious empty PRs from `release-*` if there were no changes, in spite of the check
<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

