### PR TITLE
use random cluster name in dry run integration test

### DIFF
--- a/integration/tests/dry_run/dry_run_test.go
+++ b/integration/tests/dry_run/dry_run_test.go
@@ -48,7 +48,7 @@ iam:
   withOIDC: false
 kind: ClusterConfig
 metadata:
-  name: dry-run-cluster
+  name: %[1]s
   region: us-west-2
   version: "1.18"
 nodeGroups:
@@ -72,7 +72,7 @@ nodeGroups:
       xRay: false
   instanceType: m5.large
   labels:
-    alpha.eksctl.io/cluster-name: dry-run-cluster
+    alpha.eksctl.io/cluster-name: %[1]s
     alpha.eksctl.io/nodegroup-name: ng-default
   name: ng-default
   privateNetworking: false
@@ -109,7 +109,7 @@ managedNodeGroups:
       xRay: false
   instanceType: m5.large
   labels:
-    alpha.eksctl.io/cluster-name: dry-run-cluster
+    alpha.eksctl.io/cluster-name: %[1]s
     alpha.eksctl.io/nodegroup-name: ng-default
   maxSize: 2
   minSize: 2
@@ -147,7 +147,7 @@ var _ = Describe("(Integration) [Dry-Run test]", func() {
 	parseOutput := func(output []byte) (*api.ClusterConfig, *api.ClusterConfig) {
 		actual, err := eks.ParseConfig(output)
 		Expect(err).ToNot(HaveOccurred())
-		expected, err := eks.ParseConfig([]byte(defaultClusterConfig))
+		expected, err := eks.ParseConfig([]byte(fmt.Sprintf(defaultClusterConfig, params.ClusterName)))
 		Expect(err).ToNot(HaveOccurred())
 		return actual, expected
 	}
@@ -163,7 +163,8 @@ var _ = Describe("(Integration) [Dry-Run test]", func() {
 			WithArgs(
 				"cluster",
 				"--dry-run",
-				"--name=dry-run-cluster",
+				"--name",
+				params.ClusterName,
 			).
 			WithArgs(createArgs...)
 
@@ -227,7 +228,8 @@ var _ = Describe("(Integration) [Dry-Run test]", func() {
 		cmd := params.EksctlCreateCmd.
 			WithArgs(
 				"cluster",
-				"--name=dry-run-cluster",
+				"--name",
+				params.ClusterName,
 				"--dry-run",
 				"--nodegroup-name=ng-default",
 			).


### PR DESCRIPTION
### Description
Tested locally
```
Ran 13 of 13 Specs in 1690.900 seconds
SUCCESS! -- 13 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestDryRun (1690.90s)
PASS

Ginkgo ran 1 suite in 28m12.716316408s
Test Suite Passed
```
### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

