### PR TITLE
Support sourceSecurityGroupIds for unmanaged nodegroups

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -293,9 +293,6 @@ func ValidateNodeGroup(i int, ng *NodeGroup) error {
 		if err := validateNodeGroupSSH(ng.SSH); err != nil {
 			return err
 		}
-		if len(ng.SSH.SourceSecurityGroupIDs) > 0 {
-			return fmt.Errorf("%s.sourceSecurityGroupIds is not supported for unmanaged nodegroups", path)
-		}
 	}
 
 	if ng.Bottlerocket != nil && ng.AMIFamily != NodeImageFamilyBottlerocket {

--- a/pkg/cfn/builder/api_test.go
+++ b/pkg/cfn/builder/api_test.go
@@ -1988,10 +1988,7 @@ var _ = Describe("CloudFormation template builder API", func() {
 			Expect(ltd.NetworkInterfaces[0].DeviceIndex).To(Equal(0))
 			Expect(ltd.NetworkInterfaces[0].AssociatePublicIPAddress).To(BeFalse())
 
-			Expect(ngTemplate.Resources).ToNot(HaveKey("SSHIPv4"))
-
-			Expect(ngTemplate.Resources).ToNot(HaveKey("SSHIPv6"))
-
+			assertSSHRules(`null`)
 		})
 	})
 

--- a/pkg/cfn/builder/testdata/launch_template/ssh_enabled.json
+++ b/pkg/cfn/builder/testdata/launch_template/ssh_enabled.json
@@ -158,13 +158,15 @@
                     "CidrIp": "0.0.0.0/0",
                     "FromPort": 22,
                     "IpProtocol": "tcp",
-                    "ToPort": 22
+                    "ToPort": 22,
+                    "Description": "Allow SSH access to managed worker nodes in group ssh-enabled"
                 },
                 {
                     "CidrIpv6": "::/0",
                     "FromPort": 22,
                     "IpProtocol": "tcp",
-                    "ToPort": 22
+                    "ToPort": 22,
+                    "Description": "Allow SSH access to managed worker nodes in group ssh-enabled"
                 }
             ],
             "Tags": [

--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -522,48 +522,6 @@ func (n *NodeGroupResourceSet) addResourcesForSecurityGroups() {
 	})
 }
 
-func makeSSHIngressRules(n *api.NodeGroupBase, vpcCIDR, description string) []gfnec2.SecurityGroup_Ingress {
-	allInternalIPv4 := gfnt.NewString(vpcCIDR)
-	var sgIngressRules []gfnec2.SecurityGroup_Ingress
-	if *n.SSH.Allow {
-		if len(n.SSH.SourceSecurityGroupIDs) > 0 {
-			for _, sgID := range n.SSH.SourceSecurityGroupIDs {
-				sgIngressRules = append(sgIngressRules, gfnec2.SecurityGroup_Ingress{
-					FromPort:              sgPortSSH,
-					ToPort:                sgPortSSH,
-					IpProtocol:            sgProtoTCP,
-					SourceSecurityGroupId: gfnt.NewString(sgID),
-				})
-			}
-		} else {
-			if n.PrivateNetworking {
-				sgIngressRules = append(sgIngressRules, gfnec2.SecurityGroup_Ingress{
-					CidrIp:      allInternalIPv4,
-					Description: gfnt.NewString("Allow SSH access to " + description + " (private, only inside VPC)"),
-					IpProtocol:  sgProtoTCP,
-					FromPort:    sgPortSSH,
-					ToPort:      sgPortSSH,
-				})
-			} else {
-				sgIngressRules = append(sgIngressRules, gfnec2.SecurityGroup_Ingress{
-					CidrIp:      sgSourceAnywhereIPv4,
-					Description: gfnt.NewString("Allow SSH access to " + description),
-					IpProtocol:  sgProtoTCP,
-					FromPort:    sgPortSSH,
-					ToPort:      sgPortSSH,
-				}, gfnec2.SecurityGroup_Ingress{
-					CidrIpv6:    sgSourceAnywhereIPv6,
-					Description: gfnt.NewString("Allow SSH access to " + description),
-					IpProtocol:  sgProtoTCP,
-					FromPort:    sgPortSSH,
-					ToPort:      sgPortSSH,
-				})
-			}
-		}
-	}
-	return sgIngressRules
-}
-
 func (v *VPCResourceSet) haNAT() {
 	for _, az := range v.clusterConfig.AvailabilityZones {
 		alphanumericUpperAZ := strings.ToUpper(strings.Join(strings.Split(az, "-"), ""))


### PR DESCRIPTION
### Description

Adds support for `nodegroup.ssh.sourceSecurityGroupIds` for unmanaged nodegroups.

Closes https://github.com/weaveworks/eksctl/issues/2366

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

