### PR TITLE
Error when no VPC config provided for nodegroups created on unowned cluster

### DIFF
--- a/pkg/actions/nodegroup/create.go
+++ b/pkg/actions/nodegroup/create.go
@@ -275,8 +275,8 @@ func checkARMSupport(ctl *eks.ClusterProvider, clientSet kubernetes.Interface, c
 }
 
 func loadVPCFromConfig(provider api.ClusterProvider, cfg *api.ClusterConfig) error {
-	if cfg.VPC == nil {
-		return errors.New("VPC configuration required for creating nodegroup")
+	if cfg.VPC.Subnets == nil || cfg.VPC.SecurityGroup == "" || cfg.VPC.ID == "" {
+		return errors.New("VPC configuration required for creating nodegroups on clusters not owned by eksctl: vpc.subnets, vpc.id, vpc.securityGroup")
 	}
 
 	if err := vpc.ImportSubnetsFromSpec(provider, cfg); err != nil {

--- a/userdocs/src/usage/unowned-clusters.md
+++ b/userdocs/src/usage/unowned-clusters.md
@@ -73,18 +73,18 @@ metadata:
 
 vpc:
   id: "vpc-12345"
-  securityGroup: "sg-12345"
+  securityGroup: "sg-12345"    # this is the ControlPlaneSecurityGroup
   subnets:
     private:
       private1:
           id: "subnet-12345"
-      private1:
-          id: "subnet-12345"
+      private2:
+          id: "subnet-67890"
     public:
       public1:
           id: "subnet-12345"
       public2:
-          id: "subnet-12345"
+          id: "subnet-67890"
 
 ...
 ```


### PR DESCRIPTION
### Description

Closes https://github.com/weaveworks/eksctl/issues/3484.

When users forget to provide VPC config when creating ngs on unowned clusters, eksctl panics when trying to load the subnets. We were initially checking for `VPC == nil`, and forgot that eksctl creates a blank VPC object for each command so this can never be nil. This PR changes it so that we explicitly check for every required piece of VPC configuration, and error if one is not found.

(I also improved an example yaml in the docs.)

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

