### PR TITLE
Fix Config file schema docs page horizontal scroll

### DIFF
--- a/userdocs/src/usage/schema.css
+++ b/userdocs/src/usage/schema.css
@@ -45,3 +45,6 @@ table#config td.type {
     filter: opacity(70%);
     color: #999999;
 }
+.md-typeset__scrollwrap {
+    overflow-x: inherit;
+}

--- a/userdocs/src/usage/schema.md
+++ b/userdocs/src/usage/schema.md
@@ -1,9 +1,7 @@
 # Config file schema
-
+Use `eksctl utils schema` to get the raw JSON schema.
 <script type="module" src="../schema.js"></script>
 
 <table id="config"></table>
 
-## Latest schema
 
-Use `eksctl utils schema` to get the raw JSON schema.


### PR DESCRIPTION
### Description
Fixed the scroll on the config file schema doc page. https://eksctl.io/usage/schema/ this page doesnt show full content and its bit annoying to scroll to see the information to the right side.
Below shows how it looks after changes. I have tested on ipad/ipad pro view and some phone screens to make sure its responsive.
![Screenshot 2021-07-08 at 13 04 25](https://user-images.githubusercontent.com/10995114/124919396-1efc6500-dfee-11eb-827f-36e2890481d0.png)
Fixes #3891 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

