### PR TITLE
Set new selector session when creating nodegroup

### DIFF
--- a/pkg/actions/nodegroup/create_test.go
+++ b/pkg/actions/nodegroup/create_test.go
@@ -20,10 +20,11 @@ import (
 )
 
 type ngEntry struct {
-	version   string
-	opts      nodegroup.CreateOpts
-	mockCalls func(*fakes.FakeKubeProvider, *fakes.FakeNodeGroupInitialiser, *utilFakes.FakeNodegroupFilter)
-	expErr    error
+	version       string
+	opts          nodegroup.CreateOpts
+	mockCalls     func(*fakes.FakeKubeProvider, *fakes.FakeNodeGroupInitialiser, *utilFakes.FakeNodegroupFilter)
+	expectedCalls func(*fakes.FakeKubeProvider, *fakes.FakeNodeGroupInitialiser, *utilFakes.FakeNodegroupFilter)
+	expErr        error
 }
 
 var _ = DescribeTable("Create", func(t ngEntry) {
@@ -53,19 +54,20 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 	}
 
 	err := m.Create(t.opts, &ngFilter)
-	if err != nil {
+
+	if t.expErr != nil {
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(ContainSubstring(t.expErr.Error())))
-		return
+	} else {
+		Expect(err).NotTo(HaveOccurred())
 	}
-
-	Expect(err).NotTo(HaveOccurred())
+	if t.expectedCalls != nil {
+		t.expectedCalls(k, init, &ngFilter)
+	}
 },
 	Entry("fails when cluster version is not supported", ngEntry{
 		version: "1.14",
-		mockCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
-		},
-		expErr: fmt.Errorf("invalid version, %s is no longer supported, supported values: auto, default, latest, %s\nsee also: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html", "1.14", strings.Join(api.SupportedVersions(), ", ")),
+		expErr:  fmt.Errorf("invalid version, %s is no longer supported, supported values: auto, default, latest, %s\nsee also: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html", "1.14", strings.Join(api.SupportedVersions(), ", ")),
 	}),
 
 	Entry("fails when it does not support ARM", ngEntry{
@@ -86,78 +88,101 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 
 	Entry("fails when cluster does not support managed nodes", ngEntry{
 		mockCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
-			k.NewRawClientReturns(&kubernetes.RawClient{}, nil)
-			k.ServerVersionReturns("1.17", nil)
-			k.LoadClusterIntoSpecFromStackReturns(nil)
 			k.SupportsManagedNodesReturns(false, errors.New("err"))
+		},
+		expectedCalls: func(k *fakes.FakeKubeProvider, _ *fakes.FakeNodeGroupInitialiser, _ *utilFakes.FakeNodegroupFilter) {
+			Expect(k.NewRawClientCallCount()).To(Equal(1))
+			Expect(k.ServerVersionCallCount()).To(Equal(1))
+			Expect(k.LoadClusterIntoSpecFromStackCallCount()).To(Equal(1))
+			Expect(k.SupportsManagedNodesCallCount()).To(Equal(1))
 		},
 		expErr: errors.New("err"),
 	}),
 
 	Entry("fails to set instance types to instances matched by instance selector criteria", ngEntry{
 		mockCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
-			k.NewRawClientReturns(&kubernetes.RawClient{}, nil)
-			k.ServerVersionReturns("1.17", nil)
-			k.LoadClusterIntoSpecFromStackReturns(nil)
 			k.SupportsManagedNodesReturns(true, nil)
-			init.NewAWSSelectorSessionReturns(nil)
 			init.ExpandInstanceSelectorOptionsReturns(errors.New("err"))
+		},
+		expectedCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, _ *utilFakes.FakeNodegroupFilter) {
+			Expect(k.NewRawClientCallCount()).To(Equal(1))
+			Expect(k.ServerVersionCallCount()).To(Equal(1))
+			Expect(k.LoadClusterIntoSpecFromStackCallCount()).To(Equal(1))
+			Expect(k.SupportsManagedNodesCallCount()).To(Equal(1))
+			Expect(init.NewAWSSelectorSessionCallCount()).To(Equal(1))
+			Expect(init.ExpandInstanceSelectorOptionsCallCount()).To(Equal(1))
 		},
 		expErr: errors.New("err"),
 	}),
 
 	Entry("fails when cluster is not compatible with ng config", ngEntry{
 		mockCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
-			k.NewRawClientReturns(&kubernetes.RawClient{}, nil)
-			k.ServerVersionReturns("1.17", nil)
-			k.LoadClusterIntoSpecFromStackReturns(nil)
 			k.SupportsManagedNodesReturns(true, nil)
-			init.NewAWSSelectorSessionReturns(nil)
-			init.ExpandInstanceSelectorOptionsReturns(nil)
 			k.ValidateClusterForCompatibilityReturns(errors.New("err"))
+		},
+		expectedCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, _ *utilFakes.FakeNodegroupFilter) {
+			Expect(k.NewRawClientCallCount()).To(Equal(1))
+			Expect(k.ServerVersionCallCount()).To(Equal(1))
+			Expect(k.LoadClusterIntoSpecFromStackCallCount()).To(Equal(1))
+			Expect(k.SupportsManagedNodesCallCount()).To(Equal(1))
+			Expect(init.NewAWSSelectorSessionCallCount()).To(Equal(1))
+			Expect(init.ExpandInstanceSelectorOptionsCallCount()).To(Equal(1))
+			Expect(k.ValidateClusterForCompatibilityCallCount()).To(Equal(1))
 		},
 		expErr: errors.Wrap(errors.New("err"), "cluster compatibility check failed"),
 	}),
 
 	Entry("fails when it cannot validate legacy subnets for ng", ngEntry{
 		mockCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
-			k.NewRawClientReturns(&kubernetes.RawClient{}, nil)
-			k.ServerVersionReturns("1.17", nil)
-			k.LoadClusterIntoSpecFromStackReturns(nil)
 			k.SupportsManagedNodesReturns(true, nil)
-			init.NewAWSSelectorSessionReturns(nil)
-			init.ExpandInstanceSelectorOptionsReturns(nil)
-			k.ValidateClusterForCompatibilityReturns(nil)
 			init.ValidateLegacySubnetsForNodeGroupsReturns(errors.New("err"))
+		},
+		expectedCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, _ *utilFakes.FakeNodegroupFilter) {
+			Expect(k.NewRawClientCallCount()).To(Equal(1))
+			Expect(k.ServerVersionCallCount()).To(Equal(1))
+			Expect(k.LoadClusterIntoSpecFromStackCallCount()).To(Equal(1))
+			Expect(k.SupportsManagedNodesCallCount()).To(Equal(1))
+			Expect(init.NewAWSSelectorSessionCallCount()).To(Equal(1))
+			Expect(init.ExpandInstanceSelectorOptionsCallCount()).To(Equal(1))
+			Expect(k.ValidateClusterForCompatibilityCallCount()).To(Equal(1))
+			Expect(init.ValidateLegacySubnetsForNodeGroupsCallCount()).To(Equal(1))
 		},
 		expErr: errors.New("err"),
 	}),
 
 	Entry("fails when existing local ng stacks in config file is not listed", ngEntry{
 		mockCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
-			k.NewRawClientReturns(&kubernetes.RawClient{}, nil)
-			k.ServerVersionReturns("1.17", nil)
-			k.LoadClusterIntoSpecFromStackReturns(nil)
 			k.SupportsManagedNodesReturns(true, nil)
-			init.NewAWSSelectorSessionReturns(nil)
-			init.ExpandInstanceSelectorOptionsReturns(nil)
-			k.ValidateClusterForCompatibilityReturns(nil)
 			f.SetOnlyLocalReturns(errors.New("err"))
+		},
+		expectedCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
+			Expect(k.NewRawClientCallCount()).To(Equal(1))
+			Expect(k.ServerVersionCallCount()).To(Equal(1))
+			Expect(k.LoadClusterIntoSpecFromStackCallCount()).To(Equal(1))
+			Expect(k.SupportsManagedNodesCallCount()).To(Equal(1))
+			Expect(init.NewAWSSelectorSessionCallCount()).To(Equal(1))
+			Expect(init.ExpandInstanceSelectorOptionsCallCount()).To(Equal(1))
+			Expect(k.ValidateClusterForCompatibilityCallCount()).To(Equal(1))
+			Expect(f.SetOnlyLocalCallCount()).To(Equal(1))
 		},
 		expErr: errors.New("err"),
 	}),
 
 	Entry("fails to evaluate whether aws-node uses IRSA", ngEntry{
 		mockCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
-			k.NewRawClientReturns(&kubernetes.RawClient{}, nil)
-			k.ServerVersionReturns("1.17", nil)
-			k.LoadClusterIntoSpecFromStackReturns(nil)
 			k.SupportsManagedNodesReturns(true, nil)
-			init.NewAWSSelectorSessionReturns(nil)
-			init.ExpandInstanceSelectorOptionsReturns(nil)
-			k.ValidateClusterForCompatibilityReturns(nil)
-			f.SetOnlyLocalReturns(nil)
 			init.DoesAWSNodeUseIRSAReturns(true, errors.New("err"))
+		},
+		expectedCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
+			Expect(k.NewRawClientCallCount()).To(Equal(1))
+			Expect(k.ServerVersionCallCount()).To(Equal(1))
+			Expect(k.LoadClusterIntoSpecFromStackCallCount()).To(Equal(1))
+			Expect(k.SupportsManagedNodesCallCount()).To(Equal(1))
+			Expect(init.NewAWSSelectorSessionCallCount()).To(Equal(1))
+			Expect(init.ExpandInstanceSelectorOptionsCallCount()).To(Equal(1))
+			Expect(k.ValidateClusterForCompatibilityCallCount()).To(Equal(1))
+			Expect(f.SetOnlyLocalCallCount()).To(Equal(1))
+			Expect(init.DoesAWSNodeUseIRSACallCount()).To(Equal(1))
 		},
 		expErr: errors.New("err"),
 	}),
