### PR TITLE
Fail early for non-EKS clusters

### DIFF
--- a/integration/tests/eks_connector/eks_connector_test.go
+++ b/integration/tests/eks_connector/eks_connector_test.go
@@ -104,6 +104,19 @@ var _ = Describe("(Integration) [EKS Connector test]", func() {
 			cmd = params.EksctlGetCmd.WithArgs("clusters", "-n", connectedClusterName)
 			Expect(cmd).To(RunSuccessfullyWithOutputString(ContainSubstring("OTHER")))
 
+			By("ensuring `get nodegroup` fails early with a user-friendly error")
+			cmd = params.EksctlGetCmd.
+				WithArgs(
+					"nodegroup",
+					"--cluster", connectedClusterName,
+				)
+
+			session := cmd.Run()
+			Expect(session.ExitCode()).ToNot(Equal(0))
+			output := string(session.Err.Contents())
+			Expect(output).To(ContainSubstring(fmt.Sprintf("cannot perform this operation on a non-EKS cluster; please follow the documentation for "+
+				"cluster %s's Kubernetes provider", connectedClusterName)))
+
 			By("deregistering the cluster")
 			cmd = params.EksctlDeregisterCmd.WithArgs("cluster").
 				WithArgs("--name", connectedClusterName)

--- a/pkg/actions/cluster/cluster.go
+++ b/pkg/actions/cluster/cluster.go
@@ -37,7 +37,7 @@ func New(cfg *api.ClusterConfig, ctl *eks.ClusterProvider) (Cluster, error) {
 	}
 
 	if hasClusterStack {
-		logger.Debug("Cluster %q was created by eksctl", cfg.Metadata.Name)
+		logger.Debug("cluster %q was created by eksctl", cfg.Metadata.Name)
 		return NewOwnedCluster(cfg, ctl, stackManager), nil
 	}
 

--- a/pkg/ctl/associate/identity_provider.go
+++ b/pkg/ctl/associate/identity_provider.go
@@ -60,7 +60,7 @@ func doAssociateIdentityProvider(cmd *cmdutils.Cmd, timeout time.Duration) error
 	cfg := cmd.ClusterConfig
 	meta := cmd.ClusterConfig.Metadata
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/cmdutils/utils.go
+++ b/pkg/ctl/cmdutils/utils.go
@@ -10,7 +10,7 @@ import (
 // KubernetesClientAndConfigFrom returns a Kubernetes client set and REST
 // configuration object for the currently configured cluster.
 func KubernetesClientAndConfigFrom(cmd *Cmd) (*kubernetes.Clientset, *rest.Config, error) {
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/ctl/create/addon.go
+++ b/pkg/ctl/create/addon.go
@@ -47,7 +47,7 @@ func createAddonCmd(cmd *cmdutils.Cmd) {
 			return err
 		}
 
-		clusterProvider, err := cmd.NewCtl()
+		clusterProvider, err := cmd.NewProviderForExistingCluster()
 		if err != nil {
 			return err
 		}

--- a/pkg/ctl/create/fargate.go
+++ b/pkg/ctl/create/fargate.go
@@ -32,7 +32,7 @@ func createFargateProfile(cmd *cmdutils.Cmd) {
 }
 
 func doCreateFargateProfile(cmd *cmdutils.Cmd) error {
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return errors.Wrap(err, "couldn't create cluster provider from command line options")
 	}

--- a/pkg/ctl/create/iamidentitymapping.go
+++ b/pkg/ctl/create/iamidentitymapping.go
@@ -65,15 +65,15 @@ func doCreateIAMIdentityMapping(cmd *cmdutils.Cmd, options iamIdentityMappingOpt
 
 	cfg := cmd.ClusterConfig
 
-	ctl, err := cmd.NewCtl()
+	if cfg.Metadata.Name == "" {
+		return cmdutils.ErrMustBeSet(cmdutils.ClusterNameFlag(cmd))
+	}
+
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}
 	cmdutils.LogRegionAndVersionInfo(cfg.Metadata)
-
-	if cfg.Metadata.Name == "" {
-		return cmdutils.ErrMustBeSet(cmdutils.ClusterNameFlag(cmd))
-	}
 
 	if ok, err := ctl.CanOperate(cfg); !ok {
 		return err

--- a/pkg/ctl/create/iamserviceaccount.go
+++ b/pkg/ctl/create/iamserviceaccount.go
@@ -77,7 +77,7 @@ func doCreateIAMServiceAccount(cmd *cmdutils.Cmd, overrideExistingServiceAccount
 
 	printer := printers.NewJSONPrinter()
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -39,10 +39,11 @@ func createNodeGroupCmd(cmd *cmdutils.Cmd) {
 		if err := cmdutils.NewCreateNodeGroupLoader(cmd, ng, ngFilter, options.CreateNGOptions, options.CreateManagedNGOptions).Load(); err != nil {
 			return errors.Wrap(err, "couldn't create node group filter from command line options")
 		}
-		ctl, err := cmd.NewCtl()
+		ctl, err := cmd.NewProviderForExistingCluster()
 		if err != nil {
 			return errors.Wrap(err, "couldn't create cluster provider from options")
 		}
+
 		if options.DryRun {
 			originalWriter := logger.Writer
 			logger.Writer = io.Discard

--- a/pkg/ctl/delete/addon.go
+++ b/pkg/ctl/delete/addon.go
@@ -45,7 +45,7 @@ func deleteAddon(cmd *cmdutils.Cmd, preserve bool) error {
 		return err
 	}
 
-	clusterProvider, err := cmd.NewCtl()
+	clusterProvider, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/delete/cluster.go
+++ b/pkg/ctl/delete/cluster.go
@@ -50,7 +50,7 @@ func doDeleteCluster(cmd *cmdutils.Cmd, force bool) error {
 
 	printer := printers.NewJSONPrinter()
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/delete/fargate.go
+++ b/pkg/ctl/delete/fargate.go
@@ -51,7 +51,7 @@ func configureDeleteFargateProfileCmd(cmd *cmdutils.Cmd) *fargate.Options {
 }
 
 func doDeleteFargateProfile(cmd *cmdutils.Cmd, opts *fargate.Options) error {
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/delete/iamidentitymapping.go
+++ b/pkg/ctl/delete/iamidentitymapping.go
@@ -44,7 +44,7 @@ func doDeleteIAMIdentityMapping(cmd *cmdutils.Cmd, arn string, all bool) error {
 
 	cfg := cmd.ClusterConfig
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/delete/iamserviceaccount.go
+++ b/pkg/ctl/delete/iamserviceaccount.go
@@ -70,7 +70,7 @@ func doDeleteIAMServiceAccount(cmd *cmdutils.Cmd, serviceAccount *api.ClusterIAM
 
 	printer := printers.NewJSONPrinter()
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -70,7 +70,7 @@ func doDeleteNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, updateAuthConfigMap
 
 	cfg := cmd.ClusterConfig
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/disassociate/identity_provider.go
+++ b/pkg/ctl/disassociate/identity_provider.go
@@ -74,7 +74,7 @@ func doDisassociateIdentityProvider(cmd *cmdutils.Cmd, cliProvidedIDP cliProvide
 	cfg := cmd.ClusterConfig
 	meta := cmd.ClusterConfig.Metadata
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/drain/nodegroup.go
+++ b/pkg/ctl/drain/nodegroup.go
@@ -64,7 +64,7 @@ func doDrainNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, undo, onlyMissing bo
 
 	cfg := cmd.ClusterConfig
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/enable/flux.go
+++ b/pkg/ctl/enable/flux.go
@@ -50,7 +50,7 @@ func flux2Install(cmd *cmdutils.Cmd) error {
 	logger.Info("will install Flux v2 components on cluster %s", cmd.ClusterConfig.Metadata.Name)
 
 	if kubeconfAndContextNotSet(cmd.ClusterConfig.GitOps.Flux.Flags) {
-		ctl, err := cmd.NewCtl()
+		ctl, err := cmd.NewProviderForExistingCluster()
 		if err != nil {
 			return err
 		}

--- a/pkg/ctl/get/addon.go
+++ b/pkg/ctl/get/addon.go
@@ -48,7 +48,7 @@ func getAddonCmd(cmd *cmdutils.Cmd) {
 
 func getAddon(cmd *cmdutils.Cmd, params *getCmdParams) error {
 
-	clusterProvider, err := cmd.NewCtl()
+	clusterProvider, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/get/fargate.go
+++ b/pkg/ctl/get/fargate.go
@@ -59,7 +59,7 @@ func configureGetFargateProfileCmd(cmd *cmdutils.Cmd) *options {
 }
 
 func doGetFargateProfile(cmd *cmdutils.Cmd, options *options) error {
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/get/iamidentitymapping.go
+++ b/pkg/ctl/get/iamidentitymapping.go
@@ -50,7 +50,7 @@ func doGetIAMIdentityMapping(cmd *cmdutils.Cmd, params *getCmdParams, arn string
 
 	cfg := cmd.ClusterConfig
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/get/iamserviceaccount.go
+++ b/pkg/ctl/get/iamserviceaccount.go
@@ -62,7 +62,7 @@ func doGetIAMServiceAccount(cmd *cmdutils.Cmd, options IAMServiceAccountOptions)
 
 	cfg := cmd.ClusterConfig
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/get/identityprovider.go
+++ b/pkg/ctl/get/identityprovider.go
@@ -47,7 +47,7 @@ func doGetIdentityProvider(cmd *cmdutils.Cmd, params getCmdParams, name string) 
 
 	cfg := cmd.ClusterConfig
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/get/labels.go
+++ b/pkg/ctl/get/labels.go
@@ -53,7 +53,7 @@ func getLabels(cmd *cmdutils.Cmd, nodeGroupName string) error {
 		return cmdutils.ErrUnsupportedNameArg()
 	}
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/get/nodegroup.go
+++ b/pkg/ctl/get/nodegroup.go
@@ -64,7 +64,7 @@ func doGetNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *getCmdParams) 
 		cfg.NodeGroups = append(cfg.NodeGroups, ng)
 	}
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/scale/nodegroup.go
+++ b/pkg/ctl/scale/nodegroup.go
@@ -62,7 +62,7 @@ func doScaleNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup) error {
 	}
 
 	cfg := cmd.ClusterConfig
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/set/labels.go
+++ b/pkg/ctl/set/labels.go
@@ -56,7 +56,7 @@ func setLabels(cmd *cmdutils.Cmd, options labelOptions) error {
 		return cmdutils.ErrUnsupportedNameArg()
 	}
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/unset/labels.go
+++ b/pkg/ctl/unset/labels.go
@@ -55,7 +55,7 @@ func unsetLabels(cmd *cmdutils.Cmd, nodeGroupName string, removeLabels []string)
 		return cmdutils.ErrUnsupportedNameArg()
 	}
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/update/addon.go
+++ b/pkg/ctl/update/addon.go
@@ -49,7 +49,7 @@ func updateAddon(cmd *cmdutils.Cmd, force, wait bool) error {
 	if err := cmdutils.NewCreateOrUpgradeAddonLoader(cmd).Load(); err != nil {
 		return err
 	}
-	clusterProvider, err := cmd.NewCtl()
+	clusterProvider, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/update/iamserviceaccount.go
+++ b/pkg/ctl/update/iamserviceaccount.go
@@ -66,7 +66,7 @@ func doUpdateIAMServiceAccount(cmd *cmdutils.Cmd) error {
 
 	printer := printers.NewJSONPrinter()
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/update/nodegroup.go
+++ b/pkg/ctl/update/nodegroup.go
@@ -42,7 +42,7 @@ func updateNodegroup(cmd *cmdutils.Cmd) error {
 		return err
 	}
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/upgrade/cluster.go
+++ b/pkg/ctl/upgrade/cluster.go
@@ -61,7 +61,7 @@ func DoUpgradeCluster(cmd *cmdutils.Cmd) error {
 	cfg := cmd.ClusterConfig
 	meta := cmd.ClusterConfig.Metadata
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/upgrade/nodegroup.go
+++ b/pkg/ctl/upgrade/nodegroup.go
@@ -68,7 +68,7 @@ func upgradeNodeGroup(cmd *cmdutils.Cmd, options managed.UpgradeOptions) error {
 		return cmdutils.ErrMustBeSet("name")
 	}
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/associate_iam_oidc_provider.go
+++ b/pkg/ctl/utils/associate_iam_oidc_provider.go
@@ -41,7 +41,7 @@ func doAssociateIAMOIDCProvider(cmd *cmdutils.Cmd) error {
 
 	printer := printers.NewJSONPrinter()
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/describe_addon_versions.go
+++ b/pkg/ctl/utils/describe_addon_versions.go
@@ -44,7 +44,7 @@ func describeAddonVersionsCmd(cmd *cmdutils.Cmd) {
 }
 
 func describeAddonVersions(cmd *cmdutils.Cmd, addonName, k8sVersion, clusterName string) error {
-	clusterProvider, err := cmd.NewCtl()
+	clusterProvider, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/describe_stacks.go
+++ b/pkg/ctl/utils/describe_stacks.go
@@ -63,7 +63,7 @@ func describeStacksCmd(cmd *cmdutils.Cmd) {
 func doDescribeStacksCmd(cmd *cmdutils.Cmd, all, events, trail bool, printer printers.OutputPrinter) error {
 	cfg := cmd.ClusterConfig
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/enable_secrets_encryption.go
+++ b/pkg/ctl/utils/enable_secrets_encryption.go
@@ -54,7 +54,7 @@ func enableSecretsEncryptionCmd(cmd *cmdutils.Cmd) {
 func doEnableSecretsEncryption(cmd *cmdutils.Cmd, encryptExistingSecrets bool) error {
 	clusterConfig := cmd.ClusterConfig
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/install_vpc_controllers.go
+++ b/pkg/ctl/utils/install_vpc_controllers.go
@@ -41,7 +41,7 @@ func doInstallWindowsVPCController(cmd *cmdutils.Cmd) error {
 	cfg := cmd.ClusterConfig
 	meta := cmd.ClusterConfig.Metadata
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/nodegroup_health.go
+++ b/pkg/ctl/utils/nodegroup_health.go
@@ -39,7 +39,7 @@ func nodeGroupHealthCmd(cmd *cmdutils.Cmd) {
 func getNodeGroupHealth(cmd *cmdutils.Cmd, nodeGroupName string) error {
 	cfg := cmd.ClusterConfig
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/set_public_access_cidrs.go
+++ b/pkg/ctl/utils/set_public_access_cidrs.go
@@ -44,7 +44,7 @@ func doUpdatePublicAccessCIDRs(cmd *cmdutils.Cmd) error {
 	cfg := cmd.ClusterConfig
 	meta := cmd.ClusterConfig.Metadata
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/update_aws_node.go
+++ b/pkg/ctl/utils/update_aws_node.go
@@ -39,7 +39,7 @@ func doUpdateAWSNode(cmd *cmdutils.Cmd) error {
 	cfg := cmd.ClusterConfig
 	meta := cmd.ClusterConfig.Metadata
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/update_cluster_endpoint_access.go
+++ b/pkg/ctl/utils/update_cluster_endpoint_access.go
@@ -48,7 +48,7 @@ func doUpdateClusterEndpoints(cmd *cmdutils.Cmd, newPrivate bool, newPublic bool
 	cfg := cmd.ClusterConfig
 	meta := cmd.ClusterConfig.Metadata
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/update_cluster_logging.go
+++ b/pkg/ctl/utils/update_cluster_logging.go
@@ -63,7 +63,7 @@ func doEnableLogging(cmd *cmdutils.Cmd, logTypesToEnable []string, logTypesToDis
 
 	printer := printers.NewJSONPrinter()
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/update_coredns.go
+++ b/pkg/ctl/utils/update_coredns.go
@@ -39,7 +39,7 @@ func doUpdateCoreDNS(cmd *cmdutils.Cmd) error {
 	cfg := cmd.ClusterConfig
 	meta := cmd.ClusterConfig.Metadata
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/update_kube_proxy.go
+++ b/pkg/ctl/utils/update_kube_proxy.go
@@ -39,7 +39,7 @@ func doUpdateKubeProxy(cmd *cmdutils.Cmd) error {
 	cfg := cmd.ClusterConfig
 	meta := cmd.ClusterConfig.Metadata
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/update_legacy_subnet_settings.go
+++ b/pkg/ctl/utils/update_legacy_subnet_settings.go
@@ -35,7 +35,7 @@ func doUpdateLegacySubnetSettings(cmd *cmdutils.Cmd) error {
 	cfg := cmd.ClusterConfig
 	meta := cmd.ClusterConfig.Metadata
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/ctl/utils/write_kubeconfig.go
+++ b/pkg/ctl/utils/write_kubeconfig.go
@@ -66,7 +66,7 @@ func doWriteKubeconfigCmd(cmd *cmdutils.Cmd, outputPath, roleARN string, setCont
 		outputPath = kubeconfig.AutoPath(cfg.Metadata.Name)
 	}
 
-	ctl, err := cmd.NewCtl()
+	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {
 		return err
 	}

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -83,6 +83,11 @@ func (c *ClusterProvider) SupportsManagedNodes(clusterConfig *api.ClusterConfig)
 	return ClusterSupportsManagedNodes(c.Status.ClusterInfo.Cluster)
 }
 
+// IsNonEKSCluster returns true if the cluster is external
+func (c *ClusterProvider) IsNonEKSCluster() bool {
+	return c.Status.ClusterInfo.Cluster.ConnectorConfig != nil
+}
+
 // ClusterSupportsManagedNodes reports whether the EKS cluster supports managed nodes
 func ClusterSupportsManagedNodes(cluster *awseks.Cluster) (bool, error) {
 	supportsManagedNodes, err := utils.IsMinVersion(api.Version1_15, *cluster.Version)


### PR DESCRIPTION
### Description

This changelist adds a new function `NewProviderForExistingCluster` that checks that the cluster exists and is not a registered cluster. All commands that operate on an existing cluster are updated to use this new function. I have added an integration test to ensure unsupported commands fail early with a user-friendly error. As for unit tests, `NewProviderForExistingCluster` delegates to `NewCtl` which does not have any tests, so adding unit tests would be quite some work and a little out of scope for this PR. It might be worth revisiting the `ctl/cmdutils` package later for adding unit tests.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

