### PR TITLE
Add needed parameter --cluster to eksctl utils update-* commands

### DIFF
--- a/userdocs/src/usage/cluster-upgrade.md
+++ b/userdocs/src/usage/cluster-upgrade.md
@@ -152,19 +152,19 @@ there are 3 distinct commands that you will need to run.
 To update `kube-proxy`, run:
 
 ```
-eksctl utils update-kube-proxy
+eksctl utils update-kube-proxy --cluster=<clusterName>
 ```
 
 To update `aws-node`, run:
 
 ```
-eksctl utils update-aws-node
+eksctl utils update-aws-node --cluster=<clusterName>
 ```
 
 To update `coredns`, run:
 
 ```
-eksctl utils update-coredns
+eksctl utils update-coredns --cluster=<clusterName>
 ```
 
 Once upgraded, be sure to run `kubectl get pods -n kube-system` and check if all addon pods are in ready state, you should see


### PR DESCRIPTION
### Description
eksctl utils update-* expects the cluster name as parameter, but in the documentation this is not mentioned. I have added this here.
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

