### PR TITLE
Revert "Support parsing YAML Cloudformation templates (#3170)"

### DIFF
--- a/pkg/cfn/manager/nodegroup_test.go
+++ b/pkg/cfn/manager/nodegroup_test.go
@@ -22,21 +22,6 @@ var _ = Describe("StackCollection NodeGroup", func() {
 		p *mockprovider.MockProvider
 	)
 
-	const nodegroupResource = `
-{
-  "Resources": {
-    "NodeGroup": {
-      "Type": "AWS::AutoScaling::AutoScalingGroup",
-      "Properties": {
-        "DesiredCapacity": "2",
-        "MaxSize": "3",
-        "MinSize": "1"
-      }
-    }
-  }
-}
-`
-
 	testAZs := []string{"us-west-2b", "us-west-2a", "us-west-2c"}
 
 	newClusterConfig := func(clusterName string) *api.ClusterConfig {
@@ -92,7 +77,17 @@ var _ = Describe("StackCollection NodeGroup", func() {
 					On("GetTemplate", mock.MatchedBy(func(input *cfn.GetTemplateInput) bool {
 						return input.StackName != nil && *input.StackName == "eksctl-test-cluster-nodegroup-12345"
 					})).Return(&cfn.GetTemplateOutput{
-					TemplateBody: aws.String(nodegroupResource),
+					TemplateBody: aws.String(`{
+						"Resources": {
+							"NodeGroup": {
+								"Properties": {
+									"DesiredCapacity": 2,
+									"MinSize": 1,
+									"MaxSize": 3
+								}
+							}
+						}
+					}`),
 				}, nil)
 			})
 
@@ -176,7 +171,7 @@ var _ = Describe("StackCollection NodeGroup", func() {
 				p.MockCloudFormation().On("GetTemplate", mock.MatchedBy(func(input *cfn.GetTemplateInput) bool {
 					return input.StackName != nil && *input.StackName == "eksctl-test-cluster-nodegroup-12345"
 				})).Return(&cfn.GetTemplateOutput{
-					TemplateBody: aws.String(nodegroupResource),
+					TemplateBody: aws.String("TEMPLATE_BODY"),
 				}, nil)
 
 				p.MockCloudFormation().On("GetTemplate", mock.Anything).Return(nil, fmt.Errorf("GetTemplate failed"))

--- a/pkg/cfn/manager/template.go
+++ b/pkg/cfn/manager/template.go
@@ -3,12 +3,9 @@ package manager
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/pkg/errors"
-	"github.com/weaveworks/goformation/v4"
 )
 
 // GetStackTemplate gets the Cloudformation template for a stack
-// and returns a json string representation
 func (c *StackCollection) GetStackTemplate(stackName string) (string, error) {
 	input := &cloudformation.GetTemplateInput{
 		StackName: aws.String(stackName),
@@ -19,15 +16,5 @@ func (c *StackCollection) GetStackTemplate(stackName string) (string, error) {
 		return "", err
 	}
 
-	return ensureJSONResponse([]byte(*output.TemplateBody))
-}
-
-func ensureJSONResponse(templateBody []byte) (string, error) {
-	//since json is valid yaml we just need to check the response is valid yaml
-	template, err := goformation.ParseYAML(templateBody)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to parse GetStackTemplate response")
-	}
-	bytes, err := template.JSON()
-	return string(bytes), err
+	return *output.TemplateBody, nil
 }


### PR DESCRIPTION
This reverts commit 948dc38c5eae58865ea4a3d4607c330b3f7bef76.

### Description

See https://github.com/weaveworks/eksctl/issues/3190. If we don't implement one of the solutions we shouldn't block the next release, so this PR is here encase we need to revert.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

