### PR TITLE
Addon create and update respects general timeout flag

### DIFF
--- a/pkg/actions/addon/addon.go
+++ b/pkg/actions/addon/addon.go
@@ -34,7 +34,7 @@ type Manager struct {
 	timeout       time.Duration
 }
 
-func New(clusterConfig *api.ClusterConfig, eksAPI eksiface.EKSAPI, stackManager manager.StackManager, withOIDC bool, oidcManager *iamoidc.OpenIDConnectManager, clientSet kubeclient.Interface) (*Manager, error) {
+func New(clusterConfig *api.ClusterConfig, eksAPI eksiface.EKSAPI, stackManager manager.StackManager, withOIDC bool, oidcManager *iamoidc.OpenIDConnectManager, clientSet kubeclient.Interface, timeout time.Duration) (*Manager, error) {
 	if err := supportedVersion(clusterConfig.Metadata.Version); err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func New(clusterConfig *api.ClusterConfig, eksAPI eksiface.EKSAPI, stackManager 
 		oidcManager:   oidcManager,
 		stackManager:  stackManager,
 		clientSet:     clientSet,
-		timeout:       5 * time.Minute,
+		timeout:       timeout,
 	}, nil
 }
 

--- a/pkg/actions/addon/addon_test.go
+++ b/pkg/actions/addon/addon_test.go
@@ -1,6 +1,8 @@
 package addon_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/eksctl/pkg/actions/addon"
@@ -11,14 +13,14 @@ import (
 var _ = Describe("Addon", func() {
 	When("the version is supported", func() {
 		It("does not error", func() {
-			_, err := addon.New(&api.ClusterConfig{Metadata: &api.ClusterMeta{Version: "1.18"}}, &mocks.EKSAPI{}, nil, false, nil, nil)
+			_, err := addon.New(&api.ClusterConfig{Metadata: &api.ClusterMeta{Version: "1.18"}}, &mocks.EKSAPI{}, nil, false, nil, nil, 5*time.Minute)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
 	When("the version is not supported", func() {
 		It("errors", func() {
-			_, err := addon.New(&api.ClusterConfig{Metadata: &api.ClusterMeta{Version: "1.17"}}, &mocks.EKSAPI{}, nil, false, nil, nil)
+			_, err := addon.New(&api.ClusterConfig{Metadata: &api.ClusterMeta{Version: "1.17"}}, &mocks.EKSAPI{}, nil, false, nil, nil, 5*time.Minute)
 			Expect(err).To(MatchError("addons not supported on 1.17. Must be using 1.18 or newer"))
 		})
 	})

--- a/pkg/actions/addon/create_test.go
+++ b/pkg/actions/addon/create_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Create", func() {
 		manager, err = addon.New(&api.ClusterConfig{Metadata: &api.ClusterMeta{
 			Version: "1.18",
 			Name:    "my-cluster",
-		}}, mockProvider.EKS(), fakeStackManager, withOIDC, oidc, rawClient.ClientSet())
+		}}, mockProvider.EKS(), fakeStackManager, withOIDC, oidc, rawClient.ClientSet(), 5*time.Minute)
 		Expect(err).NotTo(HaveOccurred())
 		manager.SetTimeout(time.Second)
 	})

--- a/pkg/actions/addon/delete_test.go
+++ b/pkg/actions/addon/delete_test.go
@@ -2,6 +2,7 @@ package addon_test
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 
@@ -34,7 +35,7 @@ var _ = Describe("Delete", func() {
 		manager, err = addon.New(&api.ClusterConfig{Metadata: &api.ClusterMeta{
 			Version: "1.18",
 			Name:    "my-cluster",
-		}}, mockProvider.EKS(), fakeStackManager, withOIDC, nil, nil)
+		}}, mockProvider.EKS(), fakeStackManager, withOIDC, nil, nil, 5*time.Minute)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/pkg/actions/addon/describe_versions_test.go
+++ b/pkg/actions/addon/describe_versions_test.go
@@ -2,6 +2,7 @@ package addon_test
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	awseks "github.com/aws/aws-sdk-go/service/eks"
@@ -25,7 +26,7 @@ var _ = Describe("DescribeVersions", func() {
 		manager, err = addon.New(&api.ClusterConfig{Metadata: &api.ClusterMeta{
 			Version: "1.18",
 			Name:    "my-cluster",
-		}}, mockProvider.EKS(), nil, false, nil, nil)
+		}}, mockProvider.EKS(), nil, false, nil, nil, 5*time.Minute)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/pkg/actions/addon/get_test.go
+++ b/pkg/actions/addon/get_test.go
@@ -2,6 +2,7 @@ package addon_test
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	awseks "github.com/aws/aws-sdk-go/service/eks"
@@ -25,7 +26,7 @@ var _ = Describe("Get", func() {
 		manager, err = addon.New(&api.ClusterConfig{Metadata: &api.ClusterMeta{
 			Version: "1.18",
 			Name:    "my-cluster",
-		}}, mockProvider.EKS(), nil, false, nil, nil)
+		}}, mockProvider.EKS(), nil, false, nil, nil, 5*time.Minute)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/pkg/actions/addon/update_test.go
+++ b/pkg/actions/addon/update_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Update", func() {
 		addonManager, err = addon.New(&api.ClusterConfig{Metadata: &api.ClusterMeta{
 			Version: "1.18",
 			Name:    "my-cluster",
-		}}, mockProvider.EKS(), fakeStackManager, true, oidc, nil)
+		}}, mockProvider.EKS(), fakeStackManager, true, oidc, nil, 5*time.Minute)
 		Expect(err).NotTo(HaveOccurred())
 		addonManager.SetTimeout(time.Second)
 	})

