### PR TITLE
Fix panic for `get nodegroup`

### DIFF
--- a/pkg/actions/nodegroup/get.go
+++ b/pkg/actions/nodegroup/get.go
@@ -71,7 +71,7 @@ func (m *Manager) GetAll() ([]*manager.NodeGroupSummary, error) {
 			CreationTime:         describeOutput.Nodegroup.CreatedAt,
 			NodeInstanceRoleARN:  *describeOutput.Nodegroup.NodeRole,
 			AutoScalingGroupName: strings.Join(asgs, ","),
-			Version:              *describeOutput.Nodegroup.Version,
+			Version:              getOptionalValue(describeOutput.Nodegroup.Version),
 		})
 	}
 
@@ -131,6 +131,13 @@ func (m *Manager) Get(name string) (*manager.NodeGroupSummary, error) {
 		CreationTime:         describeOutput.Nodegroup.CreatedAt,
 		NodeInstanceRoleARN:  *describeOutput.Nodegroup.NodeRole,
 		AutoScalingGroupName: asg,
-		Version:              *describeOutput.Nodegroup.Version,
+		Version:              getOptionalValue(describeOutput.Nodegroup.Version),
 	}, nil
+}
+
+func getOptionalValue(v *string) string {
+	if v == nil {
+		return "-"
+	}
+	return *v
 }


### PR DESCRIPTION
### Description
The `version` field does not exist for nodegroups using a custom AMI

Fixes https://github.com/weaveworks/eksctl/issues/3959

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

