### PR TITLE
Fix creating private cluster in some regions

### DIFF
--- a/pkg/cfn/builder/vpc_endpoint.go
+++ b/pkg/cfn/builder/vpc_endpoint.go
@@ -189,7 +189,12 @@ func buildVPCEndpointServices(ec2API ec2iface.EC2API, region string, endpoints [
 		}
 
 		endpointType := *sd.ServiceType[0].ServiceType
-		if *sd.ServiceName == s3EndpointName && endpointType == ec2.VpcEndpointTypeInterface {
+
+		if *sd.ServiceName == s3EndpointName {
+			if endpointType != ec2.VpcEndpointTypeGateway {
+				continue
+			}
+		} else if endpointType != ec2.VpcEndpointTypeInterface {
 			continue
 		}
 

--- a/pkg/cfn/builder/vpc_endpoint.go
+++ b/pkg/cfn/builder/vpc_endpoint.go
@@ -139,15 +139,11 @@ func buildVPCEndpointServices(ec2API ec2iface.EC2API, region string, endpoints [
 	serviceNames := make([]string, len(endpoints))
 	serviceDomain := fmt.Sprintf("com.amazonaws.%s", region)
 	for i, endpoint := range endpoints {
-		name := fmt.Sprintf("%s.%s", serviceDomain, endpoint)
-		hasChinaPrefix, ok := chinaPartitionServiceHasChinaPrefix[endpoint]
-		if !ok {
-			return nil, errors.Errorf("couldn't determine endpoint domain for service %s", endpoint)
+		serviceName, err := makeServiceName(region, endpoint)
+		if err != nil {
+			return nil, err
 		}
-		if api.Partition(region) == api.PartitionChina && hasChinaPrefix {
-			name = "cn." + name
-		}
-		serviceNames[i] = name
+		serviceNames[i] = serviceName
 	}
 
 	var serviceDetails []*ec2.ServiceDetail
@@ -181,11 +177,20 @@ func buildVPCEndpointServices(ec2API ec2iface.EC2API, region string, endpoints [
 		}
 	}
 
-	ret := make([]VPCEndpointServiceDetails, len(serviceDetails))
+	var ret []VPCEndpointServiceDetails
+	s3EndpointName, err := makeServiceName(region, api.EndpointServiceS3)
+	if err != nil {
+		return nil, err
+	}
 
-	for i, sd := range serviceDetails {
+	for _, sd := range serviceDetails {
 		if len(sd.ServiceType) > 1 {
 			return nil, errors.Errorf("endpoint service %q with multiple service types isn't supported", *sd.ServiceName)
+		}
+
+		endpointType := *sd.ServiceType[0].ServiceType
+		if *sd.ServiceName == s3EndpointName && endpointType == ec2.VpcEndpointTypeInterface {
+			continue
 		}
 
 		// Trim the domain (potentially with a partition-specific part) from the `ServiceName`
@@ -195,13 +200,25 @@ func buildVPCEndpointServices(ec2API ec2iface.EC2API, region string, endpoints [
 		}
 		readableName := parts[1]
 
-		ret[i] = VPCEndpointServiceDetails{
+		ret = append(ret, VPCEndpointServiceDetails{
 			ServiceName:         *sd.ServiceName,
 			ServiceReadableName: readableName,
-			EndpointType:        *sd.ServiceType[0].ServiceType,
+			EndpointType:        endpointType,
 			AvailabilityZones:   aws.StringValueSlice(sd.AvailabilityZones),
-		}
+		})
 	}
 
 	return ret, nil
+}
+
+func makeServiceName(region, endpoint string) (string, error) {
+	serviceName := fmt.Sprintf("com.amazonaws.%s.%s", region, endpoint)
+	hasChinaPrefix, ok := chinaPartitionServiceHasChinaPrefix[endpoint]
+	if !ok {
+		return "", errors.Errorf("couldn't determine endpoint domain for service %s", endpoint)
+	}
+	if api.Partition(region) == api.PartitionChina && hasChinaPrefix {
+		serviceName = "cn." + serviceName
+	}
+	return serviceName, nil
 }

--- a/pkg/cfn/builder/vpc_endpoint.go
+++ b/pkg/cfn/builder/vpc_endpoint.go
@@ -189,12 +189,7 @@ func buildVPCEndpointServices(ec2API ec2iface.EC2API, region string, endpoints [
 		}
 
 		endpointType := *sd.ServiceType[0].ServiceType
-
-		if *sd.ServiceName == s3EndpointName {
-			if endpointType != ec2.VpcEndpointTypeGateway {
-				continue
-			}
-		} else if endpointType != ec2.VpcEndpointTypeInterface {
+		if !serviceEndpointTypeExpected(*sd.ServiceName, endpointType, s3EndpointName) {
 			continue
 		}
 
@@ -214,6 +209,14 @@ func buildVPCEndpointServices(ec2API ec2iface.EC2API, region string, endpoints [
 	}
 
 	return ret, nil
+}
+
+// serviceEndpointTypeExpected returns true if the endpoint service is expected to use the specified endpoint type
+func serviceEndpointTypeExpected(serviceName, endpointType, s3EndpointName string) bool {
+	if serviceName == s3EndpointName {
+		return endpointType == ec2.VpcEndpointTypeGateway
+	}
+	return endpointType == ec2.VpcEndpointTypeInterface
 }
 
 func makeServiceName(region, endpoint string) (string, error) {

--- a/pkg/cfn/builder/vpc_endpoint_test.go
+++ b/pkg/cfn/builder/vpc_endpoint_test.go
@@ -267,277 +267,300 @@ var _ = Describe("VPC Endpoint Builder", func() {
 
 var serviceDetailsJSON = `
 {
-    "ServiceNames": [
-        "com.amazonaws.us-west-2.ec2",
-        "com.amazonaws.us-west-2.ecr.api",
-        "com.amazonaws.us-west-2.ecr.dkr",
-        "com.amazonaws.us-west-2.s3",
-        "com.amazonaws.us-west-2.sts"
-    ],
-    "ServiceDetails": [
+  "ServiceNames": [
+    "com.amazonaws.us-west-2.ec2",
+    "com.amazonaws.us-west-2.ecr.api",
+    "com.amazonaws.us-west-2.ecr.dkr",
+    "com.amazonaws.us-west-2.s3",
+    "com.amazonaws.us-west-2.sts"
+  ],
+  "ServiceDetails": [
+    {
+      "ServiceType": [
         {
-            "ServiceType": [
-                {
-                    "ServiceType": "Interface"
-                }
-            ],
-            "Tags": [],
-            "ManagesVpcEndpoints": false,
-            "PrivateDnsName": "ec2.us-west-2.amazonaws.com",
-            "ServiceName": "com.amazonaws.us-west-2.ec2",
-            "VpcEndpointPolicySupported": true,
-            "ServiceId": "vpce-svc-0ee6723c76642b3d8",
-            "Owner": "amazon",
-            "AvailabilityZones": [
-                "us-west-2a",
-                "us-west-2b",
-                "us-west-2c"
-            ],
-            "AcceptanceRequired": false,
-            "BaseEndpointDnsNames": [
-                "ec2.us-west-2.vpce.amazonaws.com"
-            ]
-        },
-        {
-            "ServiceType": [
-                {
-                    "ServiceType": "Interface"
-                }
-            ],
-            "Tags": [],
-            "ManagesVpcEndpoints": false,
-            "PrivateDnsName": "api.ecr.us-west-2.amazonaws.com",
-            "ServiceName": "com.amazonaws.us-west-2.ecr.api",
-            "VpcEndpointPolicySupported": true,
-            "ServiceId": "vpce-svc-07d1f428f072fd172",
-            "Owner": "amazon",
-            "AvailabilityZones": [
-                "us-west-2a",
-                "us-west-2b",
-                "us-west-2c",
-                "us-west-2d"
-            ],
-            "AcceptanceRequired": false,
-            "BaseEndpointDnsNames": [
-                "api.ecr.us-west-2.vpce.amazonaws.com"
-            ]
-        },
-        {
-            "ServiceType": [
-                {
-                    "ServiceType": "Interface"
-                }
-            ],
-            "Tags": [],
-            "ManagesVpcEndpoints": false,
-            "PrivateDnsName": "*.dkr.ecr.us-west-2.amazonaws.com",
-            "ServiceName": "com.amazonaws.us-west-2.ecr.dkr",
-            "VpcEndpointPolicySupported": true,
-            "ServiceId": "vpce-svc-09d74a28015a69002",
-            "Owner": "amazon",
-            "AvailabilityZones": [
-                "us-west-2a",
-                "us-west-2b",
-                "us-west-2c",
-                "us-west-2d"
-            ],
-            "AcceptanceRequired": false,
-            "BaseEndpointDnsNames": [
-                "dkr.ecr.us-west-2.vpce.amazonaws.com"
-            ]
-        },
-        {
-            "ServiceType": [
-                {
-                    "ServiceType": "Gateway"
-                }
-            ],
-            "Tags": [],
-            "ManagesVpcEndpoints": false,
-            "AcceptanceRequired": false,
-            "ServiceName": "com.amazonaws.us-west-2.s3",
-            "VpcEndpointPolicySupported": true,
-            "ServiceId": "vpce-svc-0001be97e1865c74e",
-            "Owner": "amazon",
-            "AvailabilityZones": [
-                "us-west-2a",
-                "us-west-2b",
-                "us-west-2c",
-                "us-west-2d"
-            ],
-            "BaseEndpointDnsNames": [
-                "s3.us-west-2.amazonaws.com"
-            ]
-        },
-        {
-            "ServiceType": [
-                {
-                    "ServiceType": "Interface"
-                }
-            ],
-            "Tags": [],
-            "ManagesVpcEndpoints": false,
-            "AcceptanceRequired": false,
-            "ServiceName": "com.amazonaws.us-west-2.s3",
-            "VpcEndpointPolicySupported": true,
-            "ServiceId": "vpce-svc-0b5d83f29260cde0d",
-            "Owner": "amazon",
-            "AvailabilityZones": [
-                "us-west-2a",
-                "us-west-2b",
-                "us-west-2c",
-                "us-west-2d"
-            ],
-            "BaseEndpointDnsNames": [
-                "s3.us-west-2.amazonaws.com"
-            ]
-        },
-        {
-            "ServiceType": [
-                {
-                    "ServiceType": "Interface"
-                }
-            ],
-            "Tags": [],
-            "ManagesVpcEndpoints": false,
-            "PrivateDnsName": "sts.us-west-2.amazonaws.com",
-            "ServiceName": "com.amazonaws.us-west-2.sts",
-            "VpcEndpointPolicySupported": true,
-            "ServiceId": "vpce-svc-06681ce20e9a3e8c4",
-            "Owner": "amazon",
-            "AvailabilityZones": [
-                "us-west-2a",
-                "us-west-2b",
-                "us-west-2c"
-            ],
-            "AcceptanceRequired": false,
-            "BaseEndpointDnsNames": [
-                "sts.us-west-2.vpce.amazonaws.com"
-            ]
+          "ServiceType": "Interface"
         }
-    ]
+      ],
+      "Tags": [],
+      "ManagesVpcEndpoints": false,
+      "PrivateDnsName": "ec2.us-west-2.amazonaws.com",
+      "ServiceName": "com.amazonaws.us-west-2.ec2",
+      "VpcEndpointPolicySupported": true,
+      "ServiceId": "vpce-svc-0ee6723c76642b3d8",
+      "Owner": "amazon",
+      "AvailabilityZones": [
+        "us-west-2a",
+        "us-west-2b",
+        "us-west-2c"
+      ],
+      "AcceptanceRequired": false,
+      "BaseEndpointDnsNames": [
+        "ec2.us-west-2.vpce.amazonaws.com"
+      ]
+    },
+    {
+      "ServiceType": [
+        {
+          "ServiceType": "Interface"
+        }
+      ],
+      "Tags": [],
+      "ManagesVpcEndpoints": false,
+      "PrivateDnsName": "api.ecr.us-west-2.amazonaws.com",
+      "ServiceName": "com.amazonaws.us-west-2.ecr.api",
+      "VpcEndpointPolicySupported": true,
+      "ServiceId": "vpce-svc-07d1f428f072fd172",
+      "Owner": "amazon",
+      "AvailabilityZones": [
+        "us-west-2a",
+        "us-west-2b",
+        "us-west-2c",
+        "us-west-2d"
+      ],
+      "AcceptanceRequired": false,
+      "BaseEndpointDnsNames": [
+        "api.ecr.us-west-2.vpce.amazonaws.com"
+      ]
+    },
+    {
+      "ServiceType": [
+        {
+          "ServiceType": "Interface"
+        }
+      ],
+      "Tags": [],
+      "ManagesVpcEndpoints": false,
+      "PrivateDnsName": "*.dkr.ecr.us-west-2.amazonaws.com",
+      "ServiceName": "com.amazonaws.us-west-2.ecr.dkr",
+      "VpcEndpointPolicySupported": true,
+      "ServiceId": "vpce-svc-09d74a28015a69002",
+      "Owner": "amazon",
+      "AvailabilityZones": [
+        "us-west-2a",
+        "us-west-2b",
+        "us-west-2c",
+        "us-west-2d"
+      ],
+      "AcceptanceRequired": false,
+      "BaseEndpointDnsNames": [
+        "dkr.ecr.us-west-2.vpce.amazonaws.com"
+      ]
+    },
+    {
+      "ServiceType": [
+        {
+          "ServiceType": "Gateway"
+        }
+      ],
+      "Tags": [],
+      "ManagesVpcEndpoints": false,
+      "AcceptanceRequired": false,
+      "ServiceName": "com.amazonaws.us-west-2.s3",
+      "VpcEndpointPolicySupported": true,
+      "ServiceId": "vpce-svc-0001be97e1865c74e",
+      "Owner": "amazon",
+      "AvailabilityZones": [
+        "us-west-2a",
+        "us-west-2b",
+        "us-west-2c",
+        "us-west-2d"
+      ],
+      "BaseEndpointDnsNames": [
+        "s3.us-west-2.amazonaws.com"
+      ]
+    },
+    {
+      "ServiceType": [
+        {
+          "ServiceType": "Interface"
+        }
+      ],
+      "Tags": [],
+      "ManagesVpcEndpoints": false,
+      "AcceptanceRequired": false,
+      "ServiceName": "com.amazonaws.us-west-2.s3",
+      "VpcEndpointPolicySupported": true,
+      "ServiceId": "vpce-svc-0b5d83f29260cde0d",
+      "Owner": "amazon",
+      "AvailabilityZones": [
+        "us-west-2a",
+        "us-west-2b",
+        "us-west-2c",
+        "us-west-2d"
+      ],
+      "BaseEndpointDnsNames": [
+        "s3.us-west-2.amazonaws.com"
+      ]
+    },
+    {
+      "ServiceType": [
+        {
+          "ServiceType": "Interface"
+        }
+      ],
+      "Tags": [],
+      "ManagesVpcEndpoints": false,
+      "PrivateDnsName": "sts.us-west-2.amazonaws.com",
+      "ServiceName": "com.amazonaws.us-west-2.sts",
+      "VpcEndpointPolicySupported": true,
+      "ServiceId": "vpce-svc-06681ce20e9a3e8c4",
+      "Owner": "amazon",
+      "AvailabilityZones": [
+        "us-west-2a",
+        "us-west-2b",
+        "us-west-2c"
+      ],
+      "AcceptanceRequired": false,
+      "BaseEndpointDnsNames": [
+        "sts.us-west-2.vpce.amazonaws.com"
+      ]
+    },
+    {
+      "ServiceType": [
+        {
+          "ServiceType": "Gateway"
+        }
+      ],
+      "Tags": [],
+      "ManagesVpcEndpoints": false,
+      "AcceptanceRequired": false,
+      "ServiceName": "com.amazonaws.us-west-2.ec2",
+      "VpcEndpointPolicySupported": true,
+      "ServiceId": "vpce-svc-non-existing-endpoint-type",
+      "Owner": "amazon",
+      "AvailabilityZones": [
+        "us-west-2a",
+        "us-west-2b",
+        "us-west-2c",
+        "us-west-2d"
+      ],
+      "BaseEndpointDnsNames": [
+        "ec2.us-west-2.amazonaws.com"
+      ]
+    }
+  ]
 }
 `
 var serviceDetailsJSONChina = `
 {
-    "ServiceNames": [
-        "cn.com.amazonaws.cn-north-1.ec2",
-        "cn.com.amazonaws.cn-north-1.ecr.api",
-        "cn.com.amazonaws.cn-north-1.ecr.dkr",
-        "com.amazonaws.cn-north-1.s3",
-        "cn.com.amazonaws.cn-north-1.sts"
-    ],
-    "ServiceDetails": [
+  "ServiceNames": [
+    "cn.com.amazonaws.cn-north-1.ec2",
+    "cn.com.amazonaws.cn-north-1.ecr.api",
+    "cn.com.amazonaws.cn-north-1.ecr.dkr",
+    "com.amazonaws.cn-north-1.s3",
+    "cn.com.amazonaws.cn-north-1.sts"
+  ],
+  "ServiceDetails": [
+    {
+      "ServiceType": [
         {
-            "ServiceType": [
-                {
-                    "ServiceType": "Interface"
-                }
-            ],
-            "Tags": [],
-            "ManagesVpcEndpoints": false,
-            "PrivateDnsName": "ec2.cn-north-1.amazonaws.com.cn",
-            "ServiceName": "cn.com.amazonaws.cn-north-1.ec2",
-            "VpcEndpointPolicySupported": true,
-            "ServiceId": "vpce-svc-0ee6723c76642b3d8",
-            "Owner": "amazon",
-            "AvailabilityZones": [
-                "cn-north-1a",
-                "cn-north-1b"
-            ],
-            "AcceptanceRequired": false,
-            "BaseEndpointDnsNames": [
-                "ec2.cn-north-1.vpce.amazonaws.com.cn"
-            ]
-        },
-        {
-            "ServiceType": [
-                {
-                    "ServiceType": "Interface"
-                }
-            ],
-            "Tags": [],
-            "ManagesVpcEndpoints": false,
-            "PrivateDnsName": "api.ecr.cn-north-1.amazonaws.com.cn",
-            "ServiceName": "cn.com.amazonaws.cn-north-1.ecr.api",
-            "VpcEndpointPolicySupported": true,
-            "ServiceId": "vpce-svc-07d1f428f072fd172",
-            "Owner": "amazon",
-            "AvailabilityZones": [
-                "cn-north-1a",
-                "cn-north-1b"
-            ],
-            "AcceptanceRequired": false,
-            "BaseEndpointDnsNames": [
-                "api.ecr.cn-north-1.vpce.amazonaws.com.cn"
-            ]
-        },
-        {
-            "ServiceType": [
-                {
-                    "ServiceType": "Interface"
-                }
-            ],
-            "Tags": [],
-            "ManagesVpcEndpoints": false,
-            "PrivateDnsName": "*.dkr.ecr.cn-north-1.amazonaws.com.cn",
-            "ServiceName": "cn.com.amazonaws.cn-north-1.ecr.dkr",
-            "VpcEndpointPolicySupported": true,
-            "ServiceId": "vpce-svc-09d74a28015a69002",
-            "Owner": "amazon",
-            "AvailabilityZones": [
-                "cn-north-1a",
-                "cn-north-1b"
-            ],
-            "AcceptanceRequired": false,
-            "BaseEndpointDnsNames": [
-                "dkr.ecr.cn-north-1.vpce.amazonaws.com.cn"
-            ]
-        },
-        {
-            "ServiceType": [
-                {
-                    "ServiceType": "Gateway"
-                }
-            ],
-            "Tags": [],
-            "ManagesVpcEndpoints": false,
-            "AcceptanceRequired": false,
-            "ServiceName": "com.amazonaws.cn-north-1.s3",
-            "VpcEndpointPolicySupported": true,
-            "ServiceId": "vpce-svc-0001be97e1865c74e",
-            "Owner": "amazon",
-            "AvailabilityZones": [
-                "cn-north-1a",
-                "cn-north-1b"
-            ],
-            "BaseEndpointDnsNames": [
-                "s3.cn-north-1.amazonaws.com"
-            ]
-        },
-        {
-            "ServiceType": [
-                {
-                    "ServiceType": "Interface"
-                }
-            ],
-            "Tags": [],
-            "ManagesVpcEndpoints": false,
-            "PrivateDnsName": "sts.cn-north-1.amazonaws.com.cn",
-            "ServiceName": "cn.com.amazonaws.cn-north-1.sts",
-            "VpcEndpointPolicySupported": true,
-            "ServiceId": "vpce-svc-06681ce20e9a3e8c4",
-            "Owner": "amazon",
-            "AvailabilityZones": [
-                "cn-north-1a",
-                "cn-north-1b"
-            ],
-            "AcceptanceRequired": false,
-            "BaseEndpointDnsNames": [
-                "sts.cn-north-1.vpce.amazonaws.com.cn"
-            ]
+          "ServiceType": "Interface"
         }
-    ]
+      ],
+      "Tags": [],
+      "ManagesVpcEndpoints": false,
+      "PrivateDnsName": "ec2.cn-north-1.amazonaws.com.cn",
+      "ServiceName": "cn.com.amazonaws.cn-north-1.ec2",
+      "VpcEndpointPolicySupported": true,
+      "ServiceId": "vpce-svc-0ee6723c76642b3d8",
+      "Owner": "amazon",
+      "AvailabilityZones": [
+        "cn-north-1a",
+        "cn-north-1b"
+      ],
+      "AcceptanceRequired": false,
+      "BaseEndpointDnsNames": [
+        "ec2.cn-north-1.vpce.amazonaws.com.cn"
+      ]
+    },
+    {
+      "ServiceType": [
+        {
+          "ServiceType": "Interface"
+        }
+      ],
+      "Tags": [],
+      "ManagesVpcEndpoints": false,
+      "PrivateDnsName": "api.ecr.cn-north-1.amazonaws.com.cn",
+      "ServiceName": "cn.com.amazonaws.cn-north-1.ecr.api",
+      "VpcEndpointPolicySupported": true,
+      "ServiceId": "vpce-svc-07d1f428f072fd172",
+      "Owner": "amazon",
+      "AvailabilityZones": [
+        "cn-north-1a",
+        "cn-north-1b"
+      ],
+      "AcceptanceRequired": false,
+      "BaseEndpointDnsNames": [
+        "api.ecr.cn-north-1.vpce.amazonaws.com.cn"
+      ]
+    },
+    {
+      "ServiceType": [
+        {
+          "ServiceType": "Interface"
+        }
+      ],
+      "Tags": [],
+      "ManagesVpcEndpoints": false,
+      "PrivateDnsName": "*.dkr.ecr.cn-north-1.amazonaws.com.cn",
+      "ServiceName": "cn.com.amazonaws.cn-north-1.ecr.dkr",
+      "VpcEndpointPolicySupported": true,
+      "ServiceId": "vpce-svc-09d74a28015a69002",
+      "Owner": "amazon",
+      "AvailabilityZones": [
+        "cn-north-1a",
+        "cn-north-1b"
+      ],
+      "AcceptanceRequired": false,
+      "BaseEndpointDnsNames": [
+        "dkr.ecr.cn-north-1.vpce.amazonaws.com.cn"
+      ]
+    },
+    {
+      "ServiceType": [
+        {
+          "ServiceType": "Gateway"
+        }
+      ],
+      "Tags": [],
+      "ManagesVpcEndpoints": false,
+      "AcceptanceRequired": false,
+      "ServiceName": "com.amazonaws.cn-north-1.s3",
+      "VpcEndpointPolicySupported": true,
+      "ServiceId": "vpce-svc-0001be97e1865c74e",
+      "Owner": "amazon",
+      "AvailabilityZones": [
+        "cn-north-1a",
+        "cn-north-1b"
+      ],
+      "BaseEndpointDnsNames": [
+        "s3.cn-north-1.amazonaws.com"
+      ]
+    },
+    {
+      "ServiceType": [
+        {
+          "ServiceType": "Interface"
+        }
+      ],
+      "Tags": [],
+      "ManagesVpcEndpoints": false,
+      "PrivateDnsName": "sts.cn-north-1.amazonaws.com.cn",
+      "ServiceName": "cn.com.amazonaws.cn-north-1.sts",
+      "VpcEndpointPolicySupported": true,
+      "ServiceId": "vpce-svc-06681ce20e9a3e8c4",
+      "Owner": "amazon",
+      "AvailabilityZones": [
+        "cn-north-1a",
+        "cn-north-1b"
+      ],
+      "AcceptanceRequired": false,
+      "BaseEndpointDnsNames": [
+        "sts.cn-north-1.vpce.amazonaws.com.cn"
+      ]
+    }
+  ]
 }
 `
 

--- a/pkg/cfn/builder/vpc_endpoint_test.go
+++ b/pkg/cfn/builder/vpc_endpoint_test.go
@@ -377,6 +377,29 @@ var serviceDetailsJSON = `
             ],
             "Tags": [],
             "ManagesVpcEndpoints": false,
+            "AcceptanceRequired": false,
+            "ServiceName": "com.amazonaws.us-west-2.s3",
+            "VpcEndpointPolicySupported": true,
+            "ServiceId": "vpce-svc-0b5d83f29260cde0d",
+            "Owner": "amazon",
+            "AvailabilityZones": [
+                "us-west-2a",
+                "us-west-2b",
+                "us-west-2c",
+                "us-west-2d"
+            ],
+            "BaseEndpointDnsNames": [
+                "s3.us-west-2.amazonaws.com"
+            ]
+        },
+        {
+            "ServiceType": [
+                {
+                    "ServiceType": "Interface"
+                }
+            ],
+            "Tags": [],
+            "ManagesVpcEndpoints": false,
             "PrivateDnsName": "sts.us-west-2.amazonaws.com",
             "ServiceName": "com.amazonaws.us-west-2.sts",
             "VpcEndpointPolicySupported": true,


### PR DESCRIPTION
### Description

AWS recently added support for interface endpoints for S3, which caused the `DescribeVPCEndpointServices` call to return an additional S3 endpoint. eksctl enables PrivateDNS for all interface endpoints but it is not supported for S3, so the endpoint creation was failing. This PR filters out the S3 interface endpoint and any other unexpected endpoint types before proceeding with creating VPC endpoints. 

Fixes https://github.com/weaveworks/eksctl/issues/3214

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

