### PR TITLE
Deprecate all Flux v1 commands

### DIFF
--- a/pkg/ctl/cmdutils/gitops.go
+++ b/pkg/ctl/cmdutils/gitops.go
@@ -235,7 +235,8 @@ func (l *GitConfigLoader) Load() error {
 		return err
 	}
 
-	logger.Warning("the `enable repo` command and related git.X are marked for deprecation: Please see https://github.com/weaveworks/eksctl/issues/2963")
+	logger.Warning("the `enable repo`, `enable profile` and `generate profile` commands DEPRECATED: see https://github.com/weaveworks/eksctl/issues/2963")
+	logger.Warning("the `git.repo`, `git.operator` and `git.bootstrapProfile` config options are DEPRECATED: see https://github.com/weaveworks/eksctl/issues/2963")
 
 	if l.cmd.ClusterConfigFile == "" {
 		l.cmd.ClusterConfig.Metadata.Region = l.cmd.ProviderConfig.Region

--- a/pkg/ctl/enable/flux.go
+++ b/pkg/ctl/enable/flux.go
@@ -22,7 +22,7 @@ func configureAndRun(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd) error) {
 	cmd.ClusterConfig = api.NewClusterConfig()
 	cmd.SetDescription(
 		"flux",
-		"EXPERIMENTAL. Set up GitOps Toolkit - deploys FluxV2 and creates Git repo to store manifests",
+		"Set up GitOps Toolkit - deploys FluxV2 and creates Git repo to store manifests",
 		"",
 	)
 
@@ -46,7 +46,6 @@ func configureAndRun(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd) error) {
 }
 
 func flux2Install(cmd *cmdutils.Cmd) error {
-	logger.Warning("running experimental command")
 	logger.Info("eksctl version %s", version.GetVersion())
 	logger.Info("will install Flux v2 components on cluster %s", cmd.ClusterConfig.Metadata.Name)
 

--- a/pkg/ctl/enable/profile.go
+++ b/pkg/ctl/enable/profile.go
@@ -12,6 +12,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/gitops"
 )
 
+// FLUX V1 DEPRECATION NOTICE. https://github.com/weaveworks/eksctl/issues/2963
 func enableProfile(cmd *cmdutils.Cmd) {
 	enableProfileWithRunFunc(cmd, doEnableProfile)
 }
@@ -20,9 +21,10 @@ func enableProfileWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd)
 	cmd.ClusterConfig = api.NewClusterConfig()
 	cmd.SetDescription(
 		"profile",
-		"Commits the components from the selected Quick Start profile to the destination repository.",
+		"DEPRECATED: https://github.com/weaveworks/eksctl/issues/2963. Commits the components from the selected Quick Start profile to the destination repository.",
 		"",
 	)
+	cmd.CobraCommand.Hidden = true
 	opts := configureProfileCmd(cmd)
 	cmd.CobraCommand.RunE = func(_ *cobra.Command, args []string) error {
 		cmd.NameArg = cmdutils.GetNameArg(args)

--- a/pkg/ctl/enable/repo.go
+++ b/pkg/ctl/enable/repo.go
@@ -13,6 +13,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/gitops"
 )
 
+// FLUX V1 DEPRECATION NOTICE. https://github.com/weaveworks/eksctl/issues/2963
 type options struct {
 	cfg     api.Git
 	timeout time.Duration
@@ -26,7 +27,7 @@ func enableRepoWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd) er
 	cmd.ClusterConfig = api.NewClusterConfig()
 	cmd.SetDescription(
 		"repo",
-		"MARKED FOR DEPRECATION: https://github.com/weaveworks/eksctl/issues/2963.\nSet up a repo for gitops, installing Flux in the cluster and initializing its manifests in the specified Git repository",
+		"DEPRECATED: https://github.com/weaveworks/eksctl/issues/2963. Set up a repo for gitops, installing Flux in the cluster and initializing its manifests in the specified Git repository",
 		"",
 	)
 	cmd.CobraCommand.Hidden = true

--- a/pkg/ctl/generate/generate.go
+++ b/pkg/ctl/generate/generate.go
@@ -8,7 +8,11 @@ import (
 
 // Command creates `generate` commands
 func Command(flagGrouping *cmdutils.FlagGrouping) *cobra.Command {
-	verbCmd := cmdutils.NewVerbCmd("generate", "Generate gitops manifests", "")
+	verbCmd := cmdutils.NewVerbCmd("generate",
+		"DEPRECATED: https://github.com/weaveworks/eksctl/issues/2963\nGenerate gitops manifests",
+		"",
+	)
+	verbCmd.Hidden = true
 	cmdutils.AddResourceCmd(flagGrouping, verbCmd, generateProfile)
 	return verbCmd
 }

--- a/pkg/ctl/generate/profile.go
+++ b/pkg/ctl/generate/profile.go
@@ -13,13 +13,17 @@ import (
 	"github.com/weaveworks/eksctl/pkg/gitops/fileprocessor"
 )
 
+// FLUX V1 DEPRECATION NOTICE. https://github.com/weaveworks/eksctl/issues/2963
 func generateProfile(cmd *cmdutils.Cmd) {
 	generateProfileWithRunFunc(cmd, doGenerateProfile)
 }
 
 func generateProfileWithRunFunc(cmd *cmdutils.Cmd, runFunc func(*cmdutils.Cmd) error) {
 	cmd.ClusterConfig = api.NewClusterConfig()
-	cmd.SetDescription("profile", "Generate a gitops profile", "")
+	cmd.SetDescription("profile",
+		"DEPRECATED: https://github.com/weaveworks/eksctl/issues/2963. Generate a gitops profile",
+		"",
+	)
 
 	opts := configureGenerateProfileCmd(cmd)
 

--- a/userdocs/src/usage/gitops-v1.md
+++ b/userdocs/src/usage/gitops-v1.md
@@ -5,8 +5,8 @@
     is available from `eksctl` version `0.38.0`. See [the v2 docs](/usage/gitops-v2).
 
 !!! Warning "Flux v1 support Deprecated"
-    As full support for Flux v2 (GitOps Toolkit) is rolled out, Flux v1 (Repo, Operator, BootstrapProfile) functionality
-    will be deprecated. Any significant changes or disruptions will be noted in [releases](https://github.com/weaveworks/eksctl/releases).
+    As full support for Flux v2 (GitOps Toolkit) has now been rolled out, Flux v1 (Repo, Operator, BootstrapProfile) functionality
+    is now deprecated. Any significant changes or disruptions will be noted in [releases](https://github.com/weaveworks/eksctl/releases).
 
 [Gitops][gitops] is a way to do Kubernetes application delivery. It
 works by using Git as a single source of truth for Kubernetes resources


### PR DESCRIPTION
### Description

Closes https://github.com/weaveworks/eksctl/issues/2966

Simply adds/expands logging to all Flux v1 related commands, and makes those commands hidden.

Once Flux 2 is GA these things will be removed.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

