### PR TITLE
Delete UpdateAddonsTask

### DIFF
--- a/pkg/addons/default/addons.go
+++ b/pkg/addons/default/addons.go
@@ -1,33 +1,8 @@
 package defaultaddons
 
 import (
-	"github.com/pkg/errors"
-
 	"github.com/weaveworks/eksctl/pkg/kubernetes"
 )
-
-// EnsureAllAddonsUpToDate checks the default addons (aws-node, kube-proxy and coredns) are up to date
-// and if they are not it will update them to the latest version for the given control plane version
-// TODO Delete this function when the multi architecture images are used by default when a new cluster is created. When
-// that happens eksctl won't need to update them before creating ARM nodegroups anymore.
-func EnsureAddonsUpToDate(clientSet kubernetes.Interface, rawClient kubernetes.RawClientInterface, controlPlaneVersion string, region string) error {
-	_, err := UpdateKubeProxyImageTag(clientSet, controlPlaneVersion, false)
-	if err != nil {
-		return errors.Wrapf(err, "error updating kube-proxy")
-	}
-
-	_, err = UpdateAWSNode(rawClient, region, false)
-	if err != nil {
-		return errors.Wrapf(err, "error updating aws-node")
-	}
-
-	_, err = UpdateCoreDNS(rawClient, region, controlPlaneVersion, false)
-	if err != nil {
-		return errors.Wrapf(err, "error updating coredns")
-	}
-
-	return nil
-}
 
 func DoAddonsSupportMultiArch(clientSet kubernetes.Interface, rawClient kubernetes.RawClientInterface, controlPlaneVersion string, region string) (bool, error) {
 	kubeProxyUpToDate, err := IsKubeProxyUpToDate(clientSet, controlPlaneVersion)

--- a/userdocs/src/usage/arm-support.md
+++ b/userdocs/src/usage/arm-support.md
@@ -41,7 +41,6 @@ metadata:
   name: cluster-arm-2
   region: us-west-2
 
-
 managedNodeGroups:
   - name: mng-arm-1
     instanceType: m6g.medium
@@ -52,14 +51,10 @@ managedNodeGroups:
 eksctl create cluster -f cluster-arm-2.yaml
 ```
 
-
 The AMI resolvers, `auto` and `auto-ssm`, will see that you want to use an ARM instance type and they will select the correct AMI.
 
 !!!note
     Note that currently there are only AmazonLinux2 EKS optimized AMIs for ARM.
-
-Additionally, the default add-ons will use multi-architecture docker images. This is why, when a cluster is created, and before a nodegroup
-is created, eksctl will make sure it upgrades the add-ons.
 
 !!!note
     ARM is supported for clusters with version 1.15 and higher.


### PR DESCRIPTION
### Description

All "addons" (yes, I will use quotation marks until we stop using that name for nearly everything as a default for when we cant think of anything better. /rant) are now created with multi-architecture images by default in all versions. This means that we no longer need to ensure that the "addons" are up-to-date before creating ARM nodes.

Closes https://github.com/weaveworks/eksctl/issues/2538

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

