### PR TITLE
Propagate user defined tags to instance and volumes in EKS nodes

### DIFF
--- a/pkg/cfn/builder/fakes/fake_cfn_template.go
+++ b/pkg/cfn/builder/fakes/fake_cfn_template.go
@@ -136,9 +136,10 @@ type LaunchTemplateData struct {
 	CreditSpecification *struct {
 		CPUCredits string
 	}
-	MetadataOptions MetadataOptions
-	Placement       Placement
-	KeyName         string
+	MetadataOptions   MetadataOptions
+	TagSpecifications []TagSpecification
+	Placement         Placement
+	KeyName           string
 }
 
 type Placement struct {
@@ -153,6 +154,11 @@ type BlockDeviceMappings struct {
 type MetadataOptions struct {
 	HTTPPutResponseHopLimit float64
 	HTTPTokens              string
+}
+
+type TagSpecification struct {
+	ResourceType *string
+	Tags         []Tag
 }
 
 type NetworkInterface struct {

--- a/pkg/cfn/builder/managed_launch_template.go
+++ b/pkg/cfn/builder/managed_launch_template.go
@@ -14,7 +14,7 @@ import (
 func (m *ManagedNodeGroupResourceSet) makeLaunchTemplateData() (*gfnec2.LaunchTemplate_LaunchTemplateData, error) {
 	mng := m.nodeGroup
 	launchTemplateData := &gfnec2.LaunchTemplate_LaunchTemplateData{
-		TagSpecifications: makeTags(mng.NodeGroupBase, m.clusterConfig.Metadata, m.nodeGroup.Spot),
+		TagSpecifications: makeTags(mng.NodeGroupBase, m.clusterConfig.Metadata),
 		MetadataOptions:   makeMetadataOptions(mng.NodeGroupBase),
 	}
 
@@ -161,7 +161,7 @@ func makeSSHIngressRules(n *api.NodeGroupBase, vpcCIDR, description string) []gf
 	return sgIngressRules
 }
 
-func makeTags(ng *api.NodeGroupBase, meta *api.ClusterMeta, spotInstances bool) []gfnec2.LaunchTemplate_TagSpecification {
+func makeTags(ng *api.NodeGroupBase, meta *api.ClusterMeta) []gfnec2.LaunchTemplate_TagSpecification {
 	cfnTags := []cloudformation.Tag{
 		{
 			Key:   gfnt.NewString("Name"),
@@ -185,14 +185,6 @@ func makeTags(ng *api.NodeGroupBase, meta *api.ClusterMeta, spotInstances bool) 
 			ResourceType: gfnt.NewString("volume"),
 			Tags:         cfnTags,
 		})
-
-	if spotInstances {
-		launchTemplateTagSpecs = append(launchTemplateTagSpecs,
-			gfnec2.LaunchTemplate_TagSpecification{
-				ResourceType: gfnt.NewString("spot-instances-request"),
-				Tags:         cfnTags,
-			})
-	}
 
 	return launchTemplateTagSpecs
 }

--- a/pkg/cfn/builder/managed_launch_template.go
+++ b/pkg/cfn/builder/managed_launch_template.go
@@ -13,7 +13,6 @@ import (
 
 func (m *ManagedNodeGroupResourceSet) makeLaunchTemplateData() (*gfnec2.LaunchTemplate_LaunchTemplateData, error) {
 	mng := m.nodeGroup
-
 	launchTemplateData := &gfnec2.LaunchTemplate_LaunchTemplateData{
 		TagSpecifications: makeTags(mng.NodeGroupBase, m.clusterConfig.Metadata),
 		MetadataOptions:   makeMetadataOptions(mng.NodeGroupBase),
@@ -178,6 +177,18 @@ func makeTags(ng *api.NodeGroupBase, meta *api.ClusterMeta) []gfnec2.LaunchTempl
 	return []gfnec2.LaunchTemplate_TagSpecification{
 		{
 			ResourceType: gfnt.NewString("instance"),
+			Tags:         cfnTags,
+		},
+		{
+			ResourceType: gfnt.NewString("volume"),
+			Tags:         cfnTags,
+		},
+		{
+			ResourceType: gfnt.NewString("elastic-gpu"),
+			Tags:         cfnTags,
+		},
+		{
+			ResourceType: gfnt.NewString("spot-instances-request"),
 			Tags:         cfnTags,
 		},
 	}

--- a/pkg/cfn/builder/managed_launch_template.go
+++ b/pkg/cfn/builder/managed_launch_template.go
@@ -14,7 +14,7 @@ import (
 func (m *ManagedNodeGroupResourceSet) makeLaunchTemplateData() (*gfnec2.LaunchTemplate_LaunchTemplateData, error) {
 	mng := m.nodeGroup
 	launchTemplateData := &gfnec2.LaunchTemplate_LaunchTemplateData{
-		TagSpecifications: makeTags(mng.NodeGroupBase, m.clusterConfig.Metadata, true),
+		TagSpecifications: makeTags(mng.NodeGroupBase, m.clusterConfig.Metadata, m.nodeGroup.Spot),
 		MetadataOptions:   makeMetadataOptions(mng.NodeGroupBase),
 	}
 
@@ -161,7 +161,7 @@ func makeSSHIngressRules(n *api.NodeGroupBase, vpcCIDR, description string) []gf
 	return sgIngressRules
 }
 
-func makeTags(ng *api.NodeGroupBase, meta *api.ClusterMeta, injectGpuAndSpotInstancesTags bool) []gfnec2.LaunchTemplate_TagSpecification {
+func makeTags(ng *api.NodeGroupBase, meta *api.ClusterMeta, spotInstances bool) []gfnec2.LaunchTemplate_TagSpecification {
 	cfnTags := []cloudformation.Tag{
 		{
 			Key:   gfnt.NewString("Name"),
@@ -186,12 +186,9 @@ func makeTags(ng *api.NodeGroupBase, meta *api.ClusterMeta, injectGpuAndSpotInst
 			Tags:         cfnTags,
 		})
 
-	if injectGpuAndSpotInstancesTags {
+	if spotInstances {
 		launchTemplateTagSpecs = append(launchTemplateTagSpecs,
 			gfnec2.LaunchTemplate_TagSpecification{
-				ResourceType: gfnt.NewString("elastic-gpu"),
-				Tags:         cfnTags,
-			}, gfnec2.LaunchTemplate_TagSpecification{
 				ResourceType: gfnt.NewString("spot-instances-request"),
 				Tags:         cfnTags,
 			})

--- a/pkg/cfn/builder/managed_nodegroup.go
+++ b/pkg/cfn/builder/managed_nodegroup.go
@@ -81,6 +81,13 @@ func (m *ManagedNodeGroupResourceSet) AddAllResources() error {
 	if m.nodeGroup.DesiredCapacity != nil {
 		scalingConfig.DesiredSize = gfnt.NewInteger(*m.nodeGroup.DesiredCapacity)
 	}
+
+	for k, v := range m.clusterConfig.Metadata.Tags {
+		if _, exists := m.nodeGroup.Tags[k]; !exists {
+			m.nodeGroup.Tags[k] = v
+		}
+	}
+
 	managedResource := &gfneks.Nodegroup{
 		ClusterName:   gfnt.NewString(m.clusterConfig.Metadata.Name),
 		NodegroupName: gfnt.NewString(m.nodeGroup.Name),

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -285,9 +285,9 @@ func newLaunchTemplateData(n *NodeGroupResourceSet) (*gfnec2.LaunchTemplate_Laun
 		IamInstanceProfile: &gfnec2.LaunchTemplate_IamInstanceProfile{
 			Arn: n.instanceProfileARN,
 		},
-		ImageId:         gfnt.NewString(n.spec.AMI),
-		UserData:        gfnt.NewString(userData),
-		MetadataOptions: makeMetadataOptions(n.spec.NodeGroupBase),
+		ImageId:           gfnt.NewString(n.spec.AMI),
+		UserData:          gfnt.NewString(userData),
+		MetadataOptions:   makeMetadataOptions(n.spec.NodeGroupBase),
 		TagSpecifications: makeTags(n.spec.NodeGroupBase, n.clusterSpec.Metadata, false),
 	}
 

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -288,7 +288,7 @@ func newLaunchTemplateData(n *NodeGroupResourceSet) (*gfnec2.LaunchTemplate_Laun
 		ImageId:         gfnt.NewString(n.spec.AMI),
 		UserData:        gfnt.NewString(userData),
 		MetadataOptions: makeMetadataOptions(n.spec.NodeGroupBase),
-		TagSpecifications: makeTags(n.spec.NodeGroupBase, n.clusterSpec.Metadata),
+		TagSpecifications: makeTags(n.spec.NodeGroupBase, n.clusterSpec.Metadata, false),
 	}
 
 	if err := buildNetworkInterfaces(launchTemplateData, n.spec.InstanceTypeList(), api.IsEnabled(n.spec.EFAEnabled), n.securityGroups, n.ec2API); err != nil {

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -68,6 +68,16 @@ func (n *NodeGroupResourceSet) AddAllResources() error {
 
 	n.vpc = n.vpcImporter.VPC()
 
+	if n.spec.Tags == nil {
+		n.spec.Tags = map[string]string{}
+	}
+
+	for k, v := range n.clusterSpec.Metadata.Tags {
+		if _, exists := n.spec.Tags[k]; !exists {
+			n.spec.Tags[k] = v
+		}
+	}
+
 	// Ensure MinSize is set, as it is required by the ASG cfn resource
 	// TODO this validation and default setting should happen way earlier than this
 	if n.spec.MinSize == nil {
@@ -278,6 +288,7 @@ func newLaunchTemplateData(n *NodeGroupResourceSet) (*gfnec2.LaunchTemplate_Laun
 		ImageId:         gfnt.NewString(n.spec.AMI),
 		UserData:        gfnt.NewString(userData),
 		MetadataOptions: makeMetadataOptions(n.spec.NodeGroupBase),
+		TagSpecifications: makeTags(n.spec.NodeGroupBase, n.clusterSpec.Metadata),
 	}
 
 	if err := buildNetworkInterfaces(launchTemplateData, n.spec.InstanceTypeList(), api.IsEnabled(n.spec.EFAEnabled), n.securityGroups, n.ec2API); err != nil {

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -288,7 +288,7 @@ func newLaunchTemplateData(n *NodeGroupResourceSet) (*gfnec2.LaunchTemplate_Laun
 		ImageId:           gfnt.NewString(n.spec.AMI),
 		UserData:          gfnt.NewString(userData),
 		MetadataOptions:   makeMetadataOptions(n.spec.NodeGroupBase),
-		TagSpecifications: makeTags(n.spec.NodeGroupBase, n.clusterSpec.Metadata, false),
+		TagSpecifications: makeTags(n.spec.NodeGroupBase, n.clusterSpec.Metadata),
 	}
 
 	if err := buildNetworkInterfaces(launchTemplateData, n.spec.InstanceTypeList(), api.IsEnabled(n.spec.EFAEnabled), n.securityGroups, n.ec2API); err != nil {

--- a/pkg/cfn/builder/nodegroup_test.go
+++ b/pkg/cfn/builder/nodegroup_test.go
@@ -608,6 +608,13 @@ var _ = Describe("Unmanaged NodeGroup Template Builder", func() {
 				Expect(properties.LaunchTemplateData.InstanceType).To(Equal("m5.large"))
 				Expect(properties.LaunchTemplateData.MetadataOptions.HTTPPutResponseHopLimit).To(Equal(float64(2)))
 				Expect(properties.LaunchTemplateData.MetadataOptions.HTTPTokens).To(Equal("optional"))
+				Expect(properties.LaunchTemplateData.TagSpecifications).To(HaveLen(2))
+				Expect(properties.LaunchTemplateData.TagSpecifications[0].ResourceType).To(Equal(aws.String("instance")))
+				Expect(properties.LaunchTemplateData.TagSpecifications[0].Tags[0].Key).To(Equal("Name"))
+				Expect(properties.LaunchTemplateData.TagSpecifications[0].Tags[0].Value).To(Equal("bonsai-ng-abcd1234-Node"))
+				Expect(properties.LaunchTemplateData.TagSpecifications[1].ResourceType).To(Equal(aws.String("volume")))
+				Expect(properties.LaunchTemplateData.TagSpecifications[1].Tags[0].Key).To(Equal("Name"))
+				Expect(properties.LaunchTemplateData.TagSpecifications[1].Tags[0].Value).To(Equal("bonsai-ng-abcd1234-Node"))
 			})
 
 			Context("creating userdata fails", func() {

--- a/pkg/cfn/builder/testdata/launch_template/custom_ami.json
+++ b/pkg/cfn/builder/testdata/launch_template/custom_ami.json
@@ -41,7 +41,24 @@
                                 "Value": "managed"
                             }
                         ]
-                    }
+                    },
+                  {
+                    "ResourceType": "volume",
+                    "Tags": [
+                      {
+                        "Key": "Name",
+                        "Value": "lt-custom-ami-Node"
+                      },
+                      {
+                        "Key": "alpha.eksctl.io/nodegroup-name",
+                        "Value": "custom-ami"
+                      },
+                      {
+                        "Key": "alpha.eksctl.io/nodegroup-type",
+                        "Value": "managed"
+                      }
+                    ]
+                  }
                 ],
                 "UserData": "CiMhL2Jpbi9iYXNoCnNldCAtZXgKQjY0X0NMVVNURVJfQ0E9ZEdWemRBbz0KQVBJX1NFUlZFUl9VUkw9aHR0cHM6Ly90ZXN0LmNvbQovZXRjL2Vrcy9ib290c3RyYXAuc2ggbGF1bmNoLXRlbXBsYXRlIC0tYjY0LWNsdXN0ZXItY2EgJEI2NF9DTFVTVEVSX0NBIC0tYXBpc2VydmVyLWVuZHBvaW50ICRBUElfU0VSVkVSX1VSTAo="
             },

--- a/pkg/cfn/builder/testdata/launch_template/placement.json
+++ b/pkg/cfn/builder/testdata/launch_template/placement.json
@@ -43,7 +43,24 @@
                                 "Value": "managed"
                             }
                         ]
-                    }
+                    },
+                  {
+                    "ResourceType": "volume",
+                    "Tags": [
+                      {
+                        "Key": "Name",
+                        "Value": "lt-standard-Node"
+                      },
+                      {
+                        "Key": "alpha.eksctl.io/nodegroup-name",
+                        "Value": "standard"
+                      },
+                      {
+                        "Key": "alpha.eksctl.io/nodegroup-type",
+                        "Value": "managed"
+                      }
+                    ]
+                  }
                 ]
             },
             "LaunchTemplateName": {

--- a/pkg/cfn/builder/testdata/launch_template/spot.json
+++ b/pkg/cfn/builder/testdata/launch_template/spot.json
@@ -57,23 +57,6 @@
                         "Value": "managed"
                       }
                     ]
-                  },
-                  {
-                    "ResourceType": "spot-instances-request",
-                    "Tags": [
-                      {
-                        "Key": "Name",
-                        "Value": "lt-spot-Node"
-                      },
-                      {
-                        "Key": "alpha.eksctl.io/nodegroup-name",
-                        "Value": "spot"
-                      },
-                      {
-                        "Key": "alpha.eksctl.io/nodegroup-type",
-                        "Value": "managed"
-                      }
-                    ]
                   }
                 ]
             },

--- a/pkg/cfn/builder/testdata/launch_template/spot.json
+++ b/pkg/cfn/builder/testdata/launch_template/spot.json
@@ -40,7 +40,41 @@
                                 "Value": "managed"
                             }
                         ]
-                    }
+                    },
+                  {
+                    "ResourceType": "volume",
+                    "Tags": [
+                      {
+                        "Key": "Name",
+                        "Value": "lt-spot-Node"
+                      },
+                      {
+                        "Key": "alpha.eksctl.io/nodegroup-name",
+                        "Value": "spot"
+                      },
+                      {
+                        "Key": "alpha.eksctl.io/nodegroup-type",
+                        "Value": "managed"
+                      }
+                    ]
+                  },
+                  {
+                    "ResourceType": "spot-instances-request",
+                    "Tags": [
+                      {
+                        "Key": "Name",
+                        "Value": "lt-spot-Node"
+                      },
+                      {
+                        "Key": "alpha.eksctl.io/nodegroup-name",
+                        "Value": "spot"
+                      },
+                      {
+                        "Key": "alpha.eksctl.io/nodegroup-type",
+                        "Value": "managed"
+                      }
+                    ]
+                  }
                 ]
             },
             "LaunchTemplateName": {

--- a/pkg/cfn/builder/testdata/launch_template/ssh_disabled.json
+++ b/pkg/cfn/builder/testdata/launch_template/ssh_disabled.json
@@ -41,6 +41,23 @@
                 "Value": "managed"
               }
             ]
