### PR TITLE
Deprecate `ssh.enableSsm` and disallow enabling it

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -42,7 +42,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
           TEST_V: "1"
           GITHUB_TOKEN: "${{ secrets.EKSCTLBOT_TOKEN }}"
-          _____INTERNAL_NODEGROUP_ENABLE_SSM: "true"
         run: make integration-test
       - name: Notify slack on success
         if: success() && github.event_name == 'schedule'

--- a/pkg/apis/eksctl.io/v1alpha5/managed_nodegroup_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/managed_nodegroup_test.go
@@ -150,11 +150,6 @@ var _ = Describe("Managed Nodegroup Validation", func() {
 				Allow: Enabled(),
 			},
 		}),
-		Entry("enableSSM", &NodeGroupBase{
-			SSH: &NodeGroupSSH{
-				EnableSSM: Enabled(),
-			},
-		}),
 		Entry("volumeSize", &NodeGroupBase{
 			VolumeSize: aws.Int(100),
 		}),

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -1638,3 +1638,13 @@ type UnsupportedFeatureError struct {
 func (u *UnsupportedFeatureError) Error() string {
 	return fmt.Sprintf("%s: %v", u.Message, u.Err)
 }
+
+// DeprecationError represents a deprecation error.
+// +k8s:deepcopy-gen=false
+type DeprecationError struct {
+	Message string
+}
+
+func (d *DeprecationError) Error() string {
+	return d.Message
+}

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -269,6 +269,17 @@ func validateNodeGroupBase(ng *NodeGroupBase, path string) error {
 		return fmt.Errorf("AMI Family %s is not supported - use one of: %s", ng.AMIFamily, strings.Join(supportedAMIFamilies(), ", "))
 	}
 
+	if ng.SSH != nil {
+		if enableSSM := ng.SSH.EnableSSM; enableSSM != nil {
+			if !*enableSSM {
+				return errors.New("SSM agent is now built into EKS AMIs and cannot be disabled")
+			}
+			return &DeprecationError{
+				Message: "SSM is now enabled by default; `ssh.enableSSM` is deprecated and will be removed in a future release",
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -157,8 +157,7 @@ func (n *NodeGroupResourceSet) addResourcesForIAM() error {
 		n.rs.withNamedIAM = true
 	}
 
-	enableSSM := n.spec.SSH != nil && api.IsEnabled(n.spec.SSH.EnableSSM)
-	if err := createRole(n.rs, n.clusterSpec.IAM, n.spec.IAM, false, enableSSM, n.forceAddCNIPolicy); err != nil {
+	if err := createRole(n.rs, n.clusterSpec.IAM, n.spec.IAM, false, n.forceAddCNIPolicy); err != nil {
 		return err
 	}
 

--- a/pkg/cfn/builder/iam_helper.go
+++ b/pkg/cfn/builder/iam_helper.go
@@ -76,8 +76,8 @@ func createWellKnownPolicies(wellKnownPolicies api.WellKnownPolicies) ([]managed
 }
 
 // createRole creates an IAM role with policies required for the worker nodes and addons
-func createRole(cfnTemplate cfnTemplate, clusterIAMConfig *api.ClusterIAM, iamConfig *api.NodeGroupIAM, managed, enableSSM, forceAddCNIPolicy bool) error {
-	managedPolicyARNs, err := makeManagedPolicies(clusterIAMConfig, iamConfig, managed, enableSSM, forceAddCNIPolicy)
+func createRole(cfnTemplate cfnTemplate, clusterIAMConfig *api.ClusterIAM, iamConfig *api.NodeGroupIAM, managed, forceAddCNIPolicy bool) error {
+	managedPolicyARNs, err := makeManagedPolicies(clusterIAMConfig, iamConfig, managed, forceAddCNIPolicy)
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func createRole(cfnTemplate cfnTemplate, clusterIAMConfig *api.ClusterIAM, iamCo
 	return nil
 }
 
-func makeManagedPolicies(iamCluster *api.ClusterIAM, iamConfig *api.NodeGroupIAM, managed, enableSSM, forceAddCNIPolicy bool) (*gfnt.Value, error) {
+func makeManagedPolicies(iamCluster *api.ClusterIAM, iamConfig *api.NodeGroupIAM, managed, forceAddCNIPolicy bool) (*gfnt.Value, error) {
 	managedPolicyNames := sets.NewString()
 	if len(iamConfig.AttachPolicyARNs) == 0 {
 		managedPolicyNames.Insert(iamDefaultNodePolicies...)
@@ -157,9 +157,6 @@ func makeManagedPolicies(iamCluster *api.ClusterIAM, iamConfig *api.NodeGroupIAM
 			// actions allowed by this managed policy
 			managedPolicyNames.Insert(iamPolicyAmazonEC2ContainerRegistryReadOnly)
 		}
-	}
-
-	if enableSSM {
 		managedPolicyNames.Insert(iamPolicyAmazonSSMManagedInstanceCore)
 	}
 

--- a/pkg/cfn/builder/managed_launch_template_test.go
+++ b/pkg/cfn/builder/managed_launch_template_test.go
@@ -159,7 +159,6 @@ API_SERVER_URL=https://test.com
 					SSH: &api.NodeGroupSSH{
 						Allow:         api.Enabled(),
 						PublicKeyName: aws.String("test-keypair"),
-						EnableSSM:     api.Enabled(),
 					},
 				},
 			},
@@ -175,7 +174,6 @@ API_SERVER_URL=https://test.com
 					SSH: &api.NodeGroupSSH{
 						Allow:         api.Disabled(),
 						PublicKeyName: aws.String("test-keypair"),
-						EnableSSM:     api.Enabled(),
 					},
 				},
 			},

--- a/pkg/cfn/builder/managed_nodegroup.go
+++ b/pkg/cfn/builder/managed_nodegroup.go
@@ -58,9 +58,7 @@ func (m *ManagedNodeGroupResourceSet) AddAllResources() error {
 
 	var nodeRole *gfnt.Value
 	if m.nodeGroup.IAM.InstanceRoleARN == "" {
-		enableSSM := m.nodeGroup.SSH != nil && api.IsEnabled(m.nodeGroup.SSH.EnableSSM)
-
-		if err := createRole(m.resourceSet, m.clusterConfig.IAM, m.nodeGroup.IAM, true, enableSSM, m.forceAddCNIPolicy); err != nil {
+		if err := createRole(m.resourceSet, m.clusterConfig.IAM, m.nodeGroup.IAM, true, m.forceAddCNIPolicy); err != nil {
 			return err
 		}
 		nodeRole = gfnt.MakeFnGetAttString(cfnIAMInstanceRoleName, "Arn")

--- a/pkg/cfn/builder/managed_nodegroup_test.go
+++ b/pkg/cfn/builder/managed_nodegroup_test.go
@@ -23,7 +23,7 @@ func TestManagedPolicyResources(t *testing.T) {
 		description             string
 	}{
 		{
-			expectedManagedPolicies: makePartitionedPolicies("AmazonEKSWorkerNodePolicy", "AmazonEKS_CNI_Policy", "AmazonEC2ContainerRegistryReadOnly"),
+			expectedManagedPolicies: makePartitionedPolicies("AmazonEKSWorkerNodePolicy", "AmazonEKS_CNI_Policy", "AmazonEC2ContainerRegistryReadOnly", "AmazonSSMManagedInstanceCore"),
 			description:             "Default policies",
 		},
 		{
@@ -31,7 +31,7 @@ func TestManagedPolicyResources(t *testing.T) {
 				ImageBuilder: api.Enabled(),
 			},
 			expectedManagedPolicies: makePartitionedPolicies("AmazonEKSWorkerNodePolicy", "AmazonEKS_CNI_Policy",
-				"AmazonEC2ContainerRegistryReadOnly", "AmazonEC2ContainerRegistryPowerUser"),
+				"AmazonEC2ContainerRegistryReadOnly", "AmazonEC2ContainerRegistryPowerUser", "AmazonSSMManagedInstanceCore"),
 			description: "ImageBuilder enabled",
 		},
 		{
@@ -39,7 +39,7 @@ func TestManagedPolicyResources(t *testing.T) {
 				CloudWatch: api.Enabled(),
 			},
 			expectedManagedPolicies: makePartitionedPolicies("AmazonEKSWorkerNodePolicy", "AmazonEKS_CNI_Policy",
-				"AmazonEC2ContainerRegistryReadOnly", "CloudWatchAgentServerPolicy"),
+				"AmazonEC2ContainerRegistryReadOnly", "AmazonSSMManagedInstanceCore", "CloudWatchAgentServerPolicy"),
 			description: "CloudWatch enabled",
 		},
 		{

--- a/pkg/cfn/builder/nodegroup_test.go
+++ b/pkg/cfn/builder/nodegroup_test.go
@@ -192,7 +192,7 @@ var _ = Describe("Unmanaged NodeGroup Template Builder", func() {
 			})
 		})
 
-		Context("neither iam.InstanceRoleARN or ng.InstanceProfileARN are set", func() {
+		Context("neither iam.InstanceRoleARN or ng.InstanceProfileARN is set", func() {
 			It("creates a new role", func() {
 				Expect(ngTemplate.Resources).To(HaveKey("NodeInstanceRole"))
 				Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.Path).To(Equal("/"))
@@ -253,10 +253,13 @@ var _ = Describe("Unmanaged NodeGroup Template Builder", func() {
 				})
 
 				It("adds the default policies to the role", func() {
-					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(HaveLen(3))
+					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(HaveLen(4))
+
 					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(ContainElement(makePolicyARNRef("AmazonEC2ContainerRegistryReadOnly")))
 					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(ContainElement(makePolicyARNRef("AmazonEKSWorkerNodePolicy")))
 					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(ContainElement(makePolicyARNRef("AmazonEKS_CNI_Policy")))
+					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(ContainElement(makePolicyARNRef("AmazonEKS_CNI_Policy")))
+					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(ContainElement(makePolicyARNRef("AmazonSSMManagedInstanceCore")))
 				})
 
 				Context("forceAddCNIPolicy is true", func() {
@@ -265,7 +268,7 @@ var _ = Describe("Unmanaged NodeGroup Template Builder", func() {
 					})
 
 					It("adds the AmazonEKS_CNI_Policy", func() {
-						Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(HaveLen(3))
+						Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(HaveLen(4))
 						Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(ContainElement(makePolicyARNRef("AmazonEKS_CNI_Policy")))
 					})
 				})
@@ -276,23 +279,9 @@ var _ = Describe("Unmanaged NodeGroup Template Builder", func() {
 					})
 
 					It("does not add the AmazonEKS_CNI_Policy", func() {
-						Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(HaveLen(2))
+						Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(HaveLen(3))
 						Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).ToNot(ContainElement(makePolicyARNRef("AmazonEKS_CNI_Policy")))
 					})
-				})
-			})
-
-			Context("ssm is enabled", func() {
-				BeforeEach(func() {
-					ng.SSH = &api.NodeGroupSSH{
-						Allow:     aws.Bool(true),
-						EnableSSM: aws.Bool(true),
-					}
-				})
-
-				It("adds the AmazonSSMManagedInstanceCore arn to the role", func() {
-					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(HaveLen(4))
-					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(ContainElement(makePolicyARNRef("AmazonSSMManagedInstanceCore")))
 				})
 			})
 
@@ -302,7 +291,7 @@ var _ = Describe("Unmanaged NodeGroup Template Builder", func() {
 				})
 
 				It("adds the AmazonSSMManagedInstanceCore arn to the role", func() {
-					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(HaveLen(3))
+					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(HaveLen(4))
 					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(ContainElement(makePolicyARNRef("AmazonEC2ContainerRegistryPowerUser")))
 				})
 			})
@@ -313,7 +302,7 @@ var _ = Describe("Unmanaged NodeGroup Template Builder", func() {
 				})
 
 				It("adds the AmazonSSMManagedInstanceCore arn to the role", func() {
-					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(HaveLen(4))
+					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(HaveLen(5))
 					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(ContainElement(makePolicyARNRef("CloudWatchAgentServerPolicy")))
 				})
 			})
@@ -324,7 +313,7 @@ var _ = Describe("Unmanaged NodeGroup Template Builder", func() {
 				})
 
 				It("adds the AmazonSSMManagedInstanceCore arn to the role", func() {
-					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(HaveLen(4))
+					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(HaveLen(5))
 					Expect(ngTemplate.Resources["NodeInstanceRole"].Properties.ManagedPolicyArns).To(ContainElement(makePolicyARNRef("CloudWatchAgentServerPolicy")))
 				})
 			})

