### PR TITLE
Reduce cloudformation calls in eksctl get clusters

### DIFF
--- a/pkg/actions/cluster/cluster.go
+++ b/pkg/actions/cluster/cluster.go
@@ -19,7 +19,7 @@ func New(cfg *api.ClusterConfig, ctl *eks.ClusterProvider) (Cluster, error) {
 	}
 
 	stackManager := ctl.NewStackManager(cfg)
-	isClusterStack, err := stackManager.IsClusterStack()
+	isClusterStack, err := stackManager.HasClusterStack()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -476,7 +476,7 @@ func (c *StackCollection) DescribeStacks() ([]*Stack, error) {
 	return stacks, nil
 }
 func (c *StackCollection) IsClusterStack() (bool, error) {
-	clusterStackNames, err := c.ListStackNamesMatching("eksctl.*-cluster")
+	clusterStackNames, err := c.ListStackNamesMatching("eksctl-.*-cluster")
 	if err != nil {
 		return false, err
 	}

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -26,6 +26,7 @@ var (
 	stackCapabilitiesIAM      = aws.StringSlice([]string{cloudformation.CapabilityCapabilityIam})
 	stackCapabilitiesNamedIAM = aws.StringSlice([]string{cloudformation.CapabilityCapabilityNamedIam})
 )
+var DescribeCount, ListCount int
 
 // Stack represents the CloudFormation stack
 type Stack = cloudformation.Stack
@@ -187,6 +188,8 @@ func (c *StackCollection) UpdateStack(stackName, changeSetName, description stri
 
 // DescribeStack describes a cloudformation stack.
 func (c *StackCollection) DescribeStack(i *Stack) (*Stack, error) {
+	DescribeCount = DescribeCount + 1
+
 	input := &cloudformation.DescribeStacksInput{
 		StackName: i.StackName,
 	}

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -26,7 +26,6 @@ var (
 	stackCapabilitiesIAM      = aws.StringSlice([]string{cloudformation.CapabilityCapabilityIam})
 	stackCapabilitiesNamedIAM = aws.StringSlice([]string{cloudformation.CapabilityCapabilityNamedIam})
 )
-var DescribeCount, ListCount int
 
 // Stack represents the CloudFormation stack
 type Stack = cloudformation.Stack
@@ -188,8 +187,6 @@ func (c *StackCollection) UpdateStack(stackName, changeSetName, description stri
 
 // DescribeStack describes a cloudformation stack.
 func (c *StackCollection) DescribeStack(i *Stack) (*Stack, error) {
-	DescribeCount = DescribeCount + 1
-
 	input := &cloudformation.DescribeStacksInput{
 		StackName: i.StackName,
 	}

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -20,6 +20,8 @@ const (
 	resourcesRootPath = "Resources"
 	outputsRootPath   = "Outputs"
 	mappingsRootPath  = "Mappings"
+	ourStackRegexFmt  = "^(eksctl|EKS)-%s-((cluster|nodegroup-.+|addon-.+)|(VPC|ServiceRole|ControlPlane|DefaultNodeGroup))$"
+	clusterStackRegex = "eksctl-.*-cluster"
 )
 
 var (
@@ -267,9 +269,9 @@ func (c *StackCollection) ListStacksMatching(nameRegex string, statusFilters ...
 }
 
 // ListStackNamesMatching gets all stack names matching regex
-func (c *StackCollection) ListStackNamesMatching(nameRegex string) ([]string, error) {
+func (c *StackCollection) ListClusterStackNamesMatching() ([]string, error) {
 	stacks := []string{}
-	re, err := regexp.Compile(nameRegex)
+	re, err := regexp.Compile(clusterStackRegex)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot list stacks")
 	}
@@ -456,7 +458,6 @@ func (c *StackCollection) DeleteStackBySpecSync(s *Stack, errs chan error) error
 }
 
 func fmtStacksRegexForCluster(name string) string {
-	const ourStackRegexFmt = "^(eksctl|EKS)-%s-((cluster|nodegroup-.+|addon-.+)|(VPC|ServiceRole|ControlPlane|DefaultNodeGroup))$"
 	return fmt.Sprintf(ourStackRegexFmt, name)
 }
 
@@ -476,7 +477,7 @@ func (c *StackCollection) DescribeStacks() ([]*Stack, error) {
 	return stacks, nil
 }
 func (c *StackCollection) IsClusterStack() (bool, error) {
-	clusterStackNames, err := c.ListStackNamesMatching("eksctl-.*-cluster")
+	clusterStackNames, err := c.ListClusterStackNamesMatching()
 	if err != nil {
 		return false, err
 	}

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -269,7 +269,7 @@ func (c *StackCollection) ListStacksMatching(nameRegex string, statusFilters ...
 }
 
 // ListStackNamesMatching gets all stack names matching regex
-func (c *StackCollection) ListClusterStackNamesMatching() ([]string, error) {
+func (c *StackCollection) ListClusterStackNames() ([]string, error) {
 	stacks := []string{}
 	re, err := regexp.Compile(clusterStackRegex)
 	if err != nil {
@@ -477,7 +477,7 @@ func (c *StackCollection) DescribeStacks() ([]*Stack, error) {
 	return stacks, nil
 }
 func (c *StackCollection) IsClusterStack() (bool, error) {
-	clusterStackNames, err := c.ListClusterStackNamesMatching()
+	clusterStackNames, err := c.ListClusterStackNames()
 	if err != nil {
 		return false, err
 	}

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -476,15 +476,15 @@ func (c *StackCollection) DescribeStacks() ([]*Stack, error) {
 	}
 	return stacks, nil
 }
-func (c *StackCollection) IsClusterStack() (bool, error) {
+func (c *StackCollection) HasClusterStack() (bool, error) {
 	clusterStackNames, err := c.ListClusterStackNames()
 	if err != nil {
 		return false, err
 	}
-	return c.IsClusterStackUsingCachedList(clusterStackNames)
+	return c.HasClusterStackUsingCachedList(clusterStackNames)
 }
 
-func (c *StackCollection) IsClusterStackUsingCachedList(clusterStackNames []string) (bool, error) {
+func (c *StackCollection) HasClusterStackUsingCachedList(clusterStackNames []string) (bool, error) {
 	clusterStackName := c.makeClusterStackName()
 	for _, stack := range clusterStackNames {
 		if stack == clusterStackName {

--- a/pkg/ctl/get/cluster.go
+++ b/pkg/ctl/get/cluster.go
@@ -101,6 +101,9 @@ func getAndPrinterClusters(ctl *eks.ClusterProvider, params *getCmdParams, listA
 		return err
 	}
 
+	logger.Info("DescribeCount: %d", manager.DescribeCount)
+	logger.Info("ListCount: %d", manager.ListCount)
+
 	return printer.PrintObjWithKind("clusters", clusters, os.Stdout)
 }
 

--- a/pkg/ctl/get/cluster.go
+++ b/pkg/ctl/get/cluster.go
@@ -102,9 +102,6 @@ func getAndPrinterClusters(ctl *eks.ClusterProvider, params *getCmdParams, listA
 		return err
 	}
 
-	logger.Info("DescribeCount: %d", manager.DescribeCount)
-	logger.Info("ListCount: %d", manager.ListCount)
-
 	return printer.PrintObjWithKind("clusters", clusters, os.Stdout)
 }
 

--- a/pkg/ctl/get/cluster.go
+++ b/pkg/ctl/get/cluster.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/weaveworks/eksctl/pkg/cfn/manager"
-
 	awseks "github.com/aws/aws-sdk-go/service/eks"
 	"k8s.io/apimachinery/pkg/util/sets"
 

--- a/pkg/ctl/get/cluster.go
+++ b/pkg/ctl/get/cluster.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/weaveworks/eksctl/pkg/cfn/manager"
+
 	awseks "github.com/aws/aws-sdk-go/service/eks"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -86,7 +88,6 @@ func doGetCluster(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) 
 }
 
 func getAndPrinterClusters(ctl *eks.ClusterProvider, params *getCmdParams, listAllRegions bool) error {
-
 	printer, err := printers.NewPrinter(params.output)
 	if err != nil {
 		return err

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 	"github.com/weaveworks/eksctl/pkg/utils/waiters"
 
 	"github.com/aws/aws-sdk-go/aws"

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -333,7 +333,7 @@ func (c *ClusterProvider) listClusters(chunkSize int64) ([]*api.ClusterConfig, e
 	allClusters := []*api.ClusterConfig{}
 
 	spec := &api.ClusterConfig{Metadata: &api.ClusterMeta{Name: ""}}
-	allStacks, err := c.NewStackManager(spec).ListStackNamesMatching("eksctl-.*-cluster")
+	allStacks, err := c.NewStackManager(spec).ListClusterStackNamesMatching()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -409,7 +409,6 @@ func (c *ClusterProvider) getClustersRequest(chunkSize int64, nextToken string) 
 	if nextToken != "" {
 		input = input.SetNextToken(nextToken)
 	}
-	manager.ListCount = manager.ListCount + 1
 	output, err := c.Provider.EKS().ListClusters(input)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "listing control planes")

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -402,6 +402,7 @@ func (c *ClusterProvider) getClustersRequest(chunkSize int64, nextToken string) 
 	if nextToken != "" {
 		input = input.SetNextToken(nextToken)
 	}
+	manager.ListCount = manager.ListCount + 1
 	output, err := c.Provider.EKS().ListClusters(input)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "listing control planes")

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -333,7 +333,7 @@ func (c *ClusterProvider) listClusters(chunkSize int64) ([]*api.ClusterConfig, e
 	allClusters := []*api.ClusterConfig{}
 
 	spec := &api.ClusterConfig{Metadata: &api.ClusterMeta{Name: ""}}
-	allStacks, err := c.NewStackManager(spec).ListClusterStackNamesMatching()
+	allStacks, err := c.NewStackManager(spec).ListClusterStackNames()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -347,7 +347,7 @@ func (c *ClusterProvider) listClusters(chunkSize int64) ([]*api.ClusterConfig, e
 
 		for _, clusterName := range clusters {
 			spec := &api.ClusterConfig{Metadata: &api.ClusterMeta{Name: *clusterName}}
-			isClusterStack, err := c.NewStackManager(spec).IsClusterStackUsingCachedList(allStacks)
+			isClusterStack, err := c.NewStackManager(spec).HasClusterStackUsingCachedList(allStacks)
 			managed := eksctlCreatedFalse
 			if err != nil {
 				managed = eksctlCreatedUnknown

--- a/pkg/eks/eks_test.go
+++ b/pkg/eks/eks_test.go
@@ -249,7 +249,7 @@ var _ = Describe("EKS API wrapper", func() {
 				})
 
 				It("should check if the clusters are eksctl created", func() {
-					Expect(p.MockCloudFormation().AssertNumberOfCalls(GinkgoT(), "ListStacksPages", 2)).To(BeTrue())
+					Expect(p.MockCloudFormation().AssertNumberOfCalls(GinkgoT(), "ListStacksPages", 1)).To(BeTrue())
 				})
 			})
 		})
@@ -313,6 +313,8 @@ var _ = Describe("EKS API wrapper", func() {
 			p.MockEKS().On("ListClusters", mock.MatchedBy(func(input *awseks.ListClustersInput) bool {
 				return *input.MaxResults == int64(chunkSize)
 			})).Return(mockResultFn, nil)
+
+			p.MockCloudFormation().On("ListStacksPages", mock.Anything, mock.Anything).Return(nil)
 
 			clusters, err := c.ListClusters(chunkSize, false)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
### Description

When running `eksctl get cluster` with 14 eks clusters existing we would issue 44 `DescribeCluster` calls and `15` `ListStacks` calls. This PR changes it so that we now do 14 `DescribeCluster` (1 per cluster) and 2 `ListStack` calls

Related issue: https://github.com/weaveworks/eksctl/issues/2946
### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

