### PR TITLE
improve get nodegroups error message

### DIFF
--- a/pkg/ctl/get/nodegroup.go
+++ b/pkg/ctl/get/nodegroup.go
@@ -88,6 +88,10 @@ func doGetNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *getCmdParams) 
 
 	// Empty summary implies no nodegroups
 	if len(summaries) == 0 {
+		if ng.Name == "" {
+			return errors.Errorf("No Nodegroups found")
+
+		}
 		return errors.Errorf("Nodegroup with name %v not found", ng.Name)
 	}
 

--- a/pkg/ctl/get/nodegroup.go
+++ b/pkg/ctl/get/nodegroup.go
@@ -89,7 +89,7 @@ func doGetNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *getCmdParams) 
 	// Empty summary implies no nodegroups
 	if len(summaries) == 0 {
 		if ng.Name == "" {
-			return errors.Errorf("No Nodegroups found")
+			return errors.Errorf("No nodegroups found")
 
 		}
 		return errors.Errorf("Nodegroup with name %v not found", ng.Name)

--- a/pkg/ctl/get/nodegroup.go
+++ b/pkg/ctl/get/nodegroup.go
@@ -90,7 +90,6 @@ func doGetNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *getCmdParams) 
 	if len(summaries) == 0 {
 		if ng.Name == "" {
 			return errors.Errorf("No nodegroups found")
-
 		}
 		return errors.Errorf("Nodegroup with name %v not found", ng.Name)
 	}


### PR DESCRIPTION
### Description

If you attempted to get the nodegroups for a cluster that has none you would get:
```
./eksctl get nodegroups --cluster jk-console
Error: Nodegroup with name  not found
```

Now instead:
```
./eksctl get nodegroups --cluster jk-console
Error: No Nodegroups found
```
### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

