### PR TITLE
pin p2.xlarge instance test to not use us-west-2d

### DIFF
--- a/integration/tests/crud/creategetdelete_test.go
+++ b/integration/tests/crud/creategetdelete_test.go
@@ -282,6 +282,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					"--nodes", "1",
 					"--node-type", "p2.xlarge",
 					"--node-private-networking",
+					"--node-zones", "us-west-2a,us-west-2b,us-west-2c",
 					testNG,
 				)
 				Expect(cmd).To(RunSuccessfully())


### PR DESCRIPTION
### Description

Running it locally to verify. Should fix the following failure:
`AWS::EKS::Nodegroup/ManagedNodeGroup: CREATE_FAILED – "Your requested instance type (p2.xlarge) is not supported in your requested Availability Zone (us-west-2d). Please retry your request by not specifying an Availability Zone or choosing us-west-2a, us-west-2b, us-west-2c. (Service: AmazonEKS; Status Code: 400; Error Code: InvalidRequestException; Request ID: 2a428d54-7770-4842-b039-a98f5335fdb2; Proxy: null)"`

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

