### PR TITLE
add fargateprofiles as alias for fargateprofile

### DIFF
--- a/pkg/ctl/get/fargate.go
+++ b/pkg/ctl/get/fargate.go
@@ -23,6 +23,7 @@ func getFargateProfileWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.
 		"fargateprofile",
 		"Get Fargate profile(s)",
 		"",
+		"fargateprofiles",
 	)
 	options := configureGetFargateProfileCmd(cmd)
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {


### PR DESCRIPTION
### Description

before:
```
eksctl get fargateprofiles --cluster cb-fg-test
Error: unknown resource type "fargateprofiles"

Get resource(s)

Usage: eksctl get [flags]

Commands:
  eksctl get addon                           Get an Addon
  eksctl get cluster                         Get cluster(s)
  eksctl get fargateprofile                  Get Fargate profile(s)
  eksctl get iamidentitymapping              Get IAM identity mapping(s)
  eksctl get iamserviceaccount               Get iamserviceaccount(s)
  eksctl get labels                          Get nodegroup labels
  eksctl get nodegroup                       Get nodegroup(s)

Common flags:
  -C, --color string   toggle colorized logs (valid options: true, false, fabulous) (default "true")
  -h, --help           help for this command
  -v, --verbose int    set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging (default 3)

Use 'eksctl get [command] --help' for more information about a command.

Error: unknown resource type "fargateprofiles"
```

Now:
```
eksctl get fargateprofiles --cluster cb-fg-test
[ℹ]  eksctl version 0.38.0-dev+948dc38c.2021-02-01T16:13:09Z
[ℹ]  using region us-west-2
No fargateprofiles found
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