--- a/pkg/cfn/builder/testdata/launch_template/custom_ami.json
+++ b/pkg/cfn/builder/testdata/launch_template/custom_ami.json
@@ -160,6 +160,9 @@
                 },
                 {
                     "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+                },
+                {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
                 }
             ],
             "Path": "/",

--- a/pkg/cfn/builder/testdata/launch_template/launch_template.json
+++ b/pkg/cfn/builder/testdata/launch_template/launch_template.json
@@ -73,6 +73,9 @@
                 },
                 {
                     "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+                },
+                {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
                 }
             ],
             "Path": "/",

--- a/pkg/cfn/builder/testdata/launch_template/launch_template_custom_ami.json
+++ b/pkg/cfn/builder/testdata/launch_template/launch_template_custom_ami.json
@@ -73,6 +73,9 @@
                 },
                 {
                     "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+                },
+                {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
                 }
             ],
             "Path": "/",

--- a/pkg/cfn/builder/testdata/launch_template/lt_instance_types.json
+++ b/pkg/cfn/builder/testdata/launch_template/lt_instance_types.json
@@ -74,6 +74,9 @@
                 },
                 {
                     "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+                },
+                {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
                 }
             ],
             "Path": "/",

--- a/pkg/cfn/builder/testdata/launch_template/placement.json
+++ b/pkg/cfn/builder/testdata/launch_template/placement.json
@@ -162,6 +162,9 @@
                 },
                 {
                     "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+                },
+                {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
                 }
             ],
             "Path": "/",

