### PR TITLE
Add support for powershell completion

### DIFF
--- a/pkg/ctl/completion/completion.go
+++ b/pkg/ctl/completion/completion.go
@@ -59,6 +59,20 @@ eksctl completion fish > ~/.config/fish/completions/eksctl.fish
 		},
 	}
 
+	var powershellCompletionCmd = &cobra.Command{
+		Use:   "powershell",
+		Short: "Generates powershell completion scripts",
+		Long: `To configure your powershell, run:
+
+eksctl completion powershell > C:\Users\Documents\WindowsPowerShell\Scripts\eksctl.ps1
+
+Note: the path might be different depending on your system settings.
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return rootCmd.GenPowerShellCompletion(cmd.OutOrStdout())
+		},
+	}
+
 	cmd := &cobra.Command{
 		Use:   "completion",
 		Short: "Generates shell completion scripts for bash, zsh or fish",
@@ -72,6 +86,7 @@ eksctl completion fish > ~/.config/fish/completions/eksctl.fish
 	cmd.AddCommand(bashCompletionCmd)
 	cmd.AddCommand(zshCompletionCmd)
 	cmd.AddCommand(fishCompletionCmd)
+	cmd.AddCommand(powershellCompletionCmd)
 
 	return cmd
 }

--- a/pkg/ctl/completion/completion_test.go
+++ b/pkg/ctl/completion/completion_test.go
@@ -30,6 +30,12 @@ var _ = Describe("completion", func() {
 		Expect(out).To(ContainSubstring("fish completion for eksctl"))
 	})
 
+	It("with powershell", func() {
+		cmd := newMockCmd("powershell")
+		out, _ := cmd.execute()
+		Expect(out).To(ContainSubstring("Register-ArgumentCompleter -Native -CommandName 'eksctl'"))
+	})
+
 	It("with invalid shell", func() {
 		cmd := newMockCmd("invalid-shell")
 		out, err := cmd.execute()

--- a/userdocs/src/introduction.md
+++ b/userdocs/src/introduction.md
@@ -246,6 +246,15 @@ mkdir -p ~/.config/fish/completions
 eksctl completion fish > ~/.config/fish/completions/eksctl.fish
 ```
 
+#### Powershell
+
+The below command can be referred for setting it up. Please note that the path might be different depending on your
+system settings.
+
+```
+eksctl completion powershell > C:\Users\Documents\WindowsPowerShell\Scripts\eksctl.ps1
+```
+
 ## Features
 
 The features that are currently implemented are:


### PR DESCRIPTION
### Description

This commit is to add powershell completion script generation.

Signed-off-by: Tam Mach <sayboras@yahoo.com>

<details>
<summary>powershell completion script</summary>

```powershell
using namespace System.Management.Automation
using namespace System.Management.Automation.Language
Register-ArgumentCompleter -Native -CommandName 'eksctl' -ScriptBlock {
    param($wordToComplete, $commandAst, $cursorPosition)
    $commandElements = $commandAst.CommandElements
    $command = @(
        'eksctl'
        for ($i = 1; $i -lt $commandElements.Count; $i++) {
            $element = $commandElements[$i]
            if ($element -isnot [StringConstantExpressionAst] -or
                $element.StringConstantType -ne [StringConstantType]::BareWord -or
                $element.Value.StartsWith('-')) {
                break
            }
            $element.Value
        }
    ) -join ';'
    $completions = @(switch ($command) {
        'eksctl' {
            [CompletionResult]::new('-C', 'C', [CompletionResultType]::ParameterName, 'toggle colorized logs (valid options: true, false, fabulous)')
            [CompletionResult]::new('--color', 'color', [CompletionResultType]::ParameterName, 'toggle colorized logs (valid options: true, false, fabulous)')
            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'help for this command')
            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'help for this command')
            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging')
            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging')
            [CompletionResult]::new('completion', 'completion', [CompletionResultType]::ParameterValue, 'Generates shell completion scripts for bash, zsh or fish')
            [CompletionResult]::new('create', 'create', [CompletionResultType]::ParameterValue, 'Create resource(s)')
            [CompletionResult]::new('delete', 'delete', [CompletionResultType]::ParameterValue, 'Delete resource(s)')
            [CompletionResult]::new('drain', 'drain', [CompletionResultType]::ParameterValue, 'Drain resource(s)')
            [CompletionResult]::new('enable', 'enable', [CompletionResultType]::ParameterValue, 'Enable features in a cluster')
            [CompletionResult]::new('generate', 'generate', [CompletionResultType]::ParameterValue, 'Generate gitops manifests')
            [CompletionResult]::new('get', 'get', [CompletionResultType]::ParameterValue, 'Get resource(s)')
            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Help about any command')
            [CompletionResult]::new('scale', 'scale', [CompletionResultType]::ParameterValue, 'Scale resources(s)')
            [CompletionResult]::new('set', 'set', [CompletionResultType]::ParameterValue, 'Set values')
            [CompletionResult]::new('unset', 'unset', [CompletionResultType]::ParameterValue, 'Unset values')
            [CompletionResult]::new('update', 'update', [CompletionResultType]::ParameterValue, 'Update resource(s)')
            [CompletionResult]::new('upgrade', 'upgrade', [CompletionResultType]::ParameterValue, 'Upgrade resource(s)')
            [CompletionResult]::new('utils', 'utils', [CompletionResultType]::ParameterValue, 'Various utils')
            [CompletionResult]::new('version', 'version', [CompletionResultType]::ParameterValue, 'Output the version of eksctl')
            break
        }
        'eksctl;completion' {
            [CompletionResult]::new('-C', 'C', [CompletionResultType]::ParameterName, 'toggle colorized logs (valid options: true, false, fabulous)')
            [CompletionResult]::new('--color', 'color', [CompletionResultType]::ParameterName, 'toggle colorized logs (valid options: true, false, fabulous)')
            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'help for this command')
            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'help for this command')
            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging')
            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging')
            [CompletionResult]::new('bash', 'bash', [CompletionResultType]::ParameterValue, 'Generates bash completion scripts')
            [CompletionResult]::new('fish', 'fish', [CompletionResultType]::ParameterValue, 'Generates fish completion scripts')
            [CompletionResult]::new('powershell', 'powershell', [CompletionResultType]::ParameterValue, 'Generates powershell completion scripts')
            [CompletionResult]::new('zsh', 'zsh', [CompletionResultType]::ParameterValue, 'Generates zsh completion scripts')
            break
        }
        'eksctl;completion;bash' {
            break
        }
        'eksctl;completion;fish' {
            break
        }
        'eksctl;completion;powershell' {
            [CompletionResult]::new('-C', 'C', [CompletionResultType]::ParameterName, 'toggle colorized logs (valid options: true, false, fabulous)')
            [CompletionResult]::new('--color', 'color', [CompletionResultType]::ParameterName, 'toggle colorized logs (valid options: true, false, fabulous)')
            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'help for this command')
            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'help for this command')
            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging')
            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging')
            break
        }
        'eksctl;completion;zsh' {
            break
        }
        'eksctl;create' {
            [CompletionResult]::new('cluster', 'cluster', [CompletionResultType]::ParameterValue, 'Create a cluster')
            [CompletionResult]::new('fargateprofile', 'fargateprofile', [CompletionResultType]::ParameterValue, 'Create a Fargate profile')
            [CompletionResult]::new('iamidentitymapping', 'iamidentitymapping', [CompletionResultType]::ParameterValue, 'Create an IAM identity mapping')
            [CompletionResult]::new('iamserviceaccount', 'iamserviceaccount', [CompletionResultType]::ParameterValue, 'Create an iamserviceaccount - AWS IAM role bound to a Kubernetes service account')
            [CompletionResult]::new('nodegroup', 'nodegroup', [CompletionResultType]::ParameterValue, 'Create a nodegroup')
            break
        }
        'eksctl;create;cluster' {
            [CompletionResult]::new('--alb-ingress-access', 'alb-ingress-access', [CompletionResultType]::ParameterName, 'enable full access for alb-ingress-controller')
            [CompletionResult]::new('--appmesh-access', 'appmesh-access', [CompletionResultType]::ParameterName, 'enable full access to AppMesh')
            [CompletionResult]::new('--appmesh-preview-access', 'appmesh-preview-access', [CompletionResultType]::ParameterName, 'enable full access to AppMesh Preview')
            [CompletionResult]::new('--asg-access', 'asg-access', [CompletionResultType]::ParameterName, 'enable IAM policy for cluster-autoscaler')
            [CompletionResult]::new('--authenticator-role-arn', 'authenticator-role-arn', [CompletionResultType]::ParameterName, 'AWS IAM role to assume for authenticator')
            [CompletionResult]::new('--auto-kubeconfig', 'auto-kubeconfig', [CompletionResultType]::ParameterName, 'save kubeconfig file by cluster name, e.g. "/home/tammach/.kube/eksctl/clusters/scrumptious-gopher-1602393406"')
            [CompletionResult]::new('--cfn-role-arn', 'cfn-role-arn', [CompletionResultType]::ParameterName, 'IAM role used by CloudFormation to call AWS API on your behalf')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--disable-pod-imds', 'disable-pod-imds', [CompletionResultType]::ParameterName, 'Blocks IMDS requests from non host networking pods')
            [CompletionResult]::new('--external-dns-access', 'external-dns-access', [CompletionResultType]::ParameterName, 'enable IAM policy for external-dns')
            [CompletionResult]::new('--fargate', 'fargate', [CompletionResultType]::ParameterName, 'Create a Fargate profile scheduling pods in the default and kube-system namespaces onto Fargate')
            [CompletionResult]::new('--full-ecr-access', 'full-ecr-access', [CompletionResultType]::ParameterName, 'enable full access to ECR')
            [CompletionResult]::new('--install-neuron-plugin', 'install-neuron-plugin', [CompletionResultType]::ParameterName, 'install Neuron plugin for Inferentia nodes')
            [CompletionResult]::new('--install-vpc-controllers', 'install-vpc-controllers', [CompletionResultType]::ParameterName, 'Install VPC controller that''s required for Windows workloads')
            [CompletionResult]::new('--instance-name', 'instance-name', [CompletionResultType]::ParameterName, 'overrides the default instance''s name')
            [CompletionResult]::new('--instance-prefix', 'instance-prefix', [CompletionResultType]::ParameterName, 'add a prefix value in front of the instance''s name')
            [CompletionResult]::new('--kubeconfig', 'kubeconfig', [CompletionResultType]::ParameterName, 'path to write kubeconfig (incompatible with --auto-kubeconfig)')
            [CompletionResult]::new('--managed', 'managed', [CompletionResultType]::ParameterName, 'Create EKS-managed nodegroup')
            [CompletionResult]::new('--max-pods-per-node', 'max-pods-per-node', [CompletionResultType]::ParameterName, 'maximum number of pods per node (set automatically if unspecified)')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'EKS cluster name (generated if unspecified, e.g. "scrumptious-gopher-1602393406")')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'EKS cluster name (generated if unspecified, e.g. "scrumptious-gopher-1602393406")')
            [CompletionResult]::new('--node-ami', 'node-ami', [CompletionResultType]::ParameterName, '''auto-ssm'' (default), ''auto'', ''static'' (deprecated, will be removed in 0.33.0) or an AMI id (advanced use)')
            [CompletionResult]::new('--node-ami-family', 'node-ami-family', [CompletionResultType]::ParameterName, '''AmazonLinux2'' for the Amazon EKS optimized AMI or ''Ubuntu1804'' for the official Canonical EKS AMIs (Ubuntu 18.04)')
            [CompletionResult]::new('--node-labels', 'node-labels', [CompletionResultType]::ParameterName, 'extra labels to add when registering the nodes in the nodegroup. List of comma separated KV pairs "k1=v1,k2=v2"')
            [CompletionResult]::new('-P', 'P', [CompletionResultType]::ParameterName, 'whether to make nodegroup networking private')
            [CompletionResult]::new('--node-private-networking', 'node-private-networking', [CompletionResultType]::ParameterName, 'whether to make nodegroup networking private')
            [CompletionResult]::new('--node-security-groups', 'node-security-groups', [CompletionResultType]::ParameterName, 'attach additional security groups to nodes')
            [CompletionResult]::new('-t', 't', [CompletionResultType]::ParameterName, 'node instance type')
            [CompletionResult]::new('--node-type', 'node-type', [CompletionResultType]::ParameterName, 'node instance type')
            [CompletionResult]::new('--node-volume-size', 'node-volume-size', [CompletionResultType]::ParameterName, 'node volume size in GB')
            [CompletionResult]::new('--node-volume-type', 'node-volume-type', [CompletionResultType]::ParameterName, 'node volume type (valid options: gp2, io1, sc1, st1)')
            [CompletionResult]::new('--node-zones', 'node-zones', [CompletionResultType]::ParameterName, '(inherited from the cluster if unspecified)')
            [CompletionResult]::new('--nodegroup-name', 'nodegroup-name', [CompletionResultType]::ParameterName, 'name of the nodegroup (generated if unspecified, e.g. "ng-9521cdb8")')
            [CompletionResult]::new('-N', 'N', [CompletionResultType]::ParameterName, 'total number of nodes (for a static ASG)')
            [CompletionResult]::new('--nodes', 'nodes', [CompletionResultType]::ParameterName, 'total number of nodes (for a static ASG)')
            [CompletionResult]::new('-M', 'M', [CompletionResultType]::ParameterName, 'maximum nodes in ASG')
            [CompletionResult]::new('--nodes-max', 'nodes-max', [CompletionResultType]::ParameterName, 'maximum nodes in ASG')
            [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'minimum nodes in ASG')
            [CompletionResult]::new('--nodes-min', 'nodes-min', [CompletionResultType]::ParameterName, 'minimum nodes in ASG')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--set-kubeconfig-context', 'set-kubeconfig-context', [CompletionResultType]::ParameterName, 'if true then current-context will be set in kubeconfig; if a context is already set then it will be overwritten')
            [CompletionResult]::new('--ssh-access', 'ssh-access', [CompletionResultType]::ParameterName, 'control SSH access for nodes. Uses ~/.ssh/id_rsa.pub as default key path if enabled')
            [CompletionResult]::new('--ssh-public-key', 'ssh-public-key', [CompletionResultType]::ParameterName, 'SSH public key to use for nodes (import from local path, or use existing EC2 key pair)')
            [CompletionResult]::new('--tags', 'tags', [CompletionResultType]::ParameterName, 'Used to tag the AWS resources. List of comma separated KV pairs "k1=v1,k2=v2"')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Kubernetes version (valid options: 1.14, 1.15, 1.16, 1.17)')
            [CompletionResult]::new('--vpc-cidr', 'vpc-cidr', [CompletionResultType]::ParameterName, 'global CIDR to use for VPC')
            [CompletionResult]::new('--vpc-from-kops-cluster', 'vpc-from-kops-cluster', [CompletionResultType]::ParameterName, 're-use VPC from a given kops cluster')
            [CompletionResult]::new('--vpc-nat-mode', 'vpc-nat-mode', [CompletionResultType]::ParameterName, 'VPC NAT mode, valid options: HighlyAvailable, Single, Disable')
            [CompletionResult]::new('--vpc-private-subnets', 'vpc-private-subnets', [CompletionResultType]::ParameterName, 're-use private subnets of an existing VPC')
            [CompletionResult]::new('--vpc-public-subnets', 'vpc-public-subnets', [CompletionResultType]::ParameterName, 're-use public subnets of an existing VPC')
            [CompletionResult]::new('--with-oidc', 'with-oidc', [CompletionResultType]::ParameterName, 'Enable the IAM OIDC provider')
            [CompletionResult]::new('--without-nodegroup', 'without-nodegroup', [CompletionResultType]::ParameterName, 'if set, initial nodegroup will not be created')
            [CompletionResult]::new('--write-kubeconfig', 'write-kubeconfig', [CompletionResultType]::ParameterName, 'toggle writing of kubeconfig')
            [CompletionResult]::new('--zones', 'zones', [CompletionResultType]::ParameterName, '(auto-select if unspecified)')
            break
        }
        'eksctl;create;fargateprofile' {
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('-l', 'l', [CompletionResultType]::ParameterName, 'Kubernetes selector labels of the workloads to schedule on Fargate. List of comma separated KV pairs "k1=v1,k2=v2"')
            [CompletionResult]::new('--labels', 'labels', [CompletionResultType]::ParameterName, 'Kubernetes selector labels of the workloads to schedule on Fargate. List of comma separated KV pairs "k1=v1,k2=v2"')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'Fargate profile''s name')
            [CompletionResult]::new('--namespace', 'namespace', [CompletionResultType]::ParameterName, 'Kubernetes namespace of the workloads to schedule on Fargate')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('-t', 't', [CompletionResultType]::ParameterName, 'Used to tag the AWS resources. List of comma separated KV pairs "k1=v1,k2=v2"')
            [CompletionResult]::new('--tags', 'tags', [CompletionResultType]::ParameterName, 'Used to tag the AWS resources. List of comma separated KV pairs "k1=v1,k2=v2"')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;create;iamidentitymapping' {
            [CompletionResult]::new('--account', 'account', [CompletionResultType]::ParameterName, 'Account ID to automatically map to its username')
            [CompletionResult]::new('--arn', 'arn', [CompletionResultType]::ParameterName, 'ARN of the IAM role or user to create')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--group', 'group', [CompletionResultType]::ParameterName, 'Group within Kubernetes to which IAM role is mapped')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            [CompletionResult]::new('--username', 'username', [CompletionResultType]::ParameterName, 'User name within Kubernetes to map to IAM role')
            break
        }
        'eksctl;create;iamserviceaccount' {
            [CompletionResult]::new('--approve', 'approve', [CompletionResultType]::ParameterName, 'Apply the changes')
            [CompletionResult]::new('--attach-policy-arn', 'attach-policy-arn', [CompletionResultType]::ParameterName, 'ARN of the policy where to create the iamserviceaccount')
            [CompletionResult]::new('--cfn-role-arn', 'cfn-role-arn', [CompletionResultType]::ParameterName, 'IAM role used by CloudFormation to call AWS API on your behalf')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'name of the EKS cluster to add the iamserviceaccount to')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--exclude', 'exclude', [CompletionResultType]::ParameterName, 'iamserviceaccounts to exclude (list of globs), e.g.: ''default/s3-reader,*/dynamo-*''')
            [CompletionResult]::new('--include', 'include', [CompletionResultType]::ParameterName, 'iamserviceaccounts to include (list of globs), e.g.: ''default/s3-reader,*/dynamo-*''')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'name of the iamserviceaccount to create')
            [CompletionResult]::new('--namespace', 'namespace', [CompletionResultType]::ParameterName, 'namespace where to create the iamserviceaccount')
            [CompletionResult]::new('--override-existing-serviceaccounts', 'override-existing-serviceaccounts', [CompletionResultType]::ParameterName, 'create IAM roles for existing serviceaccounts and update the serviceaccount')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--tags', 'tags', [CompletionResultType]::ParameterName, 'Used to tag the IAM role. List of comma separated KV pairs "k1=v1,k2=v2"')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;create;nodegroup' {
            [CompletionResult]::new('--alb-ingress-access', 'alb-ingress-access', [CompletionResultType]::ParameterName, 'enable full access for alb-ingress-controller')
            [CompletionResult]::new('--appmesh-access', 'appmesh-access', [CompletionResultType]::ParameterName, 'enable full access to AppMesh')
            [CompletionResult]::new('--appmesh-preview-access', 'appmesh-preview-access', [CompletionResultType]::ParameterName, 'enable full access to AppMesh Preview')
            [CompletionResult]::new('--asg-access', 'asg-access', [CompletionResultType]::ParameterName, 'enable IAM policy for cluster-autoscaler')
            [CompletionResult]::new('--cfn-role-arn', 'cfn-role-arn', [CompletionResultType]::ParameterName, 'IAM role used by CloudFormation to call AWS API on your behalf')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'name of the EKS cluster to add the nodegroup to')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--disable-pod-imds', 'disable-pod-imds', [CompletionResultType]::ParameterName, 'Blocks IMDS requests from non host networking pods')
            [CompletionResult]::new('--exclude', 'exclude', [CompletionResultType]::ParameterName, 'nodegroups to exclude (list of globs), e.g.: ''ng-team-?,prod-*''')
            [CompletionResult]::new('--external-dns-access', 'external-dns-access', [CompletionResultType]::ParameterName, 'enable IAM policy for external-dns')
            [CompletionResult]::new('--full-ecr-access', 'full-ecr-access', [CompletionResultType]::ParameterName, 'enable full access to ECR')
            [CompletionResult]::new('--include', 'include', [CompletionResultType]::ParameterName, 'nodegroups to include (list of globs), e.g.: ''ng-team-?,prod-*''')
            [CompletionResult]::new('--install-neuron-plugin', 'install-neuron-plugin', [CompletionResultType]::ParameterName, 'install Neuron plugin for Inferentia nodes')
            [CompletionResult]::new('--instance-name', 'instance-name', [CompletionResultType]::ParameterName, 'overrides the default instance''s name')
            [CompletionResult]::new('--instance-prefix', 'instance-prefix', [CompletionResultType]::ParameterName, 'add a prefix value in front of the instance''s name')
            [CompletionResult]::new('--managed', 'managed', [CompletionResultType]::ParameterName, 'Create EKS-managed nodegroup')
            [CompletionResult]::new('--max-pods-per-node', 'max-pods-per-node', [CompletionResultType]::ParameterName, 'maximum number of pods per node (set automatically if unspecified)')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'name of the new nodegroup (generated if unspecified, e.g. "ng-c0c040da")')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'name of the new nodegroup (generated if unspecified, e.g. "ng-c0c040da")')
            [CompletionResult]::new('--node-ami', 'node-ami', [CompletionResultType]::ParameterName, '''auto-ssm'' (default), ''auto'', ''static'' (deprecated, will be removed in 0.33.0) or an AMI id (advanced use)')
            [CompletionResult]::new('--node-ami-family', 'node-ami-family', [CompletionResultType]::ParameterName, '''AmazonLinux2'' for the Amazon EKS optimized AMI or ''Ubuntu1804'' for the official Canonical EKS AMIs (Ubuntu 18.04)')
            [CompletionResult]::new('--node-labels', 'node-labels', [CompletionResultType]::ParameterName, 'extra labels to add when registering the nodes in the nodegroup. List of comma separated KV pairs "k1=v1,k2=v2"')
            [CompletionResult]::new('-P', 'P', [CompletionResultType]::ParameterName, 'whether to make nodegroup networking private')
            [CompletionResult]::new('--node-private-networking', 'node-private-networking', [CompletionResultType]::ParameterName, 'whether to make nodegroup networking private')
            [CompletionResult]::new('--node-security-groups', 'node-security-groups', [CompletionResultType]::ParameterName, 'attach additional security groups to nodes')
            [CompletionResult]::new('-t', 't', [CompletionResultType]::ParameterName, 'node instance type')
            [CompletionResult]::new('--node-type', 'node-type', [CompletionResultType]::ParameterName, 'node instance type')
            [CompletionResult]::new('--node-volume-size', 'node-volume-size', [CompletionResultType]::ParameterName, 'node volume size in GB')
            [CompletionResult]::new('--node-volume-type', 'node-volume-type', [CompletionResultType]::ParameterName, 'node volume type (valid options: gp2, io1, sc1, st1)')
            [CompletionResult]::new('--node-zones', 'node-zones', [CompletionResultType]::ParameterName, '(inherited from the cluster if unspecified)')
            [CompletionResult]::new('-N', 'N', [CompletionResultType]::ParameterName, 'total number of nodes (for a static ASG)')
            [CompletionResult]::new('--nodes', 'nodes', [CompletionResultType]::ParameterName, 'total number of nodes (for a static ASG)')
            [CompletionResult]::new('-M', 'M', [CompletionResultType]::ParameterName, 'maximum nodes in ASG')
            [CompletionResult]::new('--nodes-max', 'nodes-max', [CompletionResultType]::ParameterName, 'maximum nodes in ASG')
            [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'minimum nodes in ASG')
            [CompletionResult]::new('--nodes-min', 'nodes-min', [CompletionResultType]::ParameterName, 'minimum nodes in ASG')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--ssh-access', 'ssh-access', [CompletionResultType]::ParameterName, 'control SSH access for nodes. Uses ~/.ssh/id_rsa.pub as default key path if enabled')
            [CompletionResult]::new('--ssh-public-key', 'ssh-public-key', [CompletionResultType]::ParameterName, 'SSH public key to use for nodes (import from local path, or use existing EC2 key pair)')
            [CompletionResult]::new('--tags', 'tags', [CompletionResultType]::ParameterName, 'Used to tag the AWS resources. List of comma separated KV pairs "k1=v1,k2=v2"')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            [CompletionResult]::new('--update-auth-configmap', 'update-auth-configmap', [CompletionResultType]::ParameterName, 'Add nodegroup IAM role to aws-auth configmap')
            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Kubernetes version (valid options: 1.14, 1.15, 1.16, 1.17) [for nodegroups "auto" and "latest" can be used to automatically inherit version from the control plane or force latest]')
            break
        }
        'eksctl;delete' {
            [CompletionResult]::new('cluster', 'cluster', [CompletionResultType]::ParameterValue, 'Delete a cluster')
            [CompletionResult]::new('fargateprofile', 'fargateprofile', [CompletionResultType]::ParameterValue, 'Delete Fargate profile')
            [CompletionResult]::new('iamidentitymapping', 'iamidentitymapping', [CompletionResultType]::ParameterValue, 'Delete a IAM identity mapping')
            [CompletionResult]::new('iamserviceaccount', 'iamserviceaccount', [CompletionResultType]::ParameterValue, 'Delete an IAM service account')
            [CompletionResult]::new('nodegroup', 'nodegroup', [CompletionResultType]::ParameterValue, 'Delete a nodegroup')
            break
        }
        'eksctl;delete;cluster' {
            [CompletionResult]::new('--cfn-role-arn', 'cfn-role-arn', [CompletionResultType]::ParameterName, 'IAM role used by CloudFormation to call AWS API on your behalf')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            [CompletionResult]::new('-w', 'w', [CompletionResultType]::ParameterName, 'wait for deletion of all resources before exiting')
            [CompletionResult]::new('--wait', 'wait', [CompletionResultType]::ParameterName, 'wait for deletion of all resources before exiting')
            break
        }
        'eksctl;delete;fargateprofile' {
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'Fargate profile''s name')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            [CompletionResult]::new('-w', 'w', [CompletionResultType]::ParameterName, 'wait for wait for the deletion of the Fargate profile, which may take from a couple seconds to a couple minutes. before exiting')
            [CompletionResult]::new('--wait', 'wait', [CompletionResultType]::ParameterName, 'wait for wait for the deletion of the Fargate profile, which may take from a couple seconds to a couple minutes. before exiting')
            break
        }
        'eksctl;delete;iamidentitymapping' {
            [CompletionResult]::new('--all', 'all', [CompletionResultType]::ParameterName, 'Delete all matching mappings instead of just one')
            [CompletionResult]::new('--arn', 'arn', [CompletionResultType]::ParameterName, 'ARN of the IAM role or user to create')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;delete;iamserviceaccount' {
            [CompletionResult]::new('--approve', 'approve', [CompletionResultType]::ParameterName, 'Apply the changes')
            [CompletionResult]::new('--cfn-role-arn', 'cfn-role-arn', [CompletionResultType]::ParameterName, 'IAM role used by CloudFormation to call AWS API on your behalf')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'name of the EKS cluster to delete the iamserviceaccount from')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--exclude', 'exclude', [CompletionResultType]::ParameterName, 'iamserviceaccounts to exclude (list of globs), e.g.: ''default/s3-reader,*/dynamo-*''')
            [CompletionResult]::new('--include', 'include', [CompletionResultType]::ParameterName, 'iamserviceaccounts to include (list of globs), e.g.: ''default/s3-reader,*/dynamo-*''')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'name of the iamserviceaccount to delete')
            [CompletionResult]::new('--namespace', 'namespace', [CompletionResultType]::ParameterName, 'namespace where to delete the iamserviceaccount')
            [CompletionResult]::new('--only-missing', 'only-missing', [CompletionResultType]::ParameterName, 'Only delete nodegroups that are not defined in the given config file')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            [CompletionResult]::new('-w', 'w', [CompletionResultType]::ParameterName, 'wait for deletion of all resources before exiting')
            [CompletionResult]::new('--wait', 'wait', [CompletionResultType]::ParameterName, 'wait for deletion of all resources before exiting')
            break
        }
        'eksctl;delete;nodegroup' {
            [CompletionResult]::new('--approve', 'approve', [CompletionResultType]::ParameterName, 'Apply the changes')
            [CompletionResult]::new('--cfn-role-arn', 'cfn-role-arn', [CompletionResultType]::ParameterName, 'IAM role used by CloudFormation to call AWS API on your behalf')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--drain', 'drain', [CompletionResultType]::ParameterName, 'Drain and cordon all nodes in the nodegroup before deletion')
            [CompletionResult]::new('--exclude', 'exclude', [CompletionResultType]::ParameterName, 'nodegroups to exclude (list of globs), e.g.: ''ng-team-?,prod-*''')
            [CompletionResult]::new('--include', 'include', [CompletionResultType]::ParameterName, 'nodegroups to include (list of globs), e.g.: ''ng-team-?,prod-*''')
            [CompletionResult]::new('--max-grace-period', 'max-grace-period', [CompletionResultType]::ParameterName, 'Maximum pods termination grace period')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Name of the nodegroup to delete')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'Name of the nodegroup to delete')
            [CompletionResult]::new('--only-missing', 'only-missing', [CompletionResultType]::ParameterName, 'Only delete nodegroups that are not defined in the given config file')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            [CompletionResult]::new('--update-auth-configmap', 'update-auth-configmap', [CompletionResultType]::ParameterName, 'Remove nodegroup IAM role from aws-auth configmap')
            [CompletionResult]::new('-w', 'w', [CompletionResultType]::ParameterName, 'wait for deletion of all resources before exiting')
            [CompletionResult]::new('--wait', 'wait', [CompletionResultType]::ParameterName, 'wait for deletion of all resources before exiting')
            break
        }
        'eksctl;drain' {
            [CompletionResult]::new('nodegroup', 'nodegroup', [CompletionResultType]::ParameterValue, 'Cordon and drain a nodegroup')
            break
        }
        'eksctl;drain;nodegroup' {
            [CompletionResult]::new('--approve', 'approve', [CompletionResultType]::ParameterName, 'Apply the changes')
            [CompletionResult]::new('--cfn-role-arn', 'cfn-role-arn', [CompletionResultType]::ParameterName, 'IAM role used by CloudFormation to call AWS API on your behalf')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--exclude', 'exclude', [CompletionResultType]::ParameterName, 'nodegroups to exclude (list of globs), e.g.: ''ng-team-?,prod-*''')
            [CompletionResult]::new('--include', 'include', [CompletionResultType]::ParameterName, 'nodegroups to include (list of globs), e.g.: ''ng-team-?,prod-*''')
            [CompletionResult]::new('--max-grace-period', 'max-grace-period', [CompletionResultType]::ParameterName, 'Maximum pods termination grace period')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Name of the nodegroup to drain')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'Name of the nodegroup to drain')
            [CompletionResult]::new('--only-missing', 'only-missing', [CompletionResultType]::ParameterName, 'Only drain nodegroups that are not defined in the given config file')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            [CompletionResult]::new('--undo', 'undo', [CompletionResultType]::ParameterName, 'Uncordon the nodegroup')
            break
        }
        'eksctl;enable' {
            [CompletionResult]::new('profile', 'profile', [CompletionResultType]::ParameterValue, 'Commits the components from the selected Quick Start profile to the destination repository.')
            [CompletionResult]::new('repo', 'repo', [CompletionResultType]::ParameterValue, 'Set up a repo for gitops, installing Flux in the cluster and initializing its manifests in the specified Git repository')
            break
        }
        'eksctl;enable;profile' {
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'name of the EKS cluster to enable this Quick Start profile on')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--git-branch', 'git-branch', [CompletionResultType]::ParameterName, 'Git branch to be used for GitOps')
            [CompletionResult]::new('--git-email', 'git-email', [CompletionResultType]::ParameterName, 'Email to use as Git committer')
            [CompletionResult]::new('--git-private-ssh-key-path', 'git-private-ssh-key-path', [CompletionResultType]::ParameterName, 'Optional path to the private SSH key to use with Git, e.g. ~/.ssh/id_rsa')
            [CompletionResult]::new('--git-url', 'git-url', [CompletionResultType]::ParameterName, 'SSH URL of the Git repository to be used for GitOps, e.g. git@github.com:<github_org>/<repo_name>')
            [CompletionResult]::new('--git-user', 'git-user', [CompletionResultType]::ParameterName, 'Username to use as Git committer')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile-revision', 'profile-revision', [CompletionResultType]::ParameterName, 'revision of the Quick Start profile.')
            [CompletionResult]::new('--profile-source', 'profile-source', [CompletionResultType]::ParameterName, 'name or URL of the Quick Start profile. For example, app-dev.')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;enable;repo' {
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'name of the EKS cluster to enable gitops on')
            [CompletionResult]::new('--commit-operator-manifests', 'commit-operator-manifests', [CompletionResultType]::ParameterName, 'Commit and push Flux manifests to the Git repo on install')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--git-branch', 'git-branch', [CompletionResultType]::ParameterName, 'Git branch to be used for GitOps')
            [CompletionResult]::new('--git-email', 'git-email', [CompletionResultType]::ParameterName, 'Email to use as Git committer')
            [CompletionResult]::new('--git-flux-subdir', 'git-flux-subdir', [CompletionResultType]::ParameterName, 'Directory within the Git repository where to commit the Flux manifests')
            [CompletionResult]::new('--git-label', 'git-label', [CompletionResultType]::ParameterName, 'Git label to keep track of Flux''s sync progress; this is equivalent to overriding --git-sync-tag and --git-notes-ref in Flux')
            [CompletionResult]::new('--git-paths', 'git-paths', [CompletionResultType]::ParameterName, 'Relative paths within the Git repo for Flux to locate Kubernetes manifests')
            [CompletionResult]::new('--git-private-ssh-key-path', 'git-private-ssh-key-path', [CompletionResultType]::ParameterName, 'Optional path to the private SSH key to use with Git, e.g. ~/.ssh/id_rsa')
            [CompletionResult]::new('--git-url', 'git-url', [CompletionResultType]::ParameterName, 'SSH URL of the Git repository to be used for GitOps, e.g. git@github.com:<github_org>/<repo_name>')
            [CompletionResult]::new('--git-user', 'git-user', [CompletionResultType]::ParameterName, 'Username to use as Git committer')
            [CompletionResult]::new('--namespace', 'namespace', [CompletionResultType]::ParameterName, 'Cluster namespace where to install Flux and the Helm Operator')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--read-only', 'read-only', [CompletionResultType]::ParameterName, 'Configure Flux in read-only mode and create the deploy key as read-only (Github only)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            [CompletionResult]::new('--with-helm', 'with-helm', [CompletionResultType]::ParameterName, 'Install the Helm Operator')
            break
        }
        'eksctl;generate' {
            [CompletionResult]::new('profile', 'profile', [CompletionResultType]::ParameterValue, 'Generate a gitops profile')
            break
        }
        'eksctl;generate;profile' {
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'name of the EKS cluster to enable gitops on')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile-path', 'profile-path', [CompletionResultType]::ParameterName, 'path to generate the profile in. Defaults to ./<quickstart-repo-name>')
            [CompletionResult]::new('--profile-revision', 'profile-revision', [CompletionResultType]::ParameterName, 'revision of the Quick Start profile.')
            [CompletionResult]::new('--profile-source', 'profile-source', [CompletionResultType]::ParameterName, 'name or URL of the Quick Start profile. For example, app-dev.')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            break
        }
        'eksctl;get' {
            [CompletionResult]::new('cluster', 'cluster', [CompletionResultType]::ParameterValue, 'Get cluster(s)')
            [CompletionResult]::new('fargateprofile', 'fargateprofile', [CompletionResultType]::ParameterValue, 'Get Fargate profile(s)')
            [CompletionResult]::new('iamidentitymapping', 'iamidentitymapping', [CompletionResultType]::ParameterValue, 'Get IAM identity mapping(s)')
            [CompletionResult]::new('iamserviceaccount', 'iamserviceaccount', [CompletionResultType]::ParameterValue, 'Get iamserviceaccount(s)')
            [CompletionResult]::new('labels', 'labels', [CompletionResultType]::ParameterValue, 'Get nodegroup labels')
            [CompletionResult]::new('nodegroup', 'nodegroup', [CompletionResultType]::ParameterValue, 'Get nodegroup(s)')
            break
        }
        'eksctl;get;cluster' {
            [CompletionResult]::new('-A', 'A', [CompletionResultType]::ParameterName, 'List clusters across all supported regions')
            [CompletionResult]::new('--all-regions', 'all-regions', [CompletionResultType]::ParameterName, 'List clusters across all supported regions')
            [CompletionResult]::new('--chunk-size', 'chunk-size', [CompletionResultType]::ParameterName, 'return large lists in chunks rather than all at once, pass 0 to disable')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'specifies the output format (valid option: table, json, yaml)')
            [CompletionResult]::new('--output', 'output', [CompletionResultType]::ParameterName, 'specifies the output format (valid option: table, json, yaml)')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;get;fargateprofile' {
            [CompletionResult]::new('--chunk-size', 'chunk-size', [CompletionResultType]::ParameterName, 'return large lists in chunks rather than all at once, pass 0 to disable')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'Fargate profile''s name')
            [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'specifies the output format (valid option: table, json, yaml)')
            [CompletionResult]::new('--output', 'output', [CompletionResultType]::ParameterName, 'specifies the output format (valid option: table, json, yaml)')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;get;iamidentitymapping' {
            [CompletionResult]::new('--arn', 'arn', [CompletionResultType]::ParameterName, 'ARN of the IAM role or user to create')
            [CompletionResult]::new('--chunk-size', 'chunk-size', [CompletionResultType]::ParameterName, 'return large lists in chunks rather than all at once, pass 0 to disable')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'specifies the output format (valid option: table, json, yaml)')
            [CompletionResult]::new('--output', 'output', [CompletionResultType]::ParameterName, 'specifies the output format (valid option: table, json, yaml)')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;get;iamserviceaccount' {
            [CompletionResult]::new('--chunk-size', 'chunk-size', [CompletionResultType]::ParameterName, 'return large lists in chunks rather than all at once, pass 0 to disable')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'name of the iamserviceaccount to delete')
            [CompletionResult]::new('--namespace', 'namespace', [CompletionResultType]::ParameterName, 'namespace where to delete the iamserviceaccount')
            [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'specifies the output format (valid option: table, json, yaml)')
            [CompletionResult]::new('--output', 'output', [CompletionResultType]::ParameterName, 'specifies the output format (valid option: table, json, yaml)')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;get;labels' {
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Nodegroup name')
            [CompletionResult]::new('--nodegroup', 'nodegroup', [CompletionResultType]::ParameterName, 'Nodegroup name')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;get;nodegroup' {
            [CompletionResult]::new('--chunk-size', 'chunk-size', [CompletionResultType]::ParameterName, 'return large lists in chunks rather than all at once, pass 0 to disable')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Name of the nodegroup')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'Name of the nodegroup')
            [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'specifies the output format (valid option: table, json, yaml)')
            [CompletionResult]::new('--output', 'output', [CompletionResultType]::ParameterName, 'specifies the output format (valid option: table, json, yaml)')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;help' {
            break
        }
        'eksctl;scale' {
            [CompletionResult]::new('nodegroup', 'nodegroup', [CompletionResultType]::ParameterValue, 'Scale a nodegroup')
            break
        }
        'eksctl;scale;nodegroup' {
            [CompletionResult]::new('--cfn-role-arn', 'cfn-role-arn', [CompletionResultType]::ParameterName, 'IAM role used by CloudFormation to call AWS API on your behalf')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Name of the nodegroup to scale')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'Name of the nodegroup to scale')
            [CompletionResult]::new('-N', 'N', [CompletionResultType]::ParameterName, 'desired number of nodes (required)')
            [CompletionResult]::new('--nodes', 'nodes', [CompletionResultType]::ParameterName, 'desired number of nodes (required)')
            [CompletionResult]::new('-M', 'M', [CompletionResultType]::ParameterName, 'maximum number of nodes')
            [CompletionResult]::new('--nodes-max', 'nodes-max', [CompletionResultType]::ParameterName, 'maximum number of nodes')
            [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'minimum number of nodes')
            [CompletionResult]::new('--nodes-min', 'nodes-min', [CompletionResultType]::ParameterName, 'minimum number of nodes')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;set' {
            [CompletionResult]::new('labels', 'labels', [CompletionResultType]::ParameterValue, 'Create or overwrite labels')
            break
        }
        'eksctl;set;labels' {
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-l', 'l', [CompletionResultType]::ParameterName, 'Labels. List of comma separated KV pairs "k1=v1,k2=v2"')
            [CompletionResult]::new('--labels', 'labels', [CompletionResultType]::ParameterName, 'Labels. List of comma separated KV pairs "k1=v1,k2=v2"')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Nodegroup name')
            [CompletionResult]::new('--nodegroup', 'nodegroup', [CompletionResultType]::ParameterName, 'Nodegroup name')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;unset' {
            [CompletionResult]::new('labels', 'labels', [CompletionResultType]::ParameterValue, 'Create removeLabels')
            break
        }
        'eksctl;unset;labels' {
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-l', 'l', [CompletionResultType]::ParameterName, 'List of labels to remove')
            [CompletionResult]::new('--labels', 'labels', [CompletionResultType]::ParameterName, 'List of labels to remove')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Nodegroup name')
            [CompletionResult]::new('--nodegroup', 'nodegroup', [CompletionResultType]::ParameterName, 'Nodegroup name')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;update' {
            [CompletionResult]::new('cluster', 'cluster', [CompletionResultType]::ParameterValue, 'DEPRECATED: use ''upgrade cluster'' instead. Upgrade control plane to the next version. ')
            break
        }
        'eksctl;update;cluster' {
            [CompletionResult]::new('--approve', 'approve', [CompletionResultType]::ParameterName, 'Apply the changes')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Kubernetes version (valid options: 1.14, 1.15, 1.16, 1.17)')
            break
        }
        'eksctl;upgrade' {
            [CompletionResult]::new('cluster', 'cluster', [CompletionResultType]::ParameterValue, 'Upgrade control plane to the next version')
            [CompletionResult]::new('nodegroup', 'nodegroup', [CompletionResultType]::ParameterValue, 'Upgrade nodegroup')
            break
        }
        'eksctl;upgrade;cluster' {
            [CompletionResult]::new('--approve', 'approve', [CompletionResultType]::ParameterName, 'Apply the changes')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Kubernetes version (valid options: 1.14, 1.15, 1.16, 1.17)')
            break
        }
        'eksctl;upgrade;nodegroup' {
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--kubernetes-version', 'kubernetes-version', [CompletionResultType]::ParameterName, 'Kubernetes version')
            [CompletionResult]::new('--launch-template-version', 'launch-template-version', [CompletionResultType]::ParameterName, 'Launch template version')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'Nodegroup name')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            [CompletionResult]::new('-w', 'w', [CompletionResultType]::ParameterName, 'wait for nodegroup upgrade to complete before exiting')
            [CompletionResult]::new('--wait', 'wait', [CompletionResultType]::ParameterName, 'wait for nodegroup upgrade to complete before exiting')
            break
        }
        'eksctl;utils' {
            [CompletionResult]::new('associate-iam-oidc-provider', 'associate-iam-oidc-provider', [CompletionResultType]::ParameterValue, 'Setup IAM OIDC provider for a cluster to enable IAM roles for pods')
            [CompletionResult]::new('describe-stacks', 'describe-stacks', [CompletionResultType]::ParameterValue, 'Describe CloudFormation stack for a given cluster')
            [CompletionResult]::new('install-vpc-controllers', 'install-vpc-controllers', [CompletionResultType]::ParameterValue, 'Install Windows VPC controller to support running Windows workloads')
            [CompletionResult]::new('nodegroup-health', 'nodegroup-health', [CompletionResultType]::ParameterValue, 'Get nodegroup health for a managed node')
            [CompletionResult]::new('schema', 'schema', [CompletionResultType]::ParameterValue, 'Output the ClusterConfig JSON Schema')
            [CompletionResult]::new('set-public-access-cidrs', 'set-public-access-cidrs', [CompletionResultType]::ParameterValue, 'Update public access CIDRs')
            [CompletionResult]::new('update-aws-node', 'update-aws-node', [CompletionResultType]::ParameterValue, 'Update aws-node add-on to latest released version')
            [CompletionResult]::new('update-cluster-endpoints', 'update-cluster-endpoints', [CompletionResultType]::ParameterValue, 'Update Kubernetes API endpoint access configuration')
            [CompletionResult]::new('update-cluster-logging', 'update-cluster-logging', [CompletionResultType]::ParameterValue, 'Update cluster logging configuration')
            [CompletionResult]::new('update-cluster-stack', 'update-cluster-stack', [CompletionResultType]::ParameterValue, 'DEPRECATED: Use ''eksctl update cluster'' instead')
            [CompletionResult]::new('update-coredns', 'update-coredns', [CompletionResultType]::ParameterValue, 'Update coredns add-on to ensure image matches the standard Amazon EKS version')
            [CompletionResult]::new('update-kube-proxy', 'update-kube-proxy', [CompletionResultType]::ParameterValue, 'Update kube-proxy add-on to ensure image matches Kubernetes control plane version')
            [CompletionResult]::new('update-legacy-subnet-settings', 'update-legacy-subnet-settings', [CompletionResultType]::ParameterValue, 'Update the configuration of the cluster''s public subnets with MapPublicIpOnLaunch enabled')
            [CompletionResult]::new('wait-nodes', 'wait-nodes', [CompletionResultType]::ParameterValue, 'Wait for nodes')
            [CompletionResult]::new('write-kubeconfig', 'write-kubeconfig', [CompletionResultType]::ParameterValue, 'Write kubeconfig file for a given cluster')
            break
        }
        'eksctl;utils;associate-iam-oidc-provider' {
            [CompletionResult]::new('--approve', 'approve', [CompletionResultType]::ParameterName, 'Apply the changes')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            break
        }
        'eksctl;utils;describe-stacks' {
            [CompletionResult]::new('--all', 'all', [CompletionResultType]::ParameterName, 'include deleted stacks')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--events', 'events', [CompletionResultType]::ParameterName, 'include stack events')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            [CompletionResult]::new('--trail', 'trail', [CompletionResultType]::ParameterName, 'lookup CloudTrail events for the cluster')
            break
        }
        'eksctl;utils;install-vpc-controllers' {
            [CompletionResult]::new('--approve', 'approve', [CompletionResultType]::ParameterName, 'Apply the changes')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;utils;nodegroup-health' {
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Name of the nodegroup')
            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'Name of the nodegroup')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;utils;schema' {
            break
        }
        'eksctl;utils;set-public-access-cidrs' {
            [CompletionResult]::new('--approve', 'approve', [CompletionResultType]::ParameterName, 'Apply the changes')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;utils;update-aws-node' {
            [CompletionResult]::new('--approve', 'approve', [CompletionResultType]::ParameterName, 'Apply the changes')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;utils;update-cluster-endpoints' {
            [CompletionResult]::new('--approve', 'approve', [CompletionResultType]::ParameterName, 'Apply the changes')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--private-access', 'private-access', [CompletionResultType]::ParameterName, 'access for private (VPC) clients')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--public-access', 'public-access', [CompletionResultType]::ParameterName, 'access for public clients')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;utils;update-cluster-logging' {
            [CompletionResult]::new('--approve', 'approve', [CompletionResultType]::ParameterName, 'Apply the changes')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--disable-types', 'disable-types', [CompletionResultType]::ParameterName, 'Log types to be disabled, the rest will be disabled. Supported log types: (all, none, api, audit, authenticator, controllerManager, scheduler)')
            [CompletionResult]::new('--enable-types', 'enable-types', [CompletionResultType]::ParameterName, 'Log types to be enabled. Supported log types: (all, none, api, audit, authenticator, controllerManager, scheduler)')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;utils;update-cluster-stack' {
            break
        }
        'eksctl;utils;update-coredns' {
            [CompletionResult]::new('--approve', 'approve', [CompletionResultType]::ParameterName, 'Apply the changes')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;utils;update-kube-proxy' {
            [CompletionResult]::new('--approve', 'approve', [CompletionResultType]::ParameterName, 'Apply the changes')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'load configuration from a file (or stdin if set to ''-'')')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;utils;update-legacy-subnet-settings' {
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;utils;wait-nodes' {
            [CompletionResult]::new('--kubeconfig', 'kubeconfig', [CompletionResultType]::ParameterName, 'path to read kubeconfig')
            [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'minimum number of nodes to wait for')
            [CompletionResult]::new('--nodes-min', 'nodes-min', [CompletionResultType]::ParameterName, 'minimum number of nodes to wait for')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'how long to wait')
            break
        }
        'eksctl;utils;write-kubeconfig' {
            [CompletionResult]::new('--authenticator-role-arn', 'authenticator-role-arn', [CompletionResultType]::ParameterName, 'AWS IAM role to assume for authenticator')
            [CompletionResult]::new('--auto-kubeconfig', 'auto-kubeconfig', [CompletionResultType]::ParameterName, 'save kubeconfig file by cluster name, e.g. "/home/tammach/.kube/eksctl/clusters/<name>"')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--cluster', 'cluster', [CompletionResultType]::ParameterName, 'EKS cluster name')
            [CompletionResult]::new('--kubeconfig', 'kubeconfig', [CompletionResultType]::ParameterName, 'path to write kubeconfig (incompatible with --auto-kubeconfig)')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'AWS credentials profile to use (overrides the AWS_PROFILE environment variable)')
            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--region', 'region', [CompletionResultType]::ParameterName, 'AWS region')
            [CompletionResult]::new('--set-kubeconfig-context', 'set-kubeconfig-context', [CompletionResultType]::ParameterName, 'if true then current-context will be set in kubeconfig; if a context is already set then it will be overwritten')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'maximum waiting time for any long-running operation')
            break
        }
        'eksctl;version' {
            [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'specifies the output format (valid option: json)')
            [CompletionResult]::new('--output', 'output', [CompletionResultType]::ParameterName, 'specifies the output format (valid option: json)')
            break
        }
    })
    $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
        Sort-Object -Property ListItemText
}
```

</details>

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

