### PR TITLE
remove ifconfig curl

### DIFF
--- a/integration/data/test-http.yaml
+++ b/integration/data/test-http.yaml
@@ -44,21 +44,6 @@ spec:
             - --head
             - kubernetes.io
       - image: tutum/curl@sha256:b6f16e88387acd4e6326176b212b3dae63f5b2134e69560d0b0673cfb0fb976f
-        name: https-test-ifconfig
-        stdin: true
-        tty: true
-        readinessProbe:
-          initialDelaySeconds: 0
-          periodSeconds: 3
-          failureThreshold: 3
-          timeoutSeconds: 1
-          exec:
-            command:
-            - curl
-            - --fail
-            - --silent
-            - https://ifconfig.co/
-      - image: tutum/curl@sha256:b6f16e88387acd4e6326176b212b3dae63f5b2134e69560d0b0673cfb0fb976f
         name: https-test-metadata
         stdin: true
         tty: true
@@ -73,4 +58,4 @@ spec:
             - --fail
             - --silent
             - http://169.254.169.254/latest/meta-data/local-ipv4
-        
+


### PR DESCRIPTION
### Description

This site has started throwing 429's a lot and seems like an unnecessary extra curl, so I'm removing it. More context: https://github.com/weaveworks/eksctl/issues/3480#issuecomment-810225306

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

