### PR TITLE
log undeleted stacks during cluster deletion

### DIFF
--- a/pkg/actions/cluster/delete.go
+++ b/pkg/actions/cluster/delete.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/pkg/errors"
 
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 	"github.com/weaveworks/eksctl/pkg/fargate"
@@ -118,7 +119,7 @@ func deleteDeprecatedStacks(stackManager *manager.StackCollection) (bool, error)
 	return false, nil
 }
 
-func logUndeletedStacks(stackManager *manager.StackCollection) error {
+func checkForUndeletedStacks(stackManager *manager.StackCollection) error {
 	stacks, err := stackManager.DescribeStacks()
 	if err != nil {
 		return err
@@ -136,6 +137,7 @@ func logUndeletedStacks(stackManager *manager.StackCollection) error {
 
 	if len(undeletedStacks) > 0 {
 		logger.Warning("found the following undeleted stacks: %s", strings.Join(undeletedStacks, ","))
+		return errors.New("failed to delete all resources")
 	}
 
 	return nil

--- a/pkg/actions/cluster/delete.go
+++ b/pkg/actions/cluster/delete.go
@@ -3,7 +3,10 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
 
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 	"github.com/weaveworks/eksctl/pkg/fargate"
@@ -113,4 +116,27 @@ func deleteDeprecatedStacks(stackManager *manager.StackCollection) (bool, error)
 		return true, nil
 	}
 	return false, nil
+}
+
+func logUndeletedStacks(stackManager *manager.StackCollection) error {
+	stacks, err := stackManager.DescribeStacks()
+	if err != nil {
+		return err
+	}
+
+	var undeletedStacks []string
+
+	for _, stack := range stacks {
+		if *stack.StackStatus == cloudformation.StackStatusDeleteInProgress {
+			continue
+		}
+
+		undeletedStacks = append(undeletedStacks, *stack.StackName)
+	}
+
+	if len(undeletedStacks) > 0 {
+		logger.Warning("found the following undeleted stacks: %s", strings.Join(undeletedStacks, ","))
+	}
+
+	return nil
 }

--- a/pkg/actions/cluster/owned.go
+++ b/pkg/actions/cluster/owned.go
@@ -121,6 +121,10 @@ func (c *OwnedCluster) Delete(_ time.Duration, wait bool) error {
 		return handleErrors(errs, "cluster with nodegroup(s)")
 	}
 
+	if err := logUndeletedStacks(c.stackManager); err != nil {
+		return err
+	}
+
 	logger.Success("all cluster resources were deleted")
 
 	return gitops.DeleteKey(c.cfg)

--- a/pkg/actions/cluster/owned.go
+++ b/pkg/actions/cluster/owned.go
@@ -121,7 +121,7 @@ func (c *OwnedCluster) Delete(_ time.Duration, wait bool) error {
 		return handleErrors(errs, "cluster with nodegroup(s)")
 	}
 
-	if err := logUndeletedStacks(c.stackManager); err != nil {
+	if err := checkForUndeletedStacks(c.stackManager); err != nil {
 		return err
 	}
 

--- a/pkg/actions/cluster/unowned.go
+++ b/pkg/actions/cluster/unowned.go
@@ -78,6 +78,10 @@ func (c *UnownedCluster) Delete(waitInterval time.Duration, wait bool) error {
 		return err
 	}
 
+	if err := logUndeletedStacks(c.ctl.NewStackManager(c.cfg)); err != nil {
+		return err
+	}
+
 	logger.Success("all cluster resources were deleted")
 	return nil
 }

--- a/pkg/actions/cluster/unowned.go
+++ b/pkg/actions/cluster/unowned.go
@@ -78,7 +78,7 @@ func (c *UnownedCluster) Delete(waitInterval time.Duration, wait bool) error {
 		return err
 	}
 
-	if err := logUndeletedStacks(c.ctl.NewStackManager(c.cfg)); err != nil {
+	if err := checkForUndeletedStacks(c.ctl.NewStackManager(c.cfg)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### Description

Example output:
```
./eksctl delete cluster --name jk-console
[ℹ]  eksctl version 0.38.0-dev+9f64d9de.2021-01-27T10:28:15Z
[ℹ]  using region us-west-2
[ℹ]  deleting EKS cluster "jk-console"
[!]  found the following undeleted stacks: eksctl-jk-console-addon-iamserviceaccount-baz-foo
[✔]  all cluster resources were deleted
```

I think printing `[✔]  all cluster resources were deleted` is misleading to the user as there are clearly some resources left, but eksctl doesn't know to clean them up so it shouldn't error either. Unsure what the UX should be, open to suggestions 
### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

