### PR TITLE
Upgrade cluster prints output when an updates not needed

### DIFF
--- a/pkg/actions/cluster/unowned.go
+++ b/pkg/actions/cluster/unowned.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/eks"
 )
 
@@ -19,5 +20,7 @@ func NewUnownedCluster(cfg *api.ClusterConfig, ctl *eks.ClusterProvider) (*Unown
 
 func (c *UnownedCluster) Upgrade(dryRun bool) error {
 	_, err := upgrade(c.cfg, c.ctl, dryRun)
+
+	cmdutils.LogPlanModeWarning(dryRun)
 	return err
 }

--- a/pkg/actions/cluster/unowned.go
+++ b/pkg/actions/cluster/unowned.go
@@ -19,8 +19,9 @@ func NewUnownedCluster(cfg *api.ClusterConfig, ctl *eks.ClusterProvider) (*Unown
 }
 
 func (c *UnownedCluster) Upgrade(dryRun bool) error {
-	_, err := upgrade(c.cfg, c.ctl, dryRun)
+	versionUpdateRequired, err := upgrade(c.cfg, c.ctl, dryRun)
 
-	cmdutils.LogPlanModeWarning(dryRun)
+	// if no version update is required, don't log asking them to rerun with --approve
+	cmdutils.LogPlanModeWarning(dryRun && versionUpdateRequired)
 	return err
 }

--- a/pkg/actions/cluster/unowned.go
+++ b/pkg/actions/cluster/unowned.go
@@ -20,8 +20,11 @@ func NewUnownedCluster(cfg *api.ClusterConfig, ctl *eks.ClusterProvider) (*Unown
 
 func (c *UnownedCluster) Upgrade(dryRun bool) error {
 	versionUpdateRequired, err := upgrade(c.cfg, c.ctl, dryRun)
+	if err != nil {
+		return err
+	}
 
 	// if no version update is required, don't log asking them to rerun with --approve
 	cmdutils.LogPlanModeWarning(dryRun && versionUpdateRequired)
-	return err
+	return nil
 }

--- a/pkg/actions/cluster/upgrade.go
+++ b/pkg/actions/cluster/upgrade.go
@@ -35,6 +35,8 @@ func upgrade(cfg *api.ClusterConfig, ctl *eks.ClusterProvider, dryRun bool) (boo
 			logger.Success("cluster %q control plane has been upgraded to version %q", cfg.Metadata.Name, cfg.Metadata.Version)
 			logger.Info(msgNodeGroupsAndAddons)
 		}
+	} else {
+		logger.Info("no cluster version update required")
 	}
 	return versionUpdateRequired, nil
 }


### PR DESCRIPTION
### Description

When attempting to upgrade a non-eksctl created cluster that doesn't need upgrading you get no output.
```
./eksctl upgrade cluster --name jk-console-3 --version 1.18
[ℹ]  eksctl version 0.37.0-dev+906d2a6c.2021-01-07T16:23:46Z
[ℹ]  using region us-west-2
```

This PR changes it so that you would get the following if no upgrade is needed: 
```
./eksctl upgrade cluster --name jk-console-3 --version 1.18
[ℹ]  eksctl version 0.37.0-dev+c80f411e.2021-01-07T16:34:12Z
[ℹ]  using region us-west-2
[ℹ]  no cluster version update required
```

And more descriptive update when upgrade is needed:
```
./eksctl upgrade cluster --name jk-console-3 --version 1.18
[ℹ]  eksctl version 0.37.0-dev+c80f411e.2021-01-07T16:36:03Z
[ℹ]  using region us-west-2
[ℹ]  (plan) would upgrade cluster "jk-console-3" control plane from current version "1.17" to "1.18"
[!]  no changes were applied, run again with '--approve' to apply the changes
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

