### PR TITLE
return non-zero when a given nodegroup doesn't exist

### DIFF
--- a/pkg/ctl/get/nodegroup.go
+++ b/pkg/ctl/get/nodegroup.go
@@ -76,6 +76,11 @@ func doGetNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *getCmdParams) 
 		return errors.Wrap(err, "getting nodegroup stack summaries")
 	}
 
+	// Empty summary implies no nodegroups
+	if len(summaries) == 0 {
+		return errors.Errorf("Nodegroup with name %v not found", ng.Name)
+	}
+
 	printer, err := printers.NewPrinter(params.output)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Description

return non-zero when a given nodegroup doesn't exist , fixes #2728 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

