### PR TITLE
Fix 3393: fully-private clusters are not supported in region ""

### DIFF
--- a/pkg/cfn/builder/cluster.go
+++ b/pkg/cfn/builder/cluster.go
@@ -38,6 +38,7 @@ func NewClusterResourceSet(ec2API ec2iface.EC2API, region string, spec *api.Clus
 		rs:                   rs,
 		spec:                 spec,
 		ec2API:               ec2API,
+		region:               region,
 		supportsManagedNodes: supportsManagedNodes,
 		vpcResourceSet:       NewVPCResourceSet(rs, spec, ec2API),
 	}


### PR DESCRIPTION
Fixes https://github.com/weaveworks/eksctl/issues/3393.

### Description

One line change when creating a new ClusterResourceSet: we weren't setting the region. When private cluster options are enabled we reset the VPC resource set and pass in the region from the Cluster resource set. When this is blank, everything obviously fails.

We have zero unit tests around `pkg/cfn/builder/cluster.go` and it seems no integration tests for private clusters. I will add these today, but I am doing so in separate PRs as I would like to get this fix released asap. (If people think we are okay to wait then we can delay the release, but I think we shouldn't)

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

