### PR TITLE
Add rebase action, make codegen script more robust

### DIFF
--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -1,0 +1,20 @@
+name: PR Rebase
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  rebase:
+    name: Rebase
+    if: |
+      (github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')) &&
+      (github.event.comment.author_association == 'MEMBER' || github.event.comment.user.login == github.event.pull_request.user.login)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Rebase
+        uses: cirrus-actions/rebase@1.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.WEAVEWORKSBOT_TOKEN }}

--- a/build/scripts/update-codegen.sh
+++ b/build/scripts/update-codegen.sh
@@ -6,10 +6,8 @@ set -o nounset
 
 SCRIPT_ROOT=$(git rev-parse --show-toplevel)
 
-# Grab code-generator version from go.sum.
-CODEGEN_VERSION=$(grep 'k8s.io/code-generator' go.sum | awk '{print $2}' | head -1)
-CODEGEN_PKG=$(echo `go env GOPATH`"/pkg/mod/k8s.io/code-generator@${CODEGEN_VERSION}")
-
+# Grab code-generator pkg
+CODEGEN_PKG=$(go list -m -f '{{.Dir}}' 'k8s.io/code-generator')
 echo ">> Using ${CODEGEN_PKG}"
 
 # code-generator does work with go.mod but makes assumptions about
@@ -19,16 +17,16 @@ echo ">> Using ${CODEGEN_PKG}"
 TEMP_DIR=$(mktemp -d)
 cleanup() {
     echo ">> Removing ${TEMP_DIR}"
-    rm -rf ${TEMP_DIR}
+    rm -rf "${TEMP_DIR}"
 }
 trap "cleanup" EXIT SIGINT
 
 echo ">> Temporary output directory ${TEMP_DIR}"
 
 # Ensure we can execute.
-chmod +x ${CODEGEN_PKG}/generate-groups.sh
+chmod +x "${CODEGEN_PKG}"/generate-groups.sh
 
-GOPATH=$(go env GOPATH) ${CODEGEN_PKG}/generate-groups.sh deepcopy,defaulter \
+GOPATH=$(go env GOPATH) "${CODEGEN_PKG}"/generate-groups.sh deepcopy,defaulter \
     _ github.com/weaveworks/eksctl/pkg/apis \
     eksctl.io:v1alpha5 \
     --go-header-file <(printf "/*\n%s\n*/\n" "$(cat LICENSE)") \


### PR DESCRIPTION


### Description

Closes https://github.com/weaveworks/eksctl/issues/3000.

The `Update branch` button is not always ideal, plus the PR author cannot click it. This gives us another option using https://github.com/cirrus-actions/rebase.

Triggered by commenting with `/rebase'.

(Also make codegen more robust)

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

