### PR TITLE
Remove support for creating EKS 1.15 clusters

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -408,7 +408,6 @@ func IsDeprecatedVersion(version string) bool {
 // SupportedVersions are the versions of Kubernetes that EKS supports
 func SupportedVersions() []string {
 	return []string{
-		Version1_15,
 		Version1_16,
 		Version1_17,
 		Version1_18,
@@ -417,7 +416,7 @@ func SupportedVersions() []string {
 	}
 }
 
-// IsSupportedVersion returns true if the given version is a Kubernetes supported by eksctl and EKS
+// IsSupportedVersion returns true if the given Kubernetes version is supported by eksctl and EKS
 func IsSupportedVersion(version string) bool {
 	for _, v := range SupportedVersions() {
 		if version == v {

--- a/userdocs/src/introduction.md
+++ b/userdocs/src/introduction.md
@@ -23,7 +23,7 @@ eksctl create cluster --name=cluster-1 --nodes=4
 
 ```
 
-EKS supports versions `1.15`, `1.16`, `1.17`, `1.18`, `1.19` (default) and `1.20`.
+EKS supports versions `1.16`, `1.17`, `1.18`, `1.19` (default) and `1.20`.
 With `eksctl` you can deploy any of the supported versions by passing `--version`.
 
 ```


### PR DESCRIPTION
### Description

EKS no longer supports creation of 1.15 clusters. 

Closes #3260 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

