### PR TITLE
add --wait flag for eksctl create/update addon

### DIFF
--- a/integration/tests/addons/addons_test.go
+++ b/integration/tests/addons/addons_test.go
@@ -94,6 +94,7 @@ var _ = Describe("(Integration) [EKS Addons test]", func() {
 					"addon",
 					"--name", "vpc-cni",
 					"--cluster", clusterName,
+					"--wait",
 					"--verbose", "2",
 				)
 			Expect(cmd).To(RunSuccessfully())

--- a/integration/tests/unowned_cluster/unowned_cluster_test.go
+++ b/integration/tests/unowned_cluster/unowned_cluster_test.go
@@ -257,6 +257,8 @@ var _ = Describe("(Integration) [non-eksctl cluster & nodegroup support]", func(
 				"addon",
 				"--cluster", params.ClusterName,
 				"--name", "vpc-cni",
+				"--wait",
+				"--force",
 				"--verbose", "2",
 			)
 		Expect(cmd).To(RunSuccessfully())
@@ -270,6 +272,9 @@ var _ = Describe("(Integration) [non-eksctl cluster & nodegroup support]", func(
 			)
 		Expect(cmd).To(RunSuccessfullyWithOutputStringLines(
 			ContainElement(ContainSubstring("vpc-cni")),
+		))
+		Expect(cmd).To(RunSuccessfullyWithOutputStringLines(
+			ContainElement(ContainSubstring("ACTIVE")),
 		))
 	})
 

--- a/pkg/actions/addon/addon.go
+++ b/pkg/actions/addon/addon.go
@@ -72,7 +72,7 @@ func (a *Manager) waitForAddonToBeActive(addon *api.Addon) error {
 		},
 	}
 
-	err = w.WaitWithTimeout(a.timeout)
+	err := w.WaitWithTimeout(a.timeout)
 	if err != nil {
 		if err == context.DeadlineExceeded {
 			return errors.Errorf("timed out waiting for addon %q to become active, status: %q", addon.Name, *out.Addon.Status)

--- a/pkg/actions/addon/addon.go
+++ b/pkg/actions/addon/addon.go
@@ -50,8 +50,8 @@ func New(clusterConfig *api.ClusterConfig, eksAPI eksiface.EKSAPI, stackManager 
 
 func (a *Manager) waitForAddonToBeActive(addon *api.Addon) error {
 	var out *awseks.DescribeAddonOutput
-	var err error
 	operation := func() (bool, error) {
+		var err error
 		out, err = a.eksAPI.DescribeAddon(&awseks.DescribeAddonInput{
 			ClusterName: &a.clusterConfig.Metadata.Name,
 			AddonName:   &addon.Name,

--- a/pkg/actions/addon/addon.go
+++ b/pkg/actions/addon/addon.go
@@ -1,10 +1,16 @@
 package addon
 
 import (
+	"context"
 	"fmt"
+	"time"
 
+	awseks "github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
+	"github.com/kris-nova/logger"
+	"github.com/pkg/errors"
 
+	"github.com/weaveworks/eksctl/pkg/cfn/waiter"
 	kubeclient "k8s.io/client-go/kubernetes"
 
 	"github.com/weaveworks/eksctl/pkg/utils"
@@ -23,6 +29,7 @@ type Manager struct {
 	oidcManager   *iamoidc.OpenIDConnectManager
 	stackManager  manager.StackManager
 	clientSet     kubeclient.Interface
+	timeout       time.Duration
 }
 
 func New(clusterConfig *api.ClusterConfig, eksAPI eksiface.EKSAPI, stackManager manager.StackManager, withOIDC bool, oidcManager *iamoidc.OpenIDConnectManager, clientSet kubeclient.Interface) (*Manager, error) {
@@ -37,7 +44,43 @@ func New(clusterConfig *api.ClusterConfig, eksAPI eksiface.EKSAPI, stackManager 
 		oidcManager:   oidcManager,
 		stackManager:  stackManager,
 		clientSet:     clientSet,
+		timeout:       5 * time.Minute,
 	}, nil
+}
+
+func (a *Manager) waitForAddonToBeActive(addon *api.Addon) error {
+	var out *awseks.DescribeAddonOutput
+	var err error
+	operation := func() (bool, error) {
+		out, err = a.eksAPI.DescribeAddon(&awseks.DescribeAddonInput{
+			ClusterName: &a.clusterConfig.Metadata.Name,
+			AddonName:   &addon.Name,
+		})
+		if err != nil {
+			return false, err
+		}
+		if *out.Addon.Status == awseks.AddonStatusActive {
+			return true, nil
+		}
+		return false, nil
+	}
+
+	w := waiter.Waiter{
+		Operation: operation,
+		NextDelay: func(_ int) time.Duration {
+			return a.timeout / 10
+		},
+	}
+
+	err = w.WaitWithTimeout(a.timeout)
+	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errors.Errorf("timed out waiting for addon %q to become active, status: %q", addon.Name, *out.Addon.Status)
+		}
+		return err
+	}
+	logger.Info("addon %q active", addon.Name)
+	return nil
 }
 
 func supportedVersion(version string) error {

--- a/pkg/actions/addon/create.go
+++ b/pkg/actions/addon/create.go
@@ -24,7 +24,7 @@ const (
 	vpcCNIName          = "vpc-cni"
 )
 
-func (a *Manager) Create(addon *api.Addon) error {
+func (a *Manager) Create(addon *api.Addon, wait bool) error {
 	createAddonInput := &eks.CreateAddonInput{
 		AddonName:    &addon.Name,
 		AddonVersion: &addon.Version,
@@ -108,6 +108,9 @@ func (a *Manager) Create(addon *api.Addon) error {
 		logger.Debug("EKS Create Addon output: %s", output.String())
 	}
 
+	if wait {
+		return a.waitForAddonToBeActive(addon)
+	}
 	logger.Info("successfully created addon")
 	return nil
 }

--- a/pkg/actions/addon/create_test.go
+++ b/pkg/actions/addon/create_test.go
@@ -2,6 +2,7 @@ package addon_test
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/weaveworks/eksctl/pkg/testutils"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
+	"github.com/aws/aws-sdk-go/aws"
 	awseks "github.com/aws/aws-sdk-go/service/eks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -84,6 +86,7 @@ var _ = Describe("Create", func() {
 			Name:    "my-cluster",
 		}}, mockProvider.EKS(), fakeStackManager, withOIDC, oidc, rawClient.ClientSet())
 		Expect(err).NotTo(HaveOccurred())
+		manager.SetTimeout(time.Second)
 	})
 
 	When("it fails to create addon", func() {
@@ -94,7 +97,7 @@ var _ = Describe("Create", func() {
 			err := manager.Create(&api.Addon{
 				Name:    "my-addon",
 				Version: "1.0",
-			})
+			}, false)
 			Expect(err).To(MatchError(`failed to create addon "my-addon": foo`))
 
 		})
@@ -109,7 +112,7 @@ var _ = Describe("Create", func() {
 				Name:             "my-addon",
 				Version:          "1.0",
 				AttachPolicyARNs: []string{"arn-1"},
-			})
+			}, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fakeStackManager.CreateStackCallCount()).To(Equal(0))
@@ -131,7 +134,7 @@ var _ = Describe("Create", func() {
 				Version:          "1.0",
 				AttachPolicyARNs: []string{"arn-1"},
 				Force:            true,
-			})
+			}, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fakeStackManager.CreateStackCallCount()).To(Equal(0))
@@ -143,13 +146,62 @@ var _ = Describe("Create", func() {
 		})
 	})
 
