### PR TITLE
Do not error for empty get nodegroups if output is yaml or json

### DIFF
--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -254,7 +254,8 @@ func (c *StackCollection) GetNodeGroupSummaries(name string) ([]*NodeGroupSummar
 		return nil, errors.Wrap(err, "getting nodegroup stacks")
 	}
 
-	var summaries []*NodeGroupSummary
+	// Create an empty array here so that an object is returned rather than null
+	summaries := []*NodeGroupSummary{}
 	for _, s := range stacks {
 		ngPaths, err := getNodeGroupPaths(s.Tags)
 		if err != nil {

--- a/pkg/ctl/get/nodegroup.go
+++ b/pkg/ctl/get/nodegroup.go
@@ -90,20 +90,21 @@ func doGetNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *getCmdParams) 
 		summaries = append(summaries, summary)
 	}
 
-	// Empty summary implies no nodegroups
-	if len(summaries) == 0 {
-		if ng.Name == "" {
-			return errors.Errorf("No nodegroups found")
-		}
-		return errors.Errorf("Nodegroup with name %v not found", ng.Name)
-	}
-
 	printer, err := printers.NewPrinter(params.output)
 	if err != nil {
 		return err
 	}
 
 	if params.output == "table" {
+		// Empty summary implies no nodegroups
+		// We only error if the output is table, since if the output
+		// is yaml or json we should return an empty object.
+		if len(summaries) == 0 {
+			if ng.Name == "" {
+				return errors.Errorf("No nodegroups found")
+			}
+			return errors.Errorf("Nodegroup with name %v not found", ng.Name)
+		}
 		addSummaryTableColumns(printer.(*printers.TablePrinter))
 	}
 

--- a/pkg/ctl/get/nodegroup.go
+++ b/pkg/ctl/get/nodegroup.go
@@ -103,7 +103,7 @@ func doGetNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *getCmdParams) 
 			if ng.Name == "" {
 				return errors.Errorf("No nodegroups found")
 			}
-			return errors.Errorf("Nodegroup with name %v not found", ng.Name)
+			return errors.Errorf("nodegroup with name %v not found", ng.Name)
 		}
 		addSummaryTableColumns(printer.(*printers.TablePrinter))
 	}


### PR DESCRIPTION
### Description

Fixes https://github.com/weaveworks/eksctl/issues/3177

When running `get nodegroup` returns no nodegroups, we should only report that as an error if the output is `table`. For `yaml` and `json` we should return an empty object.

```sh
$ ./eksctl get nodegroup --cluster cb-test2 -o table
[ℹ]  eksctl version 0.38.0-dev+d09881f8.2021-01-29T12:27:01Z
[ℹ]  using region us-west-2
Error: No nodegroups found

$ ./eksctl get nodegroup --cluster cb-test2 -o json
[]

$ ./eksctl get nodegroup --cluster cb-test2 -o yaml
[]
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

