### PR TITLE
only trigger goreleaser once

### DIFF
--- a/build/scripts/do-release-candidate.sh
+++ b/build/scripts/do-release-candidate.sh
@@ -9,7 +9,7 @@ if [ -z "${CIRCLE_PULL_REQUEST}" ] && [ -n "${CIRCLE_TAG}" ] && [ "${CIRCLE_PROJ
     exit 1
   fi
 
-  goreleaser release  --timeout 60m --skip-validate --config=./.goreleaser.yml --release-notes="${RELEASE_NOTES_FILE}"
+  goreleaser release --rm-dist --timeout 60m --skip-validate --config=./.goreleaser.yml --release-notes="${RELEASE_NOTES_FILE}"
 
   sleep 90 # GitHub API resolves the time to the nearest minute, so in order to control the sorting oder we need this
 

--- a/build/scripts/do-release-candidate.sh
+++ b/build/scripts/do-release-candidate.sh
@@ -11,19 +11,7 @@ if [ -z "${CIRCLE_PULL_REQUEST}" ] && [ -n "${CIRCLE_TAG}" ] && [ "${CIRCLE_PROJ
 
   goreleaser release  --timeout 60m --skip-validate --config=./.goreleaser.yml --release-notes="${RELEASE_NOTES_FILE}"
 
-  # By moving the latest_release tag to the latest release candidate we ensure the rc is accessible through
-  # the `head` statement in the brew tap formula
   sleep 90 # GitHub API resolves the time to the nearest minute, so in order to control the sorting oder we need this
-
-  git tag --delete "${CIRCLE_TAG}"
-  git tag --force latest_release
-
-  if github-release info --user weaveworks --repo "${CIRCLE_PROJECT_REPONAME}" --tag latest_release > /dev/null 2>&1 ; then
-    github-release delete --user weaveworks --repo "${CIRCLE_PROJECT_REPONAME}" --tag latest_release
-  fi
-
-  export RELEASE_DESCRIPTION="${CIRCLE_TAG}"
-  goreleaser release --skip-validate --rm-dist --config=./.goreleaser.yml --release-notes="${RELEASE_NOTES_FILE}"
 
   docker login --username weaveworkseksctlci --password "${DOCKER_HUB_PASSWORD}"
   EKSCTL_IMAGE_VERSION="${CIRCLE_TAG}" make -f Makefile.docker push-eksctl-image || true

--- a/build/scripts/do-release.sh
+++ b/build/scripts/do-release.sh
@@ -15,7 +15,7 @@ if [ -z "${CIRCLE_PULL_REQUEST}" ] && [ -n "${CIRCLE_TAG}" ] && [ "${CIRCLE_PROJ
   fi
 
   cat ./.goreleaser.yml ./.goreleaser.brew.yml > .goreleaser.brew.combined.yml
-  goreleaser release --timeout 60m --skip-validate --config=./.goreleaser.brew.combined.yml --release-notes="${RELEASE_NOTES_FILE}"
+  goreleaser release --rm-dist --timeout 60m --skip-validate --config=./.goreleaser.brew.combined.yml --release-notes="${RELEASE_NOTES_FILE}"
 
   sleep 90 # GitHub API resolves the time to the nearest minute, so in order to control the sorting oder we need this
 

--- a/build/scripts/do-release.sh
+++ b/build/scripts/do-release.sh
@@ -19,16 +19,6 @@ if [ -z "${CIRCLE_PULL_REQUEST}" ] && [ -n "${CIRCLE_TAG}" ] && [ "${CIRCLE_PROJ
 
   sleep 90 # GitHub API resolves the time to the nearest minute, so in order to control the sorting oder we need this
 
-  git tag --delete "${CIRCLE_TAG}"
-  git tag --force latest_release
-
-  if github-release info --user weaveworks --repo "${CIRCLE_PROJECT_REPONAME}" --tag latest_release > /dev/null 2>&1 ; then
-    github-release delete --user weaveworks --repo "${CIRCLE_PROJECT_REPONAME}" --tag latest_release
-  fi
-
-  export RELEASE_DESCRIPTION="${CIRCLE_TAG}"
-  goreleaser release --skip-validate --rm-dist --config=./.goreleaser.yml --release-notes="${RELEASE_NOTES_FILE}"
-
   docker login --username weaveworkseksctlci --password "${DOCKER_HUB_PASSWORD}"
   EKSCTL_IMAGE_VERSION="${CIRCLE_TAG}" make -f Makefile.docker push-eksctl-image || true
 else


### PR DESCRIPTION
### Description

Hopefully closes #4177 

For some reason we run the `goreleaser` twice, which is now erroring as I *think* the github API has changed so it now rejects re-uploading of already existing artifacts, where previously it might of either ignored it or overwritten it.

Intially I had NO idea why we run this twice, looking through the git history hasn't found any good git blame/PR describing why. I think however it gets run a second time to try and populate a new release `latest_release`, which is a tag/release that is always pointing at the latest release. However this has been working for the last year, and apparently was deprecated back at `0.14.0` https://github.com/weaveworks/eksctl/pull/1809

In short I think we can just delete this logic, and it should fix the problem :crossed_fingers: 


## Thought process
Initially I thought we were running the goreleaser twice, once to publish to `brew` and once to `github`. However looking at the script on line `17` you can see that we merge the two goreleaser files together. In the first goreleaser cal `18` we use the `combined.yaml` config, and in the later `30` call the normal `.goreleaser.yaml`, that we know is a subset of the `combined.yaml`.

What happens inbetween the two calls? We appear to delete the existing `latest_release` tag and release. However I don't think this is actually doing anything (firstly don't you need a `git push` after running a `git tag --delete` for it to take affect remotely?). Inspecting the current [`latest_release` tag](https://github.com/weaveworks/eksctl/tree/latest_release) its insanely old, it hasn't been updated since `0.25.0`. This logic is definitely broken, and no one has noticed/cared. The corresponding [`latest_release` release
](https://github.com/weaveworks/eksctl/tree/latest_release) is also stuck pointing at this tag. I think this logic has probably not worked for well over a year.



```
1: #!/bin/sh -ex
2: 
3: if [ -z "${CIRCLE_PROJECT_REPONAME}" ] ; then
4:   echo "Missing repo name, please set CIRCLE_PROJECT_REPONAME"
5:   exit 1
6: fi
7: 
8: if [ -z "${CIRCLE_PULL_REQUEST}" ] && [ -n "${CIRCLE_TAG}" ] && [ "${CIRCLE_PROJECT_USERNAME}" = "weaveworks" ] ; then
9:   export RELEASE_DESCRIPTION="${CIRCLE_TAG} (permalink)"
10:   RELEASE_NOTES_FILE="docs/release_notes/${CIRCLE_TAG}.md"
11: 
12:   if [[ ! -f "${RELEASE_NOTES_FILE}" ]]; then
13:     echo "Release notes ${RELEASE_NOTES_FILE} not found. Exiting..."
14:     exit 1
15:   fi
16: 
17:   cat ./.goreleaser.yml ./.goreleaser.brew.yml > .goreleaser.brew.combined.yml
18:   goreleaser release --timeout 60m --skip-validate --config=./.goreleaser.brew.combined.yml --release-notes="${RELEASE_NOTES_FILE}"
19: 
20:   sleep 90 # GitHub API resolves the time to the nearest minute, so in order to control the sorting oder we need this
21: 
22:   git tag --delete "${CIRCLE_TAG}"
23:   git tag --force latest_release
24: 
25:   if github-release info --user weaveworks --repo "${CIRCLE_PROJECT_REPONAME}" --tag latest_release > /dev/null 2>&1 ; then
26:     github-release delete --user weaveworks --repo "${CIRCLE_PROJECT_REPONAME}" --tag latest_release
27:   fi
28: 
29:   export RELEASE_DESCRIPTION="${CIRCLE_TAG}"
30:   goreleaser release --skip-validate --rm-dist --config=./.goreleaser.yml --release-notes="${RELEASE_NOTES_FILE}"
31: 
32:   docker login --username weaveworkseksctlci --password "${DOCKER_HUB_PASSWORD}"
33:   EKSCTL_IMAGE_VERSION="${CIRCLE_TAG}" make -f Makefile.docker push-eksctl-image || true
34: else
35:   echo "Not a tag release, skip publish"
36: fi
```


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