+	When("wait is true", func() {
+		When("the addon creation succeeds", func() {
+			BeforeEach(func() {
+				withOIDC = false
+				mockProvider.MockEKS().On("DescribeAddon", mock.Anything).
+					Return(&awseks.DescribeAddonOutput{
+						Addon: &awseks.Addon{
+							AddonName: aws.String("my-addon"),
+							Status:    aws.String("ACTIVE"),
+						},
+					}, nil)
+			})
+
+			It("creates the addon and waits for it to be running", func() {
+				err := manager.Create(&api.Addon{
+					Name:    "my-addon",
+					Version: "1.0",
+				}, true)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakeStackManager.CreateStackCallCount()).To(Equal(0))
+				Expect(*createAddonInput.ClusterName).To(Equal("my-cluster"))
+				Expect(*createAddonInput.AddonName).To(Equal("my-addon"))
+				Expect(*createAddonInput.AddonVersion).To(Equal("1.0"))
+			})
+		})
+
+		When("the addon creation fails", func() {
+			BeforeEach(func() {
+				withOIDC = false
+				mockProvider.MockEKS().On("DescribeAddon", mock.Anything).
+					Return(&awseks.DescribeAddonOutput{
+						Addon: &awseks.Addon{
+							AddonName: aws.String("my-addon"),
+							Status:    aws.String("DEGRADED"),
+						},
+					}, nil)
+			})
+
+			It("returns an error", func() {
+				err := manager.Create(&api.Addon{
+					Name:    "my-addon",
+					Version: "1.0",
+				}, true)
+				Expect(err).To(MatchError("timed out waiting for addon \"my-addon\" to become active, status: \"DEGRADED\""))
+			})
+		})
+	})
+
 	When("No policy/role is specified", func() {
 		When("we don't know the recommended policies for the specified addon", func() {
 			It("does not provide a role", func() {
 				err := manager.Create(&api.Addon{
 					Name:    "my-addon",
 					Version: "1.0",
-				})
+				}, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fakeStackManager.CreateStackCallCount()).To(Equal(0))
@@ -176,7 +228,7 @@ var _ = Describe("Create", func() {
 				err := manager.Create(&api.Addon{
 					Name:    "vpc-cni",
 					Version: "1.0",
-				})
+				}, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fakeStackManager.CreateStackCallCount()).To(Equal(1))
@@ -204,7 +256,7 @@ var _ = Describe("Create", func() {
 				Name:             "my-addon",
 				Version:          "1.0",
 				AttachPolicyARNs: []string{"arn-1"},
-			})
+			}, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fakeStackManager.CreateStackCallCount()).To(Equal(1))
@@ -228,7 +280,7 @@ var _ = Describe("Create", func() {
 				AttachPolicy: api.InlineDocument{
 					"foo": "policy-bar",
 				},
-			})
+			}, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fakeStackManager.CreateStackCallCount()).To(Equal(1))
@@ -250,7 +302,7 @@ var _ = Describe("Create", func() {
 				Name:                  "my-addon",
 				Version:               "1.0",
 				ServiceAccountRoleARN: "foo",
-			})
+			}, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fakeStackManager.CreateStackCallCount()).To(Equal(0))
 			Expect(*createAddonInput.ClusterName).To(Equal("my-cluster"))
