### PR TITLE
Cleanup fargate stack for unowned clusters

### DIFF
--- a/pkg/actions/cluster/cluster.go
+++ b/pkg/actions/cluster/cluster.go
@@ -34,5 +34,5 @@ func New(cfg *api.ClusterConfig, ctl *eks.ClusterProvider) (Cluster, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewUnownedCluster(cfg, ctl, clientSet), nil
+	return NewUnownedCluster(cfg, ctl, clientSet, stackManager), nil
 }

--- a/pkg/actions/cluster/unowned_test.go
+++ b/pkg/actions/cluster/unowned_test.go
@@ -3,6 +3,8 @@ package cluster_test
 import (
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+
 	"github.com/aws/aws-sdk-go/aws"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -45,7 +47,36 @@ var _ = Describe("Delete", func() {
 			ClusterName: strings.Pointer(clusterName),
 		}).Once().Return(&awseks.ListFargateProfilesOutput{}, nil)
 
-		p.MockCloudFormation().On("ListStacksPages", mock.Anything, mock.Anything).Return(nil)
+		fargateStackName := aws.String("eksctl-my-cluster-fargate")
+		p.MockCloudFormation().On("DescribeStacks", &cloudformation.DescribeStacksInput{
+			StackName: fargateStackName,
+		}).Return(&cloudformation.DescribeStacksOutput{
+			Stacks: []*cloudformation.Stack{
+				{
+					StackName: fargateStackName,
+					Tags: []*cloudformation.Tag{
+						{
+							Key:   aws.String("alpha.eksctl.io/cluster-name"),
+							Value: aws.String(clusterName),
+						},
+					},
+					StackStatus: aws.String(cloudformation.StackStatusCreateComplete),
+				},
+			},
+		}, nil)
+
+		p.MockCloudFormation().On("DeleteStack", mock.Anything).Return(nil, nil)
+		p.MockCloudFormation().On("ListStacksPages", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			Expect(args).To(HaveLen(2))
+			pager := args[1].(func(*cloudformation.ListStacksOutput, bool) bool)
+			pager(&cloudformation.ListStacksOutput{
+				StackSummaries: []*cloudformation.StackSummary{
+					{
+						StackName: fargateStackName,
+					},
+				},
+			}, false)
+		}).Return(nil)
 
 		p.MockEC2().On("DescribeKeyPairs", mock.Anything).Return(&ec2.DescribeKeyPairsOutput{}, nil)
 
@@ -74,8 +105,8 @@ var _ = Describe("Delete", func() {
 		})).Return(&awseks.DeleteNodegroupOutput{}, nil)
 
 		p.MockEKS().On("DeleteCluster", mock.Anything).Return(&awseks.DeleteClusterOutput{}, nil)
-
-		c := cluster.NewUnownedCluster(cfg, &eks.ClusterProvider{Provider: p, Status: &eks.ProviderStatus{}}, clientSet)
+		ctl := &eks.ClusterProvider{Provider: p, Status: &eks.ProviderStatus{}}
+		c := cluster.NewUnownedCluster(cfg, ctl, clientSet, ctl.NewStackManager(cfg))
 		err := c.Delete(time.Microsecond, false)
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/pkg/actions/cluster/unowned_test.go
+++ b/pkg/actions/cluster/unowned_test.go
@@ -66,16 +66,20 @@ var _ = Describe("Delete", func() {
 		}, nil)
 
 		p.MockCloudFormation().On("DeleteStack", mock.Anything).Return(nil, nil)
+		firstListStacksCall := true
 		p.MockCloudFormation().On("ListStacksPages", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 			Expect(args).To(HaveLen(2))
-			pager := args[1].(func(*cloudformation.ListStacksOutput, bool) bool)
-			pager(&cloudformation.ListStacksOutput{
-				StackSummaries: []*cloudformation.StackSummary{
-					{
-						StackName: fargateStackName,
+			if firstListStacksCall {
+				pager := args[1].(func(*cloudformation.ListStacksOutput, bool) bool)
+				pager(&cloudformation.ListStacksOutput{
+					StackSummaries: []*cloudformation.StackSummary{
+						{
+							StackName: fargateStackName,
+						},
 					},
-				},
-			}, false)
+				}, false)
+			}
+			firstListStacksCall = false
 		}).Return(nil)
 
 		p.MockEC2().On("DescribeKeyPairs", mock.Anything).Return(&ec2.DescribeKeyPairsOutput{}, nil)


### PR DESCRIPTION
### Description

https://github.com/weaveworks/eksctl/issues/3151

Going to add a general check for any remaining stacks as part of deletion in a separate PR

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

