### PR TITLE
Add default tags to OIDC provider resources

### DIFF
--- a/pkg/actions/addon/create_test.go
+++ b/pkg/actions/addon/create_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Create", func() {
 	JustBeforeEach(func() {
 		var err error
 
-		oidc, err = iamoidc.NewOpenIDConnectManager(nil, "456123987123", "https://oidc.eks.us-west-2.amazonaws.com/id/A39A2842863C47208955D753DE205E6E", "aws")
+		oidc, err = iamoidc.NewOpenIDConnectManager(nil, "456123987123", "https://oidc.eks.us-west-2.amazonaws.com/id/A39A2842863C47208955D753DE205E6E", "aws", nil)
 		Expect(err).ToNot(HaveOccurred())
 		oidc.ProviderARN = "arn:aws:iam::456123987123:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/A39A2842863C47208955D753DE205E6E"
 

--- a/pkg/actions/addon/update_test.go
+++ b/pkg/actions/addon/update_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Update", func() {
 			return nil
 		}
 
-		oidc, err := iamoidc.NewOpenIDConnectManager(nil, "456123987123", "https://oidc.eks.us-west-2.amazonaws.com/id/A39A2842863C47208955D753DE205E6E", "aws")
+		oidc, err := iamoidc.NewOpenIDConnectManager(nil, "456123987123", "https://oidc.eks.us-west-2.amazonaws.com/id/A39A2842863C47208955D753DE205E6E", "aws", nil)
 		Expect(err).ToNot(HaveOccurred())
 		oidc.ProviderARN = "arn:aws:iam::456123987123:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/A39A2842863C47208955D753DE205E6E"
 

--- a/pkg/actions/irsa/update_test.go
+++ b/pkg/actions/irsa/update_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Update", func() {
 
 		fakeStackManager = new(fakes.FakeStackManager)
 
-		oidc, err = iamoidc.NewOpenIDConnectManager(nil, "456123987123", "https://oidc.eks.us-west-2.amazonaws.com/id/A39A2842863C47208955D753DE205E6E", "aws")
+		oidc, err = iamoidc.NewOpenIDConnectManager(nil, "456123987123", "https://oidc.eks.us-west-2.amazonaws.com/id/A39A2842863C47208955D753DE205E6E", "aws", nil)
 		Expect(err).ToNot(HaveOccurred())
 		oidc.ProviderARN = "arn:aws:iam::456123987123:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/A39A2842863C47208955D753DE205E6E"
 		irsaManager = irsa.New("my-cluster", fakeStackManager, oidc, nil)

--- a/pkg/cfn/builder/iam_test.go
+++ b/pkg/cfn/builder/iam_test.go
@@ -21,7 +21,7 @@ var _ = Describe("template builder for IAM", func() {
 		)
 
 		BeforeEach(func() {
-			oidc, err = iamoidc.NewOpenIDConnectManager(nil, "456123987123", "https://oidc.eks.us-west-2.amazonaws.com/id/A39A2842863C47208955D753DE205E6E", "aws")
+			oidc, err = iamoidc.NewOpenIDConnectManager(nil, "456123987123", "https://oidc.eks.us-west-2.amazonaws.com/id/A39A2842863C47208955D753DE205E6E", "aws", nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			oidc.ProviderARN = "arn:aws:iam::456123987123:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/A39A2842863C47208955D753DE205E6E"
@@ -325,7 +325,7 @@ var _ = Describe("template builder for IAM", func() {
 		)
 
 		BeforeEach(func() {
-			oidc, err = iamoidc.NewOpenIDConnectManager(nil, "456123987123", "https://oidc.eks.us-west-2.amazonaws.com/id/A39A2842863C47208955D753DE205E6E", "aws")
+			oidc, err = iamoidc.NewOpenIDConnectManager(nil, "456123987123", "https://oidc.eks.us-west-2.amazonaws.com/id/A39A2842863C47208955D753DE205E6E", "aws", nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			oidc.ProviderARN = "arn:aws:iam::456123987123:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/A39A2842863C47208955D753DE205E6E"

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -88,7 +88,7 @@ func newTag(key, value string) *cloudformation.Tag {
 	return &cloudformation.Tag{Key: &key, Value: &value}
 }
 
-// NewStackCollection create a stack manager for a single cluster
+// NewStackCollection creates a stack manager for a single cluster
 func NewStackCollection(provider api.ClusterProvider, spec *api.ClusterConfig) *StackCollection {
 	tags := []*cloudformation.Tag{
 		newTag(api.ClusterNameTag, spec.Metadata.Name),
@@ -507,7 +507,7 @@ func (c *StackCollection) DeleteStackBySpec(s *Stack) (*Stack, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("cannot delete stack %q as it doesn't bare our %q, %q tags", *s.StackName,
+	return nil, fmt.Errorf("cannot delete stack %q as it doesn't bear our %q, %q tags", *s.StackName,
 		fmt.Sprintf("%s:%s", api.OldClusterNameTag, c.spec.Metadata.Name),
 		fmt.Sprintf("%s:%s", api.ClusterNameTag, c.spec.Metadata.Name))
 }

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/weaveworks/eksctl/pkg/cfn/waiter"
-
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
+	"github.com/weaveworks/eksctl/pkg/cfn/waiter"
+	"github.com/weaveworks/eksctl/pkg/version"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -266,7 +266,16 @@ func (c *ClusterProvider) NewOpenIDConnectManager(spec *api.ClusterConfig) (*iam
 		return nil, fmt.Errorf("unknown EKS ARN: %q", spec.Status.ARN)
 	}
 
-	return iamoidc.NewOpenIDConnectManager(c.Provider.IAM(), parsedARN.AccountID, *c.Status.ClusterInfo.Cluster.Identity.Oidc.Issuer, parsedARN.Partition)
+	return iamoidc.NewOpenIDConnectManager(c.Provider.IAM(), parsedARN.AccountID,
+		*c.Status.ClusterInfo.Cluster.Identity.Oidc.Issuer, parsedARN.Partition, sharedTags(c.Status.ClusterInfo.Cluster))
+}
+
+func sharedTags(cluster *awseks.Cluster) map[string]string {
+	return map[string]string{
+		api.ClusterNameTag:   *cluster.Name,
+		api.EksctlVersionTag: version.GetVersion(),
+	}
+
 }
 
 // LoadClusterIntoSpecFromStack uses stack information to load the cluster

--- a/pkg/iam/oidc/api_test.go
+++ b/pkg/iam/oidc/api_test.go
@@ -60,26 +60,26 @@ var _ = Describe("EKS/IAM API wrapper", func() {
 		})
 
 		It("should get cluster, cache status and get issuer URL", func() {
-			oidc, err := NewOpenIDConnectManager(p.IAM(), "12345", exampleIssuer, "aws")
+			oidc, err := NewOpenIDConnectManager(p.IAM(), "12345", exampleIssuer, "aws", nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(oidc.issuerURL.Port()).To(Equal("443"))
 			Expect(oidc.issuerURL.Hostname()).To(Equal("exampleIssuer.eksctl.io"))
 		})
 
 		It("should handle bad issuer URL", func() {
-			_, err = NewOpenIDConnectManager(p.IAM(), "12345", "http://foo\x7f.com/", "aws")
+			_, err = NewOpenIDConnectManager(p.IAM(), "12345", "http://foo\x7f.com/", "aws", nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(HavePrefix("parsing OIDC issuer URL"))
 		})
 
 		It("should handle bad issuer URL scheme", func() {
-			_, err = NewOpenIDConnectManager(p.IAM(), "12345", "http://foo.com/", "aws")
+			_, err = NewOpenIDConnectManager(p.IAM(), "12345", "http://foo.com/", "aws", nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(HavePrefix("unsupported URL scheme"))
 		})
 
 		It("should get cluster, and fail to connect to fake issue URL", func() {
-			oidc, err := NewOpenIDConnectManager(p.IAM(), "12345", "https://localhost:10020/", "aws")
+			oidc, err := NewOpenIDConnectManager(p.IAM(), "12345", "https://localhost:10020/", "aws", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = oidc.getIssuerCAThumbprint()
@@ -91,7 +91,7 @@ var _ = Describe("EKS/IAM API wrapper", func() {
 		})
 
 		It("should get OIDC issuer's CA fingerprint", func() {
-			oidc, err := NewOpenIDConnectManager(p.IAM(), "12345", "https://localhost:10028/", "aws")
+			oidc, err := NewOpenIDConnectManager(p.IAM(), "12345", "https://localhost:10028/", "aws", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			srv, err := newServer(oidc.issuerURL.Host)
@@ -112,7 +112,7 @@ var _ = Describe("EKS/IAM API wrapper", func() {
 		})
 
 		It("should get OIDC issuer's CA fingerprint for a URL that returns 403", func() {
-			oidc, err := NewOpenIDConnectManager(p.IAM(), "12345", "https://localhost:10029/fake_eks", "aws")
+			oidc, err := NewOpenIDConnectManager(p.IAM(), "12345", "https://localhost:10029/fake_eks", "aws", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			srv, err := newServer(oidc.issuerURL.Host)
@@ -189,7 +189,7 @@ var _ = Describe("EKS/IAM API wrapper", func() {
 				return false
 			})).Return(nil, nil)
 
-			oidc, err = NewOpenIDConnectManager(p.IAM(), "12345", "https://localhost:10028/", "aws")
+			oidc, err = NewOpenIDConnectManager(p.IAM(), "12345", "https://localhost:10028/", "aws", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			srv, err = newServer(oidc.issuerURL.Host)
@@ -321,7 +321,7 @@ var _ = Describe("EKS/IAM API wrapper", func() {
 				OpenIDConnectProviderArn: aws.String(fmt.Sprintf("arn:%s:iam::12345:oidc-provider/localhost/", partition)),
 			}, nil)
 
-			oidc, err := NewOpenIDConnectManager(provider.IAM(), "12345", "https://localhost:10028/", partition)
+			oidc, err := NewOpenIDConnectManager(provider.IAM(), "12345", "https://localhost:10028/", partition, nil)
 			oidc.insecureSkipVerify = true
 			Expect(err).ToNot(HaveOccurred())
 			Expect(oidc.CreateProvider()).To(Succeed())


### PR DESCRIPTION
### Description

Adds default eksctl tags to OIDC provider resources.

```
alpha.eksctl.io/cluster-name: <cluster>
alpha.eksctl.io/eksctl-version: <version>
```

Unlike many other resources, eksctl does not tag OIDC provider resources. I have run into this issue while trying to debug orphan OIDC provider resources which had no information about the cluster they were created for. At the very least, eksctl should tag OIDC provider resources with the cluster information, like it does for other resources. 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