--- a/pkg/ctl/create/addon.go
+++ b/pkg/ctl/create/addon.go
@@ -84,7 +84,7 @@ func createAddonCmd(cmd *cmdutils.Cmd) {
 			return err
 		}
 
-		addonManager, err := addon.New(cmd.ClusterConfig, clusterProvider.Provider.EKS(), stackManager, oidcProviderExists, oidc, clientSet)
+		addonManager, err := addon.New(cmd.ClusterConfig, clusterProvider.Provider.EKS(), stackManager, oidcProviderExists, oidc, clientSet, cmd.ProviderConfig.WaitTimeout)
 		if err != nil {
 			return err
 		}

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -251,7 +251,7 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 
 		var taskTree *tasks.TaskTree
 		if supported {
-			createAddonTasks := addon.CreateAddonTasks(cfg, ctl, true)
+			createAddonTasks := addon.CreateAddonTasks(cfg, ctl, true, cmd.ProviderConfig.WaitTimeout)
 			createAddonTasks.IsSubTask = true
 			taskTree = stackManager.NewTasksToCreateClusterWithNodeGroups(cfg.NodeGroups, cfg.ManagedNodeGroups, supportsManagedNodes, postClusterCreationTasks, createAddonTasks)
 		} else {

--- a/pkg/ctl/delete/addon.go
+++ b/pkg/ctl/delete/addon.go
@@ -61,7 +61,7 @@ func deleteAddon(cmd *cmdutils.Cmd) error {
 	logger.Info("Kubernetes version %q in use by cluster %q", *output.Cluster.Version, cmd.ClusterConfig.Metadata.Name)
 	cmd.ClusterConfig.Metadata.Version = *output.Cluster.Version
 
-	addonManager, err := addon.New(cmd.ClusterConfig, clusterProvider.Provider.EKS(), stackManager, *cmd.ClusterConfig.IAM.WithOIDC, nil, nil)
+	addonManager, err := addon.New(cmd.ClusterConfig, clusterProvider.Provider.EKS(), stackManager, *cmd.ClusterConfig.IAM.WithOIDC, nil, nil, cmd.ProviderConfig.WaitTimeout)
 
 	if err != nil {
 		return err

--- a/pkg/ctl/get/addon.go
+++ b/pkg/ctl/get/addon.go
@@ -70,7 +70,7 @@ func getAddon(cmd *cmdutils.Cmd, params *getCmdParams) error {
 	logger.Info("Kubernetes version %q in use by cluster %q", *output.Cluster.Version, cmd.ClusterConfig.Metadata.Name)
 	cmd.ClusterConfig.Metadata.Version = *output.Cluster.Version
 
-	addonManager, err := addon.New(cmd.ClusterConfig, clusterProvider.Provider.EKS(), stackManager, *cmd.ClusterConfig.IAM.WithOIDC, nil, nil)
+	addonManager, err := addon.New(cmd.ClusterConfig, clusterProvider.Provider.EKS(), stackManager, *cmd.ClusterConfig.IAM.WithOIDC, nil, nil, cmd.ProviderConfig.WaitTimeout)
 
 	if err != nil {
 		return err

--- a/pkg/ctl/update/addon.go
+++ b/pkg/ctl/update/addon.go
@@ -81,7 +81,7 @@ func updateAddon(cmd *cmdutils.Cmd, force, wait bool) error {
 	logger.Info("Kubernetes version %q in use by cluster %q", *output.Cluster.Version, cmd.ClusterConfig.Metadata.Name)
 	cmd.ClusterConfig.Metadata.Version = *output.Cluster.Version
 
-	addonManager, err := addon.New(cmd.ClusterConfig, clusterProvider.Provider.EKS(), stackManager, oidcProviderExists, oidc, nil)
+	addonManager, err := addon.New(cmd.ClusterConfig, clusterProvider.Provider.EKS(), stackManager, oidcProviderExists, oidc, nil, cmd.ProviderConfig.WaitTimeout)
 
 	if err != nil {
 		return err

--- a/pkg/ctl/utils/describe_addon_versions.go
+++ b/pkg/ctl/utils/describe_addon_versions.go
@@ -70,7 +70,7 @@ func describeAddonVersions(cmd *cmdutils.Cmd, addonName, k8sVersion, clusterName
 
 	stackManager := clusterProvider.NewStackManager(cmd.ClusterConfig)
 
-	addonManager, err := addon.New(cmd.ClusterConfig, clusterProvider.Provider.EKS(), stackManager, *cmd.ClusterConfig.IAM.WithOIDC, nil, nil)
+	addonManager, err := addon.New(cmd.ClusterConfig, clusterProvider.Provider.EKS(), stackManager, *cmd.ClusterConfig.IAM.WithOIDC, nil, nil, cmd.ProviderConfig.WaitTimeout)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
### Description

instead of 5 minutes constant timeout eksctl create and update addon command will respect the timeout flag, the timeout will have an effect only with wait flag.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

