### PR TITLE
Fix: Misspelled serviceAccountRoleARN in documentation

### DIFF
--- a/userdocs/src/usage/addons.md
+++ b/userdocs/src/usage/addons.md
@@ -64,7 +64,7 @@ eksctl create addon -f config.yaml
 ```
 
 ```console
-eksctl create addon --name vpc-cni --version 1.7.5 --serivce-account-role-arn=<role-arn>
+eksctl create addon --name vpc-cni --version 1.7.5 --service-account-role-arn=<role-arn>
 ```
 
 ## Listing enabled addons
@@ -101,7 +101,7 @@ eksctl update addon -f config.yaml
 ```
 
 ```console
-eksctl update addon --name vpc-cni --version 1.8.0 --serivce-account-role-arn=<new-role>
+eksctl update addon --name vpc-cni --version 1.8.0 --service-account-role-arn=<new-role>
 ```
 
 ## Deleting addons


### PR DESCRIPTION
Hi, 
Was reading through the documentation, and spottet this misspelling.
I have not ran the commands, or tested it. but comparing to the yaml schema the CLI commands is mispelled. 🙂

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:

