### PR TITLE
Check nodegroup's `DesiredSize` before getting k8s version of nodes

### DIFF
--- a/pkg/actions/nodegroup/get.go
+++ b/pkg/actions/nodegroup/get.go
@@ -20,9 +20,11 @@ func (m *Manager) GetAll() ([]*manager.NodeGroupSummary, error) {
 	}
 
 	for _, summary := range summaries {
-		summary.Version, err = kubewrapper.GetNodegroupKubernetesVersion(m.clientSet.CoreV1().Nodes(), summary.Name)
-		if err != nil {
-			return nil, errors.Wrap(err, "getting nodegroup's kubernetes version")
+		if summary.DesiredCapacity > 0 {
+			summary.Version, err = kubewrapper.GetNodegroupKubernetesVersion(m.clientSet.CoreV1().Nodes(), summary.Name)
+			if err != nil {
+				return nil, errors.Wrap(err, "getting nodegroup's kubernetes version")
+			}
 		}
 	}
 
@@ -92,11 +94,12 @@ func (m *Manager) Get(name string) (*manager.NodeGroupSummary, error) {
 
 	if len(summaries) > 0 {
 		s := summaries[0]
-		s.Version, err = kubewrapper.GetNodegroupKubernetesVersion(m.clientSet.CoreV1().Nodes(), s.Name)
-		if err != nil {
-			return nil, errors.Wrap(err, "getting nodegroup's kubernetes version")
+		if s.DesiredCapacity > 0 {
+			s.Version, err = kubewrapper.GetNodegroupKubernetesVersion(m.clientSet.CoreV1().Nodes(), s.Name)
+			if err != nil {
+				return nil, errors.Wrap(err, "getting nodegroup's kubernetes version")
+			}
 		}
-
 		return s, nil
 	}
 

--- a/pkg/actions/nodegroup/get_test.go
+++ b/pkg/actions/nodegroup/get_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/weaveworks/eksctl/pkg/actions/nodegroup"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 	"github.com/weaveworks/eksctl/pkg/cfn/manager/fakes"
 	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
@@ -29,7 +30,7 @@ var _ = Describe("Get", func() {
 		fakeClientSet                  *fake.Clientset
 	)
 
-	BeforeEach(func() {
+	BeforeSuite(func() {
 		t = time.Now()
 		ngName = "my-nodegroup"
 		clusterName = "my-cluster"
@@ -44,98 +45,116 @@ var _ = Describe("Get", func() {
 	})
 
 	Describe("GetAll", func() {
-		BeforeEach(func() {
-			p.MockEKS().On("ListNodegroups", &awseks.ListNodegroupsInput{
-				ClusterName: aws.String(clusterName),
-			}).Run(func(args mock.Arguments) {
-				Expect(args).To(HaveLen(1))
-				Expect(args[0]).To(BeAssignableToTypeOf(&awseks.ListNodegroupsInput{
+		Context("when getting managed nodegroups", func() {
+			BeforeEach(func() {
+				p.MockEKS().On("ListNodegroups", &awseks.ListNodegroupsInput{
 					ClusterName: aws.String(clusterName),
-				}))
-			}).Return(&awseks.ListNodegroupsOutput{
-				Nodegroups: []*string{
-					aws.String(ngName),
-				},
-			}, nil)
-
-			p.MockEKS().On("DescribeNodegroup", &awseks.DescribeNodegroupInput{
-				ClusterName:   aws.String(clusterName),
-				NodegroupName: aws.String(ngName),
-			}).Run(func(args mock.Arguments) {
-				Expect(args).To(HaveLen(1))
-				Expect(args[0]).To(BeAssignableToTypeOf(&awseks.DescribeNodegroupInput{
-					ClusterName:   aws.String(clusterName),
-					NodegroupName: aws.String(ngName),
-				}))
-			}).Return(&awseks.DescribeNodegroupOutput{
-				Nodegroup: &awseks.Nodegroup{
-					NodegroupName: aws.String(ngName),
-					ClusterName:   aws.String(clusterName),
-					Status:        aws.String("my-status"),
-					ScalingConfig: &awseks.NodegroupScalingConfig{
-						DesiredSize: aws.Int64(2),
-						MaxSize:     aws.Int64(4),
-						MinSize:     aws.Int64(0),
+				}).Run(func(args mock.Arguments) {
+					Expect(args).To(HaveLen(1))
+					Expect(args[0]).To(BeAssignableToTypeOf(&awseks.ListNodegroupsInput{
+						ClusterName: aws.String(clusterName),
+					}))
+				}).Return(&awseks.ListNodegroupsOutput{
+					Nodegroups: []*string{
+						aws.String(ngName),
 					},
-					InstanceTypes: []*string{},
-					AmiType:       aws.String("ami-type"),
-					CreatedAt:     &t,
-					NodeRole:      aws.String("node-role"),
-					Resources: &awseks.NodegroupResources{
-						AutoScalingGroups: []*awseks.AutoScalingGroup{
-							{
-								Name: aws.String("asg-name"),
-							},
-						},
-					},
-					Version: aws.String("1.18"),
-				},
-			}, nil)
-		})
-
-		When("a nodegroup is associated to a CF Stack", func() {
-			It("returns a summary of the node group and its StackName", func() {
-				fakeStackManager.DescribeNodeGroupStackReturns(&cloudformation.Stack{
-					StackName: aws.String(stackName),
 				}, nil)
 
-				ngSummary, err := m.GetAll()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(ngSummary[0].StackName).To(Equal(stackName))
-				Expect(ngSummary[0].Name).To(Equal(ngName))
-				Expect(ngSummary[0].Cluster).To(Equal(clusterName))
-				Expect(ngSummary[0].Status).To(Equal("my-status"))
-				Expect(ngSummary[0].MaxSize).To(Equal(4))
-				Expect(ngSummary[0].MinSize).To(Equal(0))
-				Expect(ngSummary[0].DesiredCapacity).To(Equal(2))
-				Expect(ngSummary[0].InstanceType).To(Equal("-"))
-				Expect(ngSummary[0].ImageID).To(Equal("ami-type"))
-				Expect(ngSummary[0].CreationTime).To(Equal(&t))
-				Expect(ngSummary[0].NodeInstanceRoleARN).To(Equal("node-role"))
-				Expect(ngSummary[0].AutoScalingGroupName).To(Equal("asg-name"))
-				Expect(ngSummary[0].Version).To(Equal("1.18"))
+				p.MockEKS().On("DescribeNodegroup", &awseks.DescribeNodegroupInput{
+					ClusterName:   aws.String(clusterName),
+					NodegroupName: aws.String(ngName),
+				}).Run(func(args mock.Arguments) {
+					Expect(args).To(HaveLen(1))
+					Expect(args[0]).To(BeAssignableToTypeOf(&awseks.DescribeNodegroupInput{
+						ClusterName:   aws.String(clusterName),
+						NodegroupName: aws.String(ngName),
+					}))
+				}).Return(&awseks.DescribeNodegroupOutput{
+					Nodegroup: &awseks.Nodegroup{
+						NodegroupName: aws.String(ngName),
+						ClusterName:   aws.String(clusterName),
+						Status:        aws.String("my-status"),
+						ScalingConfig: &awseks.NodegroupScalingConfig{
+							DesiredSize: aws.Int64(2),
+							MaxSize:     aws.Int64(4),
+							MinSize:     aws.Int64(0),
+						},
+						InstanceTypes: []*string{},
+						AmiType:       aws.String("ami-type"),
+						CreatedAt:     &t,
+						NodeRole:      aws.String("node-role"),
+						Resources: &awseks.NodegroupResources{
+							AutoScalingGroups: []*awseks.AutoScalingGroup{
+								{
+									Name: aws.String("asg-name"),
+								},
+							},
+						},
+						Version: aws.String("1.18"),
+					},
+				}, nil)
+			})
+
+			When("a nodegroup is associated to a CF Stack", func() {
+				It("returns a summary of the node group and its StackName", func() {
+					fakeStackManager.DescribeNodeGroupStackReturns(&cloudformation.Stack{
+						StackName: aws.String(stackName),
+					}, nil)
+
+					ngSummary, err := m.GetAll()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ngSummary[0].StackName).To(Equal(stackName))
+					Expect(ngSummary[0].Name).To(Equal(ngName))
+					Expect(ngSummary[0].Cluster).To(Equal(clusterName))
+					Expect(ngSummary[0].Status).To(Equal("my-status"))
+					Expect(ngSummary[0].MaxSize).To(Equal(4))
+					Expect(ngSummary[0].MinSize).To(Equal(0))
+					Expect(ngSummary[0].DesiredCapacity).To(Equal(2))
+					Expect(ngSummary[0].InstanceType).To(Equal("-"))
+					Expect(ngSummary[0].ImageID).To(Equal("ami-type"))
+					Expect(ngSummary[0].CreationTime).To(Equal(&t))
+					Expect(ngSummary[0].NodeInstanceRoleARN).To(Equal("node-role"))
+					Expect(ngSummary[0].AutoScalingGroupName).To(Equal("asg-name"))
+					Expect(ngSummary[0].Version).To(Equal("1.18"))
+				})
+			})
+
+			When("a nodegroup is not associated to a CF Stack", func() {
+				It("returns a summary of the node group without a StackName", func() {
+					fakeStackManager.DescribeNodeGroupStackReturns(nil, fmt.Errorf("error describing cloudformation stack"))
+
+					ngSummary, err := m.GetAll()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ngSummary[0].StackName).To(Equal(""))
+					Expect(ngSummary[0].Name).To(Equal(ngName))
+					Expect(ngSummary[0].Cluster).To(Equal(clusterName))
+					Expect(ngSummary[0].Status).To(Equal("my-status"))
+					Expect(ngSummary[0].MaxSize).To(Equal(4))
+					Expect(ngSummary[0].MinSize).To(Equal(0))
+					Expect(ngSummary[0].DesiredCapacity).To(Equal(2))
+					Expect(ngSummary[0].InstanceType).To(Equal("-"))
+					Expect(ngSummary[0].ImageID).To(Equal("ami-type"))
+					Expect(ngSummary[0].CreationTime).To(Equal(&t))
+					Expect(ngSummary[0].NodeInstanceRoleARN).To(Equal("node-role"))
+					Expect(ngSummary[0].AutoScalingGroupName).To(Equal("asg-name"))
+					Expect(ngSummary[0].Version).To(Equal("1.18"))
+				})
 			})
 		})
 
-		When("a nodegroup is not associated to a CF Stack", func() {
-			It("returns a summary of the node group without a StackName", func() {
-				fakeStackManager.DescribeNodeGroupStackReturns(nil, fmt.Errorf("error describing cloudformation stack"))
+		Context("when getting unmanaged nodegroups", func() {
+			When("the DesiredCapacity is 0", func() {
+				It("does not return the k8s version of the nodes", func() {
+					fakeStackManager.GetUnmanagedNodeGroupSummariesReturns([]*manager.NodeGroupSummary{
+						{
+							DesiredCapacity: 0,
+						},
+					}, nil)
 
-				ngSummary, err := m.GetAll()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(ngSummary[0].StackName).To(Equal(""))
-				Expect(ngSummary[0].Name).To(Equal(ngName))
-				Expect(ngSummary[0].Cluster).To(Equal(clusterName))
-				Expect(ngSummary[0].Status).To(Equal("my-status"))
-				Expect(ngSummary[0].MaxSize).To(Equal(4))
-				Expect(ngSummary[0].MinSize).To(Equal(0))
-				Expect(ngSummary[0].DesiredCapacity).To(Equal(2))
-				Expect(ngSummary[0].InstanceType).To(Equal("-"))
-				Expect(ngSummary[0].ImageID).To(Equal("ami-type"))
-				Expect(ngSummary[0].CreationTime).To(Equal(&t))
-				Expect(ngSummary[0].NodeInstanceRoleARN).To(Equal("node-role"))
-				Expect(ngSummary[0].AutoScalingGroupName).To(Equal("asg-name"))
-				Expect(ngSummary[0].Version).To(Equal("1.18"))
+					ngSummary, err := m.GetAll()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ngSummary[0].Version).To(Equal(""))
+				})
 			})
 		})
 	})


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Closes #3894

#### Issue
Unmanaged nodegroups get the k8s version of nodes through the k8s client and expect nodes to be ready. However, in the case where a nodegroup has 0 nodes, `get nodegroups` fails. 

#### Solution
This PR checks the `DesiredCapacity` of an unmanaged nodegroup first to check that it's greater than 0 before pinging k8s.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

