### PR TITLE
Fix: nil pointer dereference when VPC is empty

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -52,7 +52,7 @@ func SetClusterConfigDefaults(cfg *ClusterConfig) {
 		cfg.PrivateCluster = &PrivateCluster{}
 	}
 
-	if cfg.VPC.ManageSharedNodeSecurityGroupRules == nil {
+	if cfg.VPC != nil && cfg.VPC.ManageSharedNodeSecurityGroupRules == nil {
 		cfg.VPC.ManageSharedNodeSecurityGroupRules = Enabled()
 	}
 }

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -136,7 +136,7 @@ func ValidateClusterConfig(cfg *ClusterConfig) error {
 	}
 
 	// manageSharedNodeSecurityGroupRules cannot be disabled if using eksctl managed security groups
-	if cfg.VPC.SharedNodeSecurityGroup == "" && IsDisabled(cfg.VPC.ManageSharedNodeSecurityGroupRules) {
+	if cfg.VPC != nil && cfg.VPC.SharedNodeSecurityGroup == "" && IsDisabled(cfg.VPC.ManageSharedNodeSecurityGroupRules) {
 		return errors.New("vpc.manageSharedNodeSecurityGroupRules must be enabled when using ekstcl-managed security groups")
 	}
 


### PR DESCRIPTION
This PR resolves issue #3442 introduced by #3027 that causes eksctl to panic when a cluster config with no VPC configuration is passed to `SetClusterConfigDefaults` or `ValidateClusterConfig`.