### PR TITLE
treat remote VPC as source of truth

### DIFF
--- a/pkg/vpc/vpc.go
+++ b/pkg/vpc/vpc.go
@@ -152,9 +152,7 @@ func describeVPC(provider api.ClusterProvider, vpcID string) (*ec2.Vpc, error) {
 // NOTE: it doesn't expect any fields in spec.VPC to be set, the remote state
 // is treated as the source of truth
 func UseFromCluster(provider api.ClusterProvider, stack *cfn.Stack, spec *api.ClusterConfig) error {
-	if spec.VPC == nil {
-		spec.VPC = api.NewClusterVPC()
-	}
+	spec.VPC = api.NewClusterVPC()
 	// this call is authoritative, and we can safely override the
 	// CIDR, as it can only be set to anything due to defaulting
 	spec.VPC.CIDR = nil


### PR DESCRIPTION
### Description
According to [here](https://github.com/weaveworks/eksctl/blob/ffb02a42dde001ff37da68f67cdaec268ce9d0f9/pkg/vpc/vpc.go#L150-L154) we treat the remote VPC as the source of truth, but we don't always override the provided VPC configuration. This PR changes it so that we do. Fixes https://github.com/weaveworks/eksctl/issues/2923

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

