### PR TITLE
`Update` command can update multiple nodegroups

### DIFF
--- a/integration/tests/managed/managed_nodegroup_test.go
+++ b/integration/tests/managed/managed_nodegroup_test.go
@@ -423,7 +423,7 @@ var _ = Describe("(Integration) Create Managed Nodegroups", func() {
 		})
 
 		Context("and creating a nodegroup with an update config", func() {
-			PIt("defining the UpdateConfig field in the cluster config", func() {
+			It("defining the UpdateConfig field in the cluster config", func() {
 				By("creating it")
 				updateConfig := &api.NodeGroupUpdateConfig{
 					MaxUnavailable: aws.Int(2),

--- a/pkg/actions/nodegroup/update.go
+++ b/pkg/actions/nodegroup/update.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/kris-nova/logger"
-	"github.com/pkg/errors"
 
 	"github.com/weaveworks/eksctl/pkg/managed"
 )
@@ -30,10 +29,6 @@ func (m *Manager) Update() error {
 
 		if ng.UpdateConfig == nil {
 			return fmt.Errorf("the submitted config didn't contain changes for nodegroup %s", ng.Name)
-		}
-
-		if describeNodegroupOutput.Nodegroup.UpdateConfig == nil {
-			return errors.New("cannot update updateConfig because the nodegroup is not configured to use one")
 		}
 
 		logger.Info("updating nodegroup %s's UpdateConfig", ng.Name)

--- a/pkg/actions/nodegroup/update.go
+++ b/pkg/actions/nodegroup/update.go
@@ -12,47 +12,51 @@ import (
 )
 
 func (m *Manager) Update() error {
-	ng := m.cfg.ManagedNodeGroups[0]
-	describeNodegroupOutput, err := m.ctl.Provider.EKS().DescribeNodegroup(&eks.DescribeNodegroupInput{
-		ClusterName:   &m.cfg.Metadata.Name,
-		NodegroupName: &ng.Name,
-	})
+	for _, ng := range m.cfg.ManagedNodeGroups {
 
-	if err != nil {
-		if managed.IsNotFound(err) {
-			return fmt.Errorf("could not find managed nodegroup with name %q", ng.Name)
+		logger.Info("checking that nodegroup %s is a managed nodegroup", ng.Name)
+
+		describeNodegroupOutput, err := m.ctl.Provider.EKS().DescribeNodegroup(&eks.DescribeNodegroupInput{
+			ClusterName:   &m.cfg.Metadata.Name,
+			NodegroupName: &ng.Name,
+		})
+
+		if err != nil {
+			if managed.IsNotFound(err) {
+				return fmt.Errorf("could not find managed nodegroup with name %q", ng.Name)
+			}
+			return err
 		}
-		return err
+
+		if ng.UpdateConfig == nil {
+			return fmt.Errorf("the submitted config didn't contain changes for nodegroup %s", ng.Name)
+		}
+
+		if describeNodegroupOutput.Nodegroup.UpdateConfig == nil {
+			return errors.New("cannot update updateConfig because the nodegroup is not configured to use one")
+		}
+
+		logger.Info("updating nodegroup %s's UpdateConfig", ng.Name)
+		updateConfig := &eks.NodegroupUpdateConfig{}
+
+		if ng.UpdateConfig.MaxUnavailable != nil {
+			updateConfig.MaxUnavailable = aws.Int64(int64(*ng.UpdateConfig.MaxUnavailable))
+		}
+
+		if ng.UpdateConfig.MaxUnavailablePercentage != nil {
+			updateConfig.MaxUnavailablePercentage = aws.Int64(int64(*ng.UpdateConfig.MaxUnavailablePercentage))
+		}
+
+		_, err = m.ctl.Provider.EKS().UpdateNodegroupConfig(&eks.UpdateNodegroupConfigInput{
+			UpdateConfig:  updateConfig,
+			ClusterName:   &m.cfg.Metadata.Name,
+			NodegroupName: &ng.Name,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to update nodegroup %s: %w", ng.Name, err)
+		}
+
+		logger.Info("nodegroup %s successfully updated", ng.Name)
 	}
-
-	if ng.UpdateConfig == nil {
-		return fmt.Errorf("the submitted config didn't contain changes for nodegroup %s", ng.Name)
-	}
-
-	if describeNodegroupOutput.Nodegroup.UpdateConfig == nil {
-		return errors.New("cannot update updateConfig because the nodegroup is not configured to use one")
-	}
-
-	logger.Info("updating nodegroup %s's UpdateConfig", ng.Name)
-	updateConfig := &eks.NodegroupUpdateConfig{}
-
-	if ng.UpdateConfig.MaxUnavailable != nil {
-		updateConfig.MaxUnavailable = aws.Int64(int64(*ng.UpdateConfig.MaxUnavailable))
-	}
-
-	if ng.UpdateConfig.MaxUnavailablePercentage != nil {
-		updateConfig.MaxUnavailablePercentage = aws.Int64(int64(*ng.UpdateConfig.MaxUnavailablePercentage))
-	}
-
-	_, err = m.ctl.Provider.EKS().UpdateNodegroupConfig(&eks.UpdateNodegroupConfigInput{
-		UpdateConfig:  updateConfig,
-		ClusterName:   &m.cfg.Metadata.Name,
-		NodegroupName: &ng.Name,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to update nodegroup %s: %w", ng.Name, err)
-	}
-
-	logger.Info("nodegroup %s successfully updated", ng.Name)
 	return nil
 }

--- a/pkg/actions/nodegroup/update.go
+++ b/pkg/actions/nodegroup/update.go
@@ -7,51 +7,67 @@ import (
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/kris-nova/logger"
 
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/managed"
 )
 
 func (m *Manager) Update() error {
 	for _, ng := range m.cfg.ManagedNodeGroups {
-
-		logger.Info("checking that nodegroup %s is a managed nodegroup", ng.Name)
-
-		describeNodegroupOutput, err := m.ctl.Provider.EKS().DescribeNodegroup(&eks.DescribeNodegroupInput{
-			ClusterName:   &m.cfg.Metadata.Name,
-			NodegroupName: &ng.Name,
-		})
-
-		if err != nil {
-			if managed.IsNotFound(err) {
-				return fmt.Errorf("could not find managed nodegroup with name %q", ng.Name)
-			}
+		if err := m.updateNodegroup(ng); err != nil {
 			return err
 		}
-
-		if ng.UpdateConfig == nil {
-			return fmt.Errorf("the submitted config didn't contain changes for nodegroup %s", ng.Name)
-		}
-
-		logger.Info("updating nodegroup %s's UpdateConfig", ng.Name)
-		updateConfig := &eks.NodegroupUpdateConfig{}
-
-		if ng.UpdateConfig.MaxUnavailable != nil {
-			updateConfig.MaxUnavailable = aws.Int64(int64(*ng.UpdateConfig.MaxUnavailable))
-		}
-
-		if ng.UpdateConfig.MaxUnavailablePercentage != nil {
-			updateConfig.MaxUnavailablePercentage = aws.Int64(int64(*ng.UpdateConfig.MaxUnavailablePercentage))
-		}
-
-		_, err = m.ctl.Provider.EKS().UpdateNodegroupConfig(&eks.UpdateNodegroupConfigInput{
-			UpdateConfig:  updateConfig,
-			ClusterName:   &m.cfg.Metadata.Name,
-			NodegroupName: &ng.Name,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to update nodegroup %s: %w", ng.Name, err)
-		}
-
-		logger.Info("nodegroup %s successfully updated", ng.Name)
 	}
 	return nil
+}
+
+func (m *Manager) updateNodegroup(ng *api.ManagedNodeGroup) error {
+	logger.Info("checking that nodegroup %s is a managed nodegroup", ng.Name)
+
+	_, err := m.ctl.Provider.EKS().DescribeNodegroup(&eks.DescribeNodegroupInput{
+		ClusterName:   &m.cfg.Metadata.Name,
+		NodegroupName: &ng.Name,
+	})
+
+	if err != nil {
+		if managed.IsNotFound(err) {
+			return fmt.Errorf("could not find managed nodegroup with name %q", ng.Name)
+		}
+		return err
+	}
+
+	if ng.UpdateConfig == nil {
+		return fmt.Errorf("the submitted config does not contain any changes for nodegroup %s", ng.Name)
+	}
+
+	updateConfig, err := updateUpdateConfig(ng)
+	if err != nil {
+		return err
+	}
+
+	_, err = m.ctl.Provider.EKS().UpdateNodegroupConfig(&eks.UpdateNodegroupConfigInput{
+		UpdateConfig:  updateConfig,
+		ClusterName:   &m.cfg.Metadata.Name,
+		NodegroupName: &ng.Name,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update nodegroup %s: %w", ng.Name, err)
+	}
+
+	logger.Info("nodegroup %s successfully updated", ng.Name)
+	return nil
+}
+
+func updateUpdateConfig(ng *api.ManagedNodeGroup) (*eks.NodegroupUpdateConfig, error) {
+	logger.Info("updating nodegroup %s's UpdateConfig", ng.Name)
+	updateConfig := &eks.NodegroupUpdateConfig{}
+
+	if ng.UpdateConfig.MaxUnavailable != nil {
+		updateConfig.MaxUnavailable = aws.Int64(int64(*ng.UpdateConfig.MaxUnavailable))
+	}
+
+	if ng.UpdateConfig.MaxUnavailablePercentage != nil {
+		updateConfig.MaxUnavailablePercentage = aws.Int64(int64(*ng.UpdateConfig.MaxUnavailablePercentage))
+	}
+
+	return updateConfig, nil
 }


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Closes #3857 

A config file containing multiple managed nodegroups will iterate over them and update all of them.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

