### PR TITLE
Update the `maxUnavailable` number of nodes during parallel upgrades

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.16
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/aws/amazon-ec2-instance-selector/v2 v2.0.3-0.20210303155736-3e43512d88f8
-	github.com/aws/aws-sdk-go v1.38.38
+	github.com/aws/aws-sdk-go v1.38.61
 	github.com/benjamintf1/unmarshalledmatchers v0.0.0-20190408201839-bb1c1f34eaea
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bxcodec/faker v2.0.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,8 @@ github.com/aws/aws-sdk-go v1.36.1/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zK
 github.com/aws/aws-sdk-go v1.36.30/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.38.38 h1:onWHniFItFra8Wb2vTX2M6nNX3ESW2b/haVdjDlVIeA=
 github.com/aws/aws-sdk-go v1.38.38/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.38.61 h1:wizuqQZe0K4iYJ+Slrs0aSQ4P94FAwqBUHwk46Iz5UA=
+github.com/aws/aws-sdk-go v1.38.61/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/awslabs/goformation/v4 v4.15.5 h1:q3lm7oj4yqqJ76ZcaFThUACT3MQLD6yBcJRKuZ6g87w=
 github.com/awslabs/goformation/v4 v4.15.5/go.mod h1:wB5lKZf1J0MYH1Lt4B9w3opqz0uIjP7MMCAcib3QkwA=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=

--- a/integration/tests/managed/managed_nodegroup_test.go
+++ b/integration/tests/managed/managed_nodegroup_test.go
@@ -444,23 +444,18 @@ var _ = Describe("(Integration) Create Managed Nodegroups", func() {
 					).
 					WithoutArg("--region", params.Region).
 					WithStdin(testutils.ClusterConfigReader(clusterConfig))
-
 				Expect(cmd).To(RunSuccessfully())
-			})
-		})
 
