### PR TITLE
add sub condition to vpc-cni addon policy

### DIFF
--- a/pkg/actions/addon/create.go
+++ b/pkg/actions/addon/create.go
@@ -3,7 +3,6 @@ package addon
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -83,7 +82,7 @@ func (a *Manager) Create(addon *api.Addon) error {
 		}
 	}
 
-	if strings.ToLower(addon.Name) == vpcCNIName {
+	if addon.NameLowerCase() == vpcCNIName {
 		logger.Debug("patching AWS node")
 		err := a.patchAWSNodeSA()
 		if err != nil {
@@ -169,7 +168,7 @@ func (a *Manager) patchAWSNodeDaemonSet() error {
 }
 func (a *Manager) getRecommendedPolicies(addon *api.Addon) []string {
 	// API isn't case sensitive
-	switch strings.ToLower(addon.Name) {
+	switch addon.NameLowerCase() {
 	case vpcCNIName:
 		return []string{fmt.Sprintf("arn:%s:iam::aws:policy/%s", api.Partition(a.clusterConfig.Metadata.Region), api.IAMPolicyAmazonEKSCNIPolicy)}
 	default:
@@ -179,7 +178,7 @@ func (a *Manager) getRecommendedPolicies(addon *api.Addon) []string {
 
 func (a *Manager) getKnownServiceAccountLocation(addon *api.Addon) (string, string) {
 	// API isn't case sensitive
-	switch strings.ToLower(addon.Name) {
+	switch addon.NameLowerCase() {
 	case vpcCNIName:
 		logger.Debug("found known service account location %s/%s", api.AWSNodeMeta.Namespace, api.AWSNodeMeta.Name)
 		return api.AWSNodeMeta.Namespace, api.AWSNodeMeta.Name

--- a/pkg/actions/addon/create.go
+++ b/pkg/actions/addon/create.go
@@ -82,7 +82,7 @@ func (a *Manager) Create(addon *api.Addon) error {
 		}
 	}
 
-	if addon.NameLowerCase() == vpcCNIName {
+	if addon.CanonicalName() == vpcCNIName {
 		logger.Debug("patching AWS node")
 		err := a.patchAWSNodeSA()
 		if err != nil {
@@ -168,7 +168,7 @@ func (a *Manager) patchAWSNodeDaemonSet() error {
 }
 func (a *Manager) getRecommendedPolicies(addon *api.Addon) []string {
 	// API isn't case sensitive
-	switch addon.NameLowerCase() {
+	switch addon.CanonicalName() {
 	case vpcCNIName:
 		return []string{fmt.Sprintf("arn:%s:iam::aws:policy/%s", api.Partition(a.clusterConfig.Metadata.Region), api.IAMPolicyAmazonEKSCNIPolicy)}
 	default:
@@ -178,7 +178,7 @@ func (a *Manager) getRecommendedPolicies(addon *api.Addon) []string {
 
 func (a *Manager) getKnownServiceAccountLocation(addon *api.Addon) (string, string) {
 	// API isn't case sensitive
-	switch addon.NameLowerCase() {
+	switch addon.CanonicalName() {
 	case vpcCNIName:
 		logger.Debug("found known service account location %s/%s", api.AWSNodeMeta.Namespace, api.AWSNodeMeta.Name)
 		return api.AWSNodeMeta.Namespace, api.AWSNodeMeta.Name

--- a/pkg/actions/addon/create_test.go
+++ b/pkg/actions/addon/create_test.go
@@ -190,6 +190,7 @@ var _ = Describe("Create", func() {
 				output, err := resourceSet.RenderJSON()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(output)).To(ContainSubstring("arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"))
+				Expect(string(output)).To(ContainSubstring(":sub\":\"system:serviceaccount:kube-system:aws-node"))
 				Expect(*createAddonInput.ClusterName).To(Equal("my-cluster"))
 				Expect(*createAddonInput.AddonName).To(Equal("vpc-cni"))
 				Expect(*createAddonInput.AddonVersion).To(Equal("1.0"))

--- a/pkg/actions/addon/update.go
+++ b/pkg/actions/addon/update.go
@@ -82,11 +82,13 @@ func (a *Manager) updateWithNewPolicies(addon *api.Addon) (string, error) {
 		return "", err
 	}
 
+	serviceAccount, namespace := a.getKnownServiceAccountLocation(addon)
+
 	if len(existingStacks) == 0 {
-		return a.createNewRole(addon)
+		return a.createNewRole(addon, serviceAccount, namespace)
 	}
 
-	createNewTemplate, err := a.createNewTemplate(addon)
+	createNewTemplate, err := a.createNewTemplate(addon, serviceAccount, namespace)
 	if err != nil {
 		return "", err
 	}
@@ -104,16 +106,17 @@ func (a *Manager) updateWithNewPolicies(addon *api.Addon) (string, error) {
 	return *existingStacks[0].Outputs[0].OutputValue, nil
 }
 
-func (a *Manager) createNewTemplate(addon *api.Addon) ([]byte, error) {
+func (a *Manager) createNewTemplate(addon *api.Addon, namespace, serviceAccount string) ([]byte, error) {
+
 	var resourceSet *builder.IAMRoleResourceSet
 	if addon.AttachPolicyARNs != nil && len(addon.AttachPolicyARNs) != 0 {
-		resourceSet = builder.NewIAMRoleResourceSetWithAttachPolicyARNs(addon.Name, addon.AttachPolicyARNs, a.oidcManager)
+		resourceSet = builder.NewIAMRoleResourceSetWithAttachPolicyARNs(addon.Name, serviceAccount, namespace, addon.AttachPolicyARNs, a.oidcManager)
 		err := resourceSet.AddAllResources()
 		if err != nil {
 			return []byte(""), err
 		}
 	} else {
-		resourceSet = builder.NewIAMRoleResourceSetWithAttachPolicy(addon.Name, addon.AttachPolicy, a.oidcManager)
+		resourceSet = builder.NewIAMRoleResourceSetWithAttachPolicy(addon.Name, serviceAccount, namespace, addon.AttachPolicy, a.oidcManager)
 		err := resourceSet.AddAllResources()
 		if err != nil {
 			return []byte(""), err
@@ -123,12 +126,12 @@ func (a *Manager) createNewTemplate(addon *api.Addon) ([]byte, error) {
 	return resourceSet.RenderJSON()
 }
 
-func (a *Manager) createNewRole(addon *api.Addon) (string, error) {
+func (a *Manager) createNewRole(addon *api.Addon, namespace, serviceAccount string) (string, error) {
 	if addon.AttachPolicyARNs != nil && len(addon.AttachPolicyARNs) != 0 {
 		logger.Info("creating role using provided policies ARNs")
-		return a.createRoleUsingAttachPolicyARNs(addon)
+		return a.createRoleUsingAttachPolicyARNs(addon, serviceAccount, namespace)
 	}
 
 	logger.Info("creating role using provided policies")
-	return a.createRoleUsingAttachPolicy(addon)
+	return a.createRoleUsingAttachPolicy(addon, serviceAccount, namespace)
 }

--- a/pkg/actions/addon/update.go
+++ b/pkg/actions/addon/update.go
@@ -82,13 +82,13 @@ func (a *Manager) updateWithNewPolicies(addon *api.Addon) (string, error) {
 		return "", err
 	}
 
-	serviceAccount, namespace := a.getKnownServiceAccountLocation(addon)
+	namespace, serviceAccount := a.getKnownServiceAccountLocation(addon)
 
 	if len(existingStacks) == 0 {
-		return a.createNewRole(addon, serviceAccount, namespace)
+		return a.createNewRole(addon, namespace, serviceAccount)
 	}
 
-	createNewTemplate, err := a.createNewTemplate(addon, serviceAccount, namespace)
+	createNewTemplate, err := a.createNewTemplate(addon, namespace, serviceAccount)
 	if err != nil {
 		return "", err
 	}
@@ -110,13 +110,13 @@ func (a *Manager) createNewTemplate(addon *api.Addon, namespace, serviceAccount 
 
 	var resourceSet *builder.IAMRoleResourceSet
 	if addon.AttachPolicyARNs != nil && len(addon.AttachPolicyARNs) != 0 {
-		resourceSet = builder.NewIAMRoleResourceSetWithAttachPolicyARNs(addon.Name, serviceAccount, namespace, addon.AttachPolicyARNs, a.oidcManager)
+		resourceSet = builder.NewIAMRoleResourceSetWithAttachPolicyARNs(addon.Name, namespace, serviceAccount, addon.AttachPolicyARNs, a.oidcManager)
 		err := resourceSet.AddAllResources()
 		if err != nil {
 			return []byte(""), err
 		}
 	} else {
-		resourceSet = builder.NewIAMRoleResourceSetWithAttachPolicy(addon.Name, serviceAccount, namespace, addon.AttachPolicy, a.oidcManager)
+		resourceSet = builder.NewIAMRoleResourceSetWithAttachPolicy(addon.Name, namespace, serviceAccount, addon.AttachPolicy, a.oidcManager)
 		err := resourceSet.AddAllResources()
 		if err != nil {
 			return []byte(""), err
@@ -129,9 +129,9 @@ func (a *Manager) createNewTemplate(addon *api.Addon, namespace, serviceAccount 
 func (a *Manager) createNewRole(addon *api.Addon, namespace, serviceAccount string) (string, error) {
 	if addon.AttachPolicyARNs != nil && len(addon.AttachPolicyARNs) != 0 {
 		logger.Info("creating role using provided policies ARNs")
-		return a.createRoleUsingAttachPolicyARNs(addon, serviceAccount, namespace)
+		return a.createRoleUsingAttachPolicyARNs(addon, namespace, serviceAccount)
 	}
 
 	logger.Info("creating role using provided policies")
-	return a.createRoleUsingAttachPolicy(addon, serviceAccount, namespace)
+	return a.createRoleUsingAttachPolicy(addon, namespace, serviceAccount)
 }

--- a/pkg/actions/addon/update_test.go
+++ b/pkg/actions/addon/update_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Update", func() {
 					}).Return(&awseks.UpdateAddonOutput{}, nil)
 
 					err := addonManager.Update(&api.Addon{
-						Name:             "my-addon",
+						Name:             "vpc-cni",
 						Version:          "1.1",
 						AttachPolicyARNs: []string{"arn-1"},
 					})
@@ -151,16 +151,18 @@ var _ = Describe("Update", func() {
 
 					Expect(fakeStackManager.UpdateStackCallCount()).To(Equal(1))
 					stackName, changeSetName, description, templateData, _ := fakeStackManager.UpdateStackArgsForCall(0)
-					Expect(stackName).To(Equal("eksctl-my-cluster-addon-my-addon"))
+					Expect(stackName).To(Equal("eksctl-my-cluster-addon-vpc-cni"))
 					Expect(changeSetName).To(Equal("updating-policy"))
 					Expect(description).To(Equal("updating policies"))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(templateData.(manager.TemplateBody))).To(ContainSubstring("arn-1"))
+					Expect(string(templateData.(manager.TemplateBody))).To(ContainSubstring(":sub\":\"system:serviceaccount:kube-system:aws-node"))
 
 					Expect(*updateAddonInput.ClusterName).To(Equal("my-cluster"))
-					Expect(*updateAddonInput.AddonName).To(Equal("my-addon"))
+					Expect(*updateAddonInput.AddonName).To(Equal("vpc-cni"))
 					Expect(*updateAddonInput.AddonVersion).To(Equal("1.1"))
 					Expect(*updateAddonInput.ServiceAccountRoleArn).To(Equal("new-service-account-role-arn"))
+
 				})
 			})
 

--- a/pkg/apis/eksctl.io/v1alpha5/addon.go
+++ b/pkg/apis/eksctl.io/v1alpha5/addon.go
@@ -23,7 +23,7 @@ type Addon struct {
 	Force bool
 }
 
-func (a Addon) NameLowerCase() string {
+func (a Addon) CanonicalName() string {
 	return strings.ToLower(a.Name)
 }
 

--- a/pkg/apis/eksctl.io/v1alpha5/addon.go
+++ b/pkg/apis/eksctl.io/v1alpha5/addon.go
@@ -2,6 +2,7 @@ package v1alpha5
 
 import (
 	"fmt"
+	"strings"
 )
 
 // Addon holds the EKS addon configuration
@@ -20,6 +21,10 @@ type Addon struct {
 	AttachPolicy InlineDocument `json:"attachPolicy,omitempty"`
 	// Force applies the add-on to overwrite an existing add-on
 	Force bool
+}
+
+func (a Addon) NameLowerCase() string {
+	return strings.ToLower(a.Name)
 }
 
 func (a Addon) Validate() error {

--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -14,7 +14,7 @@ const (
 )
 
 var (
-	awsNodeMeta = ClusterIAMMeta{
+	AWSNodeMeta = ClusterIAMMeta{
 		Name:      "aws-node",
 		Namespace: "kube-system",
 	}
@@ -59,11 +59,11 @@ func IAMServiceAccountsWithAWSNodeServiceAccount(cfg *ClusterConfig) []*ClusterI
 	if IsEnabled(cfg.IAM.WithOIDC) && !vpccniAddonSpecified(cfg) {
 		var found bool
 		for _, sa := range cfg.IAM.ServiceAccounts {
-			found = found || (sa.Name == awsNodeMeta.Name && sa.Namespace == awsNodeMeta.Namespace)
+			found = found || (sa.Name == AWSNodeMeta.Name && sa.Namespace == AWSNodeMeta.Namespace)
 		}
 		if !found {
 			awsNode := ClusterIAMServiceAccount{
-				ClusterIAMMeta: awsNodeMeta,
+				ClusterIAMMeta: AWSNodeMeta,
 				AttachPolicyARNs: []string{
 					fmt.Sprintf("arn:%s:iam::aws:policy/%s", Partition(cfg.Metadata.Region), IAMPolicyAmazonEKSCNIPolicy),
 				},

--- a/pkg/cfn/builder/iam_test.go
+++ b/pkg/cfn/builder/iam_test.go
@@ -263,7 +263,7 @@ var _ = Describe("template builder for IAM", func() {
 		It("can construct an iamrole template with attachPolicyARNs", func() {
 			arns := []string{"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"}
 
-			rs := NewIAMRoleResourceSetWithAttachPolicyARNs("VPC-addon", arns, oidc)
+			rs := NewIAMRoleResourceSetWithAttachPolicyARNs("VPC-addon", "", "", arns, oidc)
 
 			templateBody := []byte{}
 
@@ -299,7 +299,7 @@ var _ = Describe("template builder for IAM", func() {
 				},
 			)
 
-			rs := NewIAMRoleResourceSetWithAttachPolicy("VPC-addon", attachPolicy, oidc)
+			rs := NewIAMRoleResourceSetWithAttachPolicy("VPC-addon", "", "", attachPolicy, oidc)
 
 			templateBody := []byte{}
 


### PR DESCRIPTION
### Description

Policy will now look like:
```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "Federated": "arn:aws:iam::<redacted>:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/<redacted>"
      },
      "Action": "sts:AssumeRoleWithWebIdentity",
      "Condition": {
        "StringEquals": {
          "oidc.eks.us-west-2.amazonaws.com/id/<redacted>:aud": "sts.amazonaws.com",
          "oidc.eks.us-west-2.amazonaws.com/id/<redacted>:sub": "system:serviceaccount:kube-system:aws-node"
        }
      }
    }
  ]
}
```

before it did not have `"oidc.eks.us-west-2.amazonaws.com/id/<redacted>:sub": "system:serviceaccount:kube-system:aws-node"`

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [X] Make sure the title of the PR is a good description that can go into the release notes