--- a/pkg/cfn/builder/testdata/launch_template/spot.json
+++ b/pkg/cfn/builder/testdata/launch_template/spot.json
@@ -160,6 +160,9 @@
                 },
                 {
                     "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+                },
+                {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
                 }
             ],
             "Path": "/",

--- a/pkg/cfn/builder/testdata/launch_template/standard.json
+++ b/pkg/cfn/builder/testdata/launch_template/standard.json
@@ -159,6 +159,9 @@
                 },
                 {
                     "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+                },
+                {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
                 }
             ],
             "Path": "/",

--- a/pkg/ctl/cmdutils/cmd.go
+++ b/pkg/ctl/cmdutils/cmd.go
@@ -39,10 +39,18 @@ func (c *Cmd) NewCtl() (*eks.ClusterProvider, error) {
 		logger.Warning("ignoring validation error: %s", err.Error())
 	}
 
+	checkDeprecationError := func(err error) error {
+		if _, ok := err.(*api.DeprecationError); ok {
+			logger.Warning(err.Error())
+			return nil
+		}
+		return err
+	}
+
 	for i, ng := range c.ClusterConfig.NodeGroups {
 		if err := api.ValidateNodeGroup(i, ng); err != nil {
 			if c.Validate {
-				return nil, err
+				return nil, checkDeprecationError(err)
 			}
 			logger.Warning("ignoring validation error: %s", err.Error())
 		}
@@ -54,7 +62,7 @@ func (c *Cmd) NewCtl() (*eks.ClusterProvider, error) {
 	for i, ng := range c.ClusterConfig.ManagedNodeGroups {
 		api.SetManagedNodeGroupDefaults(ng, c.ClusterConfig.Metadata)
 		if err := api.ValidateManagedNodeGroup(ng, i); err != nil {
-			return nil, err
+			return nil, checkDeprecationError(err)
 		}
 	}
 

--- a/pkg/ctl/create/cluster_test.go
+++ b/pkg/ctl/create/cluster_test.go
@@ -189,7 +189,7 @@ var _ = Describe("create cluster", func() {
 				error: "validation for eksctl-testing-k_8_cluster01 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*",
 			}),
 			Entry("with enableSsm disabled", invalidParamsCase{
-				args:  []string{"create", "cluster", "clusterName", "--name", "test", "--enable-ssm=false"},
+				args:  []string{"--name=test", "--enable-ssm=false"},
 				error: "SSM agent is now built into EKS AMIs and cannot be disabled",
 			}),
 		)

--- a/pkg/ctl/create/cluster_test.go
+++ b/pkg/ctl/create/cluster_test.go
@@ -188,6 +188,10 @@ var _ = Describe("create cluster", func() {
 				args:  []string{"--name", "eksctl-testing-k_8_cluster01"},
 				error: "validation for eksctl-testing-k_8_cluster01 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*",
 			}),
+			Entry("with enableSsm disabled", invalidParamsCase{
+				args:  []string{"create", "cluster", "clusterName", "--name", "test", "--enable-ssm=false"},
+				error: "SSM agent is now built into EKS AMIs and cannot be disabled",
+			}),
 		)
 	})
 })

