### PR TITLE
Make MaxUnavailable less than default MaxSize

### DIFF
--- a/integration/tests/managed/managed_nodegroup_test.go
+++ b/integration/tests/managed/managed_nodegroup_test.go
@@ -426,7 +426,7 @@ var _ = Describe("(Integration) Create Managed Nodegroups", func() {
 		Context("and creating a nodegroup with an update config", func() {
 			It("defining the UpdateConfig field in the cluster config", func() {
 				updateConfig := &api.NodeGroupUpdateConfig{
-					MaxUnavailable: aws.Int(4),
+					MaxUnavailable: aws.Int(2),
 				}
 				clusterConfig := api.NewClusterConfig()
 				clusterConfig.Metadata.Name = params.ClusterName


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Fix for integration tests: `maxSize` is not set in the integration test for creating a ng with a `UpdateConfig` and it defaults to 2, so we need to make `maxUnavailable` 2

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