@@ -165,70 +190,85 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 	Entry("stack manager fails to do ng tasks", ngEntry{
 		mockCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
 			k.NewRawClientReturns(&kubernetes.RawClient{}, nil)
-			k.ServerVersionReturns("1.17", nil)
-			k.LoadClusterIntoSpecFromStackReturns(nil)
 			k.SupportsManagedNodesReturns(true, nil)
-			init.NewAWSSelectorSessionReturns(nil)
-			init.ExpandInstanceSelectorOptionsReturns(nil)
-			k.ValidateClusterForCompatibilityReturns(nil)
-			f.SetOnlyLocalReturns(nil)
-			init.DoesAWSNodeUseIRSAReturns(false, nil)
 			init.DoAllNodegroupStackTasksReturns(errors.New("err"))
+		},
+		expectedCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
+			Expect(k.NewRawClientCallCount()).To(Equal(1))
+			Expect(k.ServerVersionCallCount()).To(Equal(1))
+			Expect(k.LoadClusterIntoSpecFromStackCallCount()).To(Equal(1))
+			Expect(k.SupportsManagedNodesCallCount()).To(Equal(1))
+			Expect(init.NewAWSSelectorSessionCallCount()).To(Equal(1))
+			Expect(init.ExpandInstanceSelectorOptionsCallCount()).To(Equal(1))
+			Expect(k.ValidateClusterForCompatibilityCallCount()).To(Equal(1))
+			Expect(f.SetOnlyLocalCallCount()).To(Equal(1))
+			Expect(init.DoesAWSNodeUseIRSACallCount()).To(Equal(1))
+			Expect(init.DoAllNodegroupStackTasksCallCount()).To(Equal(1))
 		},
 		expErr: errors.New("err"),
 	}),
 
 	Entry("fails to update auth configmap", ngEntry{
 		opts: nodegroup.CreateOpts{
-			DryRun:              true,
 			UpdateAuthConfigMap: true,
 		},
 		mockCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
-			k.NewRawClientReturns(&kubernetes.RawClient{}, nil)
-			k.ServerVersionReturns("1.17", nil)
-			k.LoadClusterIntoSpecFromStackReturns(nil)
 			k.SupportsManagedNodesReturns(true, nil)
-			init.NewAWSSelectorSessionReturns(nil)
-			init.ExpandInstanceSelectorOptionsReturns(nil)
-			k.ValidateClusterForCompatibilityReturns(nil)
-			f.SetOnlyLocalReturns(nil)
-			init.DoesAWSNodeUseIRSAReturns(false, nil)
-			init.DoAllNodegroupStackTasksReturns(nil)
 			k.UpdateAuthConfigMapReturns(errors.New("err"))
+		},
+		expectedCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
+			Expect(k.NewRawClientCallCount()).To(Equal(1))
+			Expect(k.ServerVersionCallCount()).To(Equal(1))
+			Expect(k.LoadClusterIntoSpecFromStackCallCount()).To(Equal(1))
+			Expect(k.SupportsManagedNodesCallCount()).To(Equal(1))
+			Expect(init.NewAWSSelectorSessionCallCount()).To(Equal(1))
+			Expect(init.ExpandInstanceSelectorOptionsCallCount()).To(Equal(1))
+			Expect(k.ValidateClusterForCompatibilityCallCount()).To(Equal(1))
+			Expect(f.SetOnlyLocalCallCount()).To(Equal(1))
+			Expect(init.DoesAWSNodeUseIRSACallCount()).To(Equal(1))
+			Expect(init.DoAllNodegroupStackTasksCallCount()).To(Equal(1))
+			Expect(k.UpdateAuthConfigMapCallCount()).To(Equal(1))
 		},
 		expErr: errors.New("err"),
 	}),
 
