### PR TITLE
Handle aws-node 1.7 initContainer properly

### DIFF
--- a/pkg/addons/default/aws_node_test.go
+++ b/pkg/addons/default/aws_node_test.go
@@ -122,7 +122,10 @@ var _ = Describe("default addons - aws-node", func() {
 			Expect(awsNode.Spec.Template.Spec.Containers[0].Image).To(
 				Equal("602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon-k8s-cni:v1.7.5"),
 			)
-
+			Expect(awsNode.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			Expect(awsNode.Spec.Template.Spec.InitContainers[0].Image).To(
+				Equal("602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon-k8s-cni-init:v1.7.5"),
+			)
 			rawClient.ClearUpdated()
 		})
 
@@ -140,6 +143,10 @@ var _ = Describe("default addons - aws-node", func() {
 			Expect(awsNode.Spec.Template.Spec.Containers[0].Image).To(
 				Equal("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:v1.7.5"),
 			)
+			Expect(awsNode.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			Expect(awsNode.Spec.Template.Spec.InitContainers[0].Image).To(
+				Equal("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni-init:v1.7.5"),
+			)
 		})
 
 		It("can update 1.14 sample for china region to multi-architecture image", func() {
@@ -155,6 +162,10 @@ var _ = Describe("default addons - aws-node", func() {
 			Expect(awsNode.Spec.Template.Spec.Containers).To(HaveLen(1))
 			Expect(awsNode.Spec.Template.Spec.Containers[0].Image).To(
 				Equal("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.7.5"),
+			)
+			Expect(awsNode.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			Expect(awsNode.Spec.Template.Spec.InitContainers[0].Image).To(
+				Equal("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.7.5"),
 			)
 		})
 

--- a/pkg/addons/image.go
+++ b/pkg/addons/image.go
@@ -29,6 +29,12 @@ func UseRegionalImage(spec *corev1.PodTemplateSpec, region string) error {
 	}
 	regionalImage := fmt.Sprintf(imageFormat, api.EKSResourceAccountID(region), region, dnsSuffix)
 	spec.Spec.Containers[0].Image = regionalImage
+
+	if len(spec.Spec.InitContainers) > 0 {
+		imageFormat = spec.Spec.InitContainers[0].Image
+		regionalImage = fmt.Sprintf(imageFormat, api.EKSResourceAccountID(region), region, dnsSuffix)
+		spec.Spec.InitContainers[0].Image = regionalImage
+	}
 	return nil
 }
 


### PR DESCRIPTION
### Description

Since version 1.7 of AWS VPC CNI plugin for Kubernetes
the DaemonSet consists additionally of one initContainer.

This initContainer needs the same treatment as the main container regarding
usage of the regional image.

Otherwise the consequence would be a failing pod in China regions
or slow image pulls in other regions than us-west-2.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

