### PR TITLE
fix failing integration tests

### DIFF
--- a/integration/data/test-http.yaml
+++ b/integration/data/test-http.yaml
@@ -11,8 +11,11 @@ spec:
       labels: {test: http}
     spec:
       containers:
-      - image: tutum/curl@sha256:b6f16e88387acd4e6326176b212b3dae63f5b2134e69560d0b0673cfb0fb976f
+      - image: curlimages/curl@sha256:fa32ef426092b88ee0b569d6f81ab0203ee527692a94ec2e6ceb2fd0b6b2755c
         name: https-test-eksctl
+        command:
+        - sleep
+        - "3600"
         stdin: true
         tty: true
         readinessProbe:
@@ -27,8 +30,11 @@ spec:
             - --silent
             - --head
             - eksctl.io
-      - image: tutum/curl@sha256:b6f16e88387acd4e6326176b212b3dae63f5b2134e69560d0b0673cfb0fb976f
+      - image: curlimages/curl@sha256:fa32ef426092b88ee0b569d6f81ab0203ee527692a94ec2e6ceb2fd0b6b2755c
         name: https-test-kubernetes
+        command:
+        - sleep
+        - "3600"
         stdin: true
         tty: true
         readinessProbe:
@@ -43,8 +49,11 @@ spec:
             - --silent
             - --head
             - kubernetes.io
-      - image: tutum/curl@sha256:b6f16e88387acd4e6326176b212b3dae63f5b2134e69560d0b0673cfb0fb976f
+      - image: curlimages/curl@sha256:fa32ef426092b88ee0b569d6f81ab0203ee527692a94ec2e6ceb2fd0b6b2755c
         name: https-test-metadata
+        command:
+        - sleep
+        - "3600"
         stdin: true
         tty: true
         readinessProbe:

--- a/integration/tests/assertions.go
+++ b/integration/tests/assertions.go
@@ -17,12 +17,17 @@ func AssertNodeTaints(clientset kubernetes.Interface, nodeGroupName string, expe
 	})
 	Expect(err).ToNot(HaveOccurred())
 
+	//unset the time so the structs can be compared
 	for _, node := range nodeList.Items {
-		for i, t := range node.Spec.Taints {
-			expected := expectedTaints[i]
-			Expect(t.Key).To(Equal(expected.Key))
-			Expect(t.Value).To(Equal(expected.Value))
-			Expect(t.Effect).To(Equal(expected.Effect))
+		for _, t := range node.Spec.Taints {
+			t.TimeAdded = nil
+		}
+	}
+
+	for _, node := range nodeList.Items {
+		Expect(node.Spec.Taints).To(HaveLen(len(expectedTaints)))
+		for _, taint := range expectedTaints {
+			Expect(node.Spec.Taints).To(ContainElement(taint))
 		}
 	}
 }

--- a/integration/tests/assertions.go
+++ b/integration/tests/assertions.go
@@ -25,7 +25,6 @@ func AssertNodeTaints(clientset kubernetes.Interface, nodeGroupName string, expe
 	}
 
 	for _, node := range nodeList.Items {
-		Expect(node.Spec.Taints).To(HaveLen(len(expectedTaints)))
 		for _, taint := range expectedTaints {
 			Expect(node.Spec.Taints).To(ContainElement(taint))
 		}

--- a/integration/tests/crud/creategetdelete_test.go
+++ b/integration/tests/crud/creategetdelete_test.go
@@ -304,9 +304,11 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					"--cluster", params.ClusterName,
 				)
 				Expect(cmd).To(RunSuccessfullyWithOutputString(BeNodeGroupsWithNamesWhich(
-					HaveLen(3),
+					HaveLen(4),
 					ContainElement(initNG),
 					ContainElement(testNG),
+					ContainElement("n1"),
+					ContainElement("n2"),
 				)))
 			})
 


### PR DESCRIPTION
### Description
fixes:

- taint ordering not be relied on
- nodegroup listing in crud test
- `http` daemonset not coming up due to deleted image
```
2021-05-21 17:00:31 [ℹ]  checking security group configuration for all nodegroups
2021-05-21 17:00:31 [▶]  nodegroup "n1" is compatible
2021-05-21 17:00:31 [▶]  nodegroup "n2" is compatible
2021-05-21 17:00:31 [▶]  nodegroup "ng-0" is compatible
2021-05-21 17:00:31 [ℹ]  all nodegroups have up-to-date configuration

• Failure [366.519 seconds]
(Integration) Create, Get, Scale & Delete
/home/jake/weave/eksctl/integration/tests/crud/creategetdelete_test.go:57
  cluster with 1 node
  /home/jake/weave/eksctl/integration/tests/crud/creategetdelete_test.go:116
    and create a new nodegroup with taints
    /home/jake/weave/eksctl/integration/tests/crud/creategetdelete_test.go:209
      should support both formats for taints [It]
      /home/jake/weave/eksctl/integration/tests/crud/creategetdelete_test.go:210

      Expected
          <string>: key2
      to equal
          <string>: key1

      /home/jake/weave/eksctl/integration/tests/assertions.go:23
------------------------------
(Integration) Create, Get, Scale & Delete cluster with 1 node and add a second (GPU) nod
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

