### PR TITLE
Creating the FargatePodExecutionRole resource only if a Fargate profile doesn't specify a podExecutionRoleARN

### DIFF
--- a/pkg/cfn/builder/cluster.go
+++ b/pkg/cfn/builder/cluster.go
@@ -81,7 +81,7 @@ func (c *ClusterResourceSet) AddAllResources() error {
 	c.addResourcesForIAM()
 	c.addResourcesForControlPlane(vpcResource.SubnetDetails)
 
-	if len(c.spec.FargateProfiles) > 0 {
+	if c.fargateProfileRequired() {
 		c.addResourcesForFargate()
 	}
 
@@ -196,6 +196,16 @@ func (c *ClusterResourceSet) addResourcesForControlPlane(subnetDetails *subnetDe
 				return nil
 			})
 	}
+}
+
+func (c *ClusterResourceSet) fargateProfileRequired() bool {
+	for _, profile := range c.spec.FargateProfiles {
+		if profile.PodExecutionRoleARN == "" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (c *ClusterResourceSet) addResourcesForFargate() {


### PR DESCRIPTION
### Description

Splitting out https://github.com/weaveworks/eksctl/pull/3321

Fixes https://github.com/weaveworks/eksctl/issues/1945

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

