### PR TITLE
Add ISO regions (us-iso-east-1, us-isob-east-1)

### DIFF
--- a/pkg/addons/device_plugin.go
+++ b/pkg/addons/device_plugin.go
@@ -206,7 +206,10 @@ func (n *EFADevicePlugin) Manifest() []byte {
 }
 
 func (n *EFADevicePlugin) SetImage(t *v1.PodTemplateSpec) error {
-	account := api.EKSResourceAccountID(n.region)
+	account, err := api.EKSResourceAccountID(n.region)
+	if err != nil {
+		return err
+	}
 	return useRegionalImage(t, n.region, account)
 }
 

--- a/pkg/addons/image.go
+++ b/pkg/addons/image.go
@@ -27,12 +27,16 @@ func UseRegionalImage(spec *corev1.PodTemplateSpec, region string) error {
 	if err != nil {
 		return err
 	}
-	regionalImage := fmt.Sprintf(imageFormat, api.EKSResourceAccountID(region), region, dnsSuffix)
+	resourceAccountID, err := api.EKSResourceAccountID(region)
+	if err != nil {
+		return err
+	}
+	regionalImage := fmt.Sprintf(imageFormat, resourceAccountID, region, dnsSuffix)
 	spec.Spec.Containers[0].Image = regionalImage
 
 	if len(spec.Spec.InitContainers) > 0 {
 		imageFormat = spec.Spec.InitContainers[0].Image
-		regionalImage = fmt.Sprintf(imageFormat, api.EKSResourceAccountID(region), region, dnsSuffix)
+		regionalImage = fmt.Sprintf(imageFormat, resourceAccountID, region, dnsSuffix)
 		spec.Spec.InitContainers[0].Image = regionalImage
 	}
 	return nil

--- a/pkg/ami/auto_resolver.go
+++ b/pkg/ami/auto_resolver.go
@@ -49,7 +49,7 @@ func OwnerAccountID(imageFamily, region string) (string, error) {
 	case api.NodeImageFamilyUbuntu2004, api.NodeImageFamilyUbuntu1804:
 		return ownerIDUbuntuFamily, nil
 	case api.NodeImageFamilyAmazonLinux2:
-		return api.EKSResourceAccountID(region), nil
+		return api.EKSResourceAccountID(region)
 	default:
 		if api.IsWindowsImage(imageFamily) {
 			return ownerIDWindowsFamily, nil

--- a/pkg/apis/eksctl.io/v1alpha5/account.go
+++ b/pkg/apis/eksctl.io/v1alpha5/account.go
@@ -1,0 +1,96 @@
+package v1alpha5
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	IsoEKSAccountIDEnv = "ISO_EKS_ACCOUNT_ID"
+
+	// eksResourceAccountStandard defines the AWS EKS account ID that provides node resources in default regions
+	// for standard AWS partition
+	eksResourceAccountStandard = "602401143452"
+
+	// eksResourceAccountAPEast1 defines the AWS EKS account ID that provides node resources in ap-east-1 region
+	eksResourceAccountAPEast1 = "800184023465"
+
+	// eksResourceAccountMESouth1 defines the AWS EKS account ID that provides node resources in me-south-1 region
+	eksResourceAccountMESouth1 = "558608220178"
+
+	// eksResourceAccountCNNorthWest1 defines the AWS EKS account ID that provides node resources in cn-northwest-1 region
+	eksResourceAccountCNNorthWest1 = "961992271922"
+
+	// eksResourceAccountCNNorth1 defines the AWS EKS account ID that provides node resources in cn-north-1
+	eksResourceAccountCNNorth1 = "918309763551"
+
+	// eksResourceAccountAFSouth1 defines the AWS EKS account ID that provides node resources in af-south-1
+	eksResourceAccountAFSouth1 = "877085696533"
+
+	// eksResourceAccountEUSouth1 defines the AWS EKS account ID that provides node resources in eu-south-1
+	eksResourceAccountEUSouth1 = "590381155156"
+
+	// eksResourceAccountUSGovWest1 defines the AWS EKS account ID that provides node resources in us-gov-west-1
+	eksResourceAccountUSGovWest1 = "013241004608"
+
+	// eksResourceAccountUSGovEast1 defines the AWS EKS account ID that provides node resources in us-gov-east-1
+	eksResourceAccountUSGovEast1 = "151742754352"
+)
+
+// EKSResourceAccountID provides worker node resources(ami/ecr image) in different aws account
+// for different aws partitions & opt-in regions.
+func EKSResourceAccountID(region string) (string, error) {
+	switch region {
+	case RegionUSIsoEast1:
+		return lookupIsoAccountID(region)
+	case RegionUSIsobEast1:
+		return lookupIsoAccountID(region)
+	default:
+		return publicResourceAccountID(region), nil
+	}
+}
+
+// ValidateEKSAccountID check that the ISO_EKS_ACCOUNT_ID env var has been set
+// when an isolated region is requested
+func ValidateEKSAccountID(region string) error {
+	if region == RegionUSIsoEast1 || region == RegionUSIsobEast1 {
+		if _, err := lookupIsoAccountID(region); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func lookupIsoAccountID(region string) (string, error) {
+	id := os.Getenv(IsoEKSAccountIDEnv)
+	if id == "" {
+		return "", errors.Errorf("%s not set, required for use of region: %s", IsoEKSAccountIDEnv, region)
+	}
+
+	return id, nil
+}
+
+func publicResourceAccountID(region string) string {
+	switch region {
+	case RegionAPEast1:
+		return eksResourceAccountAPEast1
+	case RegionMESouth1:
+		return eksResourceAccountMESouth1
+	case RegionCNNorthwest1:
+		return eksResourceAccountCNNorthWest1
+	case RegionCNNorth1:
+		return eksResourceAccountCNNorth1
+	case RegionUSGovWest1:
+		return eksResourceAccountUSGovWest1
+	case RegionUSGovEast1:
+		return eksResourceAccountUSGovEast1
+	case RegionAFSouth1:
+		return eksResourceAccountAFSouth1
+	case RegionEUSouth1:
+		return eksResourceAccountEUSouth1
+	default:
+		return eksResourceAccountStandard
+	}
+}

--- a/pkg/apis/eksctl.io/v1alpha5/account_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/account_test.go
@@ -1,0 +1,39 @@
+package v1alpha5_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+)
+
+var _ = Describe("Resource Account IDs", func() {
+	DescribeTable("when 'ISO_EKS_ACCOUNT_ID' environment variable is set", func(region string) {
+		Expect(os.Setenv(api.IsoEKSAccountIDEnv, "1234567890")).To(Succeed())
+
+		Expect(api.ValidateEKSAccountID(region)).To(Succeed())
+	},
+		Entry("using RegionUSIsoEast1 should not produce an error", api.RegionUSIsoEast1),
+		Entry("using RegionUSIsobEast1 should not produce an error", api.RegionUSIsobEast1),
+	)
+
+	DescribeTable("when 'ISO_EKS_ACCOUNT_ID' environment variable IS present but is NOT set", func(region string) {
+		Expect(os.Setenv(api.IsoEKSAccountIDEnv, "")).To(Succeed())
+
+		Expect(api.ValidateEKSAccountID(region)).To(MatchError(ContainSubstring("ISO_EKS_ACCOUNT_ID not set, required for use of region:")))
+	},
+		Entry("setting RegionUSIsoEast1 should fail", api.RegionUSIsoEast1),
+		Entry("setting RegionUSIsobEast1 should fail", api.RegionUSIsobEast1),
+	)
+
+	DescribeTable("when 'ISO_EKS_ACCOUNT_ID' environment variable is NOT set", func(region string) {
+		Expect(os.Unsetenv(api.IsoEKSAccountIDEnv)).To(Succeed())
+
+		Expect(api.ValidateEKSAccountID(region)).To(MatchError(ContainSubstring("ISO_EKS_ACCOUNT_ID not set, required for use of region:")))
+	},
+		Entry("setting RegionUSIsoEast1 should fail", api.RegionUSIsoEast1),
+		Entry("setting RegionUSIsobEast1 should fail", api.RegionUSIsobEast1),
+	)
+})

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -152,15 +152,23 @@ const (
 	// RegionUSGovEast1 represents the region GovCloud (US-East)
 	RegionUSGovEast1 = "us-gov-east-1"
 
+	// RegionUSIsoEast1 represents the region ISO (US-East)
+	RegionUSIsoEast1 = "us-iso-east-1"
+
+	// RegionUSIsobEast1 represents the region ISOB (US-East)
+	RegionUSIsobEast1 = "us-isob-east-1"
+
 	// DefaultRegion defines the default region, where to deploy the EKS cluster
 	DefaultRegion = RegionUSWest2
 )
 
 // Partitions
 const (
-	PartitionAWS   = "aws"
-	PartitionChina = "aws-cn"
-	PartitionUSGov = "aws-us-gov"
+	PartitionAWS    = "aws"
+	PartitionChina  = "aws-cn"
+	PartitionUSGov  = "aws-us-gov"
+	PartitionUSIso  = "aws-iso"
+	PartitionUSIsob = "aws-iso-b"
 )
 
 // Values for `NodeAMIFamily`
@@ -240,34 +248,6 @@ const (
 	// minimized, but also the preference for certain instance types matters.
 	// https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-purchase-options.html#asg-spot-strategy
 	SpotAllocationStrategyCapacityOptimizedPrioritized = "capacity-optimized-prioritized"
-
-	// eksResourceAccountStandard defines the AWS EKS account ID that provides node resources in default regions
-	// for standard AWS partition
-	eksResourceAccountStandard = "602401143452"
-
-	// eksResourceAccountAPEast1 defines the AWS EKS account ID that provides node resources in ap-east-1 region
-	eksResourceAccountAPEast1 = "800184023465"
-
-	// eksResourceAccountMESouth1 defines the AWS EKS account ID that provides node resources in me-south-1 region
-	eksResourceAccountMESouth1 = "558608220178"
-
-	// eksResourceAccountCNNorthWest1 defines the AWS EKS account ID that provides node resources in cn-northwest-1 region
-	eksResourceAccountCNNorthWest1 = "961992271922"
-
-	// eksResourceAccountCNNorth1 defines the AWS EKS account ID that provides node resources in cn-north-1
-	eksResourceAccountCNNorth1 = "918309763551"
-
-	// eksResourceAccountAFSouth1 defines the AWS EKS account ID that provides node resources in af-south-1
-	eksResourceAccountAFSouth1 = "877085696533"
-
-	// eksResourceAccountEUSouth1 defines the AWS EKS account ID that provides node resources in eu-south-1
-	eksResourceAccountEUSouth1 = "590381155156"
-
-	// eksResourceAccountUSGovWest1 defines the AWS EKS account ID that provides node resources in us-gov-west-1
-	eksResourceAccountUSGovWest1 = "013241004608"
-
-	// eksResourceAccountUSGovEast1 defines the AWS EKS account ID that provides node resources in us-gov-east-1
-	eksResourceAccountUSGovEast1 = "151742754352"
 )
 
 // Values for `VolumeType`
@@ -367,6 +347,8 @@ func SupportedRegions() []string {
 		RegionCNNorth1,
 		RegionUSGovWest1,
 		RegionUSGovEast1,
+		RegionUSIsoEast1,
+		RegionUSIsobEast1,
 	}
 }
 
@@ -375,6 +357,10 @@ func Partition(region string) string {
 	switch region {
 	case RegionUSGovWest1, RegionUSGovEast1:
 		return PartitionUSGov
+	case RegionUSIsoEast1:
+		return PartitionUSIso
+	case RegionUSIsobEast1:
+		return PartitionUSIsob
 	case RegionCNNorth1, RegionCNNorthwest1:
 		return PartitionChina
 	default:
@@ -468,31 +454,6 @@ func isSpotAllocationStrategySupported(allocationStrategy string) bool {
 		}
 	}
 	return false
-}
-
-// EKSResourceAccountID provides worker node resources(ami/ecr image) in different aws account
-// for different aws partitions & opt-in regions.
-func EKSResourceAccountID(region string) string {
-	switch region {
-	case RegionAPEast1:
-		return eksResourceAccountAPEast1
-	case RegionMESouth1:
-		return eksResourceAccountMESouth1
-	case RegionCNNorthwest1:
-		return eksResourceAccountCNNorthWest1
-	case RegionCNNorth1:
-		return eksResourceAccountCNNorth1
-	case RegionUSGovWest1:
-		return eksResourceAccountUSGovWest1
-	case RegionUSGovEast1:
-		return eksResourceAccountUSGovEast1
-	case RegionAFSouth1:
-		return eksResourceAccountAFSouth1
-	case RegionEUSouth1:
-		return eksResourceAccountEUSouth1
-	default:
-		return eksResourceAccountStandard
-	}
 }
 
 // ClusterMeta contains general cluster information

--- a/pkg/cfn/builder/partition.go
+++ b/pkg/cfn/builder/partition.go
@@ -3,24 +3,35 @@ package builder
 import (
 	"fmt"
 
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	gfnt "github.com/weaveworks/goformation/v4/cloudformation/types"
 )
 
 var servicePrincipalPartitionMappings = map[string]map[string]string{
-	"aws": {
+	api.PartitionAWS: {
 		"EC2":            "ec2.amazonaws.com",
 		"EKS":            "eks.amazonaws.com",
 		"EKSFargatePods": "eks-fargate-pods.amazonaws.com",
 	},
-	"aws-us-gov": {
+	api.PartitionUSGov: {
 		"EC2":            "ec2.amazonaws.com",
 		"EKS":            "eks.amazonaws.com",
 		"EKSFargatePods": "eks-fargate-pods.amazonaws.com",
 	},
-	"aws-cn": {
+	api.PartitionChina: {
 		"EC2":            "ec2.amazonaws.com.cn",
-		"EKS":            "eks.amazonaws.com",
+		"EKS":            "eks.amazonaws.com.cn",
 		"EKSFargatePods": "eks-fargate-pods.amazonaws.com",
+	},
+	api.PartitionUSIso: {
+		"EC2":            "ec2.c2s.ic.gov",
+		"EKS":            "eks.c2s.ic.gov",
+		"EKSFargatePods": "eks-fargate-pods.c2s.ic.gov",
+	},
+	api.PartitionUSIsob: {
+		"EC2":            "ec2.sc2s.sgov.gov",
+		"EKS":            "eks.sc2s.sgov.gov",
+		"EKSFargatePods": "eks-fargate-pods.sc2s.sgov.gov",
 	},
 }
 

--- a/pkg/ctl/cmdutils/cmd.go
+++ b/pkg/ctl/cmdutils/cmd.go
@@ -67,6 +67,10 @@ func (c *Cmd) NewCtl() (*eks.ClusterProvider, error) {
 		return nil, ErrUnsupportedRegion(&c.ProviderConfig)
 	}
 
+	if err := api.ValidateEKSAccountID(ctl.Provider.Region()); err != nil {
+		return nil, err
+	}
+
 	return ctl, nil
 }
 

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -269,7 +269,7 @@ func (c *ClusterProvider) NewOpenIDConnectManager(spec *api.ClusterConfig) (*iam
 		return nil, errors.Wrapf(err, "unexpected invalid ARN: %q", spec.Status.ARN)
 	}
 	switch parsedARN.Partition {
-	case "aws", "aws-cn", "aws-us-gov":
+	case api.PartitionAWS, api.PartitionChina, api.PartitionUSGov, api.PartitionUSIso, api.PartitionUSIsob:
 	default:
 		return nil, fmt.Errorf("unknown EKS ARN: %q", spec.Status.ARN)
 	}
@@ -325,7 +325,6 @@ func (c *ClusterProvider) loadClusterKubernetesNetworkConfig(spec *api.ClusterCo
 func (c *ClusterProvider) ListClusters(chunkSize int, listAllRegions bool) ([]*api.ClusterConfig, error) {
 	if listAllRegions {
 		var clusters []*api.ClusterConfig
-		// reset region and re-create the client, then make a recursive call
 		authorizedRegions, err := c.Provider.EC2().DescribeRegions(&ec2.DescribeRegionsInput{})
 		if err != nil {
 			return nil, err

--- a/pkg/eks/eks_test.go
+++ b/pkg/eks/eks_test.go
@@ -305,6 +305,23 @@ var _ = Describe("EKS API wrapper", func() {
 				p.MockEC2().AssertNumberOfCalls(GinkgoT(), "DescribeRegions", 1)
 			})
 		})
+
+		When("`listAllRegions` is true", func() {
+			BeforeEach(func() {
+				chunkSize = 100
+				listAllRegions = true
+
+				p.MockEC2().On("DescribeRegions", mock.Anything).Return(&ec2.DescribeRegionsOutput{}, nil)
+			})
+
+			JustBeforeEach(func() {
+				clusters, err = c.ListClusters(chunkSize, listAllRegions)
+			})
+
+			It("should have called AWS EC2 service once", func() {
+				Expect(p.MockEC2().AssertNumberOfCalls(GinkgoT(), "DescribeRegions", 1)).To(BeTrue())
+			})
+		})
 	})
 
 	Describe("ListClusters when no clusters exist", func() {

--- a/pkg/nodebootstrap/legacy/al2.go
+++ b/pkg/nodebootstrap/legacy/al2.go
@@ -93,6 +93,11 @@ func makeAmazonLinux2Config(spec *api.ClusterConfig, ng *api.NodeGroup) ([]confi
 		return nil, err
 	}
 
+	metadata, err := makeMetadata(spec)
+	if err != nil {
+		return nil, err
+	}
+
 	files := []configFile{{
 		dir:     kubeletDropInUnitDir,
 		name:    "10-eksctl.al2.conf",
@@ -100,7 +105,7 @@ func makeAmazonLinux2Config(spec *api.ClusterConfig, ng *api.NodeGroup) ([]confi
 	}, {
 		dir:      configDir,
 		name:     "metadata.env",
-		contents: strings.Join(makeMetadata(spec), "\n"),
+		contents: strings.Join(metadata, "\n"),
 	}, {
 		dir:      configDir,
 		name:     "kubelet.env",

--- a/pkg/nodebootstrap/legacy/ubuntu.go
+++ b/pkg/nodebootstrap/legacy/ubuntu.go
@@ -90,12 +90,18 @@ func makeUbuntuConfig(spec *api.ClusterConfig, ng *api.NodeGroup) ([]configFile,
 	dockerConfigData, err := makeDockerConfigJSON()
 	if err != nil {
 		return nil, err
+
+	}
+
+	metadata, err := makeMetadata(spec)
+	if err != nil {
+		return nil, err
 	}
 
 	files := []configFile{{
 		dir:      configDir,
 		name:     "metadata.env",
-		contents: strings.Join(makeMetadata(spec), "\n"),
+		contents: strings.Join(metadata, "\n"),
 	}, {
 		dir:      configDir,
 		name:     "kubelet.env",

--- a/pkg/nodebootstrap/legacy/userdata.go
+++ b/pkg/nodebootstrap/legacy/userdata.go
@@ -207,13 +207,18 @@ func makeCommonKubeletEnvParams(ng *api.NodeGroup) []string {
 	return variables
 }
 
-func makeMetadata(spec *api.ClusterConfig) []string {
+func makeMetadata(spec *api.ClusterConfig) ([]string, error) {
+	accountID, err := api.EKSResourceAccountID(spec.Metadata.Region)
+	if err != nil {
+		return nil, err
+	}
+
 	return []string{
 		fmt.Sprintf("AWS_DEFAULT_REGION=%s", spec.Metadata.Region),
 		fmt.Sprintf("AWS_EKS_CLUSTER_NAME=%s", spec.Metadata.Name),
 		fmt.Sprintf("AWS_EKS_ENDPOINT=%s", spec.Status.Endpoint),
-		fmt.Sprintf("AWS_EKS_ECR_ACCOUNT=%s", api.EKSResourceAccountID(spec.Metadata.Region)),
-	}
+		fmt.Sprintf("AWS_EKS_ECR_ACCOUNT=%s", accountID),
+	}, nil
 }
 
 func makeMaxPodsMapping() string {


### PR DESCRIPTION
## Description

### TLDR 
- Add isolated regions and partition mappings
- Fetch account id from environment if isolated region is set (`ISO_EKS_ACCOUNT_ID`, name up for debate)
  - Try to fail fast when this is not set

### Detail
This PR adds the ISO regions and partitions, and also includes a change to the way we fetch [Resource/Account/Owner IDs](https://github.com/weaveworks/eksctl/blob/master/pkg/apis/eksctl.io/v1alpha5/types.go#L220-L244). This is because the account numbers for the AMIs which can be used in these secret isolated regions are also secret and cannot be made public.

All the other account IDs (for this particular AMI family) are simply stored in constants where they can be called from anywhere in the code... and they are, from just about everywhere. So adding a once-in-a-while user input flow is a little fiddly. I spiked on/considered several approaches:

1. The ["F the UX" plan](https://github.com/Callisto13/eksctl/commit/8ea941d2efb91c1049ab7244089677ec4138bcd2)
    - This involves checking the env in the same place we would normally just return a constant. It sucks because, if you had forgotten to set the env var, you would not know about it until _after_ your stack had been created.
1. The ["Passing it through everywhere" plan](https://github.com/Callisto13/eksctl/commit/8d312581d7ee78bec2c826296232226a0334a382)
    - This involves checking the region and validating the env var (or not) at the "top" of any command which would end up needing it (there are 5) and passing it down through the various threads. This is technically the "correct" thing to do, but since this account is used _everywhere_ and quite a long way down sometimes, it is super invasive. In one instance it may end up not being used at all, depending on whether a different image family was chosen for the nodegroup.
      - Since you ask, setting the "true" account id (based on both region _and_ AMI family) is not possible since each node group could ask for a different family, therefore there is no "true" id which can be applied everywhere.
1. The ["Java-style getter/setter" plan](https://github.com/Callisto13/eksctl/commit/da452579894e6cffe155635e472d488cb0aca78a)
    - In which the account ID is set once at the very beginning, stored in a private variable which can then be called via a public function when needed. This feels like an odd pattern in Go.
1. The "Sneaky init" plan (no spike)
    - Similar to the above, but done in an `init()` at the start. This would only be possible if I moved the whole flag/config loading into an init too, because I would need the region to decide whether or not to find the env var. I decided moving our already complicated cmd starting points into an init would be a deathtrap as inits are very hard to debug when something goes wrong.
1. **The "Just check twice" plan (this PR)**
    - Similar to plan 1, except we also check for the presence of the env var at the start of the call if an iso region is set.

I chose the approach in this PR (5) based on the fact I hated it the least. I am happy to change things if anyone has a better idea.

## Questions
1. Any thoughts on the name `ISO_EKS_ACCOUNT_ID` for the env var?
1. How do we want to document this? _Do_ we want to document it? Where?
1. Also: have I missed anything for adding the regions?

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested (has to be sent to aws)
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

