### PR TITLE
Deprecate static AMI resolver

### DIFF
--- a/pkg/ctl/cmdutils/nodegroup_flags.go
+++ b/pkg/ctl/cmdutils/nodegroup_flags.go
@@ -38,7 +38,7 @@ func AddCommonCreateNodeGroupFlags(fs *pflag.FlagSet, cmd *Cmd, ng *api.NodeGrou
 	ng.SSH.Allow = fs.Bool("ssh-access", *ng.SSH.Allow, "control SSH access for nodes. Uses ~/.ssh/id_rsa.pub as default key path if enabled")
 	ng.SSH.PublicKeyPath = fs.String("ssh-public-key", "", "SSH public key to use for nodes (import from local path, or use existing EC2 key pair)")
 
-	fs.StringVar(&ng.AMI, "node-ami", "", "'auto-ssm' (default), 'auto', 'static' (will be deprecated) or an AMI id (advanced use)")
+	fs.StringVar(&ng.AMI, "node-ami", "", "'auto-ssm' (default), 'auto', 'static' (deprecated, will be removed in 0.33.0) or an AMI id (advanced use)")
 	fs.StringVar(&ng.AMIFamily, "node-ami-family", api.DefaultNodeImageFamily, "'AmazonLinux2' for the Amazon EKS optimized AMI or 'Ubuntu1804' for the official Canonical EKS AMIs (Ubuntu 18.04)")
 
 	fs.BoolVarP(&ng.PrivateNetworking, "node-private-networking", "P", false, "whether to make nodegroup networking private")

--- a/pkg/ctl/cmdutils/nodegroup_flags.go
+++ b/pkg/ctl/cmdutils/nodegroup_flags.go
@@ -38,7 +38,7 @@ func AddCommonCreateNodeGroupFlags(fs *pflag.FlagSet, cmd *Cmd, ng *api.NodeGrou
 	ng.SSH.Allow = fs.Bool("ssh-access", *ng.SSH.Allow, "control SSH access for nodes. Uses ~/.ssh/id_rsa.pub as default key path if enabled")
 	ng.SSH.PublicKeyPath = fs.String("ssh-public-key", "", "SSH public key to use for nodes (import from local path, or use existing EC2 key pair)")
 
-	fs.StringVar(&ng.AMI, "node-ami", "", "'auto-ssm' (default), 'auto', 'static' (deprecated) or an AMI id (advanced use)")
+	fs.StringVar(&ng.AMI, "node-ami", "", "'auto-ssm' (default), 'auto', 'static' (will be deprecated) or an AMI id (advanced use)")
 	fs.StringVar(&ng.AMIFamily, "node-ami-family", api.DefaultNodeImageFamily, "'AmazonLinux2' for the Amazon EKS optimized AMI or 'Ubuntu1804' for the official Canonical EKS AMIs (Ubuntu 18.04)")
 
 	fs.BoolVarP(&ng.PrivateNetworking, "node-private-networking", "P", false, "whether to make nodegroup networking private")

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -275,7 +275,7 @@ func ResolveAMI(provider api.ClusterProvider, version string, ng *api.NodeGroup)
 	case api.NodeImageResolverAutoSSM:
 		resolver = ami.NewSSMResolver(provider.SSM())
 	case api.NodeImageResolverStatic:
-		logger.Warning("'static' value for node-ami flag is deprecated and will be removed with release 0.33.0. Valid values will be 'auto-ssm' (default), 'auto' or an AMI id (advanced use)")
+		logger.Warning("'static' value for node-ami flag (nodeGroup.ami field) is deprecated and will be removed with release 0.33.0. Valid values will be 'auto-ssm' (default), 'auto' or an AMI id (advanced use)")
 		resolver = ami.NewStaticResolver()
 	default:
 		resolver = ami.NewMultiResolver(

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -275,7 +275,7 @@ func ResolveAMI(provider api.ClusterProvider, version string, ng *api.NodeGroup)
 	case api.NodeImageResolverAutoSSM:
 		resolver = ami.NewSSMResolver(provider.SSM())
 	case api.NodeImageResolverStatic:
-		logger.Warning("'static' value for node-ami flag will soon be deprecated (by release 0.33.0). Valid values will be 'auto-ssm' (default), 'auto' or an AMI id (advanced use)")
+		logger.Warning("'static' value for node-ami flag is deprecated and will be removed with release 0.33.0. Valid values will be 'auto-ssm' (default), 'auto' or an AMI id (advanced use)")
 		resolver = ami.NewStaticResolver()
 	default:
 		resolver = ami.NewMultiResolver(

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -275,6 +275,7 @@ func ResolveAMI(provider api.ClusterProvider, version string, ng *api.NodeGroup)
 	case api.NodeImageResolverAutoSSM:
 		resolver = ami.NewSSMResolver(provider.SSM())
 	case api.NodeImageResolverStatic:
+		logger.Warning("'static' value for node-ami flag will soon be deprecated (by release 0.33.0). Valid values will be 'auto-ssm' (default), 'auto' or an AMI id (advanced use)")
 		resolver = ami.NewStaticResolver()
 	default:
 		resolver = ami.NewMultiResolver(


### PR DESCRIPTION
### Description

This MR contains a warning in the command description of `create nodegroup` to warn about the deprecation of the static AMI resolver.
Related to #2661 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes