### PR TITLE
Respect volume size for Bottlerocket nodegroups

### DIFF
--- a/pkg/ami/ami_test.go
+++ b/pkg/ami/ami_test.go
@@ -18,6 +18,8 @@ func TestUseAMI(t *testing.T) {
 		blockDeviceMappings []*ec2.BlockDeviceMapping
 		rootDeviceName      string
 		description         string
+		volumeName          string
+		amiFamily           string
 
 		encrypted bool
 	}{
@@ -41,7 +43,8 @@ func TestUseAMI(t *testing.T) {
 				},
 			},
 
-			encrypted: true,
+			encrypted:  true,
+			volumeName: "/dev/sda1",
 		},
 		{
 			description:    "Only one device mapping (AL2 AMIs)",
@@ -55,7 +58,8 @@ func TestUseAMI(t *testing.T) {
 				},
 			},
 
-			encrypted: true,
+			encrypted:  true,
+			volumeName: "/dev/sda1",
 		},
 		{
 			description:    "Different root device name",
@@ -77,7 +81,24 @@ func TestUseAMI(t *testing.T) {
 				},
 			},
 
-			encrypted: false,
+			encrypted:  false,
+			volumeName: "/dev/xvda",
+		},
+		{
+			description:    "uses /dev/xvdb disk for bottlerocket images",
+			rootDeviceName: "/dev/xvda",
+			amiFamily:      api.NodeImageFamilyBottlerocket,
+			blockDeviceMappings: []*ec2.BlockDeviceMapping{
+				{
+					DeviceName: aws.String("/dev/xvda"),
+					Ebs: &ec2.EbsBlockDevice{
+						Encrypted: aws.Bool(false),
+					},
+				},
+			},
+
+			encrypted:  false,
+			volumeName: "/dev/xvdb",
 		},
 	}
 
@@ -86,7 +107,8 @@ func TestUseAMI(t *testing.T) {
 			mockProvider := mockDescribeImages(tt.blockDeviceMappings, tt.rootDeviceName)
 			ng := &api.NodeGroup{
 				NodeGroupBase: &api.NodeGroupBase{
-					AMI: "ami-0121d8347f8191f90",
+					AMI:       "ami-0121d8347f8191f90",
+					AMIFamily: tt.amiFamily,
 				},
 			}
 			err := ami.Use(mockProvider.MockEC2(), ng.NodeGroupBase)
@@ -97,6 +119,11 @@ func TestUseAMI(t *testing.T) {
 
 			if *ng.VolumeEncrypted != tt.encrypted {
 				t.Errorf("expected VolumeEncrypted to be %v", tt.encrypted)
+			}
+
+			if *ng.VolumeName != tt.volumeName {
+				t.Errorf("expected VolumeName to be %v", tt.volumeName)
+
 			}
 		})
 	}

--- a/pkg/ami/ami_test.go
+++ b/pkg/ami/ami_test.go
@@ -123,7 +123,6 @@ func TestUseAMI(t *testing.T) {
 
 			if *ng.VolumeName != tt.volumeName {
 				t.Errorf("expected VolumeName to be %v", tt.volumeName)
-
 			}
 		})
 	}

--- a/pkg/ami/api.go
+++ b/pkg/ami/api.go
@@ -53,10 +53,9 @@ func Use(ec2api ec2iface.EC2API, ng *api.NodeGroupBase) error {
 
 	case "ebs":
 		if !api.IsSetAndNonEmptyString(ng.VolumeName) {
+			ng.VolumeName = image.RootDeviceName
 			if ng.AMIFamily == api.NodeImageFamilyBottlerocket {
 				ng.VolumeName = aws.String("/dev/xvdb")
-			} else {
-				ng.VolumeName = image.RootDeviceName
 			}
 		}
 		rootDeviceMapping, err := findRootDeviceMapping(image)

--- a/pkg/ami/api.go
+++ b/pkg/ami/api.go
@@ -21,6 +21,9 @@ const (
 	ImageClassARM
 )
 
+// Bottlerocket disk used by kubelet
+const bottlerocketDataDisk = "/dev/xvdb"
+
 // ImageClasses is a list of image class names
 var ImageClasses = []string{
 	"ImageClassGeneral",
@@ -55,7 +58,7 @@ func Use(ec2api ec2iface.EC2API, ng *api.NodeGroupBase) error {
 		if !api.IsSetAndNonEmptyString(ng.VolumeName) {
 			ng.VolumeName = image.RootDeviceName
 			if ng.AMIFamily == api.NodeImageFamilyBottlerocket {
-				ng.VolumeName = aws.String("/dev/xvdb")
+				ng.VolumeName = aws.String(bottlerocketDataDisk)
 			}
 		}
 		rootDeviceMapping, err := findRootDeviceMapping(image)

--- a/pkg/ami/api.go
+++ b/pkg/ami/api.go
@@ -53,7 +53,11 @@ func Use(ec2api ec2iface.EC2API, ng *api.NodeGroupBase) error {
 
 	case "ebs":
 		if !api.IsSetAndNonEmptyString(ng.VolumeName) {
-			ng.VolumeName = image.RootDeviceName
+			if ng.AMIFamily == api.NodeImageFamilyBottlerocket {
+				ng.VolumeName = aws.String("/dev/xvdb")
+			} else {
+				ng.VolumeName = image.RootDeviceName
+			}
 		}
 		rootDeviceMapping, err := findRootDeviceMapping(image)
 		if err != nil {


### PR DESCRIPTION
### Description
Currently we increase the `/dev/xvda` disk by default for all nodegroups. When Bottlerocket images are used the disk setup is different:

Related issue: https://github.com/weaveworks/eksctl/issues/2776
> /dev/xvda is used to hold the operating system itself and contains the active & passive partitions, the bootloader, the dm-verity data, and the data store for the Bottlerocket API. /dev/xvdb is used for all of the things you run on top of Bottlerocket: container images, storage for running containers, and persistent storage/volumes.

This PR updates eksctl to increase the size of `/dev/xvdb` when using Bottlerocket

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [X] Make sure the title of the PR is a good description that can go into the release notes

