### PR TITLE
Support comma separated array for group flag in create iamidentitymapping

### DIFF
--- a/pkg/ctl/create/iamidentitymapping.go
+++ b/pkg/ctl/create/iamidentitymapping.go
@@ -45,7 +45,7 @@ func createIAMIdentityMappingCmd(cmd *cmdutils.Cmd) {
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVar(&options.Account, "account", "", "Account ID to automatically map to its username")
 		fs.StringVar(&options.Username, "username", "", "User name within Kubernetes to map to IAM role")
-		fs.StringArrayVar(&options.Groups, "group", []string{}, "Group within Kubernetes to which IAM role is mapped")
+		fs.StringSliceVar(&options.Groups, "group", []string{}, "Group within Kubernetes to which IAM role is mapped")
 		fs.StringVar(&options.ServiceName, "service-name", "", "Service name; valid value: emr-containers")
 		fs.StringVar(&options.Namespace, "namespace", "", "Namespace in which to create RBAC resources (only valid with --service-name)")
 		cmdutils.AddIAMIdentityMappingARNFlags(fs, cmd, &options.ARN, "create")


### PR DESCRIPTION
### Description

Before attempting:
```
eksctl create iamidentitymapping --cluster jk --arn arn:aws:iam::123456:role/testing --group="system:masters","foo:bar" --username admin
```
would result in:
```
apiVersion: v1
data:
  mapRoles: |
    - groups:
      - system:masters,foo:bar
      rolearn: arn:aws:iam::123456:role/testing
      username: admin
```
now it results in:
```
apiVersion: v1
data:
  mapRoles: |
   - groups:
      - system:masters
      - foo:bar
      rolearn: arn:aws:iam::123456:role/testing
      username: admin3
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

