### PR TITLE
Support arm/arm64 binaries as part of release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ build/docker/
 eksctl_*_*.snap
 
 userdocs/src/usage/schema.json
+
+# Goreleaser
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,12 +21,17 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
+      - arm
+    goarm:
+      - 6
+      - 7
 
 archives:
   - id: default
     builds:
       - default
-    name_template: "eksctl_{{ .Os }}_{{ .Arch }}"
+    name_template: "eksctl_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     replacements:
       darwin: Darwin
       linux: Linux

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/d
 sudo mv /tmp/eksctl /usr/local/bin
 ```
 
+For ARM system, please change ARCH (e.g. armv6, armv7 or arm64) accordingly
+
+```
+curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_arm64.tar.gz" | tar xz -C /tmp
+sudo mv /tmp/eksctl /usr/local/bin
+```
+
 Alternatively, macOS users can use [Homebrew](https://brew.sh):
 
 ```


### PR DESCRIPTION
### Description

This commit is to provide arm/arm64 binary releases. Both goarm 6 and 7
are supported.

Naming will be something like eksctl_Linux_{arm64,armv6,armv7}.tar.gz

Fixes #2621 

Signed-off-by: Tam Mach <sayboras@yahoo.com>

### Testing
Testing was done in forked repo https://github.com/sayboras/eksctl/releases/tag/v0.30.0, please refer to the below:

<details>
<summary><b>Testing in new release in forked repo sayboras/eksctl</b></summary>

```shell script
$ goreleaser release --rm-dist

   • releasing...     
   • loading config file       file=.goreleaser.yml
   • running before hooks
   • loading environment variables
   • getting and validating git state
      • releasing v0.30.0, commit 8ca1771bd1e25273146fbb0292b75ec7f585c628
   • parsing tag      
   • setting defaults 
      • snapshotting     
      • github/gitlab/gitea releases
      • project name     
      • building binaries
      • creating source archive
      • archives         
      • linux packages   
      • snapcraft packages
      • calculating checksums
      • signing artifacts
      • docker images    
      • artifactory      
      • blobs            
      • homebrew tap formula
      • scoop manifests  
   • snapshotting     
      • pipe skipped              error=not a snapshot
   • checking ./dist  
      • --rm-dist is set, cleaning it up
   • writing effective config file
      • writing                   config=dist/config.yaml
   • generating changelog
      • writing                   changelog=dist/CHANGELOG.md
   • building binaries
      • building                  binary=/home/tammach/go/src/github.com/weaveworks/eksctl/dist/default_linux_arm_7/eksctl
      • building                  binary=/home/tammach/go/src/github.com/weaveworks/eksctl/dist/default_linux_arm64/eksctl
      • building                  binary=/home/tammach/go/src/github.com/weaveworks/eksctl/dist/default_darwin_amd64/eksctl
      • building                  binary=/home/tammach/go/src/github.com/weaveworks/eksctl/dist/default_windows_amd64/eksctl.exe
      • building                  binary=/home/tammach/go/src/github.com/weaveworks/eksctl/dist/default_linux_arm_6/eksctl
      • building                  binary=/home/tammach/go/src/github.com/weaveworks/eksctl/dist/default_linux_amd64/eksctl
   • archives         
      • creating                  archive=dist/eksctl_Darwin_amd64.tar.gz
      • creating                  archive=dist/eksctl_Linux_armv6.tar.gz
      • creating                  archive=dist/eksctl_Windows_amd64.zip
      • creating                  archive=dist/eksctl_Linux_arm64.tar.gz
      • creating                  archive=dist/eksctl_Linux_armv7.tar.gz
      • creating                  archive=dist/eksctl_Linux_amd64.tar.gz
   • creating source archive
      • pipe skipped              error=source pipe is disabled
   • linux packages   
   • snapcraft packages
   • calculating checksums
      • checksumming              file=eksctl_Linux_amd64.tar.gz
      • checksumming              file=eksctl_Linux_armv7.tar.gz
      • checksumming              file=eksctl_Windows_amd64.zip
      • checksumming              file=eksctl_Linux_armv6.tar.gz
      • checksumming              file=eksctl_Linux_arm64.tar.gz
      • checksumming              file=eksctl_Darwin_amd64.tar.gz
   • signing artifacts
   • docker images    
      • pipe skipped              error=docker section is not configured
   • publishing       
      • blobs            
         • pipe skipped              error=blobs section is not configured
      • http upload      
         • pipe skipped              error=uploads section is not configured
      • custom publisher 
         • pipe skipped              error=publishers section is not configured
      • artifactory      
         • pipe skipped              error=artifactory section is not configured
      • docker images    
      • snapcraft packages
      • github/gitlab/gitea releases
         • token type                type=github
         • creating or updating release repo=sayboras/eksctl tag=v0.30.0
         • release updated           url=https://github.com/sayboras/eksctl/releases/tag/v0.30.0
         • uploading to release      file=dist/eksctl_checksums.txt name=eksctl_checksums.txt
         • uploading to release      file=dist/eksctl_Windows_amd64.zip name=eksctl_Windows_amd64.zip
         • uploading to release      file=dist/eksctl_Linux_armv6.tar.gz name=eksctl_Linux_armv6.tar.gz
         • uploading to release      file=dist/eksctl_Linux_armv7.tar.gz name=eksctl_Linux_armv7.tar.gz
         • uploading to release      file=dist/eksctl_Darwin_amd64.tar.gz name=eksctl_Darwin_amd64.tar.gz
         • uploading to release      file=dist/eksctl_Linux_arm64.tar.gz name=eksctl_Linux_arm64.tar.gz
         • uploading to release      file=dist/eksctl_Linux_amd64.tar.gz name=eksctl_Linux_amd64.tar.gz
      • homebrew tap formula
         • token type                type=github
      • scoop manifests  
         • token type                type=github
         • pipe skipped              error=scoop section is not configured
   • release succeeded after 76.63s
```

</details>

Download the above binary from ARM node:

```shell script
ubuntu :: ~ » curl --location "https://github.com/sayboras/eksctl/releases/download/v0.30.0/eksctl_$(uname -s)_arm64.tar.gz" | tar xz -C ./
 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   651  100   651    0     0   4018      0 --:--:-- --:--:-- --:--:--  4018
100 17.5M  100 17.5M    0     0  2554k      0  0:00:07  0:00:07 --:--:-- 3767k
ubuntu :: ~ » uname -a
Linux ubuntu 5.4.0-1019-raspi #21-Ubuntu SMP PREEMPT Mon Sep 14 07:20:34 UTC 2020 aarch64 aarch64 aarch64 GNU/Linux
ubuntu :: ~ » ./eksctl version
0.30.0-dev+8ca1771b.2020-10-11T04:42:30Z
```


### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

