### PR TITLE
Set cgroupdriver to systemd on GPU nodes

### DIFF
--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -26,11 +26,11 @@ const (
 )
 
 type configFile struct {
-	content string
-	isAsset bool
+	dir      string
+	name     string
+	contents string
+	isAsset  bool
 }
-
-type configFiles = map[string]map[string]configFile
 
 func getAsset(name string) (string, error) {
 	data, err := Asset(name)
@@ -40,24 +40,25 @@ func getAsset(name string) (string, error) {
 	return string(data), nil
 }
 
-func addFilesAndScripts(config *cloudconfig.CloudConfig, files configFiles, scripts []string) error {
-	for dir, fileNames := range files {
-		for fileName, file := range fileNames {
-			f := cloudconfig.File{
-				Path: dir + fileName,
-			}
-			if file.isAsset {
-				data, err := getAsset(fileName)
-				if err != nil {
-					return err
-				}
-				f.Content = data
-			} else {
-				f.Content = file.content
-			}
-			config.AddFile(f)
+func addFilesAndScripts(config *cloudconfig.CloudConfig, files []configFile, scripts []string) error {
+	for _, file := range files {
+		f := cloudconfig.File{
+			Path: file.dir + file.name,
 		}
+
+		if file.isAsset {
+			data, err := getAsset(file.name)
+			if err != nil {
+				return err
+			}
+			f.Content = data
+		} else {
+			f.Content = file.contents
+		}
+
+		config.AddFile(f)
 	}
+
 	for _, scriptName := range scripts {
 		data, err := getAsset(scriptName)
 		if err != nil {

--- a/pkg/nodebootstrap/userdata_al2.go
+++ b/pkg/nodebootstrap/userdata_al2.go
@@ -83,6 +83,14 @@ func NewUserDataForAmazonLinux2(spec *api.ClusterConfig, ng *api.NodeGroup) (str
 		scripts = append(scripts, "install-ssm.al2.sh")
 	}
 
+	// This is the worst but I am very tired
+	// When using GPU instance types, the daemon.json is removed and a service
+	// override file used instead. We can alter the daemon command by adding
+	// to the OPTIONS var in /etc/sysconfig/docker
+	if utils.IsGPUInstanceType(ng.InstanceType) {
+		config.AddShellCommand("sed -i 's/^OPTIONS=\"/&--exec-opt native.cgroupdriver=systemd /' /etc/sysconfig/docker")
+	}
+
 	for _, command := range ng.PreBootstrapCommands {
 		config.AddShellCommand(command)
 	}

--- a/pkg/nodebootstrap/userdata_ubuntu.go
+++ b/pkg/nodebootstrap/userdata_ubuntu.go
@@ -13,7 +13,7 @@ import (
 
 const ubuntu2004ResolveConfPath = "/run/systemd/resolve/resolv.conf"
 
-func makeUbuntuConfig(spec *api.ClusterConfig, ng *api.NodeGroup) (configFiles, error) {
+func makeUbuntuConfig(spec *api.ClusterConfig, ng *api.NodeGroup) ([]configFile, error) {
 	clientConfigData, err := makeClientConfigData(spec, kubeconfig.HeptioAuthenticatorAWS)
 	if err != nil {
 		return nil, err
@@ -47,20 +47,35 @@ func makeUbuntuConfig(spec *api.ClusterConfig, ng *api.NodeGroup) (configFiles, 
 		return nil, err
 	}
 
-	files := configFiles{
-		configDir: {
-			"metadata.env": {content: strings.Join(makeMetadata(spec), "\n")},
-			"kubelet.env":  {content: strings.Join(kubeletEnvParams, "\n")},
-			"kubelet.yaml": {content: string(kubeletConfigData)},
-			// TODO: https://github.com/weaveworks/eksctl/issues/161
-			"ca.crt":          {content: string(spec.Status.CertificateAuthorityData)},
-			"kubeconfig.yaml": {content: string(clientConfigData)},
-			"max_pods.map":    {content: makeMaxPodsMapping()},
-		},
-		dockerConfigDir: {
-			"daemon.json": {content: string(dockerConfigData)},
-		},
-	}
+	files := []configFile{{
+		dir:      configDir,
+		name:     "metadata.env",
+		contents: strings.Join(makeMetadata(spec), "\n"),
+	}, {
+		dir:      configDir,
+		name:     "kubelet.env",
+		contents: strings.Join(kubeletEnvParams, "\n"),
+	}, {
+		dir:      configDir,
+		name:     "kubelet.yaml",
+		contents: string(kubeletConfigData),
+	}, {
+		dir:      configDir,
+		name:     "ca.crt",
+		contents: string(spec.Status.CertificateAuthorityData),
+	}, {
+		dir:      configDir,
+		name:     "kubeconfig.yaml",
+		contents: string(clientConfigData),
+	}, {
+		dir:      configDir,
+		name:     "max_pods.map",
+		contents: makeMaxPodsMapping(),
+	}, {
+		dir:      dockerConfigDir,
+		name:     "daemon.json",
+		contents: string(dockerConfigData),
+	}}
 
 	return files, nil
 }


### PR DESCRIPTION
### Description

Fixes https://github.com/weaveworks/eksctl/issues/3005. Maybe.

https://github.com/weaveworks/eksctl/pull/2962 set the cgroupdriver of both the docker daemon and the kubelet to systemd. Unfortunately, the GPU AMIs remove the `/etc/docker/daemon.json` file* and set things via flags. This meant that `0.35.0` broke things for people who want to create new node groups with GPU instances: the kubelet was set to use `systemd`, while the docker daemon (that file removed) defaulted to `cgroupfs`.

\* _which is a COMPLETE pain in the ass and I am VERY mad about it._

**There are 2 workarounds** (in the form of `preBootstrapCommands`) for users. This PR is a quick hack to get things working again, while we hopefully figure out something better OR wait for AWS to default to `systemd` in those accelerated AMIs (the standard ones are about to do this).


**Alternatives** to simply sedding the flag into that `OPTIONS` string:
- Provide our own `/etc/sysconfig/docker` file
- Provide our own `/etc/systemd/system/docker.service.d/override.conf`
- Write to that file a bit nicer than using `sed` 🤷‍♀️ 

The first 2 run the risk of getting out of step with the originals. The 3rd may be more trouble than it is worth.

I have asked AWS to ensure those accelerated AMIs set the cgroup driver to `systemd` by default, so we could just leave the hack in while we wait. Don't know how long that will be tho... (The standard AMIs are about to do `systemd` by default, but a different builder is used for GPU ones.)

**I am open to any and all suggestions.**

More information can be found here https://github.com/weaveworks/eksctl/issues/3005#issuecomment-752955957

I am gonna add an integration test as part of regression testing.

(I also simplified some other stuff around writing config files, but can take or leave that.)

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [x] Make sure the title of the PR is a good description that can go into the release notes

