### PR TITLE
use eksbuild.1 for kube-proxy on 18 and older

### DIFF
--- a/pkg/addons/default/kube_proxy.go
+++ b/pkg/addons/default/kube_proxy.go
@@ -162,7 +162,7 @@ func addArm64NodeSelector(daemonSet *v1.DaemonSet, archLabel string) {
 }
 
 func kubeProxyImageTag(controlPlaneVersion string) (string, error) {
-	isMinVersion, err := utils.IsMinVersion(api.Version1_18, controlPlaneVersion)
+	isMinVersion, err := utils.IsMinVersion(api.Version1_19, controlPlaneVersion)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
### Description

https://github.com/weaveworks/eksctl/issues/4084#issuecomment-897773870

AWS docs have `build.2` only being used from 19 and newer, code had accidentally set 18 as the minimum.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

