### PR TITLE
Fix release-merge workflow issues

### DIFF
--- a/.github/workflows/release-merge.yaml
+++ b/.github/workflows/release-merge.yaml
@@ -2,7 +2,7 @@ name: Merge release changes to master
 on:
   push:
     branches:
-      - release-*
+      - "release-[0-9]+.[0-9]+"
 env:
   VERSION_FILE: pkg/version/release.go
   DEFAULT_BRANCH: master

--- a/.github/workflows/release-merge.yaml
+++ b/.github/workflows/release-merge.yaml
@@ -24,7 +24,7 @@ jobs:
           git checkout ORIG_HEAD -- $VERSION_FILE
           git add $VERSION_FILE
           EDITOR=true git merge --continue
-          ! git diff --exit-code $DEFAULT_BRANCH...HEAD
+          ! git diff --exit-code $DEFAULT_BRANCH...HEAD || exit 1
           git push --set-upstream origin HEAD
       - uses: actions/github-script@v2.0.0
         name: Open PR to ${{env.DEFAULT_BRANCH}}


### PR DESCRIPTION
### Description

It turns out [`set -e` doesn't fail if the command uses `!`](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#The-Set-Builtin)

<!-- Please explain the changes you made here. -->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

