### PR TITLE
Fix typo in userdocs additionalEndpointServices Example

### DIFF
--- a/userdocs/src/usage/eks-private-cluster.md
+++ b/userdocs/src/usage/eks-private-cluster.md
@@ -52,7 +52,7 @@ privateCluster:
   # For Cluster Autoscaler
   - "autoscaling"
   # CloudWatch logging
-  - "log"
+  - "logs"
 ```
 
 The endpoints supported in `additionalEndpointServices` are `autoscaling`, `cloudformation` and `logs`.


### PR DESCRIPTION
### Description
Just fix a typo in example:

Before this patch, copying the example resulted in the following eksctl error:
    Error: invalid value in privateCluster.additionalEndpointServices: unsupported endpoint service "log"

This patch fixes the example to correctly use "logs" instead of "log".


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

