### PR TITLE
Parse ng taints correctly

### DIFF
--- a/pkg/nodebootstrap/ubuntu_test.go
+++ b/pkg/nodebootstrap/ubuntu_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Ubuntu User Data", func() {
 
 	When("taints are set on the node config", func() {
 		BeforeEach(func() {
-			ng.Taints = map[string]string{"foo": "bar"}
+			ng.Taints = map[string]string{"foo": "bar", "one": "two:three"}
 			bootstrapper = nodebootstrap.NewUbuntuBootstrapper(clusterName, ng)
 		})
 
@@ -117,7 +117,9 @@ var _ = Describe("Ubuntu User Data", func() {
 
 			cloudCfg := decode(userData)
 			Expect(cloudCfg.WriteFiles[2].Path).To(Equal("/etc/eksctl/kubelet.env"))
-			Expect(cloudCfg.WriteFiles[2].Content).To(ContainSubstring("NODE_TAINTS=foo=:bar"))
+			Expect(cloudCfg.WriteFiles[2].Content).To(ContainSubstring("NODE_TAINTS"))
+			Expect(cloudCfg.WriteFiles[2].Content).To(ContainSubstring("foo=:bar"))
+			Expect(cloudCfg.WriteFiles[2].Content).To(ContainSubstring("one=two:three"))
 			Expect(cloudCfg.WriteFiles[2].Permissions).To(Equal("0644"))
 		})
 	})

--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -160,6 +160,10 @@ func makeBootstrapEnv(clusterName string, ng *api.NodeGroup) cloudconfig.File {
 func mapTaints(kv map[string]string) string {
 	var params []string
 	for k, v := range kv {
+		if strings.Contains(v, ":") {
+			params = append(params, fmt.Sprintf("%s=%s", k, v))
+			continue
+		}
 		params = append(params, fmt.Sprintf("%s=:%s", k, v))
 	}
 	return strings.Join(params, ",")


### PR DESCRIPTION
Fixes https://github.com/weaveworks/eksctl/issues/3654.

Taints with the format `foo: bar` should be appended as `"foo=:bar"`,
taints with the format `one: two:three` should be appended as
`"one=two:three"`.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

