### PR TITLE
Int timeouts

### DIFF
--- a/integration/tests/fargate/fargate_test.go
+++ b/integration/tests/fargate/fargate_test.go
@@ -54,7 +54,7 @@ var _ = Describe("(Integration) Fargate", func() {
 			"--verbose", "4",
 			"--kubeconfig", params.KubeconfigPath,
 			"--nodes", "1",
-			"--timeout", "55m",
+			"--timeout", "1h10m",
 		}
 
 		args = append(args, createArgs...)

--- a/integration/tests/params.go
+++ b/integration/tests/params.go
@@ -72,15 +72,15 @@ func (p *Params) GenerateCommands() {
 
 	p.EksctlCreateCmd = p.EksctlCmd.
 		WithArgs("create").
-		WithTimeout(30 * time.Minute)
+		WithTimeout(90 * time.Minute)
 
 	p.EksctlUpgradeCmd = p.EksctlCmd.
 		WithArgs("upgrade").
-		WithTimeout(50 * time.Minute)
+		WithTimeout(90 * time.Minute)
 
 	p.EksctlUpdateCmd = p.EksctlCmd.
 		WithArgs("update").
-		WithTimeout(20 * time.Minute)
+		WithTimeout(90 * time.Minute)
 
 	p.EksctlGetCmd = p.EksctlCmd.
 		WithArgs("get").
@@ -99,11 +99,12 @@ func (p *Params) GenerateCommands() {
 		WithTimeout(15 * time.Minute)
 
 	p.EksctlDeleteClusterCmd = p.EksctlDeleteCmd.
-		WithArgs("cluster", "--verbose", "4")
+		WithArgs("cluster", "--verbose", "4").
+		WithTimeout(40 * time.Minute)
 
 	p.EksctlDrainNodeGroupCmd = p.EksctlCmd.
 		WithArgs("drain", "nodegroup", "--verbose", "4").
-		WithTimeout(5 * time.Minute)
+		WithTimeout(10 * time.Minute)
 
 	p.EksctlScaleNodeGroupCmd = p.EksctlCmd.
 		WithArgs("scale", "nodegroup", "--verbose", "4").
@@ -119,7 +120,7 @@ func (p *Params) GenerateCommands() {
 
 	p.EksctlCreateNodegroupCmd = runner.NewCmd(p.EksctlPath).
 		WithArgs("create", "nodegroup").
-		WithTimeout(30 * time.Minute)
+		WithTimeout(40 * time.Minute)
 
 }
 

--- a/pkg/ctl/cmdutils/scale.go
+++ b/pkg/ctl/cmdutils/scale.go
@@ -132,7 +132,7 @@ func validateNumberOfNodesCLI(ng *api.NodeGroup) error {
 	}
 
 	if ng.MinSize != nil && ng.DesiredCapacity != nil && *ng.MinSize > *ng.DesiredCapacity {
-		return fmt.Errorf("minimum number of nodes must be less than or equal to number of nodes")
+		return fmt.Errorf("minimum number of nodes must be fewer than or equal to number of nodes")
 	}
 	return nil
 }

--- a/pkg/ctl/cmdutils/scale.go
+++ b/pkg/ctl/cmdutils/scale.go
@@ -109,7 +109,7 @@ func validateNumberOfNodesCLI(ng *api.NodeGroup) error {
 	}
 
 	if ng.DesiredCapacity == nil && ng.MinSize == nil && ng.MaxSize == nil {
-		return fmt.Errorf("atleast one of minmum, maximum and desired nodes must be set")
+		return fmt.Errorf("at least one of minimum, maximum and desired nodes must be set")
 	}
 
 	if ng.DesiredCapacity != nil && *ng.DesiredCapacity < 0 {

--- a/pkg/ctl/cmdutils/scale.go
+++ b/pkg/ctl/cmdutils/scale.go
@@ -44,7 +44,7 @@ func NewScaleNodeGroupLoader(cmd *Cmd, ng *api.NodeGroup) ClusterConfigLoader {
 			return err
 		}
 
-		if err := validateNumberOfNodes(ng); err != nil {
+		if err := validateNumberOfNodesCLI(ng); err != nil {
 			return err
 		}
 		l.Plan = false
@@ -99,5 +99,40 @@ func validateNumberOfNodes(ng *api.NodeGroup) error {
 		return fmt.Errorf("minimum number of nodes must be less than or equal to number of nodes")
 	}
 
+	return nil
+}
+
+//only 1 of desired/min/max has to be set on the cli
+func validateNumberOfNodesCLI(ng *api.NodeGroup) error {
+	if ng.ScalingConfig == nil {
+		ng.ScalingConfig = &api.ScalingConfig{}
+	}
+
+	if ng.DesiredCapacity == nil && ng.MinSize == nil && ng.MaxSize == nil {
+		return fmt.Errorf("atleast one of minmum, maximum and desired nodes must be set")
+	}
+
+	if ng.DesiredCapacity != nil && *ng.DesiredCapacity < 0 {
+		return fmt.Errorf("number of nodes must be 0 or greater")
+	}
+
+	if ng.MinSize != nil && *ng.MinSize < 0 {
+		return fmt.Errorf("minimum of nodes must be 0 or greater")
+	}
+	if ng.MaxSize != nil && *ng.MaxSize < 0 {
+		return fmt.Errorf("maximum of nodes must be 0 or greater")
+	}
+
+	if ng.MaxSize != nil && ng.MinSize != nil && *ng.MaxSize < *ng.MinSize {
+		return fmt.Errorf("maximum number of nodes must be greater than minmum number of nodes")
+	}
+
+	if ng.MaxSize != nil && ng.DesiredCapacity != nil && *ng.MaxSize < *ng.DesiredCapacity {
+		return fmt.Errorf("maximum number of nodes must be greater than or equal to number of nodes")
+	}
+
+	if ng.MinSize != nil && ng.DesiredCapacity != nil && *ng.MinSize > *ng.DesiredCapacity {
+		return fmt.Errorf("minimum number of nodes must be less than or equal to number of nodes")
+	}
 	return nil
 }

--- a/pkg/ctl/cmdutils/scale.go
+++ b/pkg/ctl/cmdutils/scale.go
@@ -124,7 +124,7 @@ func validateNumberOfNodesCLI(ng *api.NodeGroup) error {
 	}
 
 	if ng.MaxSize != nil && ng.MinSize != nil && *ng.MaxSize < *ng.MinSize {
-		return fmt.Errorf("maximum number of nodes must be greater than minmum number of nodes")
+		return fmt.Errorf("maximum number of nodes must be greater than minimum number of nodes")
 	}
 
 	if ng.MaxSize != nil && ng.DesiredCapacity != nil && *ng.MaxSize < *ng.DesiredCapacity {

--- a/pkg/ctl/cmdutils/scale_test.go
+++ b/pkg/ctl/cmdutils/scale_test.go
@@ -3,6 +3,7 @@ package cmdutils
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -12,8 +13,16 @@ import (
 
 type scaleNodeGroupCase struct {
 	name    string
-	error   error
+	err     error
 	minSize *int
+}
+
+type scaleNodeGroupCLICase struct {
+	name        string
+	err         error
+	minSize     *int
+	maxSize     *int
+	desiredSize *int
 }
 
 var _ = Describe("scale node group config file loader", func() {
@@ -23,9 +32,8 @@ var _ = Describe("scale node group config file loader", func() {
 			Run: func(_ *cobra.Command, _ []string) {},
 		}
 	}
-	minSizeOne := 1
 
-	DescribeTable("create nodegroup successfully",
+	DescribeTable("scale nodegroup successfully via config file",
 		func(params scaleNodeGroupCase) {
 			cmd := &Cmd{
 				CobraCommand:      newCmd(),
@@ -37,9 +45,9 @@ var _ = Describe("scale node group config file loader", func() {
 
 			ng := api.NewNodeGroup()
 			err := NewScaleNodeGroupLoader(cmd, ng).Load()
-			if params.error != nil {
+			if params.err != nil {
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(params.error.Error()))
+				Expect(err.Error()).To(ContainSubstring(params.err.Error()))
 			} else {
 				if params.minSize != nil {
 					Expect(ng.MinSize).To(Equal(params.minSize))
@@ -51,34 +59,111 @@ var _ = Describe("scale node group config file loader", func() {
 			name: "ng-all-details",
 		}),
 		Entry("no node group matched", scaleNodeGroupCase{
-			name:  "123123",
-			error: fmt.Errorf("node group 123123 not found"),
+			name: "123123",
+			err:  fmt.Errorf("node group 123123 not found"),
 		}),
 		Entry("with no desired capacity", scaleNodeGroupCase{
-			name:  "ng-no-desired-capacity",
-			error: fmt.Errorf("number of nodes must be 0 or greater"),
+			name: "ng-no-desired-capacity",
+			err:  fmt.Errorf("number of nodes must be 0 or greater"),
 		}),
 		Entry("with no minSize and no maxSize", scaleNodeGroupCase{
 			name: "ng-no-min-max",
 		}),
 		Entry("ng with minSize", scaleNodeGroupCase{
 			name:    "ng-with-min",
-			minSize: &minSizeOne,
+			minSize: aws.Int(1),
 		}),
 		Entry("ng with wrong value for minSize", scaleNodeGroupCase{
-			name:  "ng-with-wrong-min",
-			error: fmt.Errorf("minimum number of nodes must be less than or equal to number of nodes"),
+			name: "ng-with-wrong-min",
+			err:  fmt.Errorf("minimum number of nodes must be less than or equal to number of nodes"),
 		}),
 		Entry("ng with maxSize", scaleNodeGroupCase{
 			name: "ng-with-max",
 		}),
 		Entry("ng with wrong value for maxSize", scaleNodeGroupCase{
-			name:  "ng-with-wrong-max",
-			error: fmt.Errorf("maximum number of nodes must be greater than or equal to number of nodes"),
+			name: "ng-with-wrong-max",
+			err:  fmt.Errorf("maximum number of nodes must be greater than or equal to number of nodes"),
 		}),
 		Entry("ng with desired nodes outside [minSize, maxSize]", scaleNodeGroupCase{
-			name:  "ng-with-wrong-desired",
-			error: fmt.Errorf("number of nodes must be within range of min nodes and max nodes"),
+			name: "ng-with-wrong-desired",
+			err:  fmt.Errorf("number of nodes must be within range of min nodes and max nodes"),
+		}),
+	)
+
+	DescribeTable("scale nodegroup successfully via cli flags",
+		func(params scaleNodeGroupCLICase) {
+			cfg := api.NewClusterConfig()
+			cfg.Metadata.Name = "cluster"
+			cmd := &Cmd{
+				CobraCommand:   newCmd(),
+				ProviderConfig: api.ProviderConfig{},
+				ClusterConfig:  cfg,
+				NameArg:        params.name,
+			}
+
+			ng := api.NewNodeGroup()
+			ng.MinSize = params.minSize
+			ng.MaxSize = params.maxSize
+			ng.DesiredCapacity = params.desiredSize
+			err := NewScaleNodeGroupLoader(cmd, ng).Load()
+			if params.err != nil {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(params.err.Error()))
+			} else {
+				if params.minSize != nil {
+					Expect(ng.MinSize).To(Equal(params.minSize))
+				}
+				Expect(err).ToNot(HaveOccurred())
+			}
+		},
+		Entry("only specifying min-nodes", scaleNodeGroupCLICase{
+			name:    "ng-with-max",
+			minSize: aws.Int(1),
+		}),
+		Entry("only specifying max-nodes", scaleNodeGroupCLICase{
+			name:    "ng-with-max",
+			maxSize: aws.Int(1),
+		}),
+		Entry("only specifying nodes", scaleNodeGroupCLICase{
+			name:        "ng-with-max",
+			desiredSize: aws.Int(1),
+		}),
+		Entry("minSize 0", scaleNodeGroupCLICase{
+			name:    "ng-with-max",
+			minSize: aws.Int(-1),
+			err:     fmt.Errorf("minimum of nodes must be 0 or greater"),
+		}),
+		Entry("maxSize 0", scaleNodeGroupCLICase{
+			name:    "ng-with-max",
+			maxSize: aws.Int(-1),
+			err:     fmt.Errorf("maximum of nodes must be 0 or greater"),
+		}),
+		Entry("desiredSize 0", scaleNodeGroupCLICase{
+			name:        "ng-with-max",
+			desiredSize: aws.Int(-1),
+			err:         fmt.Errorf("number of nodes must be 0 or greater"),
+		}),
+		Entry("desiredSize greater than max", scaleNodeGroupCLICase{
+			name:        "ng-with-max",
+			desiredSize: aws.Int(3),
+			maxSize:     aws.Int(1),
+			err:         fmt.Errorf("maximum number of nodes must be greater than or equal to number of nodes"),
+		}),
+		Entry("desiredSize less than min", scaleNodeGroupCLICase{
+			name:        "ng-with-max",
+			desiredSize: aws.Int(2),
+			minSize:     aws.Int(3),
+			err:         fmt.Errorf("minimum number of nodes must be less than or equal to number of nodes"),
+		}),
+		Entry("min greater than max", scaleNodeGroupCLICase{
+			name:    "ng-with-max",
+			minSize: aws.Int(3),
+			maxSize: aws.Int(2),
+			err:     fmt.Errorf("maximum number of nodes must be greater than minmum number of nodes"),
+		}),
+		Entry("not specifying any", scaleNodeGroupCLICase{
+			name: "ng-with-max",
+			err:  fmt.Errorf("atleast one of minmum, maximum and desired nodes must be set"),
 		}),
 	)
 })

--- a/pkg/ctl/cmdutils/scale_test.go
+++ b/pkg/ctl/cmdutils/scale_test.go
@@ -149,21 +149,21 @@ var _ = Describe("scale node group config file loader", func() {
 			maxSize:     aws.Int(1),
 			err:         fmt.Errorf("maximum number of nodes must be greater than or equal to number of nodes"),
 		}),
-		Entry("desiredSize less than min", scaleNodeGroupCLICase{
+		Entry("desiredSize fewer than min", scaleNodeGroupCLICase{
 			name:        "ng-with-max",
 			desiredSize: aws.Int(2),
 			minSize:     aws.Int(3),
-			err:         fmt.Errorf("minimum number of nodes must be less than or equal to number of nodes"),
+			err:         fmt.Errorf("minimum number of nodes must be fewer than or equal to number of nodes"),
 		}),
 		Entry("min greater than max", scaleNodeGroupCLICase{
 			name:    "ng-with-max",
 			minSize: aws.Int(3),
 			maxSize: aws.Int(2),
-			err:     fmt.Errorf("maximum number of nodes must be greater than minmum number of nodes"),
+			err:     fmt.Errorf("maximum number of nodes must be greater than minimum number of nodes"),
 		}),
 		Entry("not specifying any", scaleNodeGroupCLICase{
 			name: "ng-with-max",
-			err:  fmt.Errorf("atleast one of minmum, maximum and desired nodes must be set"),
+			err:  fmt.Errorf("at least one of minimum, maximum and desired nodes must be set"),
 		}),
 	)
 })

--- a/pkg/ctl/scale/nodegroup_test.go
+++ b/pkg/ctl/scale/nodegroup_test.go
@@ -63,7 +63,7 @@ var _ = Describe("scale", func() {
 			}),
 			Entry("missing required nodes flag", invalidParamsCase{
 				args:  []string{"nodegroup", "ng", "--cluster", "dummy"},
-				error: fmt.Errorf("Error: atleast one of minmum, maximum and desired nodes must be set"),
+				error: fmt.Errorf("Error: at least one of minimum, maximum and desired nodes must be set"),
 			}),
 			Entry("invalid flag", invalidParamsCase{
 				args:  []string{"nodegroup", "--invalid", "dummy"},

--- a/pkg/ctl/scale/nodegroup_test.go
+++ b/pkg/ctl/scale/nodegroup_test.go
@@ -61,9 +61,9 @@ var _ = Describe("scale", func() {
 				args:  []string{"nodegroup", "ng", "--cluster", "dummy", "--name", "ng"},
 				error: fmt.Errorf("Error: --name=ng and argument ng cannot be used at the same time"),
 			}),
-			Entry("missing required nodes flag --nodes", invalidParamsCase{
+			Entry("missing required nodes flag", invalidParamsCase{
 				args:  []string{"nodegroup", "ng", "--cluster", "dummy"},
-				error: fmt.Errorf("Error: number of nodes must be 0 or greater"),
+				error: fmt.Errorf("Error: atleast one of minmum, maximum and desired nodes must be set"),
 			}),
 			Entry("invalid flag", invalidParamsCase{
 				args:  []string{"nodegroup", "--invalid", "dummy"},
@@ -81,10 +81,6 @@ var _ = Describe("scale", func() {
 			Entry("desired node less than min nodes", invalidParamsCase{
 				args:  []string{"nodegroup", "ng", "--cluster", "dummy", "--nodes", "2", "--nodes-min", "3"},
 				error: fmt.Errorf("Error: minimum number of nodes must be less than or equal to number of nodes"),
-			}),
-			Entry("desired node outside the range [min, max]", invalidParamsCase{
-				args:  []string{"nodegroup", "ng", "--cluster", "dummy", "--nodes", "2", "--nodes-min", "1", "--nodes-max", "1"},
-				error: fmt.Errorf("Error: number of nodes must be within range of min nodes and max nodes"),
 			}),
 			Entry("with config file and no name flags", invalidParamsCase{
 				args:  []string{"nodegroup", "-f", "../cmdutils/test_data/scale-ng-test.yaml"},

--- a/pkg/ctl/scale/nodegroup_test.go
+++ b/pkg/ctl/scale/nodegroup_test.go
@@ -69,18 +69,18 @@ var _ = Describe("scale", func() {
 				args:  []string{"nodegroup", "--invalid", "dummy"},
 				error: fmt.Errorf("Error: unknown flag: --invalid"),
 			}),
-			Entry("desired node less than min nodes", invalidParamsCase{
+			Entry("desired node fewer than min nodes", invalidParamsCase{
 				args:  []string{"nodegroup", "ng", "--cluster", "dummy", "--nodes", "2", "--nodes-min", "3"},
-				error: fmt.Errorf("Error: minimum number of nodes must be less than or equal to number of nodes"),
+				error: fmt.Errorf("Error: minimum number of nodes must be fewer than or equal to number of nodes"),
 			}),
 
 			Entry("desired node greater than max nodes", invalidParamsCase{
 				args:  []string{"nodegroup", "ng", "--cluster", "dummy", "--nodes", "2", "--nodes-max", "1"},
 				error: fmt.Errorf("Error: maximum number of nodes must be greater than or equal to number of nodes"),
 			}),
-			Entry("desired node less than min nodes", invalidParamsCase{
+			Entry("desired node fewer than min nodes", invalidParamsCase{
 				args:  []string{"nodegroup", "ng", "--cluster", "dummy", "--nodes", "2", "--nodes-min", "3"},
-				error: fmt.Errorf("Error: minimum number of nodes must be less than or equal to number of nodes"),
+				error: fmt.Errorf("Error: minimum number of nodes must be fewer than or equal to number of nodes"),
 			}),
 			Entry("with config file and no name flags", invalidParamsCase{
 				args:  []string{"nodegroup", "-f", "../cmdutils/test_data/scale-ng-test.yaml"},


### PR DESCRIPTION
### Description

Fargate test failed recently due to timeout https://github.com/weaveworks/eksctl/runs/2257870432?check_suite_focus=true#step:7:26138

We seem to have three ways of setting a timeout:
1. `params.go` sets an upper limit timeout, the `cmd` package will force the command to exit
2. setting `--timeout` on the eksctl cmd. 
3. the default eksctl timeout value

2 & 3 should always be shorter than 1, that wasn't the case for this fargate tests so I've updated it to be like that.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

