### PR TITLE
Revert "treat remote VPC as source of truth"

### DIFF
--- a/pkg/vpc/vpc.go
+++ b/pkg/vpc/vpc.go
@@ -152,7 +152,9 @@ func describeVPC(provider api.ClusterProvider, vpcID string) (*ec2.Vpc, error) {
 // NOTE: it doesn't expect any fields in spec.VPC to be set, the remote state
 // is treated as the source of truth
 func UseFromCluster(provider api.ClusterProvider, stack *cfn.Stack, spec *api.ClusterConfig) error {
-	spec.VPC = api.NewClusterVPC()
+	if spec.VPC == nil {
+		spec.VPC = api.NewClusterVPC()
+	}
 	// this call is authoritative, and we can safely override the
 	// CIDR, as it can only be set to anything due to defaulting
 	spec.VPC.CIDR = nil


### PR DESCRIPTION
Reverts weaveworks/eksctl#2928