### PR TITLE
bump integration base timeouts

### DIFF
--- a/integration/tests/fargate/fargate_test.go
+++ b/integration/tests/fargate/fargate_test.go
@@ -54,7 +54,7 @@ var _ = Describe("(Integration) Fargate", func() {
 			"--verbose", "4",
 			"--kubeconfig", params.KubeconfigPath,
 			"--nodes", "1",
-			"--timeout", "55m",
+			"--timeout", "1h10m",
 		}
 
 		args = append(args, createArgs...)

--- a/integration/tests/params.go
+++ b/integration/tests/params.go
@@ -72,15 +72,15 @@ func (p *Params) GenerateCommands() {
 
 	p.EksctlCreateCmd = p.EksctlCmd.
 		WithArgs("create").
-		WithTimeout(30 * time.Minute)
+		WithTimeout(90 * time.Minute)
 
 	p.EksctlUpgradeCmd = p.EksctlCmd.
 		WithArgs("upgrade").
-		WithTimeout(50 * time.Minute)
+		WithTimeout(90 * time.Minute)
 
 	p.EksctlUpdateCmd = p.EksctlCmd.
 		WithArgs("update").
-		WithTimeout(20 * time.Minute)
+		WithTimeout(90 * time.Minute)
 
 	p.EksctlGetCmd = p.EksctlCmd.
 		WithArgs("get").
@@ -99,11 +99,12 @@ func (p *Params) GenerateCommands() {
 		WithTimeout(15 * time.Minute)
 
 	p.EksctlDeleteClusterCmd = p.EksctlDeleteCmd.
-		WithArgs("cluster", "--verbose", "4")
+		WithArgs("cluster", "--verbose", "4").
+		WithTimeout(40 * time.Minute)
 
 	p.EksctlDrainNodeGroupCmd = p.EksctlCmd.
 		WithArgs("drain", "nodegroup", "--verbose", "4").
-		WithTimeout(5 * time.Minute)
+		WithTimeout(10 * time.Minute)
 
 	p.EksctlScaleNodeGroupCmd = p.EksctlCmd.
 		WithArgs("scale", "nodegroup", "--verbose", "4").
@@ -119,7 +120,7 @@ func (p *Params) GenerateCommands() {
 
 	p.EksctlCreateNodegroupCmd = runner.NewCmd(p.EksctlPath).
 		WithArgs("create", "nodegroup").
-		WithTimeout(30 * time.Minute)
+		WithTimeout(40 * time.Minute)
 
 }
 


### PR DESCRIPTION
### Description


Fargate test failed recently due to timeout https://github.com/weaveworks/eksctl/runs/2257870432?check_suite_focus=true#step:7:26138

We seem to have three ways of setting a timeout:
1. `params.go` sets an upper limit timeout, the `cmd` package will force the command to exit
2. setting `--timeout` on the eksctl cmd. 
3. the default eksctl timeout value

2 & 3 should always be shorter than 1, that wasn't the case for this fargate tests so I've updated it to be like that.


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