+          },
+          {
+            "ResourceType": "volume",
+            "Tags": [
+              {
+                "Key": "Name",
+                "Value": "lt-ssh-disabled-Node"
+              },
+              {
+                "Key": "alpha.eksctl.io/nodegroup-name",
+                "Value": "ssh-disabled"
+              },
+              {
+                "Key": "alpha.eksctl.io/nodegroup-type",
+                "Value": "managed"
+              }
+            ]
           }
         ],
         "UserData": "TUlNRS1WZXJzaW9uOiAxLjANCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT0vLw0KDQotLS8vDQpDb250ZW50LVR5cGU6IHRleHQveC1zaGVsbHNjcmlwdA0KQ29udGVudC1UeXBlOiBjaGFyc2V0PSJ1cy1hc2NpaSINCg0KIyEvYmluL2Jhc2gKCnNldCAtbyBlcnJleGl0CnNldCAtbyBwaXBlZmFpbApzZXQgLW8gbm91bnNldAoKeXVtIGluc3RhbGwgLXkgYW1hem9uLXNzbS1hZ2VudApzeXN0ZW1jdGwgZW5hYmxlIGFtYXpvbi1zc20tYWdlbnQKc3lzdGVtY3RsIHN0YXJ0IGFtYXpvbi1zc20tYWdlbnQKDQotLS8vLS0NCg=="

