### PR TITLE
Fix the policy "AmazonEC2FullAccess" on minimum-iam-policies.md

### DIFF
--- a/userdocs/src/usage/minimum-iam-policies.md
+++ b/userdocs/src/usage/minimum-iam-policies.md
@@ -40,8 +40,6 @@ AmazonEC2FullAccess
                         "autoscaling.amazonaws.com",
                         "ec2scheduled.amazonaws.com",
                         "elasticloadbalancing.amazonaws.com",
-                        "eks.amazonaws.com",
-                        "eks-fargate-pods.amazonaws.com",
                         "spot.amazonaws.com",
                         "spotfleet.amazonaws.com",
                         "transitgateway.amazonaws.com"
@@ -149,6 +147,22 @@ IamLimitedAccess
             "Resource": [
                 "arn:aws:iam::<account_id>:role/*"
             ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "iam:AWSServiceName": [
+                        "eks.amazonaws.com",
+                        "eks-nodegroup.amazonaws.com",
+                        "eks-fargate.amazonaws.com"
+                    ]
+                }
+            }
         }
     ]
 }

--- a/userdocs/src/usage/minimum-iam-policies.md
+++ b/userdocs/src/usage/minimum-iam-policies.md
@@ -5,7 +5,9 @@ run the integration tests.
 
 > **Note**: remember to replace `<account_id>` with your own.
 
-AmazonEC2FullAccess
+!!!info An AWS Managed Policy is created and administered by AWS. You cannot change the permissions defined in AWS managed policies.
+
+AmazonEC2FullAccess (AWS Managed Policy)
 ```
 {
     "Version": "2012-10-17",
@@ -51,7 +53,7 @@ AmazonEC2FullAccess
 }
 ```
 
-AWSCloudFormationFullAccess
+AWSCloudFormationFullAccess (AWS Managed Policy)
 ```
 {
     "Version": "2012-10-17",


### PR DESCRIPTION
Refer to [Improvement of the policy "AmazonEC2FullAccess" on minimum-iam-policies.md · Issue #2596 · weaveworks/eksctl](https://github.com/weaveworks/eksctl/issues/2596)

### Description

<!-- Please explain the changes you made here. -->
* I moved the action "iam:CreateServiceLinkedRole" for EKS Service-Linked Role to the policy "IamLimitedAccess".
* I fixed ima:AWSServiceName for AWSServiceRoleForAmazonEKSForFargate.
* I added ima:AWSServiceName for AWSServiceRoleForAmazonEKSNodegroup.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