-	Entry("fails to validate existing ng for compatibility", ngEntry{
+	Entry("when unable to validate existing ng for compatibility, logs but does not error", ngEntry{
 		mockCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
-			k.NewRawClientReturns(&kubernetes.RawClient{}, nil)
-			k.ServerVersionReturns("1.17", nil)
-			k.LoadClusterIntoSpecFromStackReturns(nil)
 			k.SupportsManagedNodesReturns(true, nil)
-			init.NewAWSSelectorSessionReturns(nil)
-			init.ExpandInstanceSelectorOptionsReturns(nil)
-			k.ValidateClusterForCompatibilityReturns(nil)
-			f.SetOnlyLocalReturns(nil)
-			init.DoesAWSNodeUseIRSAReturns(false, nil)
-			init.DoAllNodegroupStackTasksReturns(nil)
 			init.ValidateExistingNodeGroupsForCompatibilityReturns(errors.New("err"))
 		},
-		expErr: errors.New("err"),
+		expectedCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
+			Expect(k.NewRawClientCallCount()).To(Equal(1))
+			Expect(k.ServerVersionCallCount()).To(Equal(1))
+			Expect(k.LoadClusterIntoSpecFromStackCallCount()).To(Equal(1))
+			Expect(k.SupportsManagedNodesCallCount()).To(Equal(1))
+			Expect(init.NewAWSSelectorSessionCallCount()).To(Equal(1))
+			Expect(init.ExpandInstanceSelectorOptionsCallCount()).To(Equal(1))
+			Expect(k.ValidateClusterForCompatibilityCallCount()).To(Equal(1))
+			Expect(f.SetOnlyLocalCallCount()).To(Equal(1))
+			Expect(init.DoesAWSNodeUseIRSACallCount()).To(Equal(1))
+			Expect(init.DoAllNodegroupStackTasksCallCount()).To(Equal(1))
+			Expect(init.ValidateExistingNodeGroupsForCompatibilityCallCount()).To(Equal(1))
+		},
+		expErr: nil,
 	}),
 
 	Entry("[happy path] creates nodegroup with no options", ngEntry{
 		mockCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
-			k.NewRawClientReturns(&kubernetes.RawClient{}, nil)
-			k.ServerVersionReturns("1.17", nil)
-			k.LoadClusterIntoSpecFromStackReturns(nil)
 			k.SupportsManagedNodesReturns(true, nil)
-			init.NewAWSSelectorSessionReturns(nil)
-			init.ExpandInstanceSelectorOptionsReturns(nil)
-			k.ValidateClusterForCompatibilityReturns(nil)
-			f.SetOnlyLocalReturns(nil)
-			init.DoesAWSNodeUseIRSAReturns(false, nil)
-			init.DoAllNodegroupStackTasksReturns(nil)
-			init.ValidateExistingNodeGroupsForCompatibilityReturns(nil)
+		},
+		expectedCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
+			Expect(k.NewRawClientCallCount()).To(Equal(1))
+			Expect(k.ServerVersionCallCount()).To(Equal(1))
+			Expect(k.LoadClusterIntoSpecFromStackCallCount()).To(Equal(1))
+			Expect(k.SupportsManagedNodesCallCount()).To(Equal(1))
+			Expect(init.NewAWSSelectorSessionCallCount()).To(Equal(1))
+			Expect(init.ExpandInstanceSelectorOptionsCallCount()).To(Equal(1))
+			Expect(k.ValidateClusterForCompatibilityCallCount()).To(Equal(1))
+			Expect(f.SetOnlyLocalCallCount()).To(Equal(1))
+			Expect(init.DoesAWSNodeUseIRSACallCount()).To(Equal(1))
+			Expect(init.DoAllNodegroupStackTasksCallCount()).To(Equal(1))
+			Expect(init.ValidateExistingNodeGroupsForCompatibilityCallCount()).To(Equal(1))
 		},
 		expErr: nil,
 	}),
