### PR TITLE
Fix support for specifying subnets without ID

### DIFF
--- a/examples/24-nodegroup-subnets.yaml
+++ b/examples/24-nodegroup-subnets.yaml
@@ -22,7 +22,7 @@ vpc:
         id: subnet-03a1260affe6f9944
     private:
       private-one:
-        id: subnet-05373e0e6d03065cc
+        cidr: "192.168.160.0/19"
       private-two:
         id: subnet-00110ffa3ef259d0c
       private-three:

--- a/pkg/cfn/builder/cluster.go
+++ b/pkg/cfn/builder/cluster.go
@@ -58,7 +58,6 @@ func unsetExistingResources(existingStack *gjson.Result, clusterConfig *api.Clus
 
 // AddAllResources adds all the information about the cluster to the resource set
 func (c *ClusterResourceSet) AddAllResources() error {
-
 	if err := c.spec.HasSufficientSubnets(); err != nil {
 		return err
 	}

--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -341,7 +341,7 @@ func (v *VPCResourceSet) AddOutputs() {
 
 	addSubnetOutput := func(subnetRefs []*gfnt.Value, topology api.SubnetTopology, outputName string) {
 		v.defineJoinedOutput(outputName, subnetRefs, true, func(value string) error {
-			return vpc.ImportSubnetsFromList(v.ec2API, v.clusterConfig, topology, strings.Split(value, ","))
+			return vpc.ImportSubnetsFromList(v.ec2API, v.clusterConfig, topology, strings.Split(value, ","), []string{})
 		})
 	}
 

--- a/pkg/cfn/manager/compat.go
+++ b/pkg/cfn/manager/compat.go
@@ -92,8 +92,9 @@ func (c *StackCollection) EnsureMapPublicIPOnLaunchEnabled() error {
 	// First, make sure we enable the options in EC2. This is to make sure the settings are applied even
 	// if the stacks in Cloudformation have the setting enabled (since a stack update would produce "nothing to change"
 	// and therefore the setting would not be updated)
-	logger.Debug("enabling attribute MapPublicIpOnLaunch via EC2 on subnets %q", c.spec.PublicSubnetIDs())
-	err := vpc.EnsureMapPublicIPOnLaunchEnabled(c.ec2API, c.spec.PublicSubnetIDs())
+	publicIDs := c.spec.PublicSubnetsWithIDs()
+	logger.Debug("enabling attribute MapPublicIpOnLaunch via EC2 on subnets %q", publicIDs)
+	err := vpc.EnsureMapPublicIPOnLaunchEnabled(c.ec2API, publicIDs)
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/update_legacy_subnet_settings.go
+++ b/pkg/ctl/utils/update_legacy_subnet_settings.go
@@ -58,7 +58,7 @@ func doUpdateLegacySubnetSettings(cmd *cmdutils.Cmd) error {
 
 	stackManager := ctl.NewStackManager(cfg)
 
-	logger.Info("updating settings { MapPublicIpOnLaunch: enabled } for public subnets %q", cfg.PublicSubnetIDs())
+	logger.Info("updating settings { MapPublicIpOnLaunch: enabled } for public subnets %v", cfg.VPC.Subnets.Public)
 	err = stackManager.EnsureMapPublicIPOnLaunchEnabled()
 	if err != nil {
 		logger.Warning(err.Error())


### PR DESCRIPTION
### Description
This allows the feature of leaving out subnet IDs (and only specifying CIDRs) to actually work.
Missing part of #2793 for ~#475~ https://github.com/weaveworks/eksctl/issues/806

Can be reviewed but I'd like to test more.
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

