### PR TITLE
neuron: use the proper tutorial link

### DIFF
--- a/pkg/eks/tasks.go
+++ b/pkg/eks/tasks.go
@@ -287,7 +287,7 @@ func (c *ClusterProvider) ClusterTasksForNodeGroups(cfg *api.ClusterConfig, inst
 			tasks.Append(newNeuronDevicePluginTask(c, cfg))
 		} else {
 			logger.Info("as you are using the EKS-Optimized Accelerated AMI with an inf1 instance type, you will need to install the AWS Neuron Kubernetes device plugin.")
-			logger.Info("\t see the following page for instructions: https://github.com/aws/aws-neuron-sdk/blob/master/docs/neuron-container-tools/tutorial-k8s.md")
+			logger.Info("\t see the following page for instructions: https://awsdocs-neuron.readthedocs-hosted.com/en/latest/neuron-deploy/tutorials/tutorial-k8s.html#tutorial-k8s-env-setup-for-neuron")
 		}
 	}
 	if haveNvidiaInstanceType {


### PR DESCRIPTION
Signed-off-by: vrnatham <73142315+aws-vrnatham@users.noreply.github.com>

### Description
Since the neuron team moved their tutorials to readthedocs, making corresponding change here to use the right link


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