-		Context("and updating a nodegroup", func() {
-			It("should update a nodegroup", func() {
-				clusterConfig := makeClusterConfig()
+				By("and upddating the nodegroup's UpdateConfig")
 				clusterConfig.ManagedNodeGroups = []*api.ManagedNodeGroup{
 					{
-						NodeGroupBase: &api.NodeGroupBase{
-							Name: initialNodeGroup,
-						},
 						Spot: true,
+						UpdateConfig: &api.NodeGroupUpdateConfig{
+							MaxUnavailable: aws.Int(1),
+						},
 					},
 				}
-				cmd := params.EksctlUpdateCmd.
+				cmd = params.EksctlUpdateCmd.
 					WithArgs(
 						"nodegroup",
 						"--config-file", "-",

--- a/integration/tests/managed/managed_nodegroup_test.go
+++ b/integration/tests/managed/managed_nodegroup_test.go
@@ -457,7 +457,7 @@ var _ = Describe("(Integration) Create Managed Nodegroups", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(out.Nodegroup.UpdateConfig.MaxUnavailable).Should(Equal(aws.Int64(2)))
 
-				By("and upddating the nodegroup's UpdateConfig")
+				By("and updating the nodegroup's UpdateConfig")
 				clusterConfig.ManagedNodeGroups[0].Spot = true
 				clusterConfig.ManagedNodeGroups[0].UpdateConfig = &api.NodeGroupUpdateConfig{
 					MaxUnavailable: aws.Int(1),

--- a/pkg/actions/nodegroup/update.go
+++ b/pkg/actions/nodegroup/update.go
@@ -50,7 +50,7 @@ func (m *Manager) Update() error {
 		NodegroupName: &ng.Name,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to update nodegroup %s: %w", ng.Name, err)
 	}
 
 	logger.Info("nodegroup %s successfully updated", ng.Name)

--- a/pkg/actions/nodegroup/update.go
+++ b/pkg/actions/nodegroup/update.go
@@ -25,12 +25,15 @@ func (m *Manager) Update() error {
 		return err
 	}
 
-	if ng.UpdateConfig != nil {
-		if describeNodegroupOutput.Nodegroup.UpdateConfig == nil {
-			return errors.New("cannot update updateConfig because the nodegroup is not configured to use one")
-		}
+	if ng.UpdateConfig == nil {
+		return fmt.Errorf("the submitted config didn't contain changes for nodegroup %s", ng.Name)
 	}
 
+	if describeNodegroupOutput.Nodegroup.UpdateConfig == nil {
+		return errors.New("cannot update updateConfig because the nodegroup is not configured to use one")
+	}
+
+	logger.Info("updating nodegroup %s's UpdateConfig", ng.Name)
 	updateConfig := &eks.NodegroupUpdateConfig{}
 
 	if ng.UpdateConfig.MaxUnavailable != nil {
@@ -40,7 +43,6 @@ func (m *Manager) Update() error {
 	if ng.UpdateConfig.MaxUnavailablePercentage != nil {
 		updateConfig.MaxUnavailablePercentage = aws.Int64(int64(*ng.UpdateConfig.MaxUnavailablePercentage))
 	}
-	logger.Info("updating nodegroup %s's UpdateConfig", ng.Name)
 
 	_, err = m.ctl.Provider.EKS().UpdateNodegroupConfig(&eks.UpdateNodegroupConfigInput{
 		UpdateConfig:  updateConfig,

--- a/pkg/actions/nodegroup/update.go
+++ b/pkg/actions/nodegroup/update.go
@@ -5,22 +5,29 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/kris-nova/logger"
+	"github.com/pkg/errors"
 
 	"github.com/weaveworks/eksctl/pkg/managed"
 )
 
 func (m *Manager) Update() error {
-	ngName := m.cfg.ManagedNodeGroups[0].Name
-	_, err := m.ctl.Provider.EKS().DescribeNodegroup(&eks.DescribeNodegroupInput{
+	ng := m.cfg.ManagedNodeGroups[0]
+	describeNodegroupOutput, err := m.ctl.Provider.EKS().DescribeNodegroup(&eks.DescribeNodegroupInput{
 		ClusterName:   &m.cfg.Metadata.Name,
-		NodegroupName: &ngName,
+		NodegroupName: &ng.Name,
 	})
 
 	if err != nil {
 		if managed.IsNotFound(err) {
-			return fmt.Errorf("could not find managed nodegroup with name %q", ngName)
+			return fmt.Errorf("could not find managed nodegroup with name %q", ng.Name)
 		}
 		return err
+	}
+
+	if ng.UpdateConfig != nil {
+		if describeNodegroupOutput.Nodegroup.UpdateConfig == nil {
+			return errors.New("cannot update updateConfig because the nodegroup is not configured to use one")
+		}
 	}
 
 	logger.Info("nodegroup successfully updated")

--- a/pkg/actions/nodegroup/update_test.go
+++ b/pkg/actions/nodegroup/update_test.go
@@ -49,24 +49,6 @@ var _ = Describe("Update", func() {
 		Expect(err).To(MatchError(ContainSubstring("could not find managed nodegroup with name \"my-ng\"")))
 	})
 
-	It("fails to update nodegroup config if nodegroup does not use one", func() {
-		p.MockEKS().On("DescribeNodegroup", &awseks.DescribeNodegroupInput{
-			ClusterName:   &clusterName,
-			NodegroupName: &ngName,
-		}).Return(&awseks.DescribeNodegroupOutput{
-			Nodegroup: &awseks.Nodegroup{},
-		}, nil)
-
-		cfg.ManagedNodeGroups[0].UpdateConfig = &api.NodeGroupUpdateConfig{
-			MaxUnavailable: aws.Int(2),
-		}
-
-		m = New(cfg, &eks.ClusterProvider{Provider: p}, nil)
-		err := m.Update()
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(MatchError(ContainSubstring("cannot update updateConfig because the nodegroup is not configured to use one")))
-	})
-
 	It("[happy path] successfully updates nodegroup with updateConfig and maxUnavailable", func() {
 		p.MockEKS().On("DescribeNodegroup", &awseks.DescribeNodegroupInput{
 			ClusterName:   &clusterName,

--- a/pkg/actions/nodegroup/update_test.go
+++ b/pkg/actions/nodegroup/update_test.go
@@ -3,6 +3,7 @@ package nodegroup
 import (
 	"errors"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	awseks "github.com/aws/aws-sdk-go/service/eks"
 	. "github.com/onsi/ginkgo"
@@ -34,8 +35,6 @@ var _ = Describe("Update", func() {
 				},
 			},
 		}
-
-		m = New(cfg, &eks.ClusterProvider{Provider: p}, nil)
 	})
 
 	It("fails for unmanaged nodegroups", func() {
@@ -44,17 +43,23 @@ var _ = Describe("Update", func() {
 			NodegroupName: &ngName,
 		}).Return(nil, awserr.New(awseks.ErrCodeResourceNotFoundException, "test-err", errors.New("err")))
 
+		m = New(cfg, &eks.ClusterProvider{Provider: p}, nil)
 		err := m.Update()
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(ContainSubstring("could not find managed nodegroup with name \"my-ng\"")))
 	})
 
-	It("successfully updates nodegroup", func() {
+	It("successfully updates nodegroup with updateConfig", func() {
 		p.MockEKS().On("DescribeNodegroup", &awseks.DescribeNodegroupInput{
 			ClusterName:   &clusterName,
 			NodegroupName: &ngName,
 		}).Return(nil, nil)
 
+		cfg.ManagedNodeGroups[0].UpdateConfig = &api.NodeGroupUpdateConfig{
+			MaxUnavailable: aws.Int(2),
+		}
+
+		m = New(cfg, &eks.ClusterProvider{Provider: p}, nil)
 		err := m.Update()
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -775,7 +775,7 @@ func NewUpdateNodegroupLoader(cmd *Cmd) ClusterConfigLoader {
 			return err
 		}
 
-		if unsupportedFields, err = validateSupportedConfigFields(*ng, []string{"NodeGroupBase"}, unsupportedFields); err != nil {
+		if unsupportedFields, err = validateSupportedConfigFields(*ng, []string{"NodeGroupBase", "UpdateConfig"}, unsupportedFields); err != nil {
 			return err
 		}
 

--- a/pkg/eks/mocks/AutoScalingAPI.go
+++ b/pkg/eks/mocks/AutoScalingAPI.go
@@ -3885,6 +3885,84 @@ func (_m *AutoScalingAPI) ExitStandbyWithContext(_a0 context.Context, _a1 *autos
 	return r0, r1
 }
 
+// GetPredictiveScalingForecast provides a mock function with given fields: _a0
+func (_m *AutoScalingAPI) GetPredictiveScalingForecast(_a0 *autoscaling.GetPredictiveScalingForecastInput) (*autoscaling.GetPredictiveScalingForecastOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *autoscaling.GetPredictiveScalingForecastOutput
+	if rf, ok := ret.Get(0).(func(*autoscaling.GetPredictiveScalingForecastInput) *autoscaling.GetPredictiveScalingForecastOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*autoscaling.GetPredictiveScalingForecastOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*autoscaling.GetPredictiveScalingForecastInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetPredictiveScalingForecastRequest provides a mock function with given fields: _a0
+func (_m *AutoScalingAPI) GetPredictiveScalingForecastRequest(_a0 *autoscaling.GetPredictiveScalingForecastInput) (*request.Request, *autoscaling.GetPredictiveScalingForecastOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*autoscaling.GetPredictiveScalingForecastInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *autoscaling.GetPredictiveScalingForecastOutput
+	if rf, ok := ret.Get(1).(func(*autoscaling.GetPredictiveScalingForecastInput) *autoscaling.GetPredictiveScalingForecastOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*autoscaling.GetPredictiveScalingForecastOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// GetPredictiveScalingForecastWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *AutoScalingAPI) GetPredictiveScalingForecastWithContext(_a0 context.Context, _a1 *autoscaling.GetPredictiveScalingForecastInput, _a2 ...request.Option) (*autoscaling.GetPredictiveScalingForecastOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *autoscaling.GetPredictiveScalingForecastOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *autoscaling.GetPredictiveScalingForecastInput, ...request.Option) *autoscaling.GetPredictiveScalingForecastOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*autoscaling.GetPredictiveScalingForecastOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *autoscaling.GetPredictiveScalingForecastInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // PutLifecycleHook provides a mock function with given fields: _a0
 func (_m *AutoScalingAPI) PutLifecycleHook(_a0 *autoscaling.PutLifecycleHookInput) (*autoscaling.PutLifecycleHookOutput, error) {
 	ret := _m.Called(_a0)

--- a/pkg/eks/mocks/EC2API.go
+++ b/pkg/eks/mocks/EC2API.go
@@ -25916,6 +25916,84 @@ func (_m *EC2API) DisableFastSnapshotRestoresWithContext(_a0 context.Context, _a
 	return r0, r1
 }
 
+// DisableImageDeprecation provides a mock function with given fields: _a0
+func (_m *EC2API) DisableImageDeprecation(_a0 *ec2.DisableImageDeprecationInput) (*ec2.DisableImageDeprecationOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.DisableImageDeprecationOutput
+	if rf, ok := ret.Get(0).(func(*ec2.DisableImageDeprecationInput) *ec2.DisableImageDeprecationOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DisableImageDeprecationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.DisableImageDeprecationInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DisableImageDeprecationRequest provides a mock function with given fields: _a0
+func (_m *EC2API) DisableImageDeprecationRequest(_a0 *ec2.DisableImageDeprecationInput) (*request.Request, *ec2.DisableImageDeprecationOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.DisableImageDeprecationInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.DisableImageDeprecationOutput
+	if rf, ok := ret.Get(1).(func(*ec2.DisableImageDeprecationInput) *ec2.DisableImageDeprecationOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.DisableImageDeprecationOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// DisableImageDeprecationWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) DisableImageDeprecationWithContext(_a0 context.Context, _a1 *ec2.DisableImageDeprecationInput, _a2 ...request.Option) (*ec2.DisableImageDeprecationOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.DisableImageDeprecationOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.DisableImageDeprecationInput, ...request.Option) *ec2.DisableImageDeprecationOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.DisableImageDeprecationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.DisableImageDeprecationInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // DisableSerialConsoleAccess provides a mock function with given fields: _a0
 func (_m *EC2API) DisableSerialConsoleAccess(_a0 *ec2.DisableSerialConsoleAccessInput) (*ec2.DisableSerialConsoleAccessOutput, error) {
 	ret := _m.Called(_a0)
@@ -27156,6 +27234,84 @@ func (_m *EC2API) EnableFastSnapshotRestoresWithContext(_a0 context.Context, _a1
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *ec2.EnableFastSnapshotRestoresInput, ...request.Option) error); ok {
+		r1 = rf(_a0, _a1, _a2...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// EnableImageDeprecation provides a mock function with given fields: _a0
+func (_m *EC2API) EnableImageDeprecation(_a0 *ec2.EnableImageDeprecationInput) (*ec2.EnableImageDeprecationOutput, error) {
+	ret := _m.Called(_a0)
+
+	var r0 *ec2.EnableImageDeprecationOutput
+	if rf, ok := ret.Get(0).(func(*ec2.EnableImageDeprecationInput) *ec2.EnableImageDeprecationOutput); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.EnableImageDeprecationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ec2.EnableImageDeprecationInput) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// EnableImageDeprecationRequest provides a mock function with given fields: _a0
+func (_m *EC2API) EnableImageDeprecationRequest(_a0 *ec2.EnableImageDeprecationInput) (*request.Request, *ec2.EnableImageDeprecationOutput) {
+	ret := _m.Called(_a0)
+
+	var r0 *request.Request
+	if rf, ok := ret.Get(0).(func(*ec2.EnableImageDeprecationInput) *request.Request); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*request.Request)
+		}
+	}
+
+	var r1 *ec2.EnableImageDeprecationOutput
+	if rf, ok := ret.Get(1).(func(*ec2.EnableImageDeprecationInput) *ec2.EnableImageDeprecationOutput); ok {
+		r1 = rf(_a0)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*ec2.EnableImageDeprecationOutput)
+		}
+	}
+
+	return r0, r1
+}
+
+// EnableImageDeprecationWithContext provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EC2API) EnableImageDeprecationWithContext(_a0 context.Context, _a1 *ec2.EnableImageDeprecationInput, _a2 ...request.Option) (*ec2.EnableImageDeprecationOutput, error) {
+	_va := make([]interface{}, len(_a2))
+	for _i := range _a2 {
+		_va[_i] = _a2[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *ec2.EnableImageDeprecationOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *ec2.EnableImageDeprecationInput, ...request.Option) *ec2.EnableImageDeprecationOutput); ok {
+		r0 = rf(_a0, _a1, _a2...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ec2.EnableImageDeprecationOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *ec2.EnableImageDeprecationInput, ...request.Option) error); ok {
 		r1 = rf(_a0, _a1, _a2...)
 	} else {
 		r1 = ret.Error(1)

--- a/pkg/eks/mocks/IAMAPI.go
+++ b/pkg/eks/mocks/IAMAPI.go
@@ -9234,6 +9234,41 @@ func (_m *IAMAPI) ListUserTags(_a0 *iam.ListUserTagsInput) (*iam.ListUserTagsOut
 	return r0, r1
 }
 
+// ListUserTagsPages provides a mock function with given fields: _a0, _a1
+func (_m *IAMAPI) ListUserTagsPages(_a0 *iam.ListUserTagsInput, _a1 func(*iam.ListUserTagsOutput, bool) bool) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*iam.ListUserTagsInput, func(*iam.ListUserTagsOutput, bool) bool) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ListUserTagsPagesWithContext provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *IAMAPI) ListUserTagsPagesWithContext(_a0 context.Context, _a1 *iam.ListUserTagsInput, _a2 func(*iam.ListUserTagsOutput, bool) bool, _a3 ...request.Option) error {
+	_va := make([]interface{}, len(_a3))
+	for _i := range _a3 {
+		_va[_i] = _a3[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0, _a1, _a2)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *iam.ListUserTagsInput, func(*iam.ListUserTagsOutput, bool) bool, ...request.Option) error); ok {
+		r0 = rf(_a0, _a1, _a2, _a3...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // ListUserTagsRequest provides a mock function with given fields: _a0
 func (_m *IAMAPI) ListUserTagsRequest(_a0 *iam.ListUserTagsInput) (*request.Request, *iam.ListUserTagsOutput) {
 	ret := _m.Called(_a0)


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

This PR's base is #3828.

Changes made by this PR:
* Upgrades AWS-SDK to v1.38.61 and regenerates any mocks 
* Adds integration test for updating a managed nodegroup that has an `UpdateConfig`
* Validates that the nodegroup has an `UpdateConfig` before updating it
* Calls the AWS `UpdateNodegroupConfig` API to update the nodegroup's `UpdateConfig`

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
