### PR TITLE
Merge release 0.40.0 to main

### DIFF
--- a/docs/release_notes/0.40.0.md
+++ b/docs/release_notes/0.40.0.md
@@ -22,6 +22,7 @@
 ## Bug Fixes
 - Prevent setting internal NodeGroup fields via ClusterConfig (#3339)
 - Fix 3393: fully-private clusters are not supported in region "" (#3394)
+- Set systemd cgroupdriver when HasMixedInstances (fix 3391) (#3398)
 
 
 ## Acknowledgments

--- a/docs/release_notes/0.40.0.md
+++ b/docs/release_notes/0.40.0.md
@@ -5,6 +5,7 @@
 - Add support for Asia Pacific (Osaka) region (#3347)
 - Add disable-eviction flag for nodegroup drain and delete (#3330)
 - Allow referring to subnets by ID in nodegroups (#3331)
+- Create nodegroups/managed-nodegroups on unowned clusters (#3388)
 
 
 ## Improvements
@@ -20,6 +21,7 @@
 
 ## Bug Fixes
 - Prevent setting internal NodeGroup fields via ClusterConfig (#3339)
+- Fix 3393: fully-private clusters are not supported in region "" (#3394)
 
 
 ## Acknowledgments

--- a/pkg/version/release.go
+++ b/pkg/version/release.go
@@ -6,7 +6,7 @@ package version
 var Version = "0.41.0"
 
 // PreReleaseID can be empty for releases, "rc.X" for release candidates and "dev" for snapshots
-var PreReleaseID = ""
+var PreReleaseID = "dev"
 
 // gitCommit is the short commit hash. It will be set by the linker.
 var gitCommit = ""

--- a/pkg/version/release.go
+++ b/pkg/version/release.go
@@ -6,7 +6,7 @@ package version
 var Version = "0.41.0"
 
 // PreReleaseID can be empty for releases, "rc.X" for release candidates and "dev" for snapshots
-var PreReleaseID = "rc.0"
+var PreReleaseID = ""
 
 // gitCommit is the short commit hash. It will be set by the linker.
 var gitCommit = ""

--- a/pkg/version/release.go
+++ b/pkg/version/release.go
@@ -6,7 +6,7 @@ package version
 var Version = "0.41.0"
 
 // PreReleaseID can be empty for releases, "rc.X" for release candidates and "dev" for snapshots
-var PreReleaseID = "dev"
+var PreReleaseID = "rc.0"
 
 // gitCommit is the short commit hash. It will be set by the linker.
 var gitCommit = ""


### PR DESCRIPTION
### Description

The GitHub action that merges release changes to main failed due to a small schema conflict. This PR resolves it and merges release-0.40 with main.

