### PR TITLE
Update ALB policy, now AWS load balancer controller policy

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -180,8 +180,8 @@ func setIAMDefaults(iamConfig *NodeGroupIAM) {
 	if iamConfig.WithAddonPolicies.CertManager == nil {
 		iamConfig.WithAddonPolicies.CertManager = Disabled()
 	}
-	if iamConfig.WithAddonPolicies.ALBIngress == nil {
-		iamConfig.WithAddonPolicies.ALBIngress = Disabled()
+	if iamConfig.WithAddonPolicies.AWSLoadBalancerController == nil {
+		iamConfig.WithAddonPolicies.AWSLoadBalancerController = Disabled()
 	}
 	if iamConfig.WithAddonPolicies.XRay == nil {
 		iamConfig.WithAddonPolicies.XRay = Disabled()

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -671,18 +671,18 @@ func NewNodeGroup() *NodeGroup {
 			VolumeSize:        &DefaultNodeVolumeSize,
 			IAM: &NodeGroupIAM{
 				WithAddonPolicies: NodeGroupIAMAddonPolicies{
-					ImageBuilder:   Disabled(),
-					AutoScaler:     Disabled(),
-					ExternalDNS:    Disabled(),
-					CertManager:    Disabled(),
-					AppMesh:        Disabled(),
-					AppMeshPreview: Disabled(),
-					EBS:            Disabled(),
-					FSX:            Disabled(),
-					EFS:            Disabled(),
-					ALBIngress:     Disabled(),
-					XRay:           Disabled(),
-					CloudWatch:     Disabled(),
+					ImageBuilder:              Disabled(),
+					AutoScaler:                Disabled(),
+					ExternalDNS:               Disabled(),
+					CertManager:               Disabled(),
+					AppMesh:                   Disabled(),
+					AppMeshPreview:            Disabled(),
+					EBS:                       Disabled(),
+					FSX:                       Disabled(),
+					EFS:                       Disabled(),
+					AWSLoadBalancerController: Disabled(),
+					XRay:                      Disabled(),
+					CloudWatch:                Disabled(),
 				},
 			},
 			ScalingConfig: &ScalingConfig{},
@@ -720,18 +720,18 @@ func NewManagedNodeGroup() *ManagedNodeGroup {
 			},
 			IAM: &NodeGroupIAM{
 				WithAddonPolicies: NodeGroupIAMAddonPolicies{
-					ImageBuilder:   Disabled(),
-					AutoScaler:     Disabled(),
-					ExternalDNS:    Disabled(),
-					CertManager:    Disabled(),
-					AppMesh:        Disabled(),
-					AppMeshPreview: Disabled(),
-					EBS:            Disabled(),
-					FSX:            Disabled(),
-					EFS:            Disabled(),
-					ALBIngress:     Disabled(),
-					XRay:           Disabled(),
-					CloudWatch:     Disabled(),
+					ImageBuilder:              Disabled(),
+					AutoScaler:                Disabled(),
+					ExternalDNS:               Disabled(),
+					CertManager:               Disabled(),
+					AppMesh:                   Disabled(),
+					AppMeshPreview:            Disabled(),
+					EBS:                       Disabled(),
+					FSX:                       Disabled(),
+					EFS:                       Disabled(),
+					AWSLoadBalancerController: Disabled(),
+					XRay:                      Disabled(),
+					CloudWatch:                Disabled(),
 				},
 			},
 			ScalingConfig:  &ScalingConfig{},
@@ -976,7 +976,7 @@ type (
 		// +optional
 		EFS *bool `json:"efs"`
 		// +optional
-		ALBIngress *bool `json:"albIngress"`
+		AWSLoadBalancerController *bool `json:"albIngress"`
 		// +optional
 		XRay *bool `json:"xRay"`
 		// +optional

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -392,7 +392,7 @@ func validateNodeGroupIAMWithAddonPolicies(
 	if IsEnabled(policies.EFS) {
 		return fmtFieldConflictErr(prefix + "efs")
 	}
-	if IsEnabled(policies.ALBIngress) {
+	if IsEnabled(policies.AWSLoadBalancerController) {
 		return fmtFieldConflictErr(prefix + "albIngress")
 	}
 	if IsEnabled(policies.XRay) {

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -71,7 +71,7 @@ var _ = Describe("ClusterConfig validation", func() {
 				"arn:aws:iam::aws:policy/Bar",
 			}
 			ng0.IAM.WithAddonPolicies.ExternalDNS = Enabled()
-			ng0.IAM.WithAddonPolicies.ALBIngress = Enabled()
+			ng0.IAM.WithAddonPolicies.AWSLoadBalancerController = Enabled()
 			ng0.IAM.WithAddonPolicies.ImageBuilder = Enabled()
 
 			ng1 = cfg.NewNodeGroup()

--- a/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
@@ -1094,8 +1094,8 @@ func (in *NodeGroupIAMAddonPolicies) DeepCopyInto(out *NodeGroupIAMAddonPolicies
 		*out = new(bool)
 		**out = **in
 	}
-	if in.ALBIngress != nil {
-		in, out := &in.ALBIngress, &out.ALBIngress
+	if in.AWSLoadBalancerController != nil {
+		in, out := &in.AWSLoadBalancerController, &out.AWSLoadBalancerController
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -62,9 +62,10 @@ type Properties struct {
 
 	PolicyDocument struct {
 		Statement []struct {
-			Action   []string
-			Effect   string
-			Resource interface{}
+			Action    []string
+			Effect    string
+			Resource  interface{}
+			Condition map[string]interface{}
 		}
 	}
 
@@ -1308,87 +1309,118 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Expect(policy.Roles).To(HaveLen(1))
 			isRefTo(policy.Roles[0], "NodeInstanceRole")
 
-			Expect(policy.PolicyDocument.Statement).To(HaveLen(1))
+			Expect(policy.PolicyDocument.Statement).To(HaveLen(7))
+
 			Expect(policy.PolicyDocument.Statement[0].Effect).To(Equal("Allow"))
-			Expect(policy.PolicyDocument.Statement[0].Resource).To(Equal("*"))
-			Expect(policy.PolicyDocument.Statement[0].Action).To(Equal([]string{
-				"acm:DescribeCertificate",
-				"acm:ListCertificates",
-				"acm:GetCertificate",
-				"ec2:AuthorizeSecurityGroupIngress",
-				"ec2:CreateSecurityGroup",
-				"ec2:CreateTags",
-				"ec2:DeleteTags",
-				"ec2:DeleteSecurityGroup",
-				"ec2:DescribeAccountAttributes",
-				"ec2:DescribeAddresses",
-				"ec2:DescribeInstances",
-				"ec2:DescribeInstanceStatus",
-				"ec2:DescribeInternetGateways",
-				"ec2:DescribeNetworkInterfaces",
-				"ec2:DescribeSecurityGroups",
-				"ec2:DescribeSubnets",
-				"ec2:DescribeTags",
-				"ec2:DescribeVpcs",
-				"ec2:ModifyInstanceAttribute",
-				"ec2:ModifyNetworkInterfaceAttribute",
-				"ec2:RevokeSecurityGroupIngress",
-				"elasticloadbalancing:AddListenerCertificates",
-				"elasticloadbalancing:AddTags",
-				"elasticloadbalancing:CreateListener",
+			Expect(policy.PolicyDocument.Statement[0].Resource).To(Equal("arn:aws:ec2:*:*:security-group/*"))
+			Expect(policy.PolicyDocument.Statement[0].Action).To(Equal([]string{"ec2:CreateTags"}))
+			Expect(policy.PolicyDocument.Statement[0].Condition).To(HaveLen(2))
+
+			Expect(policy.PolicyDocument.Statement[1].Effect).To(Equal("Allow"))
+			Expect(policy.PolicyDocument.Statement[1].Resource).To(Equal("arn:aws:ec2:*:*:security-group/*"))
+			Expect(policy.PolicyDocument.Statement[1].Action).To(Equal([]string{"ec2:CreateTags", "ec2:DeleteTags"}))
+			Expect(policy.PolicyDocument.Statement[1].Condition).To(HaveLen(1))
+
+			Expect(policy.PolicyDocument.Statement[2].Effect).To(Equal("Allow"))
+			Expect(policy.PolicyDocument.Statement[2].Resource).To(Equal("*"))
+			Expect(policy.PolicyDocument.Statement[2].Action).To(Equal([]string{
 				"elasticloadbalancing:CreateLoadBalancer",
-				"elasticloadbalancing:CreateRule",
 				"elasticloadbalancing:CreateTargetGroup",
-				"elasticloadbalancing:DeleteListener",
-				"elasticloadbalancing:DeleteLoadBalancer",
-				"elasticloadbalancing:DeleteRule",
-				"elasticloadbalancing:DeleteTargetGroup",
-				"elasticloadbalancing:DeregisterTargets",
-				"elasticloadbalancing:DescribeListenerCertificates",
-				"elasticloadbalancing:DescribeListeners",
-				"elasticloadbalancing:DescribeLoadBalancers",
-				"elasticloadbalancing:DescribeLoadBalancerAttributes",
-				"elasticloadbalancing:DescribeRules",
-				"elasticloadbalancing:DescribeSSLPolicies",
-				"elasticloadbalancing:DescribeTags",
-				"elasticloadbalancing:DescribeTargetGroups",
-				"elasticloadbalancing:DescribeTargetGroupAttributes",
-				"elasticloadbalancing:DescribeTargetHealth",
-				"elasticloadbalancing:ModifyListener",
-				"elasticloadbalancing:ModifyLoadBalancerAttributes",
-				"elasticloadbalancing:ModifyRule",
-				"elasticloadbalancing:ModifyTargetGroup",
-				"elasticloadbalancing:ModifyTargetGroupAttributes",
-				"elasticloadbalancing:RegisterTargets",
-				"elasticloadbalancing:RemoveListenerCertificates",
+			}))
+			Expect(policy.PolicyDocument.Statement[2].Condition).To(HaveLen(1))
+
+			Expect(policy.PolicyDocument.Statement[3].Effect).To(Equal("Allow"))
+			Expect(policy.PolicyDocument.Statement[3].Resource).To(Equal([]interface{}{
+				"arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+				"arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+				"arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*",
+			}))
+			Expect(policy.PolicyDocument.Statement[3].Action).To(Equal([]string{
+				"elasticloadbalancing:AddTags",
 				"elasticloadbalancing:RemoveTags",
+			}))
+			Expect(policy.PolicyDocument.Statement[3].Condition).To(HaveLen(1))
+
+			Expect(policy.PolicyDocument.Statement[4].Effect).To(Equal("Allow"))
+			Expect(policy.PolicyDocument.Statement[4].Resource).To(Equal("*"))
+			Expect(policy.PolicyDocument.Statement[4].Action).To(Equal([]string{
+				"ec2:AuthorizeSecurityGroupIngress",
+				"ec2:RevokeSecurityGroupIngress",
+				"ec2:DeleteSecurityGroup",
+				"elasticloadbalancing:ModifyLoadBalancerAttributes",
 				"elasticloadbalancing:SetIpAddressType",
 				"elasticloadbalancing:SetSecurityGroups",
 				"elasticloadbalancing:SetSubnets",
-				"elasticloadbalancing:SetWebACL",
+				"elasticloadbalancing:DeleteLoadBalancer",
+				"elasticloadbalancing:ModifyTargetGroup",
+				"elasticloadbalancing:ModifyTargetGroupAttributes",
+				"elasticloadbalancing:DeleteTargetGroup",
+			}))
+			Expect(policy.PolicyDocument.Statement[4].Condition).To(HaveLen(1))
+
+			Expect(policy.PolicyDocument.Statement[5].Effect).To(Equal("Allow"))
+			Expect(policy.PolicyDocument.Statement[5].Resource).To(Equal("arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"))
+			Expect(policy.PolicyDocument.Statement[5].Action).To(Equal([]string{
+				"elasticloadbalancing:RegisterTargets",
+				"elasticloadbalancing:DeregisterTargets",
+			}))
+			Expect(policy.PolicyDocument.Statement[5].Condition).To(HaveLen(0))
+
+			Expect(policy.PolicyDocument.Statement[6].Effect).To(Equal("Allow"))
+			Expect(policy.PolicyDocument.Statement[6].Resource).To(Equal("*"))
+			Expect(policy.PolicyDocument.Statement[6].Action).To(Equal([]string{
 				"iam:CreateServiceLinkedRole",
-				"iam:GetServerCertificate",
+				"ec2:DescribeAccountAttributes",
+				"ec2:DescribeAddresses",
+				"ec2:DescribeInternetGateways",
+				"ec2:DescribeVpcs",
+				"ec2:DescribeSubnets",
+				"ec2:DescribeSecurityGroups",
+				"ec2:DescribeInstances",
+				"ec2:DescribeNetworkInterfaces",
+				"ec2:DescribeTags",
+				"elasticloadbalancing:DescribeLoadBalancers",
+				"elasticloadbalancing:DescribeLoadBalancerAttributes",
+				"elasticloadbalancing:DescribeListeners",
+				"elasticloadbalancing:DescribeListenerCertificates",
+				"elasticloadbalancing:DescribeSSLPolicies",
+				"elasticloadbalancing:DescribeRules",
+				"elasticloadbalancing:DescribeTargetGroups",
+				"elasticloadbalancing:DescribeTargetGroupAttributes",
+				"elasticloadbalancing:DescribeTargetHealth",
+				"elasticloadbalancing:DescribeTags",
+				"cognito-idp:DescribeUserPoolClient",
+				"acm:ListCertificates",
+				"acm:DescribeCertificate",
 				"iam:ListServerCertificates",
-				"waf-regional:GetWebACLForResource",
+				"iam:GetServerCertificate",
 				"waf-regional:GetWebACL",
+				"waf-regional:GetWebACLForResource",
 				"waf-regional:AssociateWebACL",
 				"waf-regional:DisassociateWebACL",
-				"tag:GetResources",
-				"tag:TagResources",
-				"waf:GetWebACL",
 				"wafv2:GetWebACL",
 				"wafv2:GetWebACLForResource",
 				"wafv2:AssociateWebACL",
 				"wafv2:DisassociateWebACL",
-				"shield:DescribeProtection",
 				"shield:GetSubscriptionState",
-				"shield:DeleteProtection",
+				"shield:DescribeProtection",
 				"shield:CreateProtection",
-				"shield:DescribeSubscription",
-				"shield:ListProtections",
+				"shield:DeleteProtection",
+				"ec2:AuthorizeSecurityGroupIngress",
+				"ec2:RevokeSecurityGroupIngress",
+				"ec2:CreateSecurityGroup",
+				"elasticloadbalancing:CreateListener",
+				"elasticloadbalancing:DeleteListener",
+				"elasticloadbalancing:CreateRule",
+				"elasticloadbalancing:DeleteRule",
+				"elasticloadbalancing:SetWebAcl",
+				"elasticloadbalancing:ModifyListener",
+				"elasticloadbalancing:AddListenerCertificates",
+				"elasticloadbalancing:RemoveListenerCertificates",
+				"elasticloadbalancing:ModifyRule",
 			}))
+			Expect(policy.PolicyDocument.Statement[6].Condition).To(HaveLen(0))
 		})
-
 	})
 
 	Context("NodeGroupXRay", func() {

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -498,18 +498,18 @@ var _ = Describe("CloudFormation template builder API", func() {
 						VolumeSize:        aws.Int(2),
 						IAM: &api.NodeGroupIAM{
 							WithAddonPolicies: api.NodeGroupIAMAddonPolicies{
-								ImageBuilder:   api.Disabled(),
-								AutoScaler:     api.Disabled(),
-								ExternalDNS:    api.Disabled(),
-								CertManager:    api.Disabled(),
-								AppMesh:        api.Disabled(),
-								AppMeshPreview: api.Disabled(),
-								EBS:            api.Disabled(),
-								FSX:            api.Disabled(),
-								EFS:            api.Disabled(),
-								ALBIngress:     api.Disabled(),
-								XRay:           api.Disabled(),
-								CloudWatch:     api.Disabled(),
+								ImageBuilder:              api.Disabled(),
+								AutoScaler:                api.Disabled(),
+								ExternalDNS:               api.Disabled(),
+								CertManager:               api.Disabled(),
+								AppMesh:                   api.Disabled(),
+								AppMeshPreview:            api.Disabled(),
+								EBS:                       api.Disabled(),
+								FSX:                       api.Disabled(),
+								EFS:                       api.Disabled(),
+								AWSLoadBalancerController: api.Disabled(),
+								XRay:                      api.Disabled(),
+								CloudWatch:                api.Disabled(),
 							},
 						},
 						ScalingConfig: &api.ScalingConfig{},
@@ -1078,7 +1078,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Expect(ngTemplate.Resources).ToNot(HaveKey("PolicyServiceLinkRole"))
 			Expect(ngTemplate.Resources).ToNot(HaveKey("PolicyEFS"))
 			Expect(ngTemplate.Resources).ToNot(HaveKey("PolicyEFSEC2"))
-			Expect(ngTemplate.Resources).ToNot(HaveKey("PolicyALBIngress"))
+			Expect(ngTemplate.Resources).ToNot(HaveKey("PolicyAWSLoadBalancerController"))
 			Expect(ngTemplate.Resources).ToNot(HaveKey("PolicyXRay"))
 		})
 
@@ -1285,15 +1285,15 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Expect(ngTemplate.Resources).ToNot(HaveKey("PolicyServiceLinkRole"))
 			Expect(ngTemplate.Resources).ToNot(HaveKey("PolicyEFS"))
 			Expect(ngTemplate.Resources).ToNot(HaveKey("PolicyEFSEC2"))
-			Expect(ngTemplate.Resources).ToNot(HaveKey("PolicyALBIngress"))
+			Expect(ngTemplate.Resources).ToNot(HaveKey("PolicyAWSLoadBalancerController"))
 			Expect(ngTemplate.Resources).ToNot(HaveKey("PolicyXRay"))
 		})
 	})
 
-	Context("NodeGroupALBIngress", func() {
+	Context("NodeGroupAWSLoadBalancerController", func() {
 		cfg, ng := newClusterConfigAndNodegroup(true)
 
-		ng.IAM.WithAddonPolicies.ALBIngress = api.Enabled()
+		ng.IAM.WithAddonPolicies.AWSLoadBalancerController = api.Enabled()
 
 		build(cfg, "eksctl-test-megaapps-cluster", ng)
 
@@ -1302,9 +1302,9 @@ var _ = Describe("CloudFormation template builder API", func() {
 		It("should have correct policies", func() {
 			Expect(ngTemplate.Resources).ToNot(BeEmpty())
 
-			Expect(ngTemplate.Resources).To(HaveKey("PolicyALBIngress"))
+			Expect(ngTemplate.Resources).To(HaveKey("PolicyAWSLoadBalancerController"))
 
-			policy := ngTemplate.Resources["PolicyALBIngress"].Properties
+			policy := ngTemplate.Resources["PolicyAWSLoadBalancerController"].Properties
 
 			Expect(policy.Roles).To(HaveLen(1))
 			isRefTo(policy.Roles[0], "NodeInstanceRole")

--- a/pkg/cfn/builder/iam_helper.go
+++ b/pkg/cfn/builder/iam_helper.go
@@ -79,8 +79,8 @@ func createRole(cfnTemplate cfnTemplate, clusterIAMConfig *api.ClusterIAM, iamCo
 		cfnTemplate.attachAllowPolicy("PolicyEFSEC2", refIR, efsEc2Statements())
 	}
 
-	if api.IsEnabled(iamConfig.WithAddonPolicies.ALBIngress) {
-		cfnTemplate.attachAllowPolicy("PolicyALBIngress", refIR, loadBalancerControllerStatements())
+	if api.IsEnabled(iamConfig.WithAddonPolicies.AWSLoadBalancerController) {
+		cfnTemplate.attachAllowPolicy("PolicyAWSLoadBalancerController", refIR, loadBalancerControllerStatements())
 	}
 
 	if api.IsEnabled(iamConfig.WithAddonPolicies.XRay) {

--- a/pkg/cfn/builder/statement.go
+++ b/pkg/cfn/builder/statement.go
@@ -1,0 +1,382 @@
+package builder
+
+import (
+	cft "github.com/weaveworks/eksctl/pkg/cfn/template"
+)
+
+const (
+	effectAllow = "Allow"
+	resourceAll = "*"
+)
+
+func loadBalancerControllerStatements() []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": "arn:aws:ec2:*:*:security-group/*",
+			"Action":   []string{"ec2:CreateTags"},
+			"Condition": map[string]interface{}{
+				"StringEquals": map[string]string{
+					"ec2:CreateAction": "CreateSecurityGroup",
+				},
+				"Null": map[string]string{
+					"aws:RequestTag/elbv2.k8s.aws/cluster": "false",
+				},
+			},
+		},
+		{
+			"Effect":   effectAllow,
+			"Resource": "arn:aws:ec2:*:*:security-group/*",
+			"Action": []string{
+				"ec2:CreateTags",
+				"ec2:DeleteTags",
+			},
+			"Condition": map[string]interface{}{
+				"Null": map[string]string{
+					"aws:RequestTag/elbv2.k8s.aws/cluster":  "true",
+					"aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
+				},
+			},
+		},
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"elasticloadbalancing:CreateLoadBalancer",
+				"elasticloadbalancing:CreateTargetGroup",
+			},
+			"Condition": map[string]interface{}{
+				"Null": map[string]string{
+					"aws:RequestTag/elbv2.k8s.aws/cluster": "false",
+				},
+			},
+		},
+		{
+			"Effect": effectAllow,
+			"Resource": []string{
+				"arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+				"arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+				"arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*",
+			},
+			"Action": []string{
+				"elasticloadbalancing:AddTags",
+				"elasticloadbalancing:RemoveTags",
+			},
+			"Condition": map[string]interface{}{
+				"Null": map[string]string{
+					"aws:RequestTag/elbv2.k8s.aws/cluster":  "true",
+					"aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
+				},
+			},
+		},
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"ec2:AuthorizeSecurityGroupIngress",
+				"ec2:RevokeSecurityGroupIngress",
+				"ec2:DeleteSecurityGroup",
+				"elasticloadbalancing:ModifyLoadBalancerAttributes",
+				"elasticloadbalancing:SetIpAddressType",
+				"elasticloadbalancing:SetSecurityGroups",
+				"elasticloadbalancing:SetSubnets",
+				"elasticloadbalancing:DeleteLoadBalancer",
+				"elasticloadbalancing:ModifyTargetGroup",
+				"elasticloadbalancing:ModifyTargetGroupAttributes",
+				"elasticloadbalancing:DeleteTargetGroup",
+			},
+			"Condition": map[string]interface{}{
+				"Null": map[string]string{
+					"aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
+				},
+			},
+		},
+		{
+			"Effect":   effectAllow,
+			"Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+			"Action": []string{
+				"elasticloadbalancing:RegisterTargets",
+				"elasticloadbalancing:DeregisterTargets",
+			},
+		},
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"iam:CreateServiceLinkedRole",
+				"ec2:DescribeAccountAttributes",
+				"ec2:DescribeAddresses",
+				"ec2:DescribeInternetGateways",
+				"ec2:DescribeVpcs",
+				"ec2:DescribeSubnets",
+				"ec2:DescribeSecurityGroups",
+				"ec2:DescribeInstances",
+				"ec2:DescribeNetworkInterfaces",
+				"ec2:DescribeTags",
+				"elasticloadbalancing:DescribeLoadBalancers",
+				"elasticloadbalancing:DescribeLoadBalancerAttributes",
+				"elasticloadbalancing:DescribeListeners",
+				"elasticloadbalancing:DescribeListenerCertificates",
+				"elasticloadbalancing:DescribeSSLPolicies",
+				"elasticloadbalancing:DescribeRules",
+				"elasticloadbalancing:DescribeTargetGroups",
+				"elasticloadbalancing:DescribeTargetGroupAttributes",
+				"elasticloadbalancing:DescribeTargetHealth",
+				"elasticloadbalancing:DescribeTags",
+				"cognito-idp:DescribeUserPoolClient",
+				"acm:ListCertificates",
+				"acm:DescribeCertificate",
+				"iam:ListServerCertificates",
+				"iam:GetServerCertificate",
+				"waf-regional:GetWebACL",
+				"waf-regional:GetWebACLForResource",
+				"waf-regional:AssociateWebACL",
+				"waf-regional:DisassociateWebACL",
+				"wafv2:GetWebACL",
+				"wafv2:GetWebACLForResource",
+				"wafv2:AssociateWebACL",
+				"wafv2:DisassociateWebACL",
+				"shield:GetSubscriptionState",
+				"shield:DescribeProtection",
+				"shield:CreateProtection",
+				"shield:DeleteProtection",
+				"ec2:AuthorizeSecurityGroupIngress",
+				"ec2:RevokeSecurityGroupIngress",
+				"ec2:CreateSecurityGroup",
+				"elasticloadbalancing:CreateListener",
+				"elasticloadbalancing:DeleteListener",
+				"elasticloadbalancing:CreateRule",
+				"elasticloadbalancing:DeleteRule",
+				"elasticloadbalancing:SetWebAcl",
+				"elasticloadbalancing:ModifyListener",
+				"elasticloadbalancing:AddListenerCertificates",
+				"elasticloadbalancing:RemoveListenerCertificates",
+				"elasticloadbalancing:ModifyRule",
+			},
+		},
+	}
+}
+
+func elbStatements() []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"ec2:DescribeAccountAttributes",
+				"ec2:DescribeAddresses",
+				"ec2:DescribeInternetGateways",
+			},
+		},
+	}
+}
+
+func cloudWatchMetricsStatements() []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"cloudwatch:PutMetricData",
+			},
+		},
+	}
+}
+
+func certManagerHostedZonesStatements(appendActions ...string) []cft.MapOfInterfaces {
+	actions := []string{
+		"route53:ListResourceRecordSets",
+		"route53:ListHostedZonesByName",
+	}
+	actions = append(actions, appendActions...)
+
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action":   actions,
+		},
+	}
+}
+
+func certManagerGetChangeStatements() []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": addARNPartitionPrefix("route53:::change/*"),
+			"Action": []string{
+				"route53:GetChange",
+			},
+		},
+	}
+}
+
+func changeSetStatements() []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": addARNPartitionPrefix("route53:::hostedzone/*"),
+			"Action": []string{
+				"route53:ChangeResourceRecordSets",
+			},
+		},
+	}
+}
+
+func externalDNSHostedZonesStatements() []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"route53:ListHostedZones",
+				"route53:ListResourceRecordSets",
+				"route53:ListTagsForResource",
+			},
+		},
+	}
+}
+
+func autoScalerStatements() []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"autoscaling:DescribeAutoScalingGroups",
+				"autoscaling:DescribeAutoScalingInstances",
+				"autoscaling:DescribeLaunchConfigurations",
+				"autoscaling:DescribeTags",
+				"autoscaling:SetDesiredCapacity",
+				"autoscaling:TerminateInstanceInAutoScalingGroup",
+				"ec2:DescribeLaunchTemplateVersions",
+			},
+		},
+	}
+}
+
+func appMeshStatements(appendAction string) []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"servicediscovery:CreateService",
+				"servicediscovery:DeleteService",
+				"servicediscovery:GetService",
+				"servicediscovery:GetInstance",
+				"servicediscovery:RegisterInstance",
+				"servicediscovery:DeregisterInstance",
+				"servicediscovery:ListInstances",
+				"servicediscovery:ListNamespaces",
+				"servicediscovery:ListServices",
+				"servicediscovery:GetInstancesHealthStatus",
+				"servicediscovery:UpdateInstanceCustomHealthStatus",
+				"servicediscovery:GetOperation",
+				"route53:GetHealthCheck",
+				"route53:CreateHealthCheck",
+				"route53:UpdateHealthCheck",
+				"route53:ChangeResourceRecordSets",
+				"route53:DeleteHealthCheck",
+				appendAction,
+			},
+		},
+	}
+}
+
+func ebsStatements() []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"ec2:AttachVolume",
+				"ec2:CreateSnapshot",
+				"ec2:CreateTags",
+				"ec2:CreateVolume",
+				"ec2:DeleteSnapshot",
+				"ec2:DeleteTags",
+				"ec2:DeleteVolume",
+				"ec2:DescribeAvailabilityZones",
+				"ec2:DescribeInstances",
+				"ec2:DescribeSnapshots",
+				"ec2:DescribeTags",
+				"ec2:DescribeVolumes",
+				"ec2:DescribeVolumesModifications",
+				"ec2:DetachVolume",
+				"ec2:ModifyVolume",
+			},
+		},
+	}
+}
+
+func serviceLinkRoleStatements() []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": addARNPartitionPrefix("iam::*:role/aws-service-role/*"),
+			"Action": []string{
+				"iam:CreateServiceLinkedRole",
+				"iam:AttachRolePolicy",
+				"iam:PutRolePolicy",
+			},
+		},
+	}
+}
+
+func fsxStatements() []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"fsx:*",
+			},
+		},
+	}
+}
+
+func xRayStatements() []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"xray:PutTraceSegments",
+				"xray:PutTelemetryRecords",
+				"xray:GetSamplingRules",
+				"xray:GetSamplingTargets",
+				"xray:GetSamplingStatisticSummaries",
+			},
+		},
+	}
+}
+
+func efsStatements() []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"elasticfilesystem:*",
+			},
+		},
+	}
+}
+
+func efsEc2Statements() []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"ec2:DescribeSubnets",
+				"ec2:CreateNetworkInterface",
+				"ec2:DescribeNetworkInterfaces",
+				"ec2:DeleteNetworkInterface",
+				"ec2:ModifyNetworkInterfaceAttribute",
+				"ec2:DescribeNetworkInterfaceAttribute",
+			},
+		},
+	}
+}

--- a/pkg/cfn/template/iam_helpers.go
+++ b/pkg/cfn/template/iam_helpers.go
@@ -2,15 +2,6 @@ package template
 
 import gfn "github.com/weaveworks/goformation/v4/cloudformation/types"
 
-// AttachAllowPolicy constructs a role with allow policy for given resources and actions
-func (t *Template) AttachAllowPolicy(name string, refRole *Value, resources interface{}, actions []string) {
-	t.AttachPolicy(name, refRole, MakePolicyDocument(MapOfInterfaces{
-		"Effect":   "Allow",
-		"Resource": resources,
-		"Action":   actions,
-	}))
-}
-
 // AttachPolicy attaches the specified policy document
 func (t *Template) AttachPolicy(name string, refRole *Value, policyDoc MapOfInterfaces) {
 	t.NewResource(name, &IAMPolicy{

--- a/pkg/ctl/cmdutils/nodegroup_flags.go
+++ b/pkg/ctl/cmdutils/nodegroup_flags.go
@@ -75,7 +75,7 @@ func AddCommonCreateNodeGroupIAMAddonsFlags(fs *pflag.FlagSet, ng *api.NodeGroup
 	ng.IAM.WithAddonPolicies.ImageBuilder = new(bool)
 	ng.IAM.WithAddonPolicies.AppMesh = new(bool)
 	ng.IAM.WithAddonPolicies.AppMeshPreview = new(bool)
-	ng.IAM.WithAddonPolicies.ALBIngress = new(bool)
+	ng.IAM.WithAddonPolicies.AWSLoadBalancerController = new(bool)
 	ng.IAM.WithAddonPolicies.XRay = new(bool)
 	ng.IAM.WithAddonPolicies.CloudWatch = new(bool)
 	fs.BoolVar(ng.IAM.WithAddonPolicies.AutoScaler, "asg-access", false, "enable IAM policy for cluster-autoscaler")
@@ -83,7 +83,7 @@ func AddCommonCreateNodeGroupIAMAddonsFlags(fs *pflag.FlagSet, ng *api.NodeGroup
 	fs.BoolVar(ng.IAM.WithAddonPolicies.ImageBuilder, "full-ecr-access", false, "enable full access to ECR")
 	fs.BoolVar(ng.IAM.WithAddonPolicies.AppMesh, "appmesh-access", false, "enable full access to AppMesh")
 	fs.BoolVar(ng.IAM.WithAddonPolicies.AppMeshPreview, "appmesh-preview-access", false, "enable full access to AppMesh Preview")
-	fs.BoolVar(ng.IAM.WithAddonPolicies.ALBIngress, "alb-ingress-access", false, "enable full access for alb-ingress-controller")
+	fs.BoolVar(ng.IAM.WithAddonPolicies.AWSLoadBalancerController, "alb-ingress-access", false, "enable full access for alb-ingress-controller")
 }
 
 // AddNodeGroupFilterFlags add common `--include` and `--exclude` flags for filtering nodegroups

--- a/userdocs/src/community.md
+++ b/userdocs/src/community.md
@@ -15,7 +15,7 @@ One or more release candidate(s) (RC) builds will be made available prior to eac
 
 ### Cluster Quick Start with gitops
 
-It should be easy to create a cluster with various applications pre-installed, e.g. Weave Flux, Helm 2 (Tiller), ALB Ingress controller. It should also be easy to manage these applications in a declarative way using config files in a git repo (with [gitops](https://www.weave.works/blog/what-is-gitops-really)).
+It should be easy to create a cluster with various applications pre-installed, e.g. Weave Flux, Helm 2 (Tiller), AWS Load Balancer Controller. It should also be easy to manage these applications in a declarative way using config files in a git repo (with [gitops](https://www.weave.works/blog/what-is-gitops-really)).
 
 ### Declarative configuration management for clusters
 

--- a/userdocs/src/gitops-quickstart.md
+++ b/userdocs/src/gitops-quickstart.md
@@ -255,7 +255,7 @@ Welcome to your fully gitopsed cluster. By choosing the `app-dev` Quick
 Start profile, you will now also have the following components running
 in your cluster:
 
-- ALB ingress controller -- to easily expose services to the World.
+- [AWS load balancer controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller) -- to easily expose services to the World.
 - [Cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) -- to [automatically add/remove nodes](https://aws.amazon.com/premiumsupport/knowledge-center/eks-cluster-autoscaler-setup/) to/from your cluster based on its usage.
 - [Prometheus](https://prometheus.io/) (its [Alertmanager](https://prometheus.io/docs/alerting/alertmanager/), its [operator](https://github.com/coreos/prometheus-operator), its [`node-exporter`](https://github.com/prometheus/node_exporter), [`kube-state-metrics`](https://github.com/kubernetes/kube-state-metrics), and [`metrics-server`](https://github.com/kubernetes-incubator/metrics-server)) -- for powerful metrics & alerts.
 - [Grafana](https://grafana.com) -- for a rich way to visualize metrics via dashboards you can create, explore, and share.

--- a/userdocs/src/usage/faq.md
+++ b/userdocs/src/usage/faq.md
@@ -28,9 +28,10 @@
 ## Ingress
 
 !!! question "How do I set up ingress with `eksctl`?"
-    If the plan is to use AWS ALB Ingress controller, setting `nodegroups[*].iam.withAddonPolicies.albIngress` to `true` will add the required IAM policies to your nodes allowing the controller to provision load balancers. Then you can follow [docs to set up the controller](https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html).
+    We recommend using the [AWS Load Balancer Controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller).
+    Documentation on how to deploy the controller to your cluster, as well as how to migrate from the old ALB Ingress Controller, can be found [here](https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html).
 
-    For Nginx Ingress Controller, setup would be the same as [any other Kubernetes cluster](https://kubernetes.github.io/ingress-nginx/deploy/#aws).
+    For the Nginx Ingress Controller, setup would be the same as [any on other Kubernetes cluster](https://kubernetes.github.io/ingress-nginx/deploy/#aws).
 
 ## Kubectl
 

--- a/userdocs/src/usage/iamserviceaccounts.md
+++ b/userdocs/src/usage/iamserviceaccounts.md
@@ -5,7 +5,7 @@
 Amazon EKS supports [IAM Roles for Service Accounts (IRSA)][eks-user-guide] that allows cluster operators to map AWS IAM Roles to Kubernetes Service Accounts.
 
 This provides fine-grained permission management for apps that run on EKS and use other AWS services. These could be apps that use S3,
-any other data services (RDS, MQ, STS, DynamoDB), or Kubernetes components like AWS ALB Ingress controller or ExternalDNS.
+any other data services (RDS, MQ, STS, DynamoDB), or Kubernetes components like AWS Load Balancer controller or ExternalDNS.
 
 You can easily create IAM Role and Service Account pairs with `eksctl`.
 


### PR DESCRIPTION
### Description

- Update the alb policy to be the new (more elaborate) load balancer policy. (I didn't rename the configuration option from `albIngress` in case it messed things up for some users, but everything beneath that has changed, so can do whatever if folks thinks it is fine to switch now.)
- I didn't so much refactor as simplify and tidy up the policy area of `pkg/cfn/builder/iam_helper.go`. Just so it is easier to read and so that all the policy statements are in one clear place and format.

Part of https://github.com/weaveworks/eksctl/issues/2770

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