--- a/pkg/cfn/builder/testdata/launch_template/ssh_enabled.json
+++ b/pkg/cfn/builder/testdata/launch_template/ssh_enabled.json
@@ -44,7 +44,24 @@
                                 "Value": "managed"
                             }
                         ]
-                    }
+                    },
+                  {
+                    "ResourceType": "volume",
+                    "Tags": [
+                      {
+                        "Key": "Name",
+                        "Value": "lt-ssh-enabled-Node"
+                      },
+                      {
+                        "Key": "alpha.eksctl.io/nodegroup-name",
+                        "Value": "ssh-enabled"
+                      },
+                      {
+                        "Key": "alpha.eksctl.io/nodegroup-type",
+                        "Value": "managed"
+                      }
+                    ]
+                  }
                 ],
               "UserData": "TUlNRS1WZXJzaW9uOiAxLjANCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L21peGVkOyBib3VuZGFyeT0vLw0KDQotLS8vDQpDb250ZW50LVR5cGU6IHRleHQveC1zaGVsbHNjcmlwdA0KQ29udGVudC1UeXBlOiBjaGFyc2V0PSJ1cy1hc2NpaSINCg0KIyEvYmluL2Jhc2gKCnNldCAtbyBlcnJleGl0CnNldCAtbyBwaXBlZmFpbApzZXQgLW8gbm91bnNldAoKeXVtIGluc3RhbGwgLXkgYW1hem9uLXNzbS1hZ2VudApzeXN0ZW1jdGwgZW5hYmxlIGFtYXpvbi1zc20tYWdlbnQKc3lzdGVtY3RsIHN0YXJ0IGFtYXpvbi1zc20tYWdlbnQKDQotLS8vLS0NCg=="
             },

