### PR TITLE
add managed-by label to eksctl created service accounts

### DIFF
--- a/pkg/cfn/manager/create_tasks.go
+++ b/pkg/cfn/manager/create_tasks.go
@@ -12,6 +12,11 @@ import (
 	"github.com/weaveworks/eksctl/pkg/vpc"
 )
 
+const (
+	managedByKubernetesLabelKey   = "app.kubernetes.io/managed-by"
+	managedByKubernetesLabelValue = "eksctl"
+)
+
 // NewTasksToCreateClusterWithNodeGroups defines all tasks required to create a cluster along
 // with some nodegroups; see CreateAllNodeGroups for how onlyNodeGroupSubset works
 func (c *StackCollection) NewTasksToCreateClusterWithNodeGroups(nodeGroups []*api.NodeGroup,
@@ -130,6 +135,11 @@ func (c *StackCollection) NewTasksToCreateIAMServiceAccounts(serviceAccounts []*
 				kubernetes: clientSetGetter,
 				call: func(clientSet kubernetes.Interface) error {
 					sa.SetAnnotations()
+					if sa.Labels == nil {
+						sa.Labels = make(map[string]string)
+					}
+
+					sa.Labels[managedByKubernetesLabelKey] = managedByKubernetesLabelValue
 					if err := kubernetes.MaybeCreateServiceAccountOrUpdateMetadata(clientSet, sa.ClusterIAMMeta.AsObjectMeta()); err != nil {
 						return errors.Wrapf(err, "failed to create service account %s", sa.NameString())
 					}


### PR DESCRIPTION
### Description

As part of https://github.com/weaveworks/eksctl/issues/3422 we need to be able to track serviceaccounts that don't have CloudFormation stacks. SA's with no stacks are using the `attachRoleARN` functionality. Alternatively it might be that the stack was deleted, which we need to pick up on.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

