### PR TITLE
Recognize ARM instance types for Bottlerocket parameters

### DIFF
--- a/pkg/ami/ssm_resolver.go
+++ b/pkg/ami/ssm_resolver.go
@@ -2,7 +2,6 @@ package ami
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
@@ -88,8 +87,7 @@ func MakeManagedSSMParameterName(version, imageFamily, amiType string) (string, 
 // instanceEC2ArchName returns the name of the architecture as used by EC2
 // resources.
 func instanceEC2ArchName(instanceType string) string {
-	// eg: a1.large - an ARM instance type.
-	if strings.HasPrefix(instanceType, "a") {
+	if utils.IsARMInstanceType(instanceType) {
 		return "arm64"
 	}
 	return "x86_64"


### PR DESCRIPTION

### Description

<!-- Please explain the changes you made here. -->

This updates the EC2 instance-type to architecture name "translator" to use the newly added `utils.IsARMInstanceType` predicate (from #2535).

In effect, this allows users to launch Bottlerocket clusters on `arm64` instance types ([mentioned here](https://github.com/bottlerocket-os/bottlerocket/issues/1096)).

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

