### PR TITLE
Use role names instead of ARN when creating instance profiles

### DIFF
--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -1618,7 +1618,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 
 			Expect(profile.Path).To(Equal("/"))
 			Expect(profile.Roles).To(HaveLen(1))
-			Expect(profile.Roles[0]).To(Equal("arn:aws:iam::1234567890:role/custom-eks-role"))
+			Expect(profile.Roles[0]).To(Equal("custom-eks-role"))
 
 			isFnGetAttOf(getLaunchTemplateData(ngTemplate).IamInstanceProfile.Arn, "NodeInstanceProfile", "Arn")
 		})

--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -151,7 +151,7 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() error {
 		// if role is set, but profile isn't - create profile
 		n.newResource(cfnIAMInstanceProfileName, &gfniam.InstanceProfile{
 			Path:  gfnt.NewString("/"),
-			Roles: gfnt.NewStringSlice(roleARN),
+			Roles: gfnt.NewStringSlice(AbstractRoleNameFromARN(roleARN)),
 		})
 		n.instanceProfileARN = gfnt.MakeFnGetAttString(cfnIAMInstanceProfileName, "Arn")
 		n.rs.defineOutputFromAtt(outputs.NodeGroupInstanceProfileARN, cfnIAMInstanceProfileName, "Arn", true, func(v string) error {

--- a/pkg/cfn/builder/iam_helper.go
+++ b/pkg/cfn/builder/iam_helper.go
@@ -338,3 +338,12 @@ func NormalizeARN(arn string) string {
 	}
 	return fmt.Sprintf("%s/%s", parts[0], parts[len(parts)-1])
 }
+
+// AbstractRoleNameFromARN returns the role name from the ARN
+func AbstractRoleNameFromARN(arn string) string {
+	parts := strings.Split(arn, "/")
+	if len(parts) <= 1 {
+		return arn
+	}
+	return parts[len(parts)-1]
+}


### PR DESCRIPTION
### Description
When creating an instance profile you need to provide the name instead of the role for the ARN. Currently if your provide an `instanceRoleARN` value but not a `instanceProfileARN` we attempt to create an `InstanceProfile`, but we provide the value ARN value instead of the role name to the spec, causing an error. Related AWS doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html

Related issue: fixes https://github.com/weaveworks/eksctl/issues/2768

### Checklist
- [X] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [X] Make sure the title of the PR is a good description that can go into the release notes

