### PR TITLE
Restructure release workflow to work through PRs

### DIFF
--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -17,7 +17,7 @@ jobs:
         name: Get integration tests status
         id: it-status
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.WEAVEWORKSBOT_TOKEN }}
           script: |
             // There's no other way to identify the integration test job
             // GH branch protections are also just a string
@@ -50,5 +50,6 @@ jobs:
         run: |
           git config user.name "weaveworksbot"
           git config user.email "weaveworksbot@users.noreply.github.com"
-      - name: Push release branch, tag RC and update main branch
+          echo "${{ secrets.WEAVEWORKSBOT_TOKEN }}" | gh auth login --with-token
+      - name: Open PRs to release branch and default branch
         run: make prepare-release-candidate

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,38 @@
+name: Tag release
+# This workflow watches release branches for PRs merged with a certain label
+# and commits with the label in their commit message and then creates a tag
+# for the version eksctl reports at that commit
+
+on:
+  pull_request: 
+    types: [closed]
+  push:
+    branches:
+      - release-[0-9]+.[0-9]+
+
+jobs:
+  tag:
+    if: |
+      contains(github.event.pull_request.labels.*.name, '/trigger-release') && github.event.pull_request.merge_commit_sha != null
+      || contains(github.event.head_commit.message, '/trigger-release')
+    name: Tag release from version
+    runs-on: ubuntu-latest
+    container: weaveworks/eksctl-build:5705efb32cdbf4531b282dba24dae03a872f5b31
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.WEAVEWORKSBOT_TOKEN }}
+          fetch-depth: 0
+      - name: Cache go-build and mod
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build/
+            ~/go/pkg/mod/
+          key: ${{ hashFiles('go.sum') }}
+      - name: Tag from version
+        run: |
+          tag=$(go run pkg/version/generate/release_generate.go full-version)
+          git tag "${tag}"
+          git push origin "${tag}"

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -16,6 +16,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, '/trigger-release') && github.event.pull_request.merge_commit_sha != null
       || contains(github.event.head_commit.message, '/trigger-release')
     name: Tag release from version
+    environment: release
     runs-on: ubuntu-latest
     container: weaveworks/eksctl-build:5705efb32cdbf4531b282dba24dae03a872f5b31
     steps:

--- a/build/scripts/tag-common.sh
+++ b/build/scripts/tag-common.sh
@@ -77,8 +77,17 @@ function bump_version_if_not_at() {
     return 0
   fi
   echo "Preparing for next development iteration"
+  git checkout -b "${default_branch}-$(git rev-parse --short HEAD)"
   release_generate development
   git add pkg/version/release.go
   git commit --message "Prepare for next development iteration"
+  git push origin "$(git branch --show-current)"
   gh pr create --fill --label "skip-release-notes"
+}
+
+function make_pr() {
+  local base_branch=$1
+  git checkout -b "${base_branch}-$(git rev-parse --short HEAD)"
+  git push origin "$(git branch --show-current)"
+  gh pr create --base "${base_branch}" --fill --label "skip-release-notes" --label "/trigger-release"
 }

--- a/build/scripts/tag-release-candidate.sh
+++ b/build/scripts/tag-release-candidate.sh
@@ -43,8 +43,8 @@ commit "${m}" "${release_notes_file}"
 
 tag_version_and_latest "${m}" "${rc_version}"
 
-git push origin "${release_branch}:${release_branch}"
-git push origin "${rc_version}"
+# Make PR to release branch
+make_pr "${release_branch}"
 
 # Make PR to update default branch if necessary
 git checkout "${default_branch}"

--- a/build/scripts/tag-release.sh
+++ b/build/scripts/tag-release.sh
@@ -31,8 +31,7 @@ tag_version_and_latest "${m}" "${release_version}"
 # Update the site by putting everything from the release into the docs branch
 git push --force origin "${release_branch}":docs
 
-git push origin "${release_branch}:${release_branch}"
-git push origin "${release_version}"
+make_pr "${release_branch}"
 
 # Make PR to update default branch if necessary
 git checkout "${default_branch}"

--- a/pkg/version/generate/release_generate.go
+++ b/pkg/version/generate/release_generate.go
@@ -34,6 +34,9 @@ func main() {
 		newVersion, newPreRelease = prepareReleaseCandidate()
 	case "development":
 		newVersion, newPreRelease = nextDevelopmentIteration()
+	case "full-version":
+		fmt.Println(version.GetVersion())
+		return
 	case "print-version":
 		// Print simplified version X.Y.Z
 		fmt.Println(version.Version)


### PR DESCRIPTION
### Description
This avoids having to mess with branch protections. Assuming we have branch protections for `release-*` and `main`, this becomes the process:
1. Run "release candidate" workflow
1. Github opens a PR to the release branch updating `pkg/release/version.go` (i.e. going from `0.38.0-dev` to `0.38.0-rc.0` or from `rc.0` to `0.38.0`
    * it has a special `/trigger-release` label
    * (here we could add the autogenerated release notes to the PR for approval)
1. When it's merged, another workflow sees the closed PR with this label and creates a tag from the `eksctl` version (i.e. `pkg/release/version.go`
1. CircleCI picks up the tag and releases

Eventually 3+4 would be merged so that the closed PR directly triggers `goreleaser` in one workflow instead of just creating the tag for CircleCI
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