@@ -243,17 +283,17 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 			ConfigFileProvided:        true,
 		},
 		mockCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
-			k.NewRawClientReturns(&kubernetes.RawClient{}, nil)
-			k.ServerVersionReturns("1.17", nil)
-			k.LoadClusterIntoSpecFromStackReturns(nil)
 			k.SupportsManagedNodesReturns(true, nil)
-			init.NewAWSSelectorSessionReturns(nil)
-			init.ExpandInstanceSelectorOptionsReturns(nil)
-			k.ValidateClusterForCompatibilityReturns(nil)
-			f.SetOnlyLocalReturns(nil)
-			init.DoesAWSNodeUseIRSAReturns(false, nil)
-			init.DoAllNodegroupStackTasksReturns(nil)
-			k.UpdateAuthConfigMapReturns(nil)
+		},
+		expectedCalls: func(k *fakes.FakeKubeProvider, init *fakes.FakeNodeGroupInitialiser, f *utilFakes.FakeNodegroupFilter) {
+			Expect(k.NewRawClientCallCount()).To(Equal(1))
+			Expect(k.ServerVersionCallCount()).To(Equal(1))
+			Expect(k.LoadClusterIntoSpecFromStackCallCount()).To(Equal(1))
+			Expect(k.SupportsManagedNodesCallCount()).To(Equal(1))
+			Expect(init.NewAWSSelectorSessionCallCount()).To(Equal(1))
+			Expect(init.ExpandInstanceSelectorOptionsCallCount()).To(Equal(1))
+			Expect(k.ValidateClusterForCompatibilityCallCount()).To(Equal(1))
+			Expect(f.SetOnlyLocalCallCount()).To(Equal(1))
 		},
 		expErr: nil,
 	}),

