### PR TITLE
add force suggestion to addon creation

### DIFF
--- a/pkg/actions/addon/create.go
+++ b/pkg/actions/addon/create.go
@@ -3,6 +3,7 @@ package addon
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -35,6 +36,11 @@ func (a *Manager) Create(addon *api.Addon) error {
 	if addon.Force {
 		createAddonInput.ResolveConflicts = aws.String("overwrite")
 		logger.Debug("setting resolve conflicts to overwrite")
+	} else {
+		addonName := strings.ToLower(addon.Name)
+		if addonName == "coredns" || addonName == "kube-proxy" || addonName == "vpc-cni" {
+			logger.Info("when creating an addon to replace an existing application, e.g. CoreDNS, kube-proxy & VPC-CNI the --force flag will ensure the currently deployed configuration is replaced")
+		}
 	}
 
 	logger.Debug("addon: %v", addon)


### PR DESCRIPTION
### Description

coredns, kube-proxy and vpc-cni will often fail if you try to create them without the `--force` flag. This adds a hint to suggest you should use it. During cluster creation we always run with the `--force` flag https://github.com/weaveworks/eksctl/pull/3438

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

