### PR TITLE
Make kubernetes-version optional and improve launch template validation for upgrade nodegroup

### DIFF
--- a/pkg/managed/service.go
+++ b/pkg/managed/service.go
@@ -155,12 +155,6 @@ func (m *Service) UpgradeNodeGroup(options UpgradeOptions) error {
 
 	nodeGroup := output.Nodegroup
 
-	if options.KubernetesVersion != "" {
-		if _, err := semver.ParseTolerant(options.KubernetesVersion); err != nil {
-			return errors.Wrap(err, "invalid Kubernetes version")
-		}
-	}
-
 	template, err := m.stackCollection.GetManagedNodeGroupTemplate(options.NodegroupName)
 	if err != nil {
 		return errors.Wrap(err, "error fetching nodegroup template")


### PR DESCRIPTION
### Description
Improves the UX for this https://github.com/weaveworks/eksctl/issues/3102

Fixes this regression https://github.com/weaveworks/eksctl/issues/3092
- Previously it was always optional, see: https://github.com/weaveworks/eksctl/blob/6cd4d4270c344f6eb1aa2c2c37397f5d7e67d203/pkg/managed/service.go#L158-L162
### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`), target version (e.g. `version/0.12.0`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

