### PR TITLE
Show progress of update

### DIFF
--- a/pkg/utils/waiters/waiters.go
+++ b/pkg/utils/waiters/waiters.go
@@ -43,7 +43,7 @@ func makeWaiter(ctx context.Context, name, msg string, acceptors []request.Waite
 		Delay:       makeWaiterDelay(),
 		Acceptors:   acceptors,
 		NewRequest: func(_ []request.Option) (*request.Request, error) {
-			logger.Debug(msg)
+			logger.Info(msg)
 			req := newRequest()
 			req.SetContext(ctx)
 			return req, nil


### PR DESCRIPTION
### Description

Show the status of the update every 20s (too frequent?)
- Lets the user see the status
- They know the cli hasn't hung

New output:
```
eksctl upgrade cluster --name jk-2 --approve
[ℹ]  eksctl version 0.36.0-dev+ce6cd153.2021-01-04T12:22:49Z
[ℹ]  using region us-west-2
[ℹ]  will upgrade cluster "jk-2" control plane from current version "1.17" to "1.18"
[ℹ]  waiting for cluster "jk-2" to be updated, current status: "InProgress"
[ℹ]  waiting for cluster "jk-2" to be updated, current status: "InProgress"
[ℹ]  waiting for cluster "jk-2" to be updated, current status: "InProgress"
[ℹ]  waiting for cluster "jk-2" to be updated, current status: "InProgress"
[ℹ]  waiting for cluster "jk-2" to be updated, current status: "InProgress"
[ℹ]  waiting for cluster "jk-2" to be updated, current status: "InProgress"
[ℹ]  waiting for cluster "jk-2" to be updated, current status: "InProgress"
[ℹ]  waiting for cluster "jk-2" to be updated, current status: "InProgress"
[ℹ]  waiting for cluster "jk-2" to be updated, current status: "InProgress"
[ℹ]  waiting for cluster "jk-2" to be updated, current status: "InProgress"
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

