### PR TITLE
Add support for using Kubernetes recommended labels in nodeGroup

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -402,6 +402,8 @@ func validateNodeGroupLabels(labels map[string]string) error {
 	// - https://github.com/kubernetes/kubernetes/blob/v1.13.2/cmd/kubelet/app/options/options.go#L257-L267
 	// - https://github.com/kubernetes/kubernetes/blob/v1.13.2/pkg/kubelet/apis/well_known_labels.go
 	// we cannot import those packages because they break other dependencies
+	// Don't forget to allow commonLabels.
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 
 	unknownKubernetesLabels := []string{}
 
@@ -433,10 +435,19 @@ func validateNodeGroupLabels(labels map[string]string) error {
 	return nil
 }
 
+func isKubernetesRecommendedLabel(namespace string) bool {
+	for _, domain := range []string{"app.kubernetes.io"} {
+		if namespace == domain {
+			return true
+		}
+	}
+	return false
+}
+
 func isKubernetesLabel(namespace string) bool {
 	for _, domain := range []string{"kubernetes.io", "k8s.io"} {
 		if namespace == domain || strings.HasSuffix(namespace, "."+domain) {
-			return true
+			return !isKubernetesRecommendedLabel(namespace)
 		}
 	}
 	return false


### PR DESCRIPTION
tags, this will allow for using them in nodeAffinities, taints
and tolerations.

### Description
When deploying nodeGroups, and using the Kubernetes recommended labels for our service and applications, while also using the recommended labels in affinities, taints and tolerations, EKSCTL goes boom!

The recommended labels are documented here https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/ 
and have existed for years, https://github.com/kubernetes/website/blame/c4b818c1f11280c5946d45475e91c890ad7289f4/content/en/docs/concepts/overview/working-with-objects/common-labels.md

So we added support to negate the validation check if the label namespace is app.kubernetes.io.


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:

