### PR TITLE
Ensure node drain timeout is respected

### DIFF
--- a/pkg/drain/nodegroup.go
+++ b/pkg/drain/nodegroup.go
@@ -149,10 +149,14 @@ func NodeGroup(clientSet kubernetes.Interface, ng eks.KubeNodeGroup, waitTimeout
 						logger.Warning("pod eviction error (%q) on node %s – will retry after delay of %s", err, node.Name, retryDelay)
 						retryTimer := time.NewTimer(retryDelay)
 						select {
-						case <-retryTimer.C:
 						case <-timer.C:
 							retryTimer.Stop()
 							break evict_loop
+						default:
+						}
+
+						select {
+						case <-retryTimer.C:
 						}
 						continue
 					}

--- a/pkg/drain/nodegroup.go
+++ b/pkg/drain/nodegroup.go
@@ -146,11 +146,7 @@ func NodeGroup(clientSet kubernetes.Interface, ng eks.KubeNodeGroup, waitTimeout
 					pending, err := evictPods(drainer, &node)
 					if err != nil {
 						logger.Warning("pod eviction error (%q) on node %s – will retry after delay of %s", err, node.Name, retryDelay)
-						retryTimer := time.NewTimer(retryDelay)
-
-						select {
-						case <-retryTimer.C:
-						}
+						time.Sleep(retryDelay)
 						continue
 					}
 					logger.Debug("%d pods to be evicted from %s", pending, node.Name)

--- a/pkg/drain/nodegroup.go
+++ b/pkg/drain/nodegroup.go
@@ -141,19 +141,12 @@ func NodeGroup(clientSet kubernetes.Interface, ng eks.KubeNodeGroup, waitTimeout
 			logger.Debug("already drained: %v", drainedNodes.List())
 			logger.Debug("will drain: %v", newPendingNodes.List())
 
-		evict_loop:
 			for _, node := range nodes.Items {
 				if newPendingNodes.Has(node.Name) {
 					pending, err := evictPods(drainer, &node)
 					if err != nil {
 						logger.Warning("pod eviction error (%q) on node %s – will retry after delay of %s", err, node.Name, retryDelay)
 						retryTimer := time.NewTimer(retryDelay)
-						select {
-						case <-timer.C:
-							retryTimer.Stop()
-							break evict_loop
-						default:
-						}
 
 						select {
 						case <-retryTimer.C:


### PR DESCRIPTION
### Description
When draining a node the timeout is not respected. Related issue: https://github.com/weaveworks/eksctl/issues/2628. This PR fixes this issue.

Good blog post explaining the issue that was occurring: https://dev.to/julianchu/go-for-select-with-timer-1ah8#timer

### Other
I'm questioning the value of the `retryDelay`, it makes sense to have a delay between attempting to re-drain the same node, but in its current format the `retryDelay` results in a delay between draining different nodes. I haven't addressed this as part of this PR as its a separate issue, just wanted to raise it.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

