### PR TITLE
Do not rebuild eksctl-build when creating releases

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -54,7 +54,8 @@ push-build-image: build-image ## Push the build image to the Docker Hub registry
 	echo "Remember to commit the image_tag and build_image_manifest files"
 
 .PHONY: eksctl-image
-eksctl-image: build-image ## Build the eksctl image that has release artefacts and no build dependencies
+eksctl-image: ## Build the eksctl image that has release artefacts and no build dependencies
+	docker pull $(build_image_name)
 	$(docker_build) \
 	  --cache-from=$(build_image_name) \
 	  --tag=$(eksctl_image_name) \


### PR DESCRIPTION
When creating `eksctl-image` as part of the release process, we should not need to rebuild `eksctl-build`. Simply pulling the latest should be fine and will hopefully speed up the job for us.

