### PR TITLE
update ebs-csi-driver policy

### DIFF
--- a/pkg/cfn/builder/statement.go
+++ b/pkg/cfn/builder/statement.go
@@ -299,24 +299,146 @@ func appMeshStatements(appendAction string) []cft.MapOfInterfaces {
 func ebsStatements() []cft.MapOfInterfaces {
 	return []cft.MapOfInterfaces{
 		{
-			"Effect":   effectAllow,
-			"Resource": resourceAll,
+			"Effect": "Allow",
 			"Action": []string{
-				"ec2:AttachVolume",
 				"ec2:CreateSnapshot",
-				"ec2:CreateTags",
-				"ec2:CreateVolume",
-				"ec2:DeleteSnapshot",
-				"ec2:DeleteTags",
-				"ec2:DeleteVolume",
+				"ec2:AttachVolume",
+				"ec2:DetachVolume",
+				"ec2:ModifyVolume",
 				"ec2:DescribeAvailabilityZones",
 				"ec2:DescribeInstances",
 				"ec2:DescribeSnapshots",
 				"ec2:DescribeTags",
 				"ec2:DescribeVolumes",
 				"ec2:DescribeVolumesModifications",
-				"ec2:DetachVolume",
-				"ec2:ModifyVolume",
+			},
+			"Resource": "*",
+		},
+		{
+			"Effect": "Allow",
+			"Action": []string{
+				"ec2:CreateTags",
+			},
+			"Resource": []string{
+				"arn:aws:ec2:*:*:volume/*",
+				"arn:aws:ec2:*:*:snapshot/*",
+			},
+			"Condition": cft.MapOfInterfaces{
+				"StringEquals": cft.MapOfInterfaces{
+					"ec2:CreateAction": []string{
+						"CreateVolume",
+						"CreateSnapshot",
+					},
+				},
+			},
+		},
+		{
+			"Effect": "Allow",
+			"Action": []string{
+				"ec2:DeleteTags",
+			},
+			"Resource": []string{
+				"arn:aws:ec2:*:*:volume/*",
+				"arn:aws:ec2:*:*:snapshot/*",
+			},
+		},
+		{
+			"Effect": "Allow",
+
+			"Action": []string{
+
+				"ec2:CreateVolume",
+			},
+			"Resource": "*",
+			"Condition": cft.MapOfInterfaces{
+				"StringLike": cft.MapOfInterfaces{
+					"aws:RequestTag/ebs.csi.aws.com/cluster": "true",
+				},
+			},
+		},
+		{
+			"Effect": "Allow",
+			"Action": []string{
+				"ec2:CreateVolume",
+			},
+			"Resource": "*",
+			"Condition": cft.MapOfInterfaces{
+				"StringLike": cft.MapOfInterfaces{
+					"aws:RequestTag/CSIVolumeName": "*",
+				},
+			},
+		},
+		{
+			"Effect": "Allow",
+			"Action": []string{
+				"ec2:CreateVolume",
+			},
+			"Resource": "*",
+			"Condition": cft.MapOfInterfaces{
+				"StringLike": cft.MapOfInterfaces{
+					"aws:RequestTag/kubernetes.io/cluster/*": "owned",
+				},
+			},
+		},
+		{
+			"Effect": "Allow",
+			"Action": []string{
+				"ec2:DeleteVolume",
+			},
+			"Resource": "*",
+			"Condition": cft.MapOfInterfaces{
+				"StringLike": cft.MapOfInterfaces{
+					"ec2:ResourceTag/ebs.csi.aws.com/cluster": "true",
+				},
+			},
+		},
+		{
+			"Effect": "Allow",
+
+			"Action": []string{
+				"ec2:DeleteVolume",
+			},
+			"Resource": "*",
+			"Condition": cft.MapOfInterfaces{
+				"StringLike": cft.MapOfInterfaces{
+					"ec2:ResourceTag/CSIVolumeName": "*",
+				},
+			},
+		},
+		{
+			"Effect": "Allow",
+			"Action": []string{
+				"ec2:DeleteVolume",
+			},
+			"Resource": "*",
+			"Condition": cft.MapOfInterfaces{
+				"StringLike": cft.MapOfInterfaces{
+					"ec2:ResourceTag/kubernetes.io/cluster/*": "owned",
+				},
+			},
+		},
+		{
+			"Effect": "Allow",
+			"Action": []string{
+				"ec2:DeleteSnapshot",
+			},
+			"Resource": "*",
+			"Condition": cft.MapOfInterfaces{
+				"StringLike": cft.MapOfInterfaces{
+					"ec2:ResourceTag/CSIVolumeSnapshotName": "*",
+				},
+			},
+		},
+		{
+			"Effect": "Allow",
+			"Action": []string{
+				"ec2:DeleteSnapshot",
+			},
+			"Resource": "*",
+			"Condition": cft.MapOfInterfaces{
+				"StringLike": cft.MapOfInterfaces{
+					"ec2:ResourceTag/ebs.csi.aws.com/cluster": "true",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
### Description

New policies taken from https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/example-iam-policy.json

Closes #4061 

```
$ cat cluster.yaml
---
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

iam:
  withOIDC: true
  serviceAccounts:
  - metadata:
      name: ebs-csi-controller-sa
      namespace: kube-system
    wellKnownPolicies:
      ebsCSIController: true

metadata:
  name: jk
  region: us-west-2
...

$ eksctl create iamserviceaccount -f cluster.yaml --approve
2021-08-16 12:57:19 [ℹ]  eksctl version 0.63.0-dev+b5ac538b.2021-08-16T12:56:28Z
2021-08-16 12:57:19 [ℹ]  using region us-west-2
2021-08-16 12:57:23 [ℹ]  1 iamserviceaccount (kube-system/ebs-csi-controller-sa) was included (based on the include/exclude rules)
2021-08-16 12:57:23 [!]  serviceaccounts that exists in Kubernetes will be excluded, use --override-existing-serviceaccounts to override
2021-08-16 12:57:23 [ℹ]  1 task: { 2 sequential sub-tasks: { create IAM role for serviceaccount "kube-system/ebs-csi-controller-sa", create serviceaccount "kube-system/ebs-csi-controller-sa" } }
2021-08-16 12:57:23 [ℹ]  building iamserviceaccount stack "eksctl-jk-addon-iamserviceaccount-kube-system-ebs-csi-controller-sa"
2021-08-16 12:57:23 [ℹ]  deploying stack "eksctl-jk-addon-iamserviceaccount-kube-system-ebs-csi-controller-sa"
2021-08-16 12:57:23 [ℹ]  waiting for CloudFormation stack "eksctl-jk-addon-iamserviceaccount-kube-system-ebs-csi-controller-sa"
2021-08-16 12:57:40 [ℹ]  waiting for CloudFormation stack "eksctl-jk-addon-iamserviceaccount-kube-system-ebs-csi-controller-sa"
2021-08-16 12:57:58 [ℹ]  waiting for CloudFormation stack "eksctl-jk-addon-iamserviceaccount-kube-system-ebs-csi-controller-sa"
2021-08-16 12:58:18 [ℹ]  waiting for CloudFormation stack "eksctl-jk-addon-iamserviceaccount-kube-system-ebs-csi-controller-sa"
2021-08-16 12:58:20 [ℹ]  created serviceaccount "kube-system/ebs-csi-controller-sa"
```

From the AWS role console: 
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Action": [
                "ec2:CreateSnapshot",
                "ec2:AttachVolume",
                "ec2:DetachVolume",
                "ec2:ModifyVolume",
                "ec2:DescribeAvailabilityZones",
                "ec2:DescribeInstances",
                "ec2:DescribeSnapshots",
                "ec2:DescribeTags",
                "ec2:DescribeVolumes",
                "ec2:DescribeVolumesModifications"
            ],
            "Resource": "*",
            "Effect": "Allow"
        },
        {
            "Condition": {
                "StringEquals": {
                    "ec2:CreateAction": [
                        "CreateVolume",
                        "CreateSnapshot"
                    ]
                }
            },
            "Action": [
                "ec2:CreateTags"
            ],
            "Resource": [
                "arn:aws:ec2:*:*:volume/*",
                "arn:aws:ec2:*:*:snapshot/*"
            ],
            "Effect": "Allow"
        },
        {
            "Action": [
                "ec2:DeleteTags"
            ],
            "Resource": [
                "arn:aws:ec2:*:*:volume/*",
                "arn:aws:ec2:*:*:snapshot/*"
            ],
            "Effect": "Allow"
        },
        {
            "Condition": {
                "StringLike": {
                    "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
                }
            },
            "Action": [
                "ec2:CreateVolume"
            ],
            "Resource": "*",
            "Effect": "Allow"
        },
        {
            "Condition": {
                "StringLike": {
                    "aws:RequestTag/CSIVolumeName": "*"
                }
            },
            "Action": [
                "ec2:CreateVolume"
            ],
            "Resource": "*",
            "Effect": "Allow"
        },
        {
            "Condition": {
                "StringLike": {
                    "aws:RequestTag/kubernetes.io/cluster/*": "owned"
                }
            },
            "Action": [
                "ec2:CreateVolume"
            ],
            "Resource": "*",
            "Effect": "Allow"
        },
        {
            "Condition": {
                "StringLike": {
                    "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
                }
            },
            "Action": [
                "ec2:DeleteVolume"
            ],
            "Resource": "*",
            "Effect": "Allow"
        },
        {
            "Condition": {
                "StringLike": {
                    "ec2:ResourceTag/CSIVolumeName": "*"
                }
            },
            "Action": [
                "ec2:DeleteVolume"
            ],
            "Resource": "*",
            "Effect": "Allow"
        },
        {
            "Condition": {
                "StringLike": {
                    "ec2:ResourceTag/kubernetes.io/cluster/*": "owned"
                }
            },
            "Action": [
                "ec2:DeleteVolume"
            ],
            "Resource": "*",
            "Effect": "Allow"
        },
        {
            "Condition": {
                "StringLike": {
                    "ec2:ResourceTag/CSIVolumeSnapshotName": "*"
                }
            },
            "Action": [
                "ec2:DeleteSnapshot"
            ],
            "Resource": "*",
            "Effect": "Allow"
        },
        {
            "Condition": {
                "StringLike": {
                    "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
                }
            },
            "Action": [
                "ec2:DeleteSnapshot"
            ],
            "Resource": "*",
            "Effect": "Allow"
        }
    ]
}
```
### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

