### PR TITLE
Use zone ID instead of zone name to avoid problematic zones

### DIFF
--- a/pkg/az/az.go
+++ b/pkg/az/az.go
@@ -114,6 +114,7 @@ func NewSelectorWithDefaults(ec2api ec2iface.EC2API, region string) *Availabilit
 		ec2api:   ec2api,
 		strategy: NewRecommendedNumberRandomStrategy(),
 		rules:    makeDefaultZoneUsageRules(region),
+		region:   region,
 	}
 }
 
@@ -124,6 +125,7 @@ func NewSelectorWithMinRequired(ec2api ec2iface.EC2API, region string) *Availabi
 		ec2api:   ec2api,
 		strategy: NewMinRequiredNumberRandomStrategy(),
 		rules:    makeDefaultZoneUsageRules(region),
+		region:   region,
 	}
 }
 

--- a/pkg/az/az.go
+++ b/pkg/az/az.go
@@ -19,6 +19,10 @@ const (
 	MinRequiredAvailabilityZones = api.MinRequiredSubnets
 )
 
+var zoneIDsToAvoid = map[string][]string{
+	api.RegionCNNorth1: {"cnn1-az4"}, // https://github.com/weaveworks/eksctl/issues/3916
+}
+
 // SelectionStrategy provides an interface to allow changing the strategy used to
 // select availability zones to use from a list available.
 type SelectionStrategy interface {
@@ -65,62 +69,67 @@ type ZoneUsageRule interface {
 	CanUseZone(zone *ec2.AvailabilityZone) bool
 }
 
-// ZonesToAvoidRule can be used to ensure that certain az aren't used. This can be used
-// to avoid zones that are know to be overpopulated.
+// ZonesToAvoidRule can be used to ensure that certain zone IDs aren't used. This can be used
+// to avoid zones that are known to be overpopulated.
 type ZonesToAvoidRule struct {
-	zonesToAvoid map[string]bool
+	zoneIDs map[string]struct{}
 }
 
 // CanUseZone checks if the supplied zone is in the list of zones to be avoided.
 func (za *ZonesToAvoidRule) CanUseZone(zone *ec2.AvailabilityZone) bool {
-	_, avoidZone := za.zonesToAvoid[*zone.ZoneName]
+	_, avoidZone := za.zoneIDs[*zone.ZoneId]
 	return !avoidZone
 }
 
 // NewZonesToAvoidRule returns a new ZonesToAvoidRule with the supplied
 // zones set to avoid
-func NewZonesToAvoidRule(zonesToAvoid map[string]bool) *ZonesToAvoidRule {
-	return &ZonesToAvoidRule{zonesToAvoid: zonesToAvoid}
+func NewZonesToAvoidRule(zoneIDs []string) *ZonesToAvoidRule {
+	z := map[string]struct{}{}
+	for _, zoneID := range zoneIDs {
+		z[zoneID] = struct{}{}
+	}
+	return &ZonesToAvoidRule{zoneIDs: z}
+}
+
+func makeDefaultZoneUsageRules(region string) []ZoneUsageRule {
+	zoneIDs, ok := zoneIDsToAvoid[region]
+	if !ok {
+		return nil
+	}
+	return []ZoneUsageRule{NewZonesToAvoidRule(zoneIDs)}
 }
 
 // AvailabilityZoneSelector used to select availability zones to use
 type AvailabilityZoneSelector struct {
 	ec2api   ec2iface.EC2API
+	region   string
 	strategy SelectionStrategy
 	rules    []ZoneUsageRule
 }
 
-// NewSelectorWithDefaults create a new AvailabilityZoneSelector with the
+// NewSelectorWithDefaults creates a new AvailabilityZoneSelector with the
 // default selection strategy and usage rules
-func NewSelectorWithDefaults(ec2api ec2iface.EC2API) *AvailabilityZoneSelector {
-	avoidZones := map[string]bool{
-		"cn-north-1d": true,
-	}
-
+func NewSelectorWithDefaults(ec2api ec2iface.EC2API, region string) *AvailabilityZoneSelector {
 	return &AvailabilityZoneSelector{
 		ec2api:   ec2api,
 		strategy: NewRecommendedNumberRandomStrategy(),
-		rules:    []ZoneUsageRule{NewZonesToAvoidRule(avoidZones)},
+		rules:    makeDefaultZoneUsageRules(region),
 	}
 }
 
 // NewSelectorWithMinRequired create a new AvailabilityZoneSelector with the
 // minimum required selection strategy and usage rules
-func NewSelectorWithMinRequired(ec2api ec2iface.EC2API) *AvailabilityZoneSelector {
-	avoidZones := map[string]bool{
-		"cn-north-1d": true,
-	}
-
+func NewSelectorWithMinRequired(ec2api ec2iface.EC2API, region string) *AvailabilityZoneSelector {
 	return &AvailabilityZoneSelector{
 		ec2api:   ec2api,
 		strategy: NewMinRequiredNumberRandomStrategy(),
-		rules:    []ZoneUsageRule{NewZonesToAvoidRule(avoidZones)},
+		rules:    makeDefaultZoneUsageRules(region),
 	}
 }
 
 // SelectZones returns a list fo az zones to use for the supplied region
-func (a *AvailabilityZoneSelector) SelectZones(regionName string) ([]string, error) {
-	availableZones, err := a.getZonesForRegion(regionName)
+func (a *AvailabilityZoneSelector) SelectZones() ([]string, error) {
+	availableZones, err := a.getZonesForRegion()
 	if err != nil {
 		return nil, err
 	}
@@ -148,10 +157,10 @@ func (a *AvailabilityZoneSelector) getUsableZones(availableZones []*ec2.Availabi
 	return usableZones
 }
 
-func (a *AvailabilityZoneSelector) getZonesForRegion(regionName string) ([]*ec2.AvailabilityZone, error) {
+func (a *AvailabilityZoneSelector) getZonesForRegion() ([]*ec2.AvailabilityZone, error) {
 	regionFilter := &ec2.Filter{
 		Name:   aws.String("region-name"),
-		Values: []*string{aws.String(regionName)},
+		Values: []*string{aws.String(a.region)},
 	}
 	stateFilter := &ec2.Filter{
 		Name:   aws.String("state"),
@@ -164,7 +173,7 @@ func (a *AvailabilityZoneSelector) getZonesForRegion(regionName string) ([]*ec2.
 
 	output, err := a.ec2api.DescribeAvailabilityZones(input)
 	if err != nil {
-		return nil, errors.Wrapf(err, "getting availability zones for %s", regionName)
+		return nil, errors.Wrapf(err, "getting availability zones for %s", a.region)
 	}
 
 	return output.AvailabilityZones, nil

--- a/pkg/az/az_test.go
+++ b/pkg/az/az_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	. "github.com/weaveworks/eksctl/pkg/az"
-	"github.com/weaveworks/eksctl/pkg/eks"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
@@ -41,7 +40,7 @@ var _ = Describe("AZ", func() {
 					region = "us-west-2"
 
 					zones = usWest2Zones(ec2.AvailabilityZoneStateAvailable)
-					_, p = createProviders()
+					p = mockprovider.NewMockProvider()
 
 					p.MockEC2().On("DescribeAvailabilityZones",
 						mock.MatchedBy(func(input *ec2.DescribeAvailabilityZonesInput) bool {
@@ -83,7 +82,7 @@ var _ = Describe("AZ", func() {
 					expectedZoneName = westZone.ZoneName
 					zones = []*ec2.AvailabilityZone{westZone}
 
-					_, p = createProviders()
+					p = mockprovider.NewMockProvider()
 
 					p.MockEC2().On("DescribeAvailabilityZones",
 						mock.MatchedBy(func(input *ec2.DescribeAvailabilityZonesInput) bool {
@@ -110,7 +109,7 @@ var _ = Describe("AZ", func() {
 				})
 
 				It("should have returned 3 identical availability zones", func() {
-					Expect(len(selectedZones)).To(Equal(3))
+					Expect(selectedZones).To(HaveLen(3))
 
 					for _, actualZoneName := range selectedZones {
 						Expect(actualZoneName).To(Equal(*expectedZoneName))
@@ -132,7 +131,7 @@ var _ = Describe("AZ", func() {
 				expectedZoneName = aws.String("us-east-1c")
 
 				zones = usEast1Zones(ec2.AvailabilityZoneStateAvailable)
-				_, p = createProviders()
+				p = mockprovider.NewMockProvider()
 
 				p.MockEC2().On("DescribeAvailabilityZones",
 					mock.MatchedBy(func(input *ec2.DescribeAvailabilityZonesInput) bool {
@@ -159,7 +158,7 @@ var _ = Describe("AZ", func() {
 			})
 
 			It("should have returned 3 availability zones", func() {
-				Expect(len(selectedZones)).To(Equal(3))
+				Expect(selectedZones).To(HaveLen(3))
 			})
 
 			It("should have returned none of the zones to avoid", func() {
@@ -175,7 +174,7 @@ var _ = Describe("AZ", func() {
 				azSelector    *AvailabilityZoneSelector
 			)
 			BeforeEach(func() {
-				_, p = createProviders()
+				p = mockprovider.NewMockProvider()
 
 				p.MockEC2().On("DescribeAvailabilityZones",
 					mock.Anything,
@@ -212,7 +211,7 @@ var _ = Describe("AZ", func() {
 			BeforeEach(func() {
 				region = "us-east-1"
 				zones = usEast1Zones(ec2.AvailabilityZoneStateAvailable)
-				_, p = createProviders()
+				p = mockprovider.NewMockProvider()
 
 				p.MockEC2().On("DescribeAvailabilityZones",
 					mock.MatchedBy(func(input *ec2.DescribeAvailabilityZonesInput) bool {
@@ -239,21 +238,11 @@ var _ = Describe("AZ", func() {
 			})
 
 			It("should have returned 2 availability zones", func() {
-				Expect(len(selectedZones)).To(Equal(2))
+				Expect(selectedZones).To(HaveLen(2))
 			})
 		})
 	})
 })
-
-func createProviders() (*eks.ClusterProvider, *mockprovider.MockProvider) {
-	p := mockprovider.NewMockProvider()
-
-	c := &eks.ClusterProvider{
-		Provider: p,
-	}
-
-	return c, p
-}
 
 func createAvailabilityZone(region string, state string, zone string) *ec2.AvailabilityZone {
 	return &ec2.AvailabilityZone{

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -391,11 +391,14 @@ func (c *ClusterProvider) SetAvailabilityZones(spec *api.ClusterConfig, given []
 	}
 
 	logger.Debug("determining availability zones")
-	azSelector := az.NewSelectorWithDefaults(c.Provider.EC2())
+	var azSelector *az.AvailabilityZoneSelector
 	if c.Provider.Region() == api.RegionUSEast1 {
-		azSelector = az.NewSelectorWithMinRequired(c.Provider.EC2())
+		azSelector = az.NewSelectorWithMinRequired(c.Provider.EC2(), c.Provider.Region())
+	} else {
+		azSelector = az.NewSelectorWithDefaults(c.Provider.EC2(), c.Provider.Region())
 	}
-	zones, err := azSelector.SelectZones(c.Provider.Region())
+
+	zones, err := azSelector.SelectZones()
 	if err != nil {
 		return errors.Wrap(err, "getting availability zones")
 	}


### PR DESCRIPTION
### Description

AZ names across AWS accounts do not always map to the same location. This changelist uses the zone ID which is a unique identifier that always maps to the same location in every AWS account. 

TODO:

- [x] Fix tests
- [x] Add more tests

Closes https://github.com/weaveworks/eksctl/issues/3916

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

