### PR TITLE
create 1.19 cluster in unowned cluster test

### DIFF
--- a/integration/tests/unowned_cluster/unowned_cluster_test.go
+++ b/integration/tests/unowned_cluster/unowned_cluster_test.go
@@ -56,7 +56,7 @@ var _ = Describe("(Integration) [non-eksctl cluster & nodegroup support]", func(
 		ng1 = "ng-1"
 		mng1 = "mng-1"
 		mng2 = "mng-2"
-		version = "1.18"
+		version = "1.19"
 		stackName = fmt.Sprintf("eksctl-%s", params.ClusterName)
 		cfg = &api.ClusterConfig{
 			TypeMeta: api.ClusterConfigTypeMeta(),


### PR DESCRIPTION
### Description

```
[4]   /__w/eksctl/eksctl/integration/tests/crud/creategetdelete_test.go:285
[4] starting '../../../eksctl "--region" "us-west-2" "utils" "update-cluster-logging" "--cluster" "it-crud-amazing-outfit-1621236575" "--enable-types" "api,controllerManager"'
[12] Error: upgrading more than one version at a time is not supported. Found upgrade from "1.18" to "1.20". Please upgrade to "1.19" first
[12] 
[12] • Failure [1.523 seconds]
[12] (Integration) [non-eksctl cluster & nodegroup support]
[12] /__w/eksctl/eksctl/integration/tests/unowned_cluster/unowned_cluster_test.go:46
[12]   supports cluster upgrades [It]
[12]   /__w/eksctl/eksctl/integration/tests/unowned_cluster/unowned_cluster_test.go:239
[12] 
[12]   Expected '../../../eksctl "--region" "us-west-2" "upgrade" "cluster" "--name" "it-uc-hilarious-gopher-1621236575" "--version" "1.20" "--timeout" "1h30m" "--approve" "--verbose" "2"' to succeed, got return code 1
[12] 
[12]   /__w/eksctl/eksctl/integration/tests/unowned_cluster/unowned_cluster_test.go:250
[12] ------------------------------
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

