### PR TITLE
Fix `delete iamserviceaccount` and withOIDC

### DIFF
--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -621,7 +621,7 @@ func NewDeleteIAMServiceAccountLoader(cmd *Cmd, sa *api.ClusterIAMServiceAccount
 	l := newCommonClusterConfigLoader(cmd)
 
 	l.validateWithConfigFile = func() error {
-		if api.IsDisabled(l.ClusterConfig.IAM.WithOIDC) {
+		if l.ClusterConfig.IAM == nil || api.IsDisabled(l.ClusterConfig.IAM.WithOIDC) {
 			return fmt.Errorf("'iam.withOIDC' is not enabled in %q", l.ClusterConfigFile)
 		}
 		return saFilter.AppendGlobs(l.Include, l.Exclude, l.ClusterConfig.IAM.ServiceAccounts)


### PR DESCRIPTION
### Description
Closes #2669 

This change makes the SA visible to all commands through `IAM.ServiceAccounts`, as opposed to inserting it at cluster creation as before
<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

