### PR TITLE
bump upgrade cluster timeout to 65

### DIFF
--- a/pkg/ctl/upgrade/cluster.go
+++ b/pkg/ctl/upgrade/cluster.go
@@ -15,7 +15,7 @@ import (
 
 // updating from 1.15 to 1.16 has been observed to take longer than the default value of 25 minutes
 // increased to 50 for flex fleet changes
-const upgradeClusterTimeout = 50 * time.Minute
+const upgradeClusterTimeout = 65 * time.Minute
 
 func upgradeCluster(cmd *cmdutils.Cmd) {
 	upgradeClusterWithRunFunc(cmd, DoUpgradeCluster)


### PR DESCRIPTION
### Description

As of 1.19 the average/expected time taken in 60 mins. I've bumped it to 65 to add some wiggle room.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

