### PR TITLE
Allow creation of iamserviceaccounts on clusters not created through eksctl

### DIFF
--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -445,7 +445,7 @@ func (c *StackCollection) DescribeStacks() ([]*Stack, error) {
 		return nil, errors.Wrapf(err, "describing CloudFormation stacks for %q", c.spec.Metadata.Name)
 	}
 	if len(stacks) == 0 {
-		return nil, c.errStackNotFound()
+		logger.Debug("No stacks found for %s", c.spec.Metadata.Name)
 	}
 	return stacks, nil
 }

--- a/pkg/cfn/manager/cluster.go
+++ b/pkg/cfn/manager/cluster.go
@@ -46,6 +46,10 @@ func (c *StackCollection) DescribeClusterStack() (*Stack, error) {
 		return nil, err
 	}
 
+	if len(stacks) == 0 {
+		return nil, c.errStackNotFound()
+	}
+
 	for _, s := range stacks {
 		if *s.StackStatus == cfn.StackStatusDeleteComplete {
 			continue

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -85,6 +85,10 @@ func (c *StackCollection) DescribeNodeGroupStacks() ([]*Stack, error) {
 		return nil, err
 	}
 
+	if len(stacks) == 0 {
+		return nil, c.errStackNotFound()
+	}
+
 	nodeGroupStacks := []*Stack{}
 	for _, s := range stacks {
 		if *s.StackStatus == cfn.StackStatusDeleteComplete {


### PR DESCRIPTION
### Description
Currently you can use `eksctl utils associate-iam-oidc-provider` on non-eksctl created clusters (more specifficaly clusters not created through CloudFormation), but when it comes to utilising this functionality and creating iamserviceaccounts via `eksctl create iamserviceaccount` this only works on eksctl created clusters (clusters with CloudFormation stacks). This PR changes it so that you can use `eksctl create iamserviceaccount` against non-eksctl clusters.

related issue: https://github.com/weaveworks/eksctl/issues/2174

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [X] Make sure the title of the PR is a good description that can go into the release notes

