### PR TITLE
Allow configuring node-volume-type for managed nodegroups using flags

### DIFF
--- a/pkg/ctl/cmdutils/nodegroup_flags.go
+++ b/pkg/ctl/cmdutils/nodegroup_flags.go
@@ -61,7 +61,6 @@ func AddCommonCreateNodeGroupFlags(fs *pflag.FlagSet, cmd *Cmd, ng *api.NodeGrou
 
 func incompatibleManagedNodesFlags() []string {
 	return []string{
-		"node-volume-type",
 		"max-pods-per-node",
 		"node-ami",
 		"node-security-groups",

--- a/pkg/ctl/create/cluster_test.go
+++ b/pkg/ctl/create/cluster_test.go
@@ -161,7 +161,6 @@ var _ = Describe("create cluster", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(fmt.Errorf("Error: %s is not supported for Managed Nodegroups (--managed=true)", args[0]).Error()))
 			},
-			Entry("node-volume-type", "--node-volume-type", "gp2"),
 			Entry("max-pods-per-node", "--max-pods-per-node", "2"),
 			Entry("node-ami", "--node-ami", "ami-dummy-123"),
 			Entry("node-security-groups", "--node-security-groups", "sg-123"),

--- a/pkg/ctl/create/nodegroup_test.go
+++ b/pkg/ctl/create/nodegroup_test.go
@@ -127,7 +127,6 @@ var _ = Describe("create nodegroup", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("%s is not supported for Managed Nodegroups (--managed=true)", args[0])))
 			},
-			Entry("node-volume-type", "--node-volume-type", "gp2"),
 			Entry("max-pods-per-node", "--max-pods-per-node", "2"),
 			Entry("node-ami", "--node-ami", "ami-dummy-123"),
 			Entry("node-security-groups", "--node-security-groups", "sg-123"),


### PR DESCRIPTION
### Description

https://github.com/weaveworks/eksctl/issues/3088
### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

