### PR TITLE
Correctly parse --install-nvidia/neuron-plugin flags

### DIFF
--- a/pkg/ctl/cmdutils/nodegroup_flags.go
+++ b/pkg/ctl/cmdutils/nodegroup_flags.go
@@ -68,7 +68,7 @@ func incompatibleManagedNodesFlags() []string {
 }
 
 // AddCommonCreateNodeGroupIAMAddonsFlags adds flags to set ng.IAM.WithAddonPolicies
-func AddCommonCreateNodeGroupAddonsFlags(fs *pflag.FlagSet, ng *api.NodeGroup, options CreateNGOptions) {
+func AddCommonCreateNodeGroupAddonsFlags(fs *pflag.FlagSet, ng *api.NodeGroup, options *CreateNGOptions) {
 	addCommonCreateNodeGroupIAMAddonsFlags(fs, ng)
 	fs.BoolVarP(&options.InstallNeuronDevicePlugin, "install-neuron-plugin", "", true, "install Neuron plugin for Inferentia nodes")
 	fs.BoolVarP(&options.InstallNvidiaDevicePlugin, "install-nvidia-plugin", "", true, "install Nvidia plugin for GPU nodes")

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -80,7 +80,7 @@ func createClusterCmdWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.C
 	})
 
 	cmd.FlagSetGroup.InFlagSet("Cluster and nodegroup add-ons", func(fs *pflag.FlagSet) {
-		cmdutils.AddCommonCreateNodeGroupAddonsFlags(fs, ng, params.CreateNGOptions)
+		cmdutils.AddCommonCreateNodeGroupAddonsFlags(fs, ng, &params.CreateNGOptions)
 	})
 
 	cmd.FlagSetGroup.InFlagSet("VPC networking", func(fs *pflag.FlagSet) {

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -102,7 +102,7 @@ func createNodeGroupCmdWithRunFunc(cmd *cmdutils.Cmd, runFunc runFn) {
 	})
 
 	cmd.FlagSetGroup.InFlagSet("Addons", func(fs *pflag.FlagSet) {
-		cmdutils.AddCommonCreateNodeGroupAddonsFlags(fs, ng, options.CreateNGOptions)
+		cmdutils.AddCommonCreateNodeGroupAddonsFlags(fs, ng, &options.CreateNGOptions)
 	})
 
 	cmdutils.AddInstanceSelectorOptions(cmd.FlagSetGroup, ng)


### PR DESCRIPTION
### Description

Before:
```
./eksctl create nodegroup --cluster jk --name inf-2 --node-type inf1.6xlarge --full-ecr-access --nodes 1 --nodes-min 1 --nodes-max 2
2021-04-23 09:59:19 [ℹ]  eksctl version 0.47.0-dev+fc1f3b4b.2021-04-23T09:58:36Z
2021-04-23 09:59:19 [ℹ]  using region us-west-2
2021-04-23 09:59:20 [ℹ]  neuron false
2021-04-23 09:59:20 [ℹ]  nvidia false

eksctl create nodegroup --cluster jk --name inf-2 --node-type inf1.6xlarge --full-ecr-access --nodes 1 --nodes-min 1 --nodes-max 2 ---install-neuron-plugin
Error: bad flag syntax: ---install-neuron-plugin
jake@jake-weave [09:59:43] [~/weave/eksctl] [fix-nueron *]

eksctl create nodegroup --cluster jk --name inf-2 --node-type inf1.6xlarge --full-ecr-access --nodes 1 --nodes-min 1 --nodes-max 2 --install-neuron-plugin
2021-04-23 09:59:53 [ℹ]  eksctl version 0.47.0-dev+fc1f3b4b.2021-04-23T09:58:36Z
2021-04-23 09:59:53 [ℹ]  using region us-west-2
2021-04-23 09:59:54 [ℹ]  neuron false
2021-04-23 09:59:54 [ℹ]  nvidia false
jake@jake-weave [09:59:54] [~/weave/eksctl] [fix-nueron *]

eksctl create nodegroup --cluster jk --name inf-2 --node-type inf1.6xlarge --full-ecr-access --nodes 1 --nodes-min 1 --nodes-max 2 --install-neuron-plugin --install-nvidia-plugin
2021-04-23 10:00:06 [ℹ]  eksctl version 0.47.0-dev+fc1f3b4b.2021-04-23T09:58:36Z
2021-04-23 10:00:06 [ℹ]  using region us-west-2
2021-04-23 10:00:06 [ℹ]  neuron false
2021-04-23 10:00:06 [ℹ]  nvidia false
```


after:
```
eksctl create nodegroup --cluster jk --name inf-2 --node-type inf1.6xlarge --full-ecr-access --nodes 1 --nodes-min 1 --nodes-max 2
2021-04-23 10:01:22 [ℹ]  eksctl version 0.47.0-dev+fc1f3b4b.2021-04-23T10:00:43Z
2021-04-23 10:01:22 [ℹ]  using region us-west-2
2021-04-23 10:01:23 [ℹ]  neuron true
2021-04-23 10:01:23 [ℹ]  nvidia true

eksctl create nodegroup --cluster jk --name inf-2 --node-type inf1.6xlarge --full-ecr-access --nodes 1 --nodes-min 1 --nodes-max 2 --install-neuron-plugin --install-nvidia-plugin
2021-04-23 10:01:29 [ℹ]  eksctl version 0.47.0-dev+fc1f3b4b.2021-04-23T10:00:43Z
2021-04-23 10:01:29 [ℹ]  using region us-west-2
2021-04-23 10:01:30 [ℹ]  neuron true
2021-04-23 10:01:30 [ℹ]  nvidia true
                                                                                                                                                                                                                                                                                                                                                                          eksctl create nodegroup --cluster jk --name inf-2 --node-type inf1.6xlarge --full-ecr-access --nodes 1 --nodes-min 1 --nodes-max 2 --install-neuron-plugin=false --install-nvidia-plugin=false
2021-04-23 10:01:37 [ℹ]  eksctl version 0.47.0-dev+fc1f3b4b.2021-04-23T10:00:43Z
2021-04-23 10:01:37 [ℹ]  using region us-west-2
2021-04-23 10:01:38 [ℹ]  neuron false
2021-04-23 10:01:38 [ℹ]  nvidia false
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

