### PR TITLE
bump cirecle ubuntu image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ commands:
 jobs:
   test-and-build:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202104-01
     environment:
       GOPRIVATE: github.com/weaveworks/aws-sdk-go-private
     steps:
@@ -131,7 +131,7 @@ jobs:
           only_for_branches: main
   build-all-distros:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202104-01
     environment:
       GOPRIVATE: github.com/weaveworks/aws-sdk-go-private
     steps:
@@ -155,7 +155,7 @@ jobs:
           only_for_branches: main
   release-candidate:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202104-01
     steps:
       - checkout
       - restore-cache
@@ -182,7 +182,7 @@ jobs:
           success_message: ':tada: `eksctl` $CIRCLE_TAG released!'
   release:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202104-01
     steps:
       - checkout
       - restore-cache


### PR DESCRIPTION
### Description

Our circle [CI build is failing](https://app.circleci.com/pipelines/github/weaveworks/eksctl/8276/workflows/00835899-5074-47fa-a7ce-229d84a6fa40/jobs/13401), this is due this issue with [alpine 3.14 & docker](https://gitlab.alpinelinux.org/alpine/aports/-/issues/12396). This apparently *might* (conflicting reports) be fixed in the latest docker versions. Bumping ubuntu to one that has the latest https://circleci.com/docs/2.0/configuration-reference/#available-machine-images

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

