### PR TITLE
Only use aws-node service account on cluster creation

### DIFF
--- a/pkg/actions/addon/create.go
+++ b/pkg/actions/addon/create.go
@@ -169,7 +169,7 @@ func (a *Manager) getRecommendedPolicies(addon *api.Addon) []string {
 	// API isn't case sensitive
 	switch strings.ToLower(addon.Name) {
 	case vpcCNIName:
-		return []string{fmt.Sprintf("arn:%s:iam::aws:policy/%s", api.Partition(a.clusterConfig.Metadata.Region), api.IamPolicyAmazonEKSCNIPolicy)}
+		return []string{fmt.Sprintf("arn:%s:iam::aws:policy/%s", api.Partition(a.clusterConfig.Metadata.Region), api.IAMPolicyAmazonEKSCNIPolicy)}
 	default:
 		return []string{}
 	}

--- a/pkg/ctl/get/iamserviceaccount.go
+++ b/pkg/ctl/get/iamserviceaccount.go
@@ -36,8 +36,8 @@ func getIAMServiceAccountCmd(cmd *cmdutils.Cmd) {
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cfg.Metadata.Name, "cluster", "", "EKS cluster name")
 
-		fs.StringVar(&serviceAccount.Name, "name", "", "name of the iamserviceaccount to delete")
-		fs.StringVar(&serviceAccount.Namespace, "namespace", "default", "namespace where to delete the iamserviceaccount")
+		fs.StringVar(&serviceAccount.Name, "name", "", "name of iamserviceaccount to get")
+		fs.StringVar(&serviceAccount.Namespace, "namespace", "default", "namespace to look for iamserviceaccount")
 
 		cmdutils.AddRegionFlag(fs, &cmd.ProviderConfig)
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
@@ -86,7 +86,7 @@ func doGetIAMServiceAccount(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAMSer
 		// reset defaulted fields to avoid output being a complete lie
 		cfg.VPC = nil
 		cfg.CloudWatch = nil
-		// only return the iamserciceaccount that user asked for
+		// only return the iamserviceaccount that user asked for
 		var notFoundErr error
 		if serviceAccount.Name != "" { // name was given
 			notFoundErr = fmt.Errorf("iamserviceaccount %q not found", serviceAccount.NameString())

--- a/pkg/eks/nodegroup.go
+++ b/pkg/eks/nodegroup.go
@@ -317,7 +317,7 @@ func DoesAWSNodeUseIRSA(provider api.ClusterProvider, clientSet kubernetes.Inter
 	}
 	logger.Debug("found following policies attached to role annotated on aws-node service account: %s", policies.AttachedPolicies)
 	for _, p := range policies.AttachedPolicies {
-		if *p.PolicyName == api.IamPolicyAmazonEKSCNIPolicy {
+		if *p.PolicyName == api.IAMPolicyAmazonEKSCNIPolicy {
 			return true, nil
 		}
 	}

--- a/pkg/eks/tasks.go
+++ b/pkg/eks/tasks.go
@@ -306,7 +306,11 @@ func (c *ClusterProvider) appendCreateTasksForIAMServiceAccounts(cfg *api.Cluste
 	// as this is non-CloudFormation context, we need to construct a new stackManager,
 	// given a clientSet getter and OpenIDConnectManager reference we can build out
 	// the list of tasks for each of the service accounts that need to be created
-	newTasks := c.NewStackManager(cfg).NewTasksToCreateIAMServiceAccounts(cfg.IAM.ServiceAccounts, oidcPlaceholder, clientSet)
+	newTasks := c.NewStackManager(cfg).NewTasksToCreateIAMServiceAccounts(
+		api.IAMServiceAccountsWithAWSNodeServiceAccount(cfg),
+		oidcPlaceholder,
+		clientSet,
+	)
 	newTasks.IsSubTask = true
 	tasks.Append(newTasks)
 	tasks.Append(&restartDaemonsetTask{


### PR DESCRIPTION
### Description

Fixes #2916 

This makes it so that the `aws-node` `ServiceAccount` is only auto added to the list of accounts at cluster creation. `delete iamserviceaccount` now doesn't delete the `aws-node` account unless explicitly listed and `create iamserviceaccount` doesn't try to create the `aws-node` account if it's not listed.
<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

