### PR TITLE
Get nodegroup desired capacity from autoscaling instead of cloudformation

### DIFF
--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/cloudtrail/cloudtrailiface"
 	"github.com/weaveworks/eksctl/pkg/cfn/waiter"
 
@@ -74,6 +75,7 @@ type StackCollection struct {
 	eksAPI            eksiface.EKSAPI
 	iamAPI            iamiface.IAMAPI
 	cloudTrailAPI     cloudtrailiface.CloudTrailAPI
+	asgAPI            autoscalingiface.AutoScalingAPI
 	spec              *api.ClusterConfig
 	disableRollback   bool
 	roleARN           string
@@ -104,6 +106,7 @@ func NewStackCollection(provider api.ClusterProvider, spec *api.ClusterConfig) *
 		eksAPI:            provider.EKS(),
 		iamAPI:            provider.IAM(),
 		cloudTrailAPI:     provider.CloudTrail(),
+		asgAPI:            provider.ASG(),
 		disableRollback:   provider.CloudFormationDisableRollback(),
 		roleARN:           provider.CloudFormationRoleARN(),
 		region:            provider.Region(),

--- a/pkg/testutils/mockprovider/mock_provider.go
+++ b/pkg/testutils/mockprovider/mock_provider.go
@@ -102,6 +102,9 @@ func (m MockProvider) MockCloudFormation() *mocks.CloudFormationAPI {
 // ASG returns a representation of the ASG API
 func (m MockProvider) ASG() autoscalingiface.AutoScalingAPI { return m.asg }
 
+// MockASG returns a mocked ASG API
+func (m MockProvider) MockASG() *mocks.AutoScalingAPI { return m.ASG().(*mocks.AutoScalingAPI) }
+
 // EKS returns a representation of the EKS API
 func (m MockProvider) EKS() eksiface.EKSAPI { return m.eks }
 


### PR DESCRIPTION
Closes #2331 

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Update nodegroup summaries to use desired capacity set at the autoscaling group level instead of in the cloudformation stack. This allows for getting more accurate desired capacity when using cluster-autoscaler since the autoscaling group desired capacity gets changed directly and isn't reflected in cloudformation.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2: