### PR TITLE
Cloudformation stack validation error because of underscore in EKS cluster name

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -52,6 +52,33 @@ var _ = Describe("ClusterConfig validation", func() {
 		})
 	})
 
+	Describe("nodeGroups[*].name validation", func() {
+		var (
+			cfg *api.ClusterConfig
+			err error
+		)
+
+		BeforeEach(func() {
+			cfg = api.NewClusterConfig()
+			ng0 := cfg.NewNodeGroup()
+			ng0.Name = "ng_invalid-name-10"
+			ng1 := cfg.NewNodeGroup()
+			ng1.Name = "ng100_invalid_name"
+			ng2 := cfg.NewNodeGroup()
+			ng2.Name = "ng100@invalid-name"
+		})
+
+		It("should reject invalid nodegroup names", func() {
+			err = api.ValidateClusterConfig(cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			for i, ng := range cfg.NodeGroups {
+				err = api.ValidateNodeGroup(i, ng)
+				Expect(err).To(HaveOccurred())
+			}
+		})
+	})
+
 	Describe("nodeGroups[*].volumeX", func() {
 		var (
 			cfg *api.ClusterConfig

--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -3,7 +3,6 @@ package cmdutils
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
@@ -102,12 +101,6 @@ func GetNameArg(args []string) string {
 		return strings.TrimSpace(args[0])
 	}
 	return ""
-}
-
-// IsValidNameArg checks whether the name contains invalid characters
-func IsValidNameArg(name string) bool {
-	re := regexp.MustCompile(`[^a-zA-Z0-9\-]+`)
-	return !re.MatchString(name)
 }
 
 // AddCommonFlagsForAWS adds common flags for api.ProviderConfig
@@ -224,11 +217,6 @@ func ErrClusterFlagAndArg(cmd *Cmd, nameFlag, nameArg string) error {
 // as flags /and/ arg but only one is allowed to be used.
 func ErrFlagAndArg(kind, flag, arg string) error {
 	return fmt.Errorf("%s=%s and argument %s %s", kind, flag, arg, IncompatibleFlags)
-}
-
-// ErrInvalidName error when invalid characters for a name is provided
-func ErrInvalidName(name string) error {
-	return fmt.Errorf("validation for %s failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*", name)
 }
 
 // ErrMustBeSet is a common error message

--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -3,6 +3,7 @@ package cmdutils
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -101,6 +102,12 @@ func GetNameArg(args []string) string {
 		return strings.TrimSpace(args[0])
 	}
 	return ""
+}
+
+// IsValidNameArg checks whether the name contains invalid characters
+func IsValidNameArg(name string) bool {
+	re := regexp.MustCompile(`[^a-zA-Z0-9\-]+`)
+	return !re.MatchString(name)
 }
 
 // AddCommonFlagsForAWS adds common flags for api.ProviderConfig
@@ -217,6 +224,11 @@ func ErrClusterFlagAndArg(cmd *Cmd, nameFlag, nameArg string) error {
 // as flags /and/ arg but only one is allowed to be used.
 func ErrFlagAndArg(kind, flag, arg string) error {
 	return fmt.Errorf("%s=%s and argument %s %s", kind, flag, arg, IncompatibleFlags)
+}
+
+// ErrInvalidName error when invalid characters for a name is provided
+func ErrInvalidName(name string) error {
+	return fmt.Errorf("validation for %s failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*", name)
 }
 
 // ErrMustBeSet is a common error message

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -107,8 +107,8 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 	cfg := cmd.ClusterConfig
 	meta := cmd.ClusterConfig.Metadata
 
-	if meta.Name != "" && !cmdutils.IsValidNameArg(meta.Name) {
-		return cmdutils.ErrInvalidName(meta.Name)
+	if meta.Name != "" && api.IsInvalidNameArg(meta.Name) {
+		return api.ErrInvalidName(meta.Name)
 	}
 
 	printer := printers.NewJSONPrinter()

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -107,6 +107,10 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 	cfg := cmd.ClusterConfig
 	meta := cmd.ClusterConfig.Metadata
 
+	if meta.Name != "" && !cmdutils.IsValidNameArg(meta.Name) {
+		return cmdutils.ErrInvalidName(meta.Name)
+	}
+
 	printer := printers.NewJSONPrinter()
 
 	ctl, err := cmd.NewCtl()

--- a/pkg/ctl/create/cluster_test.go
+++ b/pkg/ctl/create/cluster_test.go
@@ -101,11 +101,11 @@ var _ = Describe("create cluster", func() {
 			}),
 			Entry("with --name option with invalid characters that are rejected by cloudformation", invalidParamsCase{
 				args:  []string{"test-k8_cluster01"},
-				error: fmt.Errorf("Error: validation for test-k8_cluster01 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*"),
+				error: "validation for test-k8_cluster01 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*",
 			}),
 			Entry("with cluster name argument with invalid characters that are rejected by cloudformation", invalidParamsCase{
 				args:  []string{"--name", "eksctl-testing-k_8_cluster01"},
-				error: fmt.Errorf("Error: validation for eksctl-testing-k_8_cluster01 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*"),
+				error: "validation for eksctl-testing-k_8_cluster01 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*",
 			}),
 		)
 	})
@@ -181,11 +181,11 @@ var _ = Describe("create cluster", func() {
 			}),
 			Entry("with --name option with invalid characters that are rejected by cloudformation", invalidParamsCase{
 				args:  []string{"test-k8_cluster01"},
-				error: fmt.Errorf("Error: validation for test-k8_cluster01 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*"),
+				error: "validation for test-k8_cluster01 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*",
 			}),
 			Entry("with cluster name argument with invalid characters that are rejected by cloudformation", invalidParamsCase{
 				args:  []string{"--name", "eksctl-testing-k_8_cluster01"},
-				error: fmt.Errorf("Error: validation for eksctl-testing-k_8_cluster01 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*"),
+				error: "validation for eksctl-testing-k_8_cluster01 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*",
 			}),
 		)
 	})

--- a/pkg/ctl/create/cluster_test.go
+++ b/pkg/ctl/create/cluster_test.go
@@ -45,6 +45,8 @@ var _ = Describe("create cluster", func() {
 			Entry("without cluster name", ""),
 			Entry("with cluster name as flag", "--name", "clusterName"),
 			Entry("with cluster name as argument", "clusterName"),
+			Entry("with cluster name with hyphen as flag", "--name", "my-cluster-name-is-fine10"),
+			Entry("with cluster name with hyphen as argument", "my-Cluster-name-is-fine10"),
 			// vpc networking flags
 			Entry("with vpc-cidr flag", "--vpc-cidr", "10.0.0.0/20"),
 			Entry("with vpc-private-subnets flag", "--vpc-private-subnets", "10.0.0.0/24"),
@@ -97,6 +99,14 @@ var _ = Describe("create cluster", func() {
 				args:  []string{"cluster", "--invalid", "dummy"},
 				error: "unknown flag: --invalid",
 			}),
+			Entry("with --name option with invalid characters that are rejected by cloudformation", invalidParamsCase{
+				args:  []string{"test-k8_cluster01"},
+				error: fmt.Errorf("Error: validation for test-k8_cluster01 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*"),
+			}),
+			Entry("with cluster name argument with invalid characters that are rejected by cloudformation", invalidParamsCase{
+				args:  []string{"--name", "eksctl-testing-k_8_cluster01"},
+				error: fmt.Errorf("Error: validation for eksctl-testing-k_8_cluster01 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*"),
+			}),
 		)
 	})
 
