### PR TITLE
FIX 3764: Add ASG name to nodegroup output when name flag is set

### DIFF
--- a/pkg/actions/nodegroup/get.go
+++ b/pkg/actions/nodegroup/get.go
@@ -94,16 +94,24 @@ func (m *Manager) Get(name string) (*manager.NodeGroupSummary, error) {
 		return nil, err
 	}
 
+	var asg string
+	if describeOutput.Nodegroup.Resources != nil {
+		for _, v := range describeOutput.Nodegroup.Resources.AutoScalingGroups {
+			asg = aws.StringValue(v.Name)
+		}
+	}
+
 	return &manager.NodeGroupSummary{
-		Name:                *describeOutput.Nodegroup.NodegroupName,
-		Cluster:             *describeOutput.Nodegroup.ClusterName,
-		Status:              *describeOutput.Nodegroup.Status,
-		MaxSize:             int(*describeOutput.Nodegroup.ScalingConfig.MaxSize),
-		MinSize:             int(*describeOutput.Nodegroup.ScalingConfig.MinSize),
-		DesiredCapacity:     int(*describeOutput.Nodegroup.ScalingConfig.DesiredSize),
-		InstanceType:        *describeOutput.Nodegroup.InstanceTypes[0],
-		ImageID:             *describeOutput.Nodegroup.AmiType,
-		CreationTime:        describeOutput.Nodegroup.CreatedAt,
-		NodeInstanceRoleARN: *describeOutput.Nodegroup.NodeRole,
+		Name:                 *describeOutput.Nodegroup.NodegroupName,
+		Cluster:              *describeOutput.Nodegroup.ClusterName,
+		Status:               *describeOutput.Nodegroup.Status,
+		MaxSize:              int(*describeOutput.Nodegroup.ScalingConfig.MaxSize),
+		MinSize:              int(*describeOutput.Nodegroup.ScalingConfig.MinSize),
+		DesiredCapacity:      int(*describeOutput.Nodegroup.ScalingConfig.DesiredSize),
+		InstanceType:         *describeOutput.Nodegroup.InstanceTypes[0],
+		ImageID:              *describeOutput.Nodegroup.AmiType,
+		CreationTime:         describeOutput.Nodegroup.CreatedAt,
+		NodeInstanceRoleARN:  *describeOutput.Nodegroup.NodeRole,
+		AutoScalingGroupName: asg,
 	}, nil
 }


### PR DESCRIPTION
### Description

add the ASG name to the return struct for nodegroup Get method when name flag is set

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