--- a/pkg/ctl/create/nodegroup_test.go
+++ b/pkg/ctl/create/nodegroup_test.go
@@ -89,7 +89,7 @@ var _ = Describe("create nodegroup", func() {
 				error: "validation for eksctl-ng_k8s_nodegroup1 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*",
 			}),
 			Entry("with enableSsm disabled", invalidParamsCase{
-				args:  []string{"--cluster", "clusterName", "--name", "test", "--enable-ssm=false"},
+				args:  []string{"--cluster=test", "--enable-ssm=false"},
 				error: "SSM agent is now built into EKS AMIs and cannot be disabled",
 			}),
 		)

--- a/pkg/ctl/create/nodegroup_test.go
+++ b/pkg/ctl/create/nodegroup_test.go
@@ -88,6 +88,10 @@ var _ = Describe("create nodegroup", func() {
 				args:  []string{"--cluster", "clusterName", "--name", "eksctl-ng_k8s_nodegroup1"},
 				error: "validation for eksctl-ng_k8s_nodegroup1 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*",
 			}),
+			Entry("with enableSsm disabled", invalidParamsCase{
+				args:  []string{"--cluster", "clusterName", "--name", "test", "--enable-ssm=false"},
+				error: "SSM agent is now built into EKS AMIs and cannot be disabled",
+			}),
 		)
 	})
 

