### PR TITLE
always enable timestamps

### DIFF
--- a/cmd/eksctl/main.go
+++ b/cmd/eksctl/main.go
@@ -67,8 +67,7 @@ func main() {
 		// Control colored output
 		logger.Color = *colorValue == "true"
 		logger.Fabulous = *colorValue == "fabulous"
-		// Add timestamps for debugging
-		logger.Timestamps = logger.Level >= 4
+		logger.Timestamps = true
 	})
 
 	rootCmd.SetUsageFunc(flagGrouping.Usage)

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kevinburke/go-bindata v3.22.0+incompatible
 	github.com/kevinburke/rest v0.0.0-20210106114233-22cd0577e450 // indirect
-	github.com/kris-nova/logger v0.0.0-20181127235838-fd0d87064b06
 	github.com/kubicorn/kubicorn v0.0.0-20180829191017-06f6bce92acc
 	github.com/lithammer/dedent v1.1.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.3.0
@@ -48,7 +47,7 @@ require (
 	github.com/voxelbrain/goptions v0.0.0-20180630082107-58cddc247ea2 // indirect
 	github.com/weaveworks/goformation/v4 v4.10.2-0.20210202192510-c984c16fe84b
 	github.com/weaveworks/launcher v0.0.2-0.20200715141516-1ca323f1de15
-	github.com/weaveworks/logger v0.0.0-20210204141807-28118249ac72
+	github.com/weaveworks/logger v0.0.0-20210210175120-de9359622dfc
 	github.com/whilp/git-urls v0.0.0-20191001220047-6db9661140c0
 	golang.org/x/mod v0.4.1 // indirect
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect

--- a/go.sum
+++ b/go.sum
@@ -1322,8 +1322,8 @@ github.com/weaveworks/goformation/v4 v4.10.2-0.20210202192510-c984c16fe84b h1:zm
 github.com/weaveworks/goformation/v4 v4.10.2-0.20210202192510-c984c16fe84b/go.mod h1:x92o12+Azh6DQ4yoXT5oEuE7dhQHR5V2vy/fmZ6pO7k=
 github.com/weaveworks/launcher v0.0.2-0.20200715141516-1ca323f1de15 h1:i/RhLevywqC6cuUWtGdoaNrsJd+/zWh3PXbkXZIyZsU=
 github.com/weaveworks/launcher v0.0.2-0.20200715141516-1ca323f1de15/go.mod h1:w9Z1vnQmPobkEZ0F3oyiqRYP+62qDqTGnK6t5uhe1kg=
-github.com/weaveworks/logger v0.0.0-20210204141807-28118249ac72 h1:Krh10v8oU268Iq5G/cIhAWwNmHAOQR5HCTBqLkCdsbs=
-github.com/weaveworks/logger v0.0.0-20210204141807-28118249ac72/go.mod h1:bP09VFOFc69sBzZ3WmvolgcJi4qv07quNk13fYSjXSQ=
+github.com/weaveworks/logger v0.0.0-20210210175120-de9359622dfc h1:1sCkSiPvTPq2UQnomwNdVWfrpBkq2N4Z0iEqLR1WycI=
+github.com/weaveworks/logger v0.0.0-20210210175120-de9359622dfc/go.mod h1:bP09VFOFc69sBzZ3WmvolgcJi4qv07quNk13fYSjXSQ=
 github.com/weaveworks/mesh v0.0.0-20170419100114-1f158d31de55/go.mod h1:mcON9Ws1aW0crSErpXWp7U1ErCDEKliDX2OhVlbWRKk=
 github.com/weppos/publicsuffix-go v0.4.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.13.0 h1:0Tu1uzLBd1jPn4k6OnMmOPZH/l/9bj9kUOMMkoRs6Gg=

--- a/pkg/ctl/cmdutils/gitops.go
+++ b/pkg/ctl/cmdutils/gitops.go
@@ -3,9 +3,9 @@ package cmdutils
 import (
 	"fmt"
 
-	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
+	"github.com/weaveworks/logger"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"


### PR DESCRIPTION
### Description

~~This is blocked until this is merged https://github.com/weaveworks/logger/pull/2~~

New default output:
```
eksctl delete cluster -f cluster.yaml
2021-02-10 17:37:30 [ℹ]  eksctl version 0.38.0-dev+048f2055.2021-02-10T17:36:51Z
2021-02-10 17:37:30 [ℹ]  using region us-west-2
2021-02-10 17:37:30 [ℹ]  deleting EKS cluster "jk-alb"
```

Haven't made it configurable, I don't know why you would want it turned off.
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

