### PR TITLE
Add docs for non eksctl-created clusters

### DIFF
--- a/userdocs/mkdocs.yml
+++ b/userdocs/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
     - Introduction: introduction.md
     - Usage:
         - usage/creating-and-managing-clusters.md
+        - usage/unowned-clusters.md
         - usage/managing-nodegroups.md
         - usage/security.md
         - usage/cluster-upgrade.md
@@ -77,3 +78,5 @@ markdown_extensions:
     - codehilite:
         linenums: true
     - pymdownx.superfences
+    - pymdownx.tasklist:
+        custom_checkbox: true

--- a/userdocs/src/index.md
+++ b/userdocs/src/index.md
@@ -2,7 +2,10 @@
 
 sponsored by [![Weaveworks](img/empty.svg#wwinline)](https://www.weave.works/) and built by [![Contributors](img/gophers.png#inline)](https://github.com/weaveworks/eksctl/graphs/contributors) on [![Github](img/empty.svg#gitinline)](https://github.com/weaveworks/eksctl)
 
-`eksctl` is a simple CLI tool for creating clusters on EKS - Amazon's new managed Kubernetes service for EC2.
+!!! tip "New for 2021"
+    Use `eksctl` to manage clusters which were created by other tools. Find out more [here](/usage/unowned-clusters).
+
+`eksctl` is a simple CLI tool for creating and managing clusters on EKS - Amazon's managed Kubernetes service for EC2.
 It is written in Go, uses CloudFormation, was created by [Weaveworks](https://www.weave.works/) and it welcomes
 contributions from the community. Create a basic cluster in minutes with just one command:
 

--- a/userdocs/src/usage/faq.md
+++ b/userdocs/src/usage/faq.md
@@ -1,3 +1,10 @@
+## Eksctl
+
+!!! question "Can I use `eksctl` to manage clusters which weren't created by `eksctl`?"
+
+    Yes! From version `0.40.0` you can run `eksctl` against any cluster, whether it was created
+    by `eksctl` or not. Find out more [here](/usage/unowned-clusters).
+
 ## Nodegroups
 
 !!! question "How can I change the instance type of my nodegroup?"

--- a/userdocs/src/usage/unowned-clusters.md
+++ b/userdocs/src/usage/unowned-clusters.md
@@ -1,0 +1,92 @@
+# Non eksctl-created clusters
+
+From `eksctl` version `0.40.0` users can run `eksctl` commands against clusters which were
+not created by `eksctl`.
+
+## Supported commands
+
+The following commands can be used against clusters created by any means other than `eksctl`.
+The commands, flags and config file options can be used in exactly the same way.
+
+If we have missed some functionality, please [let us know](https://github.com/weaveworks/eksctl/issues).
+
+- [x] Create:
+    - [x] `eksctl create nodegroup` ([see note below](#creating-nodegroups))
+    - [x] `eksctl create fargateprofile`
+    - [x] `eksctl create iamserviceaccount`
+    - [x] `eksctl create iamidentitymapping`
+- [x] Get:
+    - [x] `eksctl get clusters/cluster`
+    - [x] `eksctl get nodegroup`
+    - [x] `eksctl get labels`
+- [x] Delete:
+    - [x] `eksctl delete cluster`
+    - [x] `eksctl delete nodegroup`
+    - [x] `eksctl delete fargateprofile`
+    - [x] `eksctl delete iamserviceaccount`
+    - [x] `eksctl delete iamidentitymapping`
+- [x] Upgrade:
+    - [x] `eksctl upgrade cluster`
+    - [x] `eksctl upgrade nodegroup`
+- [x] Set/Unset:
+    - [x] `eksctl set labels`
+    - [x] `eksctl unset labels`
+- [x] Scale:
+    - [x] `eksctl scale nodegroup`
+- [x] Drain:
+    - [x] `eksctl drain nodegroup`
+- [x] Enable:
+    - [x] `eksctl enable profile`
+    - [x] `eksctl enable repo`
+- [x] Utils:
+    - [x] `eksctl utils associate-iam-oidc-provider`
+    - [x] `eksctl utils describe-stacks`
+    - [x] `eksctl utils install-vpc-controllers`
+    - [x] `eksctl utils nodegroup-health`
+    - [x] `eksctl utils set-public-access-cidrs`
+    - [x] `eksctl utils update-cluster-endpoints`
+    - [x] `eksctl utils update-cluster-logging`
+    - [x] `eksctl utils write-kubeconfig`
+    - [x] `eksctl utils update-coredns`
+    - [x] `eksctl utils update-aws-node`
+    - [x] `eksctl utils update-kube-proxy`
+
+## Creating nodegroups
+
+`eksctl create nodegroup` is the only command which requires specific input from the user.
+
+Since users can create their clusters with any networking configuration they like,
+for the time-being, `eksctl` will not attempt to retrieve or guess these values. This
+may change in the future as we learn more about how people are using this command on non eksctl-created clusters.
+
+This means that in order to create nodegroups or managed nodegroups on a cluster which was
+not created by `eksctl`, a config file containing VPC details must be provided. At a minumum:
+
+```yaml
+---
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: non-eksctl-created-cluster
+  region: us-west-2
+
+vpc:
+  id: "vpc-12345"
+  securityGroup: "sg-12345"
+  subnets:
+    private:
+      private1:
+          id: "subnet-12345"
+      private1:
+          id: "subnet-12345"
+    public:
+      public1:
+          id: "subnet-12345"
+      public2:
+          id: "subnet-12345"
+
+...
+```
+
+Further information on VPC configuration options can be found [here](/usage/vpc-networking).


### PR DESCRIPTION
I know we are waiting for blogs and the like, but we should at least have _some_ docs, especially because people are asking about this.