### PR TITLE
netlify.toml: only build on changes to docs/

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,7 @@
   base = "userdocs"
   publish = "userdocs/site"
   command = "cd .. && make -f Makefile.docs build-pages"
+[context.deploy-preview]
   ignore = "git diff --quiet HEAD^ HEAD ./"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   base = "userdocs"
   publish = "userdocs/site"
   command = "cd .. && make -f Makefile.docs build-pages"
-  ignore = "git diff --quiet HEAD^ HEAD userdocs/"
+  ignore = "git diff --quiet HEAD^ HEAD ./"
 
 [build.environment]
   PYTHON_VERSION = "3.7"

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,7 @@
   base = "userdocs"
   publish = "userdocs/site"
   command = "cd .. && make -f Makefile.docs build-pages"
+  ignore = "git diff --quiet HEAD^ HEAD userdocs/"
 
 [build.environment]
   PYTHON_VERSION = "3.7"


### PR DESCRIPTION
### Description

Only rebuild on changes under /docs, per https://github.com/weaveworks/corp/issues/1413#issuecomment-780459932
This might be too aggressive and need to be reverted, so please review.

I'm unaware of any way to test this in a reasonable timeframe, but reverting should be easy.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

