### PR TITLE
Increase nodegroup timeout

### DIFF
--- a/pkg/ctl/upgrade/nodegroup.go
+++ b/pkg/ctl/upgrade/nodegroup.go
@@ -13,7 +13,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
 
-const upgradeNodegroupTimeout = 35 * time.Minute
+const upgradeNodegroupTimeout = 45 * time.Minute
 
 func upgradeNodeGroupCmd(cmd *cmdutils.Cmd) {
 	cfg := api.NewClusterConfig()


### PR DESCRIPTION
### Description

`upgrade nodegroup` appears to be taking longer than 35 minutes at times, bumping it by 10. 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