--- a/pkg/cfn/builder/testdata/launch_template/standard.json
+++ b/pkg/cfn/builder/testdata/launch_template/standard.json
@@ -40,7 +40,24 @@
                                 "Value": "managed"
                             }
                         ]
-                    }
+                    },
+                  {
+                    "ResourceType": "volume",
+                    "Tags": [
+                      {
+                        "Key": "Name",
+                        "Value": "lt-standard-Node"
+                      },
+                      {
+                        "Key": "alpha.eksctl.io/nodegroup-name",
+                        "Value": "standard"
+                      },
+                      {
+                        "Key": "alpha.eksctl.io/nodegroup-type",
+                        "Value": "managed"
+                      }
+                    ]
+                  }
                 ]
             },
             "LaunchTemplateName": {


### PR DESCRIPTION
### Description
Currently, `eksctl` does not support propagating user defined tags to underlaying instances and ebs volumes in managed and un-managed nodes

Add support to inject user defined tags to underlaying compute resources.

#### Changes
refactored `makeTags` function in managed_launch_template.go to add `volume`, `elastic-gpu`, and `spot-instances-request`

```go
	var launchTemplateTagSpecs []gfnec2.LaunchTemplate_TagSpecification

	launchTemplateTagSpecs = append(launchTemplateTagSpecs,
		gfnec2.LaunchTemplate_TagSpecification{
			ResourceType: gfnt.NewString("instance"),
			Tags:         cfnTags,
		}, gfnec2.LaunchTemplate_TagSpecification{
			ResourceType: gfnt.NewString("volume"),
			Tags:         cfnTags,
		})

	if injectGpuAndSpotInstancesTags {
		launchTemplateTagSpecs = append(launchTemplateTagSpecs,
			gfnec2.LaunchTemplate_TagSpecification{
				ResourceType: gfnt.NewString("elastic-gpu"),
				Tags:         cfnTags,
			}, gfnec2.LaunchTemplate_TagSpecification{
				ResourceType: gfnt.NewString("spot-instances-request"),
				Tags:         cfnTags,
			})
	}

	return launchTemplateTagSpecs
```

add `injectGpuAndSpotInstancesTags` parameter to `makeTags` function to conditionally inject gpu and spot instance tags into launch template.
```go
func makeTags(ng *api.NodeGroupBase, meta *api.ClusterMeta, injectGpuAndSpotInstancesTags bool) []gfnec2.LaunchTemplate_TagSpecification {
```
> Note: as mentioned in one of commit, currently self-managed nodes fails to launch when launch template is tagged for elastic-gpu and spot instances. However, there is no issue with managed nodes

Merge user defined tags via `--tags` in `AddAllResources()` function in `nodegroup.go`
```go
	if n.spec.Tags == nil {
		n.spec.Tags = map[string]string{}
	}

	for k, v := range n.clusterSpec.Metadata.Tags {
		if _, exists := n.spec.Tags[k]; !exists {
			n.spec.Tags[k] = v
		}
	}
``` 

Add `TagSpecifications` in `newLaunchTemplateData` in `nodegroup.go`

Merge user defined tags into nodespec tags in `AddAllResources` function in `managed_nodegroup.go`
```go
	for k, v := range m.clusterConfig.Metadata.Tags {
		if _, exists := m.nodeGroup.Tags[k]; !exists {
			m.nodeGroup.Tags[k] = v
		}
	}
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:

