### PR TITLE
Write kubeconfig to temporary location before `enable flux` runs

### DIFF
--- a/integration/tests/gitops/flux_test.go
+++ b/integration/tests/gitops/flux_test.go
@@ -83,7 +83,6 @@ var _ = Describe("Enable GitOps", func() {
 						"owner":      params.GitopsOwner,
 						"branch":     branch,
 						"repository": repository,
-						"kubeconfig": params.KubeconfigPath,
 					},
 				},
 			},

--- a/pkg/flux/flux.go
+++ b/pkg/flux/flux.go
@@ -41,7 +41,7 @@ func (c *Client) PreFlight() error {
 
 	args := []string{"check", "--pre"}
 	for k, v := range c.opts.Flags {
-		if k == "kubeconfig" {
+		if k == "kubeconfig" || k == "context" {
 			args = append(args, fmt.Sprintf("--%s", k), v)
 		}
 	}

--- a/pkg/flux/flux_test.go
+++ b/pkg/flux/flux_test.go
@@ -67,6 +67,19 @@ var _ = Describe("Flux", func() {
 			})
 		})
 
+		When("a context is provided in flags", func() {
+			BeforeEach(func() {
+				opts.Flags = api.FluxFlags{"context": "foo"}
+			})
+
+			It("sets the kubeconfig flag on the command", func() {
+				Expect(fluxClient.PreFlight()).To(Succeed())
+				Expect(fakeExecutor.ExecCallCount()).To(Equal(1))
+				_, receivedArgs := fakeExecutor.ExecArgsForCall(0)
+				Expect(receivedArgs).To(Equal([]string{"check", "--pre", "--context", "foo"}))
+			})
+		})
+
 		When("the flux binary is not found on the path", func() {
 			BeforeEach(func() {
 				Expect(os.Unsetenv("PATH")).To(Succeed())


### PR DESCRIPTION
### Description

This PR only affects the `enable flux` command. If you are bootstrapping flux as part of a cluster create, the config and context are already set as part of the post create steps.

Before running any Flux commands, we write the cluster kubeconfig to a temporary location. We then set the `kubeconfig` flag on the Flux opts (to pass into those commands). A `defer` will clean up the created temp file.

I am not thrilled about where I have implemented this; it is in the `ctl` package which is basically untestable. Testing is weird in itself, since the outcome is that a file _does not_ exist. The only checkable thing is that a flag has been set, but I could not find a nice place to do that. The change is covered by the integration test, which would fail if this didn't work.

Do we want users to ever set their own kubeconfig/context? It doesn't make a lot of sense in the context of eksctl, but I have put a guard in there anyway. If we don't think they should ever be setting this, then we can have a thing in the flux package to discount those flags.

Integration test passing.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