--- a/pkg/eks/nodegroup_service.go
+++ b/pkg/eks/nodegroup_service.go
@@ -2,7 +2,6 @@ package eks
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 
@@ -64,7 +63,6 @@ func (m *NodeGroupService) NewAWSSelectorSession(provider api.ClusterProvider) {
 
 // Normalize normalizes nodegroups
 func (m *NodeGroupService) Normalize(nodePools []api.NodePool, clusterMeta *api.ClusterMeta) error {
-	_, enableSSM := os.LookupEnv("_____INTERNAL_NODEGROUP_ENABLE_SSM")
 	for _, np := range nodePools {
 		switch ng := np.(type) {
 		case *api.ManagedNodeGroup:
@@ -108,9 +106,6 @@ func (m *NodeGroupService) Normalize(nodePools []api.NodePool, clusterMeta *api.
 		}
 		if publicKeyName != "" {
 			ng.SSH.PublicKeyName = &publicKeyName
-		}
-		if enableSSM {
-			ng.SSH.EnableSSM = api.Enabled()
 		}
 	}
 	return nil

--- a/pkg/nodebootstrap/al2.go
+++ b/pkg/nodebootstrap/al2.go
@@ -25,10 +25,6 @@ func NewAL2Bootstrapper(clusterConfig *api.ClusterConfig, ng *api.NodeGroup) *Am
 func (b *AmazonLinux2) UserData() (string, error) {
 	var scripts []string
 
-	if api.IsEnabled(b.ng.SSH.EnableSSM) {
-		scripts = append(scripts, "install-ssm.al2.sh")
-	}
-
 	if api.IsEnabled(b.ng.EFAEnabled) {
 		scripts = append(scripts, "efa.al2.sh")
 	}

--- a/pkg/nodebootstrap/al2_test.go
+++ b/pkg/nodebootstrap/al2_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/nodebootstrap"
 )
@@ -37,13 +36,17 @@ var _ = Describe("AmazonLinux2 User Data", func() {
 			bootstrapper = newBootstrapper(clusterConfig, ng)
 		})
 
-		It("adds the ssm install script to the userdata", func() {
+		It("does not add the SSM install script to the userdata", func() {
 			userData, err := bootstrapper.UserData()
 			Expect(err).NotTo(HaveOccurred())
 
 			cloudCfg := decode(userData)
-			Expect(cloudCfg.WriteFiles[2].Path).To(Equal("/var/lib/cloud/scripts/eksctl/install-ssm.al2.sh"))
-			Expect(cloudCfg.WriteFiles[2].Permissions).To(Equal("0755"))
+
+			var paths []string
+			for _, f := range cloudCfg.WriteFiles {
+				paths = append(paths, f.Path)
+			}
+			Expect(paths).ToNot(ContainElement("/var/lib/cloud/scripts/eksctl/install-ssm.al2.sh"))
 		})
 	})
 

--- a/pkg/nodebootstrap/legacy/al2.go
+++ b/pkg/nodebootstrap/legacy/al2.go
@@ -32,10 +32,6 @@ func (b AL2Bootstrapper) UserData() (string, error) {
 
 	var scripts []string
 
-	if b.ng.SSH.EnableSSM != nil && *b.ng.SSH.EnableSSM {
-		scripts = append(scripts, "install-ssm.al2.sh")
-	}
-
 	for _, command := range b.ng.PreBootstrapCommands {
 		config.AddShellCommand(command)
 	}

--- a/pkg/nodebootstrap/managed_al2.go
+++ b/pkg/nodebootstrap/managed_al2.go
@@ -6,13 +6,11 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
-	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
-	"github.com/weaveworks/eksctl/pkg/nodebootstrap/bindata"
 )
 
 // ManagedAL2 is a bootstrapper for managed Amazon Linux 2 nodegroups
@@ -43,15 +41,6 @@ func (m *ManagedAL2) UserData() (string, error) {
 		scripts   []string
 		cloudboot []string
 	)
-
-	if api.IsEnabled(ng.SSH.EnableSSM) {
-		installSSMScript, err := bindata.Asset(filepath.Join(dataDir, "install-ssm.al2.sh"))
-		if err != nil {
-			return "", err
-		}
-
-		scripts = append(scripts, string(installSSMScript))
-	}
 
 	if len(ng.PreBootstrapCommands) > 0 {
 		scripts = append(scripts, ng.PreBootstrapCommands...)

--- a/pkg/nodebootstrap/managed_al2_test.go
+++ b/pkg/nodebootstrap/managed_al2_test.go
@@ -42,25 +42,7 @@ var _ = DescribeTable("Managed AL2", func(e managedEntry) {
 			},
 		},
 
-		expectedUserData: `MIME-Version: 1.0
-Content-Type: multipart/mixed; boundary=//
-
---//
-Content-Type: text/x-shellscript
-Content-Type: charset="us-ascii"
-
-#!/bin/bash
-
-set -o errexit
-set -o pipefail
-set -o nounset
-
-yum install -y amazon-ssm-agent
-systemctl enable amazon-ssm-agent
-systemctl start amazon-ssm-agent
-
---//--
-`,
+		expectedUserData: "",
 	}),
 
 	Entry("Custom AMI with bootstrap script", managedEntry{
@@ -78,6 +60,7 @@ API_SERVER_URL=https://test.com
 			},
 		},
 
+		// remove gke
 		expectedUserData: `#!/bin/bash
 set -ex
 B64_CLUSTER_CA=dGVzdAo=
@@ -128,20 +111,6 @@ cloud-init-per once efa_info /opt/amazon/efa/bin/fi_info -p efa
 		},
 		expectedUserData: `MIME-Version: 1.0
 Content-Type: multipart/mixed; boundary=//
-
---//
-Content-Type: text/x-shellscript
-Content-Type: charset="us-ascii"
-
-#!/bin/bash
-
-set -o errexit
-set -o pipefail
-set -o nounset
-
-yum install -y amazon-ssm-agent
-systemctl enable amazon-ssm-agent
-systemctl start amazon-ssm-agent
 
 --//
 Content-Type: text/cloud-boothook

--- a/userdocs/src/introduction.md
+++ b/userdocs/src/introduction.md
@@ -119,7 +119,8 @@ eksctl create cluster --ssh-access --ssh-public-key=my_kubernetes_key --region=u
 
 ```
 
-To use [AWS Systems Manager (SSM)](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-sessions-start.html#sessions-start-cli) to SSH onto nodes, you can specify the `--enable-ssm` flag:
+[AWS Systems Manager (SSM)](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-sessions-start.html#sessions-start-cli) is enabled by default, so it can be used to SSH onto nodes.
+
 
 ```
 


### PR DESCRIPTION
### Description

SSM is now enabled by default and cannot be disabled.

Closes #3882 

TODO:

- [x] Add tests
- [x] Fix tests
- [x] Update documentation

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