@@ -266,7 +318,7 @@ var _ = Describe("Create", func() {
 				Name:    "my-addon",
 				Version: "1.0",
 				Tags:    map[string]string{"foo": "bar", "fox": "brown"},
-			})
+			}, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fakeStackManager.CreateStackCallCount()).To(Equal(0))
 			Expect(*createAddonInput.ClusterName).To(Equal("my-cluster"))

--- a/pkg/actions/addon/create_test.go
+++ b/pkg/actions/addon/create_test.go
@@ -159,7 +159,7 @@ var _ = Describe("Create", func() {
 					}, nil)
 			})
 
-			It("creates the addon and waits for it to be running", func() {
+			It("creates the addon and waits for it to be active", func() {
 				err := manager.Create(&api.Addon{
 					Name:    "my-addon",
 					Version: "1.0",

--- a/pkg/actions/addon/export_test.go
+++ b/pkg/actions/addon/export_test.go
@@ -1,0 +1,7 @@
+package addon
+
+import "time"
+
+func (m *Manager) SetTimeout(timeout time.Duration) {
+	m.timeout = timeout
+}

--- a/pkg/actions/addon/tasks.go
+++ b/pkg/actions/addon/tasks.go
@@ -63,7 +63,7 @@ func (t *createAddonTask) Do(errorCh chan error) error {
 		if t.forceAll {
 			a.Force = true
 		}
-		err := addonManager.Create(a)
+		err := addonManager.Create(a, true)
 		if err != nil {
 			go func() {
 				errorCh <- err

--- a/pkg/actions/addon/update.go
+++ b/pkg/actions/addon/update.go
@@ -13,7 +13,7 @@ import (
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 )
 
-func (a *Manager) Update(addon *api.Addon) error {
+func (a *Manager) Update(addon *api.Addon, wait bool) error {
 	logger.Debug("addon: %v", addon)
 
 	updateAddonInput := &eks.UpdateAddonInput{
@@ -71,6 +71,9 @@ func (a *Manager) Update(addon *api.Addon) error {
 	}
 	if output != nil {
 		logger.Debug(output.String())
+	}
+	if wait {
+		return a.waitForAddonToBeActive(addon)
 	}
 	return nil
 }

--- a/pkg/ctl/create/addon.go
+++ b/pkg/ctl/create/addon.go
@@ -21,13 +21,14 @@ func createAddonCmd(cmd *cmdutils.Cmd) {
 		"",
 	)
 
-	var force bool
+	var force, wait bool
 	cmd.ClusterConfig.Addons = []*api.Addon{{}}
 	cmd.FlagSetGroup.InFlagSet("Addon", func(fs *pflag.FlagSet) {
 		fs.StringVar(&cmd.ClusterConfig.Addons[0].Name, "name", "", "Add-on name")
 		fs.StringVar(&cmd.ClusterConfig.Addons[0].Version, "version", "", "Add-on version")
 		fs.StringVar(&cmd.ClusterConfig.Addons[0].ServiceAccountRoleARN, "service-account-role-arn", "", "Add-on serviceAccountRoleARN")
 		fs.BoolVar(&force, "force", false, "Force applies the add-on to overwrite an existing add-on")
+		fs.BoolVar(&wait, "wait", false, "Wait for the addon creation to complete")
 
 		fs.StringSliceVar(&cmd.ClusterConfig.Addons[0].AttachPolicyARNs, "attach-policy-arn", []string{}, "ARN of the policies to attach")
 	})
@@ -92,7 +93,7 @@ func createAddonCmd(cmd *cmdutils.Cmd) {
 			if force { //force is specified at cmdline level
 				a.Force = true
 			}
-			err := addonManager.Create(a)
+			err := addonManager.Create(a, wait)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Description

`--wait` waits until the addon reports `ACTIVE`
### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

