### PR TITLE
Add integration tests for updating addons

### DIFF
--- a/integration/tests/update/update_cluster_test.go
+++ b/integration/tests/update/update_cluster_test.go
@@ -1,0 +1,221 @@
+// +build integration
+
+package update
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	awseks "github.com/aws/aws-sdk-go/service/eks"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	. "github.com/weaveworks/eksctl/integration/matchers"
+	. "github.com/weaveworks/eksctl/integration/runner"
+	"github.com/weaveworks/eksctl/integration/tests"
+	"github.com/weaveworks/eksctl/pkg/addons"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/eks"
+	kubewrapper "github.com/weaveworks/eksctl/pkg/kubernetes"
+	"github.com/weaveworks/eksctl/pkg/testutils"
+	"github.com/weaveworks/eksctl/pkg/utils/file"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var defaultCluster string
+var noInstallCluster string
+var params *tests.Params
+
+func init() {
+	// Call testing.Init() prior to tests.NewParams(), as otherwise -test.* will not be recognised. See also: https://golang.org/doc/go1.13#testing
+	testing.Init()
+	params = tests.NewParams("up")
+	defaultCluster = params.ClusterName
+	noInstallCluster = params.NewClusterName("update")
+}
+
+func TestUpdate(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}
+
+var _ = Describe("(Integration) Update addons", func() {
+	const (
+		initNG = "kp-ng-0"
+	)
+	BeforeSuite(func() {
+		params.KubeconfigTemp = false
+		if params.KubeconfigPath == "" {
+			wd, _ := os.Getwd()
+			f, _ := ioutil.TempFile(wd, "kubeconfig-")
+			params.KubeconfigPath = f.Name()
+			params.KubeconfigTemp = true
+		}
+	})
+
+	AfterSuite(func() {
+		params.DeleteClusters()
+		gexec.KillAndWait()
+		if params.KubeconfigTemp {
+			os.Remove(params.KubeconfigPath)
+		}
+		os.RemoveAll(params.TestDirectory)
+	})
+
+	// Chose 1.15 because the upgrade to 1.16 takes less time than upgrading to 1.17
+	When("creating a cluster with version 1.15", func() {
+		It("should not return an error", func() {
+			if params.SkipCreate {
+				fmt.Fprintf(GinkgoWriter, "will use existing cluster %s", defaultCluster)
+				if !file.Exists(params.KubeconfigPath) {
+					// Generate the Kubernetes configuration that eksctl create
+					// would have generated otherwise:
+					cmd := params.EksctlUtilsCmd.WithArgs(
+						"write-kubeconfig",
+						"--verbose", "4",
+						"--cluster", defaultCluster,
+						"--kubeconfig", params.KubeconfigPath,
+					)
+					Expect(cmd).To(RunSuccessfully())
+				}
+				return
+			}
+
+			fmt.Fprintf(GinkgoWriter, "Using kubeconfig: %s\n", params.KubeconfigPath)
+
+			cmd := params.EksctlCreateCmd.WithArgs(
+				"cluster",
+				"--verbose", "4",
+				"--name", defaultCluster,
+				"--tags", "alpha.eksctl.io/description=eksctl integration test",
+				"--nodegroup-name", initNG,
+				"--node-labels", "ng-name="+initNG,
+				"--nodes", "1",
+				"--node-type", "t3.large",
+				"--version", "1.15",
+				"--kubeconfig", params.KubeconfigPath,
+			)
+			Expect(cmd).To(RunSuccessfully())
+		})
+
+		It("should have created an EKS cluster and two CloudFormation stacks", func() {
+			awsSession := NewSession(params.Region)
+
+			Expect(awsSession).To(HaveExistingCluster(params.ClusterName, awseks.ClusterStatusActive, api.Version1_15))
+
+			Expect(awsSession).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-cluster", params.ClusterName)))
+			Expect(awsSession).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", params.ClusterName, initNG)))
+		})
+
+		It("should upgrade the control plane to version 1.16", func() {
+
+			cmd := params.EksctlUpgradeCmd.
+				WithArgs(
+					"cluster",
+					"--verbose", "4",
+					"--name", params.ClusterName,
+					"--approve",
+				)
+			Expect(cmd).To(RunSuccessfully())
+
+			By(fmt.Sprintf("checking that control plane is updated to %v", "1.16"))
+			config, err := clientcmd.BuildConfigFromFlags("", params.KubeconfigPath)
+			Expect(err).ToNot(HaveOccurred())
+
+			clientSet, err := kubernetes.NewForConfig(config)
+			Expect(err).ToNot(HaveOccurred())
+
+			serverVersion, err := clientSet.ServerVersion()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fmt.Sprintf("%s.%s", serverVersion.Major, strings.TrimSuffix(serverVersion.Minor, "+"))).To(Equal("1.16"))
+		})
+
+		It("should upgrade kube-proxy", func() {
+			cmd := params.EksctlUtilsCmd.WithArgs(
+				"update-kube-proxy",
+				"--cluster", params.ClusterName,
+				"--verbose", "4",
+				"--approve",
+			)
+			Expect(cmd).To(RunSuccessfully())
+
+			clientSet := getClientSet()
+			daemonSet, err := clientSet.AppsV1().DaemonSets(metav1.NamespaceSystem).Get("kube-proxy", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			kubeProxyVersion, err := addons.ImageTag(daemonSet.Spec.Template.Spec.Containers[0].Image)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kubeProxyVersion).To(Equal("v1.16.13-eksbuild.1"))
+		})
+
+		It("should upgrade aws-node", func() {
+			cmd := params.EksctlUtilsCmd.WithArgs(
+				"update-aws-node",
+				"--cluster", params.ClusterName,
+				"--verbose", "4",
+				"--approve",
+			)
+			Expect(cmd).To(RunSuccessfully())
+
+			rawClient := getRawClient()
+			clusterDaemonSet, err := rawClient.ClientSet().AppsV1().DaemonSets(metav1.NamespaceSystem).Get("aws-node", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			awsNodeVersion, err := addons.ImageTag(clusterDaemonSet.Spec.Template.Spec.Containers[0].Image)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(awsNodeVersion).To(Equal("v1.6.3-eksbuild.1"))
+		})
+
+		It("should upgrade coredns", func() {
+			cmd := params.EksctlUtilsCmd.WithArgs(
+				"update-coredns",
+				"--cluster", params.ClusterName,
+				"--verbose", "4",
+				"--approve",
+			)
+			Expect(cmd).To(RunSuccessfully())
+
+			rawClient := getRawClient()
+			coreDNSDeployment, err := rawClient.ClientSet().AppsV1().Deployments(metav1.NamespaceSystem).Get("coredns", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			coreDNSVersion, err := addons.ImageTag(coreDNSDeployment.Spec.Template.Spec.Containers[0].Image)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(coreDNSVersion).To(Equal("v1.6.6-eksbuild.1"))
+		})
+
+	})
+})
+
+func getRawClient() *kubewrapper.RawClient {
+	cfg := &api.ClusterConfig{
+		Metadata: &api.ClusterMeta{
+			Name:   params.ClusterName,
+			Region: params.Region,
+		},
+	}
+	ctl := eks.New(&api.ProviderConfig{Region: params.Region}, cfg)
+	err := ctl.RefreshClusterStatus(cfg)
+	Expect(err).ShouldNot(HaveOccurred())
+	rawClient, err := ctl.NewRawClient(cfg)
+	Expect(err).ToNot(HaveOccurred())
+	return rawClient
+}
+
+func getClientSet() *kubernetes.Clientset {
+	cfg := &api.ClusterConfig{
+		Metadata: &api.ClusterMeta{
+			Name:   params.ClusterName,
+			Region: params.Region,
+		},
+	}
+	ctl := eks.New(&api.ProviderConfig{Region: params.Region}, cfg)
+	err := ctl.RefreshClusterStatus(cfg)
+	Expect(err).ShouldNot(HaveOccurred())
+	clientSet, err := ctl.NewStdClientSet(cfg)
+	Expect(err).ToNot(HaveOccurred())
+	return clientSet
+}


### PR DESCRIPTION
Add integration tests for the commands that update the default addons.

### Tests result
ginkgo -tags integration -v --progress integration/tests/update/... -- -test.v -ginkgo.v

```
Ran 6 of 6 Specs in 3100.024 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestUpdate (3100.02s)
PASS

Ginkgo ran 1 suite in 51m45.562835217s
Test Suite Passed
```


- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes