### PR TITLE
InstanceSelector only returns instances supported in the provided AZs

### DIFF
--- a/integration/tests/dry_run/dry_run_test.go
+++ b/integration/tests/dry_run/dry_run_test.go
@@ -41,6 +41,9 @@ func TestDryRun(t *testing.T) {
 
 const defaultClusterConfig = `
 apiVersion: eksctl.io/v1alpha5
+availabilityZones:
+- us-west-2a
+- us-west-2b
 cloudWatch:
   clusterLogging: {}
 iam:
@@ -165,6 +168,7 @@ var _ = Describe("(Integration) [Dry-Run test]", func() {
 				"--dry-run",
 				"--name",
 				params.ClusterName,
+				"--zones", "us-west-2a,us-west-2b",
 			).
 			WithArgs(createArgs...)
 
@@ -231,6 +235,7 @@ var _ = Describe("(Integration) [Dry-Run test]", func() {
 				"--name",
 				params.ClusterName,
 				"--dry-run",
+				"--zones", "us-west-2a,us-west-2b",
 				"--nodegroup-name=ng-default",
 			).
 			WithArgs(createArgs...)
@@ -289,6 +294,7 @@ var _ = Describe("(Integration) [Dry-Run test]", func() {
 					"cluster",
 					"--dry-run",
 					"--name="+params.ClusterName,
+					"--zones", "us-west-2a,us-west-2b",
 					"--nodegroup-name=ng-default",
 				)
 			session := cmd.Run()
@@ -335,6 +341,7 @@ var _ = Describe("(Integration) [Dry-Run test]", func() {
 				c.CloudWatch = nil
 				c.PrivateCluster = nil
 				c.NodeGroups = nil
+				c.AvailabilityZones = nil
 
 				ng := c.ManagedNodeGroups[0]
 				ng.Name = "private-ng"

--- a/pkg/actions/nodegroup/create.go
+++ b/pkg/actions/nodegroup/create.go
@@ -81,7 +81,7 @@ func (m *Manager) Create(options CreateOpts, nodegroupFilter filter.NodeGroupFil
 
 	nodeGroupService := eks.NewNodeGroupService(ctl.Provider, selector.New(ctl.Provider.Session()))
 	nodePools := cmdutils.ToNodePools(cfg)
-	if err := nodeGroupService.ExpandInstanceSelectorOptions(nodePools); err != nil {
+	if err := nodeGroupService.ExpandInstanceSelectorOptions(nodePools, cfg.AvailabilityZones); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### Description

Before:
```
eksctl create cluster --name development --managed --instance-selector-vcpus=4 --instance-selector-memory=16 --dry-run -v 5 --region us-east-1
2021-04-16 15:23:07 [▶]  role ARN for the current session is "arn:aws:iam::135887297313:user/jake"
apiVersion: eksctl.io/v1alpha5
cloudWatch:
  clusterLogging: {}
iam:
  vpcResourceControllerPolicy: true
  withOIDC: false
kind: ClusterConfig
managedNodeGroups:
- amiFamily: AmazonLinux2
  desiredCapacity: 2
  disableIMDSv1: false
  disablePodIMDS: false
  iam:
    withAddonPolicies:
      albIngress: false
      appMesh: false
      appMeshPreview: false
      autoScaler: false
      certManager: false
      cloudWatch: false
      ebs: false
      efs: false
      externalDNS: false
      fsx: false
      imageBuilder: false
      xRay: false
  instanceSelector:
    memory: "16"
    vCPUs: 4
  instanceTypes:
  - d3en.xlarge
  - g4dn.xlarge
  - m4.xlarge
  - m5.xlarge
  - m5a.xlarge
  - m5ad.xlarge
  - m5d.xlarge
  - m5dn.xlarge
  - m5n.xlarge
  - m5zn.xlarge
  - t2.xlarge
  - t3.xlarge
  - t3a.xlarge
  labels:
    alpha.eksctl.io/cluster-name: development
    alpha.eksctl.io/nodegroup-name: ng-0e52fca6
  maxSize: 2
  minSize: 2
  name: ng-0e52fca6
  privateNetworking: false
  releaseVersion: ""
  securityGroups:
    withLocal: null
    withShared: null
  ssh:
    allow: false
    enableSsm: false
    publicKeyPath: ""
  tags:
    alpha.eksctl.io/nodegroup-name: ng-0e52fca6
    alpha.eksctl.io/nodegroup-type: managed
  volumeIOPS: 3000
  volumeSize: 80
  volumeThroughput: 125
  volumeType: gp3
metadata:
  name: development
  region: us-east-1
  version: "1.19"
privateCluster:
  enabled: false
vpc:
  autoAllocateIPv6: false
  cidr: 192.168.0.0/16
  clusterEndpoints:
    privateAccess: false
    publicAccess: true
  manageSharedNodeSecurityGroupRules: true
  nat:
    gateway: Single
```
After:
```
eksctl create cluster --name development --managed --instance-selector-vcpus=4 --instance-selector-memory=16 --dry-run -v 5 --region us-east-1
2021-04-16 15:22:48 [▶]  role ARN for the current session is "arn:aws:iam::135887297313:user/jake"
apiVersion: eksctl.io/v1alpha5
availabilityZones:
- us-east-1a
- us-east-1e
cloudWatch:
  clusterLogging: {}
iam:
  vpcResourceControllerPolicy: true
  withOIDC: false
kind: ClusterConfig
managedNodeGroups:
- amiFamily: AmazonLinux2
  desiredCapacity: 2
  disableIMDSv1: false
  disablePodIMDS: false
  iam:
    withAddonPolicies:
      albIngress: false
      appMesh: false
      appMeshPreview: false
      autoScaler: false
      certManager: false
      cloudWatch: false
      ebs: false
      efs: false
      externalDNS: false
      fsx: false
      imageBuilder: false
      xRay: false
  instanceSelector:
    memory: "16"
    vCPUs: 4
  instanceTypes:
  - m4.xlarge
  - t2.xlarge
  labels:
    alpha.eksctl.io/cluster-name: development
    alpha.eksctl.io/nodegroup-name: ng-fa785e80
  maxSize: 2
  minSize: 2
  name: ng-fa785e80
  privateNetworking: false
  releaseVersion: ""
  securityGroups:
    withLocal: null
    withShared: null
  ssh:
    allow: false
    enableSsm: false
    publicKeyPath: ""
  tags:
    alpha.eksctl.io/nodegroup-name: ng-fa785e80
    alpha.eksctl.io/nodegroup-type: managed
  volumeIOPS: 3000
  volumeSize: 80
  volumeThroughput: 125
  volumeType: gp3
metadata:
  name: development
  region: us-east-1
  version: "1.19"
privateCluster:
  enabled: false
vpc:
  autoAllocateIPv6: false
  cidr: 192.168.0.0/16
  clusterEndpoints:
    privateAccess: false
    publicAccess: true
  manageSharedNodeSecurityGroupRules: true
  nat:
    gateway: Single
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