--- a/pkg/eks/fakes/fake_nodegroup_initialiser.go
+++ b/pkg/eks/fakes/fake_nodegroup_initialiser.go
@@ -4,7 +4,6 @@ package fakes
 import (
 	"sync"
 
-	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
 	"github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 	"github.com/weaveworks/eksctl/pkg/eks"
@@ -52,16 +51,10 @@ type FakeNodeGroupInitialiser struct {
 	expandInstanceSelectorOptionsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	NewAWSSelectorSessionStub        func(v1alpha5.ClusterProvider) *selector.Selector
+	NewAWSSelectorSessionStub        func(v1alpha5.ClusterProvider)
 	newAWSSelectorSessionMutex       sync.RWMutex
 	newAWSSelectorSessionArgsForCall []struct {
 		arg1 v1alpha5.ClusterProvider
-	}
-	newAWSSelectorSessionReturns struct {
-		result1 *selector.Selector
-	}
-	newAWSSelectorSessionReturnsOnCall map[int]struct {
-		result1 *selector.Selector
 	}
 	NormalizeStub        func([]v1alpha5.NodePool, *v1alpha5.ClusterMeta) error
 	normalizeMutex       sync.RWMutex
@@ -303,23 +296,17 @@ func (fake *FakeNodeGroupInitialiser) ExpandInstanceSelectorOptionsReturnsOnCall
 	}{result1}
 }
 
