### PR TITLE
bump integration test upgrade timeouts

### DIFF
--- a/integration/tests/unowned_cluster/unowned_cluster_test.go
+++ b/integration/tests/unowned_cluster/unowned_cluster_test.go
@@ -226,6 +226,7 @@ var _ = Describe("(Integration) [non-eksctl cluster & nodegroup support]", func(
 				"cluster",
 				"--name", params.ClusterName,
 				"--version", "1.19",
+				"--timeout", "1h30m0s",
 				"--approve",
 				"--verbose", "2",
 			)
@@ -299,6 +300,7 @@ var _ = Describe("(Integration) [non-eksctl cluster & nodegroup support]", func(
 				"--name", mng1,
 				"--cluster", params.ClusterName,
 				"--kubernetes-version", "1.19",
+				"--timeout", "1h30m0s",
 				"--wait",
 				"--verbose", "2",
 			)

--- a/integration/tests/unowned_cluster/unowned_cluster_test.go
+++ b/integration/tests/unowned_cluster/unowned_cluster_test.go
@@ -226,7 +226,7 @@ var _ = Describe("(Integration) [non-eksctl cluster & nodegroup support]", func(
 				"cluster",
 				"--name", params.ClusterName,
 				"--version", "1.19",
-				"--timeout", "1h30m0s",
+				"--timeout", "1h30m",
 				"--approve",
 				"--verbose", "2",
 			)

--- a/integration/tests/unowned_cluster/unowned_cluster_test.go
+++ b/integration/tests/unowned_cluster/unowned_cluster_test.go
@@ -300,7 +300,7 @@ var _ = Describe("(Integration) [non-eksctl cluster & nodegroup support]", func(
 				"--name", mng1,
 				"--cluster", params.ClusterName,
 				"--kubernetes-version", "1.19",
-				"--timeout", "1h30m0s",
+				"--timeout", "1h30m",
 				"--wait",
 				"--verbose", "2",
 			)


### PR DESCRIPTION
### Description

I've seen this timeout quite a bit in integration tests, most recently https://github.com/weaveworks/eksctl/actions/runs/667417148

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

