### PR TITLE
Fix integration test for `update nodegroup` command

### DIFF
--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -769,21 +769,16 @@ func NewUpdateNodegroupLoader(cmd *Cmd) ClusterConfigLoader {
 	l := newCommonClusterConfigLoader(cmd)
 
 	l.validateWithConfigFile = func() error {
-		var clusterConfig *api.ClusterConfig
-		var err error
-		if clusterConfig, err = eks.LoadConfigFromFile(l.ClusterConfigFile); err != nil {
-			return err
-		}
-
-		l := len(clusterConfig.ManagedNodeGroups)
-		if l < 1 {
+		length := len(l.ClusterConfig.ManagedNodeGroups)
+		if length < 1 {
 			return ErrMustBeSet("managedNodeGroups field")
 		}
 
-		logger.Info("validating nodegroup %q", clusterConfig.ManagedNodeGroups[0].Name)
+		logger.Info("validating nodegroup %q", l.ClusterConfig.ManagedNodeGroups[0].Name)
 
 		var unsupportedFields []string
-		ng := clusterConfig.ManagedNodeGroups[0]
+		ng := l.ClusterConfig.ManagedNodeGroups[0]
+		var err error
 		if unsupportedFields, err = validateSupportedConfigFields(*ng.NodeGroupBase, []string{"Name"}, unsupportedFields); err != nil {
 			return err
 		}


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

The issue was that piping a config file was not being read properly. The integration tests were failing because while doing something like `cat config | eksctl update nodegroup --config-file -`, where `-` was not being read properly.

Changed it to only load the config once, the way other commands do. 

Tested it locally + ran the integration tests and it seemed good to go! 🤞 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

