### PR TITLE
Check if clusters are eksctl owned using stack name

### DIFF
--- a/pkg/actions/cluster/cluster.go
+++ b/pkg/actions/cluster/cluster.go
@@ -21,7 +21,7 @@ func New(cfg *api.ClusterConfig, ctl *eks.ClusterProvider) (Cluster, error) {
 		return nil, err
 	}
 
-	if manager.IsClusterStack(stacks) {
+	if manager.IsClusterStack(cfg.Metadata.Name, stacks) {
 		logger.Debug("Cluster %q was created by eksctl", cfg.Metadata.Name)
 		return NewOwnedCluster(cfg, ctl, stackManager)
 	}

--- a/pkg/actions/cluster/cluster.go
+++ b/pkg/actions/cluster/cluster.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/kris-nova/logger"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
-	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 	"github.com/weaveworks/eksctl/pkg/eks"
 )
 
@@ -20,12 +19,12 @@ func New(cfg *api.ClusterConfig, ctl *eks.ClusterProvider) (Cluster, error) {
 	}
 
 	stackManager := ctl.NewStackManager(cfg)
-	stacks, err := stackManager.DescribeStacks()
+	isClusterStack, err := stackManager.IsClusterStack()
 	if err != nil {
 		return nil, err
 	}
 
-	if manager.IsClusterStack(cfg.Metadata.Name, stacks) {
+	if isClusterStack {
 		logger.Debug("Cluster %q was created by eksctl", cfg.Metadata.Name)
 		return NewOwnedCluster(cfg, ctl, stackManager)
 	}

--- a/pkg/actions/cluster/cluster.go
+++ b/pkg/actions/cluster/cluster.go
@@ -15,6 +15,10 @@ type Cluster interface {
 }
 
 func New(cfg *api.ClusterConfig, ctl *eks.ClusterProvider) (Cluster, error) {
+	if err := ctl.RefreshClusterStatus(cfg); err != nil {
+		return nil, err
+	}
+
 	stackManager := ctl.NewStackManager(cfg)
 	stacks, err := stackManager.DescribeStacks()
 	if err != nil {

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -450,17 +450,21 @@ func (c *StackCollection) DescribeStacks() ([]*Stack, error) {
 	return stacks, nil
 }
 
-func IsClusterStack(clusterName string, stacks []*Stack) bool {
+func (c *StackCollection) IsClusterStack() (bool, error) {
+	stacks, err := c.DescribeStacks()
+	if err != nil {
+		return false, err
+	}
 	for _, stack := range stacks {
-		if *stack.StackName == fmt.Sprintf("eksctl-%s-cluster", clusterName) {
+		if *stack.StackName == c.makeClusterStackName() {
 			for _, tag := range stack.Tags {
-				if *tag.Key == "alpha.eksctl.io/cluster-name" && *tag.Value == clusterName {
-					return true
+				if *tag.Key == api.ClusterNameTag && *tag.Value == c.spec.Metadata.Name {
+					return true, nil
 				}
 			}
 		}
 	}
-	return false
+	return false, nil
 }
 
 // DescribeStackEvents describes the events that have occurred on the stack

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -451,14 +451,15 @@ func (c *StackCollection) DescribeStacks() ([]*Stack, error) {
 }
 
 func (c *StackCollection) IsClusterStack() (bool, error) {
+	clusterStackName := c.makeClusterStackName()
 	stacks, err := c.DescribeStacks()
 	if err != nil {
 		return false, err
 	}
 	for _, stack := range stacks {
-		if *stack.StackName == c.makeClusterStackName() {
+		if *stack.StackName == clusterStackName {
 			for _, tag := range stack.Tags {
-				if *tag.Key == api.ClusterNameTag && *tag.Value == c.spec.Metadata.Name {
+				if matchesClusterName(*tag.Key, *tag.Value, c.spec.Metadata.Name) {
 					return true, nil
 				}
 			}

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -450,11 +450,13 @@ func (c *StackCollection) DescribeStacks() ([]*Stack, error) {
 	return stacks, nil
 }
 
-func IsClusterStack(stacks []*Stack) bool {
+func IsClusterStack(clusterName string, stacks []*Stack) bool {
 	for _, stack := range stacks {
-		for _, output := range stack.Outputs {
-			if *output.OutputKey == "ClusterStackName" {
-				return true
+		if *stack.StackName == fmt.Sprintf("eksctl-%s-cluster", clusterName) {
+			for _, tag := range stack.Tags {
+				if *tag.Key == "alpha.eksctl.io/cluster-name" && *tag.Value == clusterName {
+					return true
+				}
 			}
 		}
 	}

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -348,7 +348,7 @@ func (c *ClusterProvider) listClusters(chunkSize int64) ([]*api.ClusterConfig, e
 			if err != nil {
 				managed = eksctlCreatedUnknown
 				logger.Warning("error fetching stacks for cluster %s: %v", clusterName, err)
-			} else if manager.IsClusterStack(stacks) {
+			} else if manager.IsClusterStack(*clusterName, stacks) {
 				managed = eksctlCreatedTrue
 			}
 			allClusters = append(allClusters, &api.ClusterConfig{

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/weaveworks/eksctl/pkg/utils/waiters"
 
-	"github.com/weaveworks/eksctl/pkg/cfn/manager"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -343,12 +341,12 @@ func (c *ClusterProvider) listClusters(chunkSize int64) ([]*api.ClusterConfig, e
 
 		for _, clusterName := range clusters {
 			spec := &api.ClusterConfig{Metadata: &api.ClusterMeta{Name: *clusterName}}
-			stacks, err := c.NewStackManager(spec).ListStacks()
+			isClusterStack, err := c.NewStackManager(spec).IsClusterStack()
 			managed := eksctlCreatedFalse
 			if err != nil {
 				managed = eksctlCreatedUnknown
 				logger.Warning("error fetching stacks for cluster %s: %v", clusterName, err)
-			} else if manager.IsClusterStack(*clusterName, stacks) {
+			} else if isClusterStack {
 				managed = eksctlCreatedTrue
 			}
 			allClusters = append(allClusters, &api.ClusterConfig{


### PR DESCRIPTION
### Description

Currently we look for the clusterName output on the CF stack, which doesn’t exist until the cluster is finished creating. Checking the stack name instead should ensure we always correctly detect if a stack belongs to a cluster or not.
### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)
- [ ] Make sure the title of the PR is a good description that can go into the release notes

