### PR TITLE
Revert "Disable tests for the night (#3817)"

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,8 +1,8 @@
 name: Integration tests
 
 on:
-  # schedule:
-  #   - cron: '0 */4 * * *'
+  schedule:
+    - cron: '0 */4 * * *'
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
This reverts commit ebc78c9350f428a1dca6aa7540f194b8c4a575af.

turn integration tests back on
