### PR TITLE
Make addon.Force unconfigurable

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/addon.go
+++ b/pkg/apis/eksctl.io/v1alpha5/addon.go
@@ -27,7 +27,7 @@ type Addon struct {
 	// +optional
 	Tags map[string]string `json:"tags,omitempty"`
 	// Force applies the add-on to overwrite an existing add-on
-	Force bool
+	Force bool `json:"-"`
 }
 
 func (a Addon) CanonicalName() string {


### PR DESCRIPTION
### Description

`addon.Force` is an internal field but it's still configurable in ClusterConfig. 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

