### PR TITLE
fix download previous release script

### DIFF
--- a/integration/scripts/download-previous-release.sh
+++ b/integration/scripts/download-previous-release.sh
@@ -2,7 +2,7 @@
 
 
 GIT_REPO_URL="https://github.com/weaveworks/eksctl"
-RELEASE_URL_FORMAT="https://github.com/weaveworks/eksctl/releases/download/%s/eksctl_Linux_amd64.tar.gz"
+RELEASE_URL_FORMAT="https://github.com/weaveworks/eksctl/releases/download/v%s/eksctl_Linux_amd64.tar.gz"
 
 download_previous_release() {
     previous_tag=$(git ls-remote --tags $GIT_REPO_URL | grep -E -v "(refs/tags/(latest_release|v))|\-rc|\{\}" | cut -d/ -f3 | sort -Vr \


### PR DESCRIPTION
### Description

backwards compat tests were failing:
```
[2] wget: server returned error: HTTP/1.1 404 Not Found
[2] tar: invalid magic
[2] tar: short read
[2] 
```

URL should contain `v` prefix in the version section. I'm assuming this is related to #4177 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

