### PR TITLE
Fix config file support for the upgrade nodegroup command

### DIFF
--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -529,6 +529,13 @@ func NewDeleteNodeGroupLoader(cmd *Cmd, ng *api.NodeGroup, ngFilter *filter.Node
 	return l
 }
 
+// NewUpgradeNodeGroupLoader will load config or use flags for 'eksctl upgrade nodegroup'
+func NewUpgradeNodeGroupLoader(cmd *Cmd) ClusterConfigLoader {
+	l := newCommonClusterConfigLoader(cmd)
+	l.flagsIncompatibleWithConfigFile.Delete("name")
+	return l
+}
+
 // NewUtilsEnableLoggingLoader will load config or use flags for 'eksctl utils update-cluster-logging'
 func NewUtilsEnableLoggingLoader(cmd *Cmd) ClusterConfigLoader {
 	l := newCommonClusterConfigLoader(cmd)

--- a/pkg/ctl/upgrade/nodegroup.go
+++ b/pkg/ctl/upgrade/nodegroup.go
@@ -24,6 +24,11 @@ func upgradeNodeGroupCmd(cmd *cmdutils.Cmd) {
 	var options managed.UpgradeOptions
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
+
+		if err := cmdutils.NewUpgradeNodeGroupLoader(cmd).Load(); err != nil {
+			return err
+		}
+
 		return upgradeNodeGroup(cmd, options)
 	}
 


### PR DESCRIPTION
### Description

The upgrade nodegroup command would not honor settings from a config
file despite accepting the `-f/--config-file` argument. Add support for
loading the config file before running the command.

I'm not actually sure if this is the best approach. I tried to follow the conventions set by other nodegroup commands, but the to other commands all support filtering multiple nodegroups unlike `upgrade nodegroup`.

One of the challenges is that most, if not all, other commands do not support providing `--name` as an arg when using the config file. However, since the `upgrade nodegroup` command only supports a single nodegroup, you must provide `--name`.

Should `upgrade nodegroup` support multiple nodegroups, similar to `create` and `delete`?

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

