### PR TITLE
Remove usage of unsupported Ubuntu AMI family for 1.19

### DIFF
--- a/integration/tests/managed/managed_nodegroup_test.go
+++ b/integration/tests/managed/managed_nodegroup_test.go
@@ -119,7 +119,7 @@ var _ = Describe("(Integration) Create Managed Nodegroups", func() {
 			NodeGroupBase: &api.NodeGroupBase{
 				Name:       "ubuntu",
 				VolumeSize: aws.Int(25),
-				AMIFamily:  "Ubuntu1804",
+				AMIFamily:  "Ubuntu2004",
 			},
 		}),
 	)


### PR DESCRIPTION
### Description

Ubuntu 18.04 does not seem to be available/supported for EKS 1.19 (and some previous versions). 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

