### PR TITLE
Add oneOf support to schema generation

### DIFF
--- a/pkg/schema/definition/definition.go
+++ b/pkg/schema/definition/definition.go
@@ -70,7 +70,10 @@ func (dg *Generator) newStructDefinition(name string, typeSpec ast.Expr, structC
 				required = []string{fieldName}
 			}
 
-			def.AdditionalProperties = false
+			// Setting additional properties prevents oneOf from working
+			if len(def.OneOf) == 0 {
+				def.AdditionalProperties = false
+			}
 		}
 
 		def.PreferredOrder = append(def.PreferredOrder, preferredOrder...)

--- a/pkg/schema/definition/types.go
+++ b/pkg/schema/definition/types.go
@@ -10,7 +10,7 @@ type Definition struct {
 	AdditionalProperties interface{}            `json:"additionalProperties,omitempty"`
 	Type                 string                 `json:"type,omitempty"`
 	ContentEncoding      string                 `json:"contentEncoding,omitempty"`
-	AnyOf                []*Definition          `json:"anyOf,omitempty"`
+	OneOf                []*Definition          `json:"oneOf,omitempty"`
 	Description          string                 `json:"description,omitempty"`
 	HTMLDescription      string                 `json:"x-intellij-html-description,omitempty"`
 	Default              interface{}            `json:"default,omitempty"`

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -22,7 +22,9 @@ var _ = Describe("GenerateSchema", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 	It("handles the top level definition", func() {
-		props := []string{"num", "option", "pointeroption", "packageoption", "aliasedint", "unknown", "other", "version", "kind", "kinds"}
+		props := []string{
+			"num", "option", "pointeroption", "packageoption", "aliasedint", "unknown", "other", "version", "kind", "kinds", "sumType",
+		}
 		required := []string{"option"}
 		expected := Fields{
 			"Required":             Equal(required),
@@ -166,5 +168,28 @@ var _ = Describe("GenerateSchema", func() {
 			Expect(configDef().Properties).To(HaveKey("packageoption"))
 			Expect(*configDef().Properties["packageoption"]).To(BeEquivalentTo(refDef))
 		})
+	})
+	It("handles oneOf", func() {
+		refDef := definition.Definition{
+			Ref: "#/definitions/SumType",
+		}
+		Expect(configDef().Properties).To(HaveKey("sumType"))
+		Expect(*configDef().Properties["sumType"]).To(BeEquivalentTo(refDef))
+		expected := definition.Definition{
+			Properties: map[string]*definition.Definition{
+				"type": {
+					Type:            "string",
+					Enum:            []string{"a", "b"},
+					Description:     "Valid variants are: `\"a\"`: type A `\"b\"`: type B",
+					HTMLDescription: "Valid variants are: <code>&quot;a&quot;</code>: type A <code>&quot;b&quot;</code>: type B",
+				},
+			},
+			PreferredOrder: []string{"type"},
+			OneOf: []*definition.Definition{
+				{Ref: "#/definitions/SumTypeA"},
+				{Ref: "#/definitions/SumTypeB"},
+			},
+		}
+		Expect(*schema.Definitions["SumType"]).To(BeEquivalentTo(expected))
 	})
 })

--- a/pkg/schema/test/test.go
+++ b/pkg/schema/test/test.go
@@ -24,7 +24,24 @@ type Config struct {
 	// Valid variants are `Kind` constants
 	Kind string `json:"kind"`
 	// Valid entries are `Kind` constants
-	Kinds []string `json:"kinds"`
+	Kinds   []string `json:"kinds"`
+	SumType SumType  `json:"sumType"`
+}
+
+type SumTypeA struct {
+	A string `json:"a"`
+}
+
+type SumTypeB struct {
+	B string `json:"b"`
+}
+
+// Schema type is one of `SumTypeA`, `SumTypeB`
+type SumType struct {
+	// Valid variants are:
+	// `"a"`: type A
+	// `"b"`: type B
+	Type string `json:"type"`
 }
 
 // Values for `Kind`


### PR DESCRIPTION
### Description
In preparation for having a type which is `oneOf` a list of types (i.e. a sum type) 
<!-- Please explain the changes you made here. -->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

