### PR TITLE
Don't check exact helm-operator version in integration test

### DIFF
--- a/integration/matchers/flux.go
+++ b/integration/matchers/flux.go
@@ -335,7 +335,7 @@ func assertValidHelmOperatorDeployment(fileName string) {
 			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 			container := deployment.Spec.Template.Spec.Containers[0]
 			Expect(container.Name).To(Equal("helm-operator"))
-			Expect(container.Image).To(Equal("docker.io/fluxcd/helm-operator:1.0.0"))
+			Expect(container.Image).To(ContainSubstring("docker.io/fluxcd/helm-operator"))
 		} else {
 			Fail(fmt.Sprintf("Unsupported Kubernetes object. Got %s object with version %s in: %s", gvk.Kind, gvk.Version, fileName))
 		}

--- a/integration/matchers/flux.go
+++ b/integration/matchers/flux.go
@@ -335,7 +335,7 @@ func assertValidHelmOperatorDeployment(fileName string) {
 			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 			container := deployment.Spec.Template.Spec.Containers[0]
 			Expect(container.Name).To(Equal("helm-operator"))
-			Expect(container.Image).To(ContainSubstring("docker.io/fluxcd/helm-operator"))
+			Expect(container.Image).To(HavePrefix("docker.io/fluxcd/helm-operator"))
 		} else {
 			Fail(fmt.Sprintf("Unsupported Kubernetes object. Got %s object with version %s in: %s", gvk.Kind, gvk.Version, fileName))
 		}


### PR DESCRIPTION
### Description
I don't see a good reason to check the exact version here, just makes for brittle tests.
<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