-func (fake *FakeNodeGroupInitialiser) NewAWSSelectorSession(arg1 v1alpha5.ClusterProvider) *selector.Selector {
+func (fake *FakeNodeGroupInitialiser) NewAWSSelectorSession(arg1 v1alpha5.ClusterProvider) {
 	fake.newAWSSelectorSessionMutex.Lock()
-	ret, specificReturn := fake.newAWSSelectorSessionReturnsOnCall[len(fake.newAWSSelectorSessionArgsForCall)]
 	fake.newAWSSelectorSessionArgsForCall = append(fake.newAWSSelectorSessionArgsForCall, struct {
 		arg1 v1alpha5.ClusterProvider
 	}{arg1})
 	stub := fake.NewAWSSelectorSessionStub
-	fakeReturns := fake.newAWSSelectorSessionReturns
 	fake.recordInvocation("NewAWSSelectorSession", []interface{}{arg1})
 	fake.newAWSSelectorSessionMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		fake.NewAWSSelectorSessionStub(arg1)
 	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
 }
 
 func (fake *FakeNodeGroupInitialiser) NewAWSSelectorSessionCallCount() int {
@@ -328,7 +315,7 @@ func (fake *FakeNodeGroupInitialiser) NewAWSSelectorSessionCallCount() int {
 	return len(fake.newAWSSelectorSessionArgsForCall)
 }
 
-func (fake *FakeNodeGroupInitialiser) NewAWSSelectorSessionCalls(stub func(v1alpha5.ClusterProvider) *selector.Selector) {
+func (fake *FakeNodeGroupInitialiser) NewAWSSelectorSessionCalls(stub func(v1alpha5.ClusterProvider)) {
 	fake.newAWSSelectorSessionMutex.Lock()
 	defer fake.newAWSSelectorSessionMutex.Unlock()
 	fake.NewAWSSelectorSessionStub = stub
@@ -339,29 +326,6 @@ func (fake *FakeNodeGroupInitialiser) NewAWSSelectorSessionArgsForCall(i int) v1
 	defer fake.newAWSSelectorSessionMutex.RUnlock()
 	argsForCall := fake.newAWSSelectorSessionArgsForCall[i]
 	return argsForCall.arg1
-}
-
-func (fake *FakeNodeGroupInitialiser) NewAWSSelectorSessionReturns(result1 *selector.Selector) {
-	fake.newAWSSelectorSessionMutex.Lock()
-	defer fake.newAWSSelectorSessionMutex.Unlock()
-	fake.NewAWSSelectorSessionStub = nil
-	fake.newAWSSelectorSessionReturns = struct {
-		result1 *selector.Selector
-	}{result1}
-}
-
-func (fake *FakeNodeGroupInitialiser) NewAWSSelectorSessionReturnsOnCall(i int, result1 *selector.Selector) {
-	fake.newAWSSelectorSessionMutex.Lock()
-	defer fake.newAWSSelectorSessionMutex.Unlock()
-	fake.NewAWSSelectorSessionStub = nil
-	if fake.newAWSSelectorSessionReturnsOnCall == nil {
-		fake.newAWSSelectorSessionReturnsOnCall = make(map[int]struct {
-			result1 *selector.Selector
-		})
-	}
-	fake.newAWSSelectorSessionReturnsOnCall[i] = struct {
-		result1 *selector.Selector
-	}{result1}
 }
 
 func (fake *FakeNodeGroupInitialiser) Normalize(arg1 []v1alpha5.NodePool, arg2 *v1alpha5.ClusterMeta) error {

--- a/pkg/eks/nodegroup_service.go
+++ b/pkg/eks/nodegroup_service.go
@@ -34,7 +34,7 @@ type InstanceSelector interface {
 type NodeGroupInitialiser interface {
 	Normalize(nodePools []api.NodePool, clusterMeta *api.ClusterMeta) error
 	ExpandInstanceSelectorOptions(nodePools []api.NodePool, clusterAZs []string) error
-	NewAWSSelectorSession(provider api.ClusterProvider) *selector.Selector
+	NewAWSSelectorSession(provider api.ClusterProvider)
 	ValidateLegacySubnetsForNodeGroups(spec *api.ClusterConfig, provider api.ClusterProvider) error
 	DoesAWSNodeUseIRSA(provider api.ClusterProvider, clientSet kubernetes.Interface) (bool, error)
 	DoAllNodegroupStackTasks(taskTree *tasks.TaskTree, region, name string) error
@@ -58,8 +58,8 @@ func NewNodeGroupService(provider api.ClusterProvider, instanceSelector Instance
 const defaultCPUArch = "x86_64"
 
 // NewAWSSelectorSession returns a new instance of Selector provided an aws session
-func (m *NodeGroupService) NewAWSSelectorSession(provider api.ClusterProvider) *selector.Selector {
-	return selector.New(provider.Session())
+func (m *NodeGroupService) NewAWSSelectorSession(provider api.ClusterProvider) {
+	m.instanceSelector = selector.New(provider.Session())
 }
 
 // Normalize normalizes nodegroups


### PR DESCRIPTION
Fixes https://github.com/weaveworks/eksctl/issues/3982 in which the selector was not set on the nodegroup service object. This lead to a panic when expanding instance selector options.

Integration test updated to use this codepath.

This commit also tidies up and fixes some errors in the nodegroup create tests.


### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

