### PR TITLE
Fix --wait issue for eksctl upgrade nodegroup command

### DIFF
--- a/pkg/actions/nodegroup/upgrade.go
+++ b/pkg/actions/nodegroup/upgrade.go
@@ -134,4 +134,3 @@ func (m *Manager) waitForUpgrade(options managed.UpgradeOptions) error {
 	logger.Info("nodegroup successfully upgraded")
 	return nil
 }
-

--- a/pkg/actions/nodegroup/upgrade.go
+++ b/pkg/actions/nodegroup/upgrade.go
@@ -42,6 +42,8 @@ func (m *Manager) Upgrade(options managed.UpgradeOptions, wait bool) error {
 		return m.waitForUpgrade(options)
 	}
 
+	logger.Info("nodegroup upgrade request submitted successfully")
+
 	return nil
 
 }

--- a/pkg/ctl/upgrade/nodegroup.go
+++ b/pkg/ctl/upgrade/nodegroup.go
@@ -85,4 +85,3 @@ func upgradeNodeGroup(cmd *cmdutils.Cmd, options managed.UpgradeOptions) error {
 	return nodegroup.New(cfg, ctl, clientSet).Upgrade(options, cmd.Wait)
 
 }
-

--- a/pkg/ctl/upgrade/nodegroup.go
+++ b/pkg/ctl/upgrade/nodegroup.go
@@ -82,6 +82,7 @@ func upgradeNodeGroup(cmd *cmdutils.Cmd, options managed.UpgradeOptions) error {
 		return err
 	}
 
-	return nodegroup.New(cfg, ctl, clientSet).Upgrade(options)
+	return nodegroup.New(cfg, ctl, clientSet).Upgrade(options, cmd.Wait)
 
 }
+


### PR DESCRIPTION
Fixes #3889 

### Description

Currently --wait flag is ignored while performing nodegroup upgrade action. This PR checks for wait flag and accordingly performs the action.


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

