### PR TITLE
Clarify difference between fargate flag and config

### DIFF
--- a/userdocs/src/usage/fargate-support.md
+++ b/userdocs/src/usage/fargate-support.md
@@ -47,7 +47,11 @@ $ eksctl create cluster --fargate
 [✔]  EKS cluster "ridiculous-painting-1574859263" in "ap-northeast-1" region is ready
 ```
 
-This command will have created a cluster and a Fargate profile. This profile contains certain information needed by AWS to instantiate
+When the profile is not specified but support for Fargate is enabled with `--fargate` a default Fargate profile is
+created. The default profile targets the `default` and the `kube-system` namespaces so pods in those namespaces will run on
+Fargate.
+
+The default profile also contains certain information needed by AWS to instantiate
 pods in Fargate. These are:
 
 - pod execution role to define the permissions required to run the pod and the
@@ -56,10 +60,6 @@ pods in Fargate. These are:
   easier to migrate existing pods on a cluster to Fargate.
 - Selector to define which pods should run on Fargate. This is composed by a
   `namespace` and `labels`.
-
-When the profile is not specified but support for Fargate is enabled with `--fargate` a default Fargate profile is
-created. This profile targets the `default` and the `kube-system` namespaces so pods in those namespaces will run on
-Fargate.
 
 The Fargate profile that was created can be checked with the following command:
 
@@ -109,15 +109,15 @@ fargateProfiles:
       # All workloads in the "kube-system" Kubernetes namespace will be
       # scheduled onto Fargate:
       - namespace: kube-system
-  - name: fp-dev
-    selectors:
-      # All workloads in the "dev" Kubernetes namespace matching the following
-      # label selectors will be scheduled onto Fargate:
-      - namespace: dev
-        labels:
-          env: dev
-          checks: passed
 ```
+
+!!!note
+    There is no direct equivalent to the `--fargate` flag in the config file, and
+    they cannot be used together.
+
+    The `--fargate` flag will create a the default profile, as shown in the above config.
+    When enabling fargate via the config file the profiles have to be deliberately
+    specified.
 
 ```console
 $ eksctl create cluster -f cluster-fargate.yaml


### PR DESCRIPTION
### Description

Closes https://github.com/weaveworks/eksctl/issues/3311.

We do have a UX discrepancy when it comes to enabling fargate. Users can currently run `create cluster --fargate` and have a default profile created for them without any customisation. There is no direct equivalence for this in the config file: users have to define `fargateProfiles` in the spec, and be explicit about what they want. The flag sets the `FargateProfile` object, which is what we use as the marker for deciding whether to prep the cluster for Fargate (and then create profiles).

I don't believe we should have an `enableFargate: bool` in the config. Having it on the command line is fine, since flags are more useful for people playing around with `eksctl`.  We tend to assume that folks use config to have finer control over their cluster, and to use more advanced options (there are several options we do not expose via flags at all). I believe `kubectl` has a similar principle. I also think that adding this field would lead to wider UX and internal changes.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

