### PR TITLE
add force option to eksctl delete cluster 

### DIFF
--- a/pkg/actions/cluster/cluster.go
+++ b/pkg/actions/cluster/cluster.go
@@ -15,7 +15,7 @@ import (
 
 type Cluster interface {
 	Upgrade(dryRun bool) error
-	Delete(waitInterval time.Duration, wait bool) error
+	Delete(waitInterval time.Duration, wait, force bool) error
 }
 
 func New(cfg *api.ClusterConfig, ctl *eks.ClusterProvider) (Cluster, error) {

--- a/pkg/actions/cluster/owned_test.go
+++ b/pkg/actions/cluster/owned_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Delete", func() {
 				return fakeClientSet, nil
 			})
 
-			err := c.Delete(time.Microsecond, false)
+			err := c.Delete(time.Microsecond, false, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fakeStackManager.DeleteTasksForDeprecatedStacksCallCount()).To(Equal(1))
 			Expect(ranDeleteDeprecatedTasks).To(BeTrue())
@@ -137,7 +137,7 @@ var _ = Describe("Delete", func() {
 
 			c := cluster.NewOwnedCluster(cfg, ctl, fakeStackManager)
 
-			err := c.Delete(time.Microsecond, false)
+			err := c.Delete(time.Microsecond, false, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fakeStackManager.DeleteTasksForDeprecatedStacksCallCount()).To(Equal(1))
 			Expect(ranDeleteDeprecatedTasks).To(BeTrue())

--- a/pkg/actions/cluster/unowned.go
+++ b/pkg/actions/cluster/unowned.go
@@ -57,7 +57,7 @@ func (c *UnownedCluster) Upgrade(dryRun bool) error {
 	return nil
 }
 
-func (c *UnownedCluster) Delete(waitInterval time.Duration, wait bool) error {
+func (c *UnownedCluster) Delete(waitInterval time.Duration, wait, force bool) error {
 	clusterName := c.cfg.Metadata.Name
 
 	if err := c.checkClusterExists(clusterName); err != nil {
@@ -78,7 +78,13 @@ func (c *UnownedCluster) Delete(waitInterval time.Duration, wait bool) error {
 	}
 
 	if err := deleteSharedResources(c.cfg, c.ctl, c.stackManager, clusterOperable, clientSet); err != nil {
-		return err
+		if err != nil {
+			if force {
+				logger.Warning("error occurred during deletion: %v", err)
+			} else {
+				return err
+			}
+		}
 	}
 
 	if err := c.deleteFargateRoleIfExists(); err != nil {
@@ -92,7 +98,13 @@ func (c *UnownedCluster) Delete(waitInterval time.Duration, wait bool) error {
 	}
 
 	if err := c.deleteIAMAndOIDC(wait, clusterOperable, clientSet); err != nil {
-		return err
+		if err != nil {
+			if force {
+				logger.Warning("error occurred during deletion: %v", err)
+			} else {
+				return err
+			}
+		}
 	}
 
 	if err := c.deleteCluster(wait); err != nil {

--- a/pkg/actions/cluster/unowned_test.go
+++ b/pkg/actions/cluster/unowned_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Delete", func() {
 				return fakeClientSet, nil
 			})
 
-			err := c.Delete(time.Microsecond, false)
+			err := c.Delete(time.Microsecond, false, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(deleteCallCount).To(Equal(1))
 			Expect(unownedDeleteCallCount).To(Equal(1))
@@ -201,7 +201,7 @@ var _ = Describe("Delete", func() {
 			p.MockEKS().On("DeleteCluster", mock.Anything).Return(&awseks.DeleteClusterOutput{}, nil)
 
 			c := cluster.NewUnownedCluster(cfg, ctl, fakeStackManager)
-			err := c.Delete(time.Microsecond, false)
+			err := c.Delete(time.Microsecond, false, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fakeStackManager.DeleteTasksForDeprecatedStacksCallCount()).To(Equal(1))
 			Expect(deleteCallCount).To(Equal(1))

--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -20,17 +20,18 @@ func deleteClusterCmd(cmd *cmdutils.Cmd) {
 
 	cmd.SetDescription("cluster", "Delete a cluster", "")
 
+	var force bool
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)
-		return doDeleteCluster(cmd)
+		return doDeleteCluster(cmd, force)
 	}
-
 	cmd.FlagSetGroup.InFlagSet("General", func(fs *pflag.FlagSet) {
 		fs.StringVarP(&cfg.Metadata.Name, "name", "n", "", "EKS cluster name")
 		cmdutils.AddRegionFlag(fs, &cmd.ProviderConfig)
 
 		cmd.Wait = false
 		cmdutils.AddWaitFlag(fs, &cmd.Wait, "deletion of all resources")
+		fs.BoolVar(&force, "force", false, "Force deletion to continue when errors occur")
 
 		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
@@ -39,7 +40,7 @@ func deleteClusterCmd(cmd *cmdutils.Cmd) {
 	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, &cmd.ProviderConfig, true)
 }
 
-func doDeleteCluster(cmd *cmdutils.Cmd) error {
+func doDeleteCluster(cmd *cmdutils.Cmd, force bool) error {
 	if err := cmdutils.NewMetadataLoader(cmd).Load(); err != nil {
 		return err
 	}
@@ -69,5 +70,5 @@ func doDeleteCluster(cmd *cmdutils.Cmd) error {
 		return err
 	}
 
-	return cluster.Delete(time.Second*20, cmd.Wait)
+	return cluster.Delete(time.Second*20, cmd.Wait, force)
 }


### PR DESCRIPTION
### Description

```
eksctl delete cluster --name it-uc-beautiful-mushroom-1618356481
2021-04-14 16:46:42 [ℹ]  eksctl version 0.44.0
2021-04-14 16:46:42 [ℹ]  using region us-west-2
2021-04-14 16:46:42 [ℹ]  deleting EKS cluster "it-uc-beautiful-mushroom-1618356481"
2021-04-14 16:46:44 [ℹ]  deleted 0 Fargate profile(s)
2021-04-14 16:46:46 [ℹ]  cleaning up AWS load balancers created by Kubernetes objects of Kind Service or Ingress
Error: cannot list Kubernetes Services: Unauthorized

eksctl delete cluster --name it-uc-beautiful-mushroom-1618356481 --force
2021-04-14 16:52:00 [ℹ]  eksctl version 0.46.0-dev+4e2b8dec.2021-04-14T16:51:32Z
2021-04-14 16:52:00 [ℹ]  using region us-west-2
2021-04-14 16:52:00 [ℹ]  deleting EKS cluster "it-uc-beautiful-mushroom-1618356481"
2021-04-14 16:52:03 [ℹ]  deleted 0 Fargate profile(s)
2021-04-14 16:52:04 [ℹ]  cleaning up AWS load balancers created by Kubernetes objects of Kind Service or Ingress
2021-04-14 16:52:05 [!]  error occurred during deletion: cannot list Kubernetes Services: Unauthorized
2021-04-14 16:52:05 [!]  no nodegroups found for it-uc-beautiful-mushroom-1618356481
2021-04-14 16:52:06 [!]  no IAM and OIDC resources were found for "it-uc-beautiful-mushroom-1618356481"
2021-04-14 16:52:07 [ℹ]  initiated deletion of cluster "it-uc-beautiful-mushroom-1618356481"
2021-04-14 16:52:07 [ℹ]  to see the status of the deletion run `eksctl get cluster --name it-uc-beautiful-mushroom-1618356481 --region us-west-2`
2021-04-14 16:52:07 [✔]  all cluster resources were deleted
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

