### PR TITLE
revert back to build.1 for kube-proxy addon versions

### DIFF
--- a/pkg/addons/default/kube_proxy.go
+++ b/pkg/addons/default/kube_proxy.go
@@ -162,13 +162,5 @@ func addArm64NodeSelector(daemonSet *v1.DaemonSet, archLabel string) {
 }
 
 func kubeProxyImageTag(controlPlaneVersion string) (string, error) {
-	isMinVersion, err := utils.IsMinVersion(api.Version1_19, controlPlaneVersion)
-	if err != nil {
-		return "", err
-	}
-
-	if isMinVersion {
-		return fmt.Sprintf("v%s-eksbuild.2", controlPlaneVersion), nil
-	}
 	return fmt.Sprintf("v%s-eksbuild.1", controlPlaneVersion), nil
 }


### PR DESCRIPTION
### Description

I think the change for this made as part of https://github.com/weaveworks/eksctl/pull/4021 was a mistake. The [AWS docs ](https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html#kube-proxy-default-versions-table) document `The kube-proxy version deployed to your nodes is the same major, minor, and patch version that was deployed with the platform version that was current for the Kubernetes version that you initially deployed with your cluster`, this does not mean its the latest versions. We currently default to deploying the same `major.minor.patch` as your kubernetes version, which *should always exist*. However theirs no guarantee its a `build.2`, but it should at least be  a `build.1`. I think this change it the safest route, you will have a reasonably up-to-date version installed.

Closes https://github.com/weaveworks/eksctl/issues/4078

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