@@ -120,6 +130,8 @@ var _ = Describe("create cluster", func() {
 			Entry("without cluster name", ""),
 			Entry("with cluster name as flag", "--name", "clusterName"),
 			Entry("with cluster name as argument", "clusterName"),
+			Entry("with cluster name with hyphen as flag", "--name", "my-cluster-name-is-fine10"),
+			Entry("with cluster name with hyphen as argument", "my-Cluster-name-is-fine10"),
 			// vpc networking flags
 			Entry("with vpc-cidr flag", "--vpc-cidr", "10.0.0.0/20"),
 			Entry("with vpc-private-subnets flag", "--vpc-private-subnets", "10.0.0.0/24"),
@@ -166,6 +178,14 @@ var _ = Describe("create cluster", func() {
 			Entry("with invalid flags", invalidParamsCase{
 				args:  []string{"cluster", "--invalid", "dummy"},
 				error: "unknown flag: --invalid",
+			}),
+			Entry("with --name option with invalid characters that are rejected by cloudformation", invalidParamsCase{
+				args:  []string{"test-k8_cluster01"},
+				error: fmt.Errorf("Error: validation for test-k8_cluster01 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*"),
+			}),
+			Entry("with cluster name argument with invalid characters that are rejected by cloudformation", invalidParamsCase{
+				args:  []string{"--name", "eksctl-testing-k_8_cluster01"},
+				error: fmt.Errorf("Error: validation for eksctl-testing-k_8_cluster01 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*"),
 			}),
 		)
 	})

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -26,6 +26,10 @@ type nodegroupOptions struct {
 
 func createNodeGroupCmd(cmd *cmdutils.Cmd) {
 	createNodeGroupCmdWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *api.NodeGroup, options nodegroupOptions) error {
+		if ng.Name != "" && !cmdutils.IsValidNameArg(ng.Name) {
+			return cmdutils.ErrInvalidName(ng.Name)
+		}
+
 		ngFilter := filter.NewNodeGroupFilter()
 		if err := cmdutils.NewCreateNodeGroupLoader(cmd, ng, ngFilter, options.CreateNGOptions, options.CreateManagedNGOptions).Load(); err != nil {
 			return errors.Wrap(err, "couldn't create node group filter from command line options")

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -26,8 +26,8 @@ type nodegroupOptions struct {
 
 func createNodeGroupCmd(cmd *cmdutils.Cmd) {
 	createNodeGroupCmdWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *api.NodeGroup, options nodegroupOptions) error {
-		if ng.Name != "" && !cmdutils.IsValidNameArg(ng.Name) {
-			return cmdutils.ErrInvalidName(ng.Name)
+		if ng.Name != "" && api.IsInvalidNameArg(ng.Name) {
+			return api.ErrInvalidName(ng.Name)
 		}
 
 		ngFilter := filter.NewNodeGroupFilter()

--- a/pkg/ctl/create/nodegroup_test.go
+++ b/pkg/ctl/create/nodegroup_test.go
@@ -29,7 +29,9 @@ var _ = Describe("create nodegroup", func() {
 				Expect(count).To(Equal(1))
 			},
 			Entry("with nodegroup name as flag", "--name", "nodegroupName"),
+			Entry("with nodegroup name with a hyphen as flag", "--name", "nodegroup-name"),
 			Entry("with nodegroup name as argument", "nodegroupName"),
+			Entry("with nodegroup name with a hyphen as argument", "nodegroup-name"),
 			Entry("with node-type flag", "--node-type", "m5.large"),
 			Entry("with nodes flag", "--nodes", "2"),
 			Entry("with nodes-min flag", "--nodes-min", "2"),
@@ -81,6 +83,10 @@ var _ = Describe("create nodegroup", func() {
 				args:  []string{"--cluster", "foo", "--instance-types", "some-type"},
 				error: "--instance-types is only valid with managed nodegroups (--managed)",
 			}),
+			Entry("with nodegroup name as flag with invalid characters", invalidParamsCase{
+				args:  []string{"--cluster", "clusterName", "--name", "eksctl-ng_k8s_nodegroup1"},
+				error: fmt.Errorf("Error: validation for eksctl-ng_k8s_nodegroup1 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*"),
+			}),
 		)
 	})
 
@@ -104,7 +110,9 @@ var _ = Describe("create nodegroup", func() {
 			},
 			Entry("without nodegroup name", ""),
 			Entry("with nodegroup name as flag", "--name", "nodegroupName"),
+			Entry("with nodegroup name with a hyphen as flag", "--name", "nodegroup-name"),
 			Entry("with nodegroup name as argument", "nodegroupName"),
+			Entry("with nodegroup name with a hyphen as argument", "nodegroup-name"),
 			Entry("with node-type flag", "--node-type", "m5.large"),
 			Entry("with nodes flag", "--nodes", "2"),
 			Entry("with nodes-min flag", "--nodes-min", "2"),
@@ -139,6 +147,10 @@ var _ = Describe("create nodegroup", func() {
 			Entry("with invalid flags", invalidParamsCase{
 				args:  []string{"--invalid", "dummy"},
 				error: "unknown flag: --invalid",
+			}),
+			Entry("with nodegroup name as flag with invalid characters", invalidParamsCase{
+				args:  []string{"--name", "eksctl-ng_k8s_nodegroup1"},
+				error: fmt.Errorf("Error: validation for eksctl-ng_k8s_nodegroup1 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*"),
 			}),
 		)
 	})

--- a/pkg/ctl/create/nodegroup_test.go
+++ b/pkg/ctl/create/nodegroup_test.go
@@ -85,7 +85,7 @@ var _ = Describe("create nodegroup", func() {
 			}),
 			Entry("with nodegroup name as flag with invalid characters", invalidParamsCase{
 				args:  []string{"--cluster", "clusterName", "--name", "eksctl-ng_k8s_nodegroup1"},
-				error: fmt.Errorf("Error: validation for eksctl-ng_k8s_nodegroup1 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*"),
+				error: "validation for eksctl-ng_k8s_nodegroup1 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*",
 			}),
 		)
 	})
@@ -150,7 +150,7 @@ var _ = Describe("create nodegroup", func() {
 			}),
 			Entry("with nodegroup name as flag with invalid characters", invalidParamsCase{
 				args:  []string{"--name", "eksctl-ng_k8s_nodegroup1"},
-				error: fmt.Errorf("Error: validation for eksctl-ng_k8s_nodegroup1 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*"),
+				error: "validation for eksctl-ng_k8s_nodegroup1 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*",
 			}),
 		)
 	})

