### PR TITLE
Skip upgrading nodegroup if SSM release version is older

### DIFF
--- a/pkg/managed/managed_suite_test.go
+++ b/pkg/managed/managed_suite_test.go
@@ -1,0 +1,11 @@
+package managed
+
+import (
+	"testing"
+
+	"github.com/weaveworks/eksctl/pkg/testutils"
+)
+
+func TestManagedService(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}

--- a/pkg/managed/release_version_test.go
+++ b/pkg/managed/release_version_test.go
@@ -1,0 +1,64 @@
+package managed
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AMI Release Version", func() {
+	type versionCase struct {
+		v1     string
+		v2     string
+		cmp    int
+		errMsg string
+	}
+
+	DescribeTable("AMI release version comparison", func(vc versionCase) {
+		cmp, err := compareReleaseVersion(vc.v1, vc.v2)
+		if vc.errMsg != "" {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(vc.errMsg))
+			return
+		}
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cmp).To(Equal(vc.cmp))
+	},
+		Entry("Equal", versionCase{
+			v1:  "1.18.8-20201007",
+			v2:  "1.18.8-20201007",
+			cmp: 0,
+		}),
+		Entry("Less", versionCase{
+			v1:  "1.18.8-20201007",
+			v2:  "1.18.9-20201112",
+			cmp: -1,
+		}),
+		Entry("Greater", versionCase{
+			v1:  "1.18.25-20201007",
+			v2:  "1.18.20-20201007",
+			cmp: 1,
+		}),
+		Entry("Older major version", versionCase{
+			v1:  "1.17.9-20200101",
+			v2:  "1.18.0-20200101",
+			cmp: -1,
+		}),
+		Entry("Newer minor version", versionCase{
+			v1:  "1.18.9-20201112",
+			v2:  "1.18.8-20201007",
+			cmp: 1,
+		}),
+		Entry("Malformed version", versionCase{
+			v1:     "1.18.9-20200101",
+			v2:     "1.18.9",
+			errMsg: "unexpected format",
+		}),
+		Entry("Both versions invalid", versionCase{
+			v1:     "a-b",
+			v2:     "1.17.d",
+			errMsg: "invalid SemVer version",
+		}),
+	)
+
+})

--- a/pkg/managed/release_version_test.go
+++ b/pkg/managed/release_version_test.go
@@ -14,8 +14,20 @@ var _ = Describe("AMI Release Version", func() {
 		errMsg string
 	}
 
+	compare := func(a, b string) (int, error) {
+		v1, err := parseReleaseVersion(a)
+		if err != nil {
+			return 0, err
+		}
+		v2, err := parseReleaseVersion(b)
+		if err != nil {
+			return 0, err
+		}
+		return v1.Compare(v2), nil
+	}
+
 	DescribeTable("AMI release version comparison", func(vc versionCase) {
-		cmp, err := compareReleaseVersion(vc.v1, vc.v2)
+		cmp, err := compare(vc.v1, vc.v2)
 		if vc.errMsg != "" {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(vc.errMsg))

--- a/pkg/managed/service.go
+++ b/pkg/managed/service.go
@@ -286,14 +286,17 @@ type amiReleaseVersion struct {
 	Date    string
 }
 
+// LTE checks if a is less than or equal to b.
 func (a amiReleaseVersion) LTE(b amiReleaseVersion) bool {
 	return a.Compare(b) <= 0
 }
 
+// GTE checks if a is greater than or equal to b.
 func (a amiReleaseVersion) GTE(b amiReleaseVersion) bool {
 	return a.Compare(b) >= 0
 }
 
+// Compare returns 0 if a==b, -1 if a < b, and +1 if a > b.
 func (a amiReleaseVersion) Compare(b amiReleaseVersion) int {
 	cmp := a.Version.Compare(b.Version)
 	if cmp == 0 {


### PR DESCRIPTION
### Description
The release version reported by the SSM query for MNG is sometimes older than a nodegroup's current version, and because the Managed Nodegroup API does not support rolling back to a previous version, the upgrade fails.

This PR skips the upgrade if the release version obtained from SSM is older than the nodegroup's current version.

Fixes #2850 

<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