--- a/pkg/ctl/get/cluster.go
+++ b/pkg/ctl/get/cluster.go
@@ -47,7 +47,7 @@ func getClusterCmd(cmd *cmdutils.Cmd) {
 
 func doGetCluster(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) error {
 	cfg := cmd.ClusterConfig
-	regionGiven := cfg.Metadata.Region != "" // eks.New resets this field, so we need to check if it was set in the fist place
+	regionGiven := cfg.Metadata.Region != "" // eks.New resets this field, so we need to check if it was set in the first place
 
 	ctl, err := cmd.NewCtl()
 	if err != nil {

--- a/userdocs/src/usage/creating-and-managing-clusters.md
+++ b/userdocs/src/usage/creating-and-managing-clusters.md
@@ -97,6 +97,9 @@ nodeGroups:
         imageBuilder: true
 ```
 
+!!! note
+    The cluster name or nodegroup name can contain only alphanumeric characters (case-sensitive) and hyphens. It must start with an alphabetic character and can't be longer than 128 characters otherwise you will get a validation error. More information can be found [here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console-create-stack-parameters.html)
+
 To delete this cluster, run:
 
 ```

--- a/userdocs/src/usage/unowned-clusters.md
+++ b/userdocs/src/usage/unowned-clusters.md
@@ -3,6 +3,9 @@
 From `eksctl` version `0.40.0` users can run `eksctl` commands against clusters which were
 not created by `eksctl`.
 
+!!!note
+    Eksctl can only support unowned clusters with names which comply with the guidelines mentioned [here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console-create-stack-parameters.html). Any cluster names which do not match this will fail CloudFormation API validation check.
+
 ## Supported commands
 
 The following commands can be used against clusters created by any means other than `eksctl`.


### PR DESCRIPTION
Added validation for cluster name and node group name for cloudformation error.
The code now checks the clustername or nodegroup name passed to have any invalid chars. If it does then the command displays error instead of trying to create the cluster which eventually crashes with a Cloudformation error. Also updated the docs for users with the Cloudformation naming guidelines information.

Fixes #2943 

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

