### PR TITLE
Drain nodegroups during cluster deletion

### DIFF
--- a/pkg/actions/cluster/delete.go
+++ b/pkg/actions/cluster/delete.go
@@ -159,6 +159,7 @@ func drainAllNodegroups(cfg *api.ClusterConfig, ctl *eks.ClusterProvider, stackM
 		return nil
 	}
 
+	cfg.NodeGroups = []*api.NodeGroup{}
 	for _, s := range allStacks {
 		if s.Type == api.NodeGroupTypeUnmanaged {
 			cmdutils.PopulateUnmanagedNodegroup(s.NodeGroupName, cfg)
@@ -167,8 +168,7 @@ func drainAllNodegroups(cfg *api.ClusterConfig, ctl *eks.ClusterProvider, stackM
 
 	logger.Info("will drain %d unmanaged nodegroup(s) in cluster %q", len(cfg.NodeGroups), cfg.Metadata.Name)
 	nodeGroupManager := nodegroup.New(cfg, ctl, clientSet)
-	plan, disableEviction := false, false
-	if err := nodeGroupManager.Drain(cmdutils.ToKubeNodeGroups(cfg), plan, ctl.Provider.WaitTimeout(), disableEviction); err != nil {
+	if err := nodeGroupManager.Drain(cmdutils.ToKubeNodeGroups(cfg), false, ctl.Provider.WaitTimeout(), false); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/actions/cluster/delete.go
+++ b/pkg/actions/cluster/delete.go
@@ -165,13 +165,14 @@ func drainAllNodegroups(cfg *api.ClusterConfig, ctl *eks.ClusterProvider, stackM
 	}
 
 	for _, s := range allStacks {
-		if s.Type != api.NodeGroupTypeManaged {
+		if s.Type == api.NodeGroupTypeUnmanaged {
 			if err := cmdutils.PopulateNodegroupFromStack(s.Type, s.NodeGroupName, cfg); err != nil {
 				return err
 			}
 		}
 	}
 
+	logger.Info("will drain %d unmanaged nodegroup(s) in cluster %q", len(cfg.NodeGroups), cfg.Metadata.Name)
 	nodeGroupManager := nodegroup.New(cfg, ctl, clientSet)
 	plan, disableEviction := false, false
 	if err := nodeGroupManager.Drain(cmdutils.ToKubeNodeGroups(cfg), plan, ctl.Provider.WaitTimeout(), disableEviction); err != nil {

--- a/pkg/actions/cluster/delete.go
+++ b/pkg/actions/cluster/delete.go
@@ -154,21 +154,14 @@ func checkForUndeletedStacks(stackManager manager.StackManager) error {
 	return nil
 }
 
-func drainAllNodegroups(cfg *api.ClusterConfig, ctl *eks.ClusterProvider, stackManager manager.StackManager, clientSet kubernetes.Interface) error {
-	allStacks, err := stackManager.ListNodeGroupStacks()
-	if err != nil {
-		return err
-	}
-
+func drainAllNodegroups(cfg *api.ClusterConfig, ctl *eks.ClusterProvider, stackManager manager.StackManager, clientSet kubernetes.Interface, allStacks []manager.NodeGroupStack) error {
 	if len(allStacks) == 0 {
 		return nil
 	}
 
 	for _, s := range allStacks {
 		if s.Type == api.NodeGroupTypeUnmanaged {
-			if err := cmdutils.PopulateNodegroupFromStack(s.Type, s.NodeGroupName, cfg); err != nil {
-				return err
-			}
+			cmdutils.PopulateUnmanagedNodegroup(s.NodeGroupName, cfg)
 		}
 	}
 

--- a/pkg/actions/cluster/delete.go
+++ b/pkg/actions/cluster/delete.go
@@ -9,7 +9,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/pkg/errors"
 
+	"github.com/weaveworks/eksctl/pkg/actions/nodegroup"
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
+	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/fargate"
 	"github.com/weaveworks/eksctl/pkg/kubernetes"
 
@@ -149,5 +151,31 @@ func checkForUndeletedStacks(stackManager manager.StackManager) error {
 		return errors.New("failed to delete all resources")
 	}
 
+	return nil
+}
+
+func drainAllNodegroups(cfg *api.ClusterConfig, ctl *eks.ClusterProvider, stackManager manager.StackManager, clientSet kubernetes.Interface) error {
+	allStacks, err := stackManager.ListNodeGroupStacks()
+	if err != nil {
+		return err
+	}
+
+	if len(allStacks) == 0 {
+		return nil
+	}
+
+	for _, s := range allStacks {
+		if s.Type != api.NodeGroupTypeManaged {
+			if err := cmdutils.PopulateNodegroupFromStack(s.Type, s.NodeGroupName, cfg); err != nil {
+				return err
+			}
+		}
+	}
+
+	nodeGroupManager := nodegroup.New(cfg, ctl, clientSet)
+	plan, disableEviction := false, false
+	if err := nodeGroupManager.Drain(cmdutils.ToKubeNodeGroups(cfg), plan, ctl.Provider.WaitTimeout(), disableEviction); err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/actions/cluster/owned.go
+++ b/pkg/actions/cluster/owned.go
@@ -101,7 +101,11 @@ func (c *OwnedCluster) Delete(_ time.Duration, wait, force bool) error {
 			oidcSupported = false
 		}
 
-		if err := drainAllNodegroups(c.cfg, c.ctl, c.stackManager, clientSet); err != nil {
+		allStacks, err := c.stackManager.ListNodeGroupStacks()
+		if err != nil {
+			return err
+		}
+		if err := drainAllNodegroups(c.cfg, c.ctl, c.stackManager, clientSet, allStacks); err != nil {
 			return err
 		}
 	}

--- a/pkg/actions/cluster/owned.go
+++ b/pkg/actions/cluster/owned.go
@@ -100,7 +100,6 @@ func (c *OwnedCluster) Delete(_ time.Duration, wait, force bool) error {
 			}
 			oidcSupported = false
 		}
-
 		allStacks, err := c.stackManager.ListNodeGroupStacks()
 		if err != nil {
 			return err

--- a/pkg/actions/cluster/owned.go
+++ b/pkg/actions/cluster/owned.go
@@ -100,6 +100,10 @@ func (c *OwnedCluster) Delete(_ time.Duration, wait, force bool) error {
 			}
 			oidcSupported = false
 		}
+
+		if err := drainAllNodegroups(c.cfg, c.ctl, c.stackManager, clientSet); err != nil {
+			return err
+		}
 	}
 
 	if err := deleteSharedResources(c.cfg, c.ctl, c.stackManager, clusterOperable, clientSet); err != nil {

--- a/pkg/actions/cluster/unowned.go
+++ b/pkg/actions/cluster/unowned.go
@@ -69,6 +69,11 @@ func (c *UnownedCluster) Delete(waitInterval time.Duration, wait, force bool) er
 		logger.Debug("failed to check if cluster is operable: %v", err)
 	}
 
+	allStacks, err := c.stackManager.ListNodeGroupStacks()
+	if err != nil {
+		return err
+	}
+
 	var clientSet kubernetes.Interface
 	if clusterOperable {
 		clientSet, err = c.newClientSet()
@@ -76,7 +81,7 @@ func (c *UnownedCluster) Delete(waitInterval time.Duration, wait, force bool) er
 			return err
 		}
 
-		if err := drainAllNodegroups(c.cfg, c.ctl, c.stackManager, clientSet); err != nil {
+		if err := drainAllNodegroups(c.cfg, c.ctl, c.stackManager, clientSet, allStacks); err != nil {
 			return err
 		}
 	}
@@ -97,7 +102,7 @@ func (c *UnownedCluster) Delete(waitInterval time.Duration, wait, force bool) er
 
 	// we have to wait for nodegroups to delete before deleting the cluster
 	// so the `wait` value is ignored here
-	if err := c.deleteAndWaitForNodegroupsDeletion(waitInterval); err != nil {
+	if err := c.deleteAndWaitForNodegroupsDeletion(waitInterval, allStacks); err != nil {
 		return err
 	}
 
@@ -241,7 +246,7 @@ func (c *UnownedCluster) deleteCluster(wait bool) error {
 	return waiters.Wait(clusterName, msg, acceptors, newRequest, c.ctl.Provider.WaitTimeout(), nil)
 }
 
-func (c *UnownedCluster) deleteAndWaitForNodegroupsDeletion(waitInterval time.Duration) error {
+func (c *UnownedCluster) deleteAndWaitForNodegroupsDeletion(waitInterval time.Duration, allStacks []manager.NodeGroupStack) error {
 	clusterName := c.cfg.Metadata.Name
 	eksAPI := c.ctl.Provider.EKS()
 
@@ -249,12 +254,6 @@ func (c *UnownedCluster) deleteAndWaitForNodegroupsDeletion(waitInterval time.Du
 	nodeGroups, err := eksAPI.ListNodegroups(&awseks.ListNodegroupsInput{
 		ClusterName: &clusterName,
 	})
-	if err != nil {
-		return err
-	}
-
-	// get all nodegroup stacks for this cluster
-	allStacks, err := c.stackManager.ListNodeGroupStacks()
 	if err != nil {
 		return err
 	}

--- a/pkg/actions/cluster/unowned.go
+++ b/pkg/actions/cluster/unowned.go
@@ -75,6 +75,10 @@ func (c *UnownedCluster) Delete(waitInterval time.Duration, wait, force bool) er
 		if err != nil {
 			return err
 		}
+
+		if err := drainAllNodegroups(c.cfg, c.ctl, c.stackManager, clientSet); err != nil {
+			return err
+		}
 	}
 
 	if err := deleteSharedResources(c.cfg, c.ctl, c.stackManager, clusterOperable, clientSet); err != nil {

--- a/pkg/actions/nodegroup/drain.go
+++ b/pkg/actions/nodegroup/drain.go
@@ -5,13 +5,10 @@ import (
 
 	"github.com/weaveworks/eksctl/pkg/eks"
 
-	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/drain"
 )
 
 func (m *Manager) Drain(nodeGroups []eks.KubeNodeGroup, plan bool, maxGracePeriod time.Duration, disableEviction bool) error {
-	cmdutils.LogIntendedAction(plan, "drain %d nodegroup(s) in cluster %q", len(nodeGroups), m.cfg.Metadata.Name)
-
 	if !plan {
 		for _, n := range nodeGroups {
 			nodeGroupDrainer := drain.NewNodeGroupDrainer(m.clientSet, n, m.ctl.Provider.WaitTimeout(), maxGracePeriod, false, disableEviction)

--- a/pkg/actions/nodegroup/drain.go
+++ b/pkg/actions/nodegroup/drain.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/weaveworks/eksctl/pkg/eks"
 
-	"github.com/kris-nova/logger"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/drain"
 )
@@ -17,7 +16,6 @@ func (m *Manager) Drain(nodeGroups []eks.KubeNodeGroup, plan bool, maxGracePerio
 		for _, n := range nodeGroups {
 			nodeGroupDrainer := drain.NewNodeGroupDrainer(m.clientSet, n, m.ctl.Provider.WaitTimeout(), maxGracePeriod, false, disableEviction)
 			if err := nodeGroupDrainer.Drain(); err != nil {
-				logger.Warning("error occurred during drain, to skip drain use '--drain=false' flag")
 				return err
 			}
 		}

--- a/pkg/ctl/cmdutils/nodegroup.go
+++ b/pkg/ctl/cmdutils/nodegroup.go
@@ -21,12 +21,21 @@ func PopulateNodegroup(stackManager manager.StackManager, name string, cfg *api.
 		}
 		nodeGroupType = api.NodeGroupTypeUnowned
 	}
+	if err = PopulateNodegroupFromStack(nodeGroupType, name, cfg); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// PopulateNodegroupFromStack populates the nodegroup field of an api.ClusterConfig by type from its CF stack.
+func PopulateNodegroupFromStack(nodeGroupType api.NodeGroupType, nodeGroupName string, cfg *api.ClusterConfig) error {
 	switch nodeGroupType {
 	case api.NodeGroupTypeUnmanaged:
 		cfg.NodeGroups = []*api.NodeGroup{
 			{
 				NodeGroupBase: &api.NodeGroupBase{
-					Name: name,
+					Name: nodeGroupName,
 				},
 			},
 		}
@@ -34,7 +43,7 @@ func PopulateNodegroup(stackManager manager.StackManager, name string, cfg *api.
 		cfg.ManagedNodeGroups = []*api.ManagedNodeGroup{
 			{
 				NodeGroupBase: &api.NodeGroupBase{
-					Name: name,
+					Name: nodeGroupName,
 				},
 			},
 		}
@@ -42,12 +51,11 @@ func PopulateNodegroup(stackManager manager.StackManager, name string, cfg *api.
 		cfg.ManagedNodeGroups = []*api.ManagedNodeGroup{
 			{
 				NodeGroupBase: &api.NodeGroupBase{
-					Name: name,
+					Name: nodeGroupName,
 				},
 				Unowned: true,
 			},
 		}
 	}
-
 	return nil
 }

--- a/pkg/ctl/cmdutils/nodegroup.go
+++ b/pkg/ctl/cmdutils/nodegroup.go
@@ -32,11 +32,7 @@ func PopulateNodegroup(stackManager manager.StackManager, name string, cfg *api.
 func PopulateNodegroupFromStack(nodeGroupType api.NodeGroupType, nodeGroupName string, cfg *api.ClusterConfig) error {
 	switch nodeGroupType {
 	case api.NodeGroupTypeUnmanaged:
-		cfg.NodeGroups = append(cfg.NodeGroups, &api.NodeGroup{
-			NodeGroupBase: &api.NodeGroupBase{
-				Name: nodeGroupName,
-			},
-		})
+		PopulateUnmanagedNodegroup(nodeGroupName, cfg)
 	case api.NodeGroupTypeManaged:
 		cfg.ManagedNodeGroups = append(cfg.ManagedNodeGroups, &api.ManagedNodeGroup{
 			NodeGroupBase: &api.NodeGroupBase{
@@ -52,4 +48,13 @@ func PopulateNodegroupFromStack(nodeGroupType api.NodeGroupType, nodeGroupName s
 		})
 	}
 	return nil
+}
+
+// PopulateUnmanagedNodegroup populates the unmanaged nodegroup field of a ClucterConfig.
+func PopulateUnmanagedNodegroup(nodeGroupName string, cfg *api.ClusterConfig) {
+	cfg.NodeGroups = append(cfg.NodeGroups, &api.NodeGroup{
+		NodeGroupBase: &api.NodeGroupBase{
+			Name: nodeGroupName,
+		},
+	})
 }

--- a/pkg/ctl/cmdutils/nodegroup.go
+++ b/pkg/ctl/cmdutils/nodegroup.go
@@ -32,30 +32,24 @@ func PopulateNodegroup(stackManager manager.StackManager, name string, cfg *api.
 func PopulateNodegroupFromStack(nodeGroupType api.NodeGroupType, nodeGroupName string, cfg *api.ClusterConfig) error {
 	switch nodeGroupType {
 	case api.NodeGroupTypeUnmanaged:
-		cfg.NodeGroups = []*api.NodeGroup{
-			{
-				NodeGroupBase: &api.NodeGroupBase{
-					Name: nodeGroupName,
-				},
+		cfg.NodeGroups = append(cfg.NodeGroups, &api.NodeGroup{
+			NodeGroupBase: &api.NodeGroupBase{
+				Name: nodeGroupName,
 			},
-		}
+		})
 	case api.NodeGroupTypeManaged:
-		cfg.ManagedNodeGroups = []*api.ManagedNodeGroup{
-			{
-				NodeGroupBase: &api.NodeGroupBase{
-					Name: nodeGroupName,
-				},
+		cfg.ManagedNodeGroups = append(cfg.ManagedNodeGroups, &api.ManagedNodeGroup{
+			NodeGroupBase: &api.NodeGroupBase{
+				Name: nodeGroupName,
 			},
-		}
+		})
 	case api.NodeGroupTypeUnowned:
-		cfg.ManagedNodeGroups = []*api.ManagedNodeGroup{
-			{
-				NodeGroupBase: &api.NodeGroupBase{
-					Name: nodeGroupName,
-				},
-				Unowned: true,
+		cfg.ManagedNodeGroups = append(cfg.ManagedNodeGroups, &api.ManagedNodeGroup{
+			NodeGroupBase: &api.NodeGroupBase{
+				Name: nodeGroupName,
 			},
-		}
+			Unowned: true,
+		})
 	}
 	return nil
 }

--- a/pkg/ctl/cmdutils/nodegroup_test.go
+++ b/pkg/ctl/cmdutils/nodegroup_test.go
@@ -1,0 +1,63 @@
+package cmdutils
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	awseks "github.com/aws/aws-sdk-go/service/eks"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/cfn/manager/fakes"
+	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
+)
+
+var _ = Describe("PopulateNodegroup", func() {
+	var (
+		ngName           string
+		cfg              *api.ClusterConfig
+		fakeStackManager *fakes.FakeStackManager
+		mockProvider     *mockprovider.MockProvider
+		err              error
+	)
+
+	BeforeEach(func() {
+		fakeStackManager = new(fakes.FakeStackManager)
+		ngName = "ng"
+		cfg = api.NewClusterConfig()
+		mockProvider = mockprovider.NewMockProvider()
+	})
+
+	Context("unmanaged nodegroup", func() {
+		It("is added to the cfg", func() {
+			fakeStackManager.GetNodeGroupStackTypeReturns(api.NodeGroupTypeUnmanaged, nil)
+			err = PopulateNodegroup(fakeStackManager, ngName, cfg, mockProvider)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.NodeGroups[0].Name).To(Equal(ngName))
+		})
+	})
+
+	Context("managed nodegroup", func() {
+		It("is added to the cfg", func() {
+			fakeStackManager.GetNodeGroupStackTypeReturns(api.NodeGroupTypeManaged, nil)
+			err = PopulateNodegroup(fakeStackManager, ngName, cfg, mockProvider)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.ManagedNodeGroups[0].Name).To(Equal(ngName))
+		})
+	})
+
+	Context("unowned nodegroup", func() {
+		It("is added to the cfg", func() {
+			clusterName := "cluster-name"
+			cfg.Metadata.Name = clusterName
+			fakeStackManager.GetNodeGroupStackTypeReturns("", errors.New(""))
+			mockProvider.MockEKS().On("DescribeNodegroup", &awseks.DescribeNodegroupInput{
+				ClusterName:   aws.String(clusterName),
+				NodegroupName: aws.String(ngName),
+			}).Return(&awseks.DescribeNodegroupOutput{Nodegroup: &awseks.Nodegroup{}}, nil)
+
+			err = PopulateNodegroup(fakeStackManager, ngName, cfg, mockProvider)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.ManagedNodeGroups[0].Name).To(Equal(ngName))
+		})
+	})
+})

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -120,6 +120,7 @@ func doDeleteNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, updateAuthConfigMap
 
 	nodeGroupManager := nodegroup.New(cfg, ctl, clientSet)
 	if deleteNodeGroupDrain {
+		cmdutils.LogIntendedAction(cmd.Plan, "drain %d nodegroup(s) in cluster %q", len(allNodeGroups), cfg.Metadata.Name)
 		err := nodeGroupManager.Drain(allNodeGroups, cmd.Plan, maxGracePeriod, disableEviction)
 		if err != nil {
 			logger.Warning("error occurred during drain, to skip drain use '--drain=false' flag")

--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -122,6 +122,7 @@ func doDeleteNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, updateAuthConfigMap
 	if deleteNodeGroupDrain {
 		err := nodeGroupManager.Drain(allNodeGroups, cmd.Plan, maxGracePeriod, disableEviction)
 		if err != nil {
+			logger.Warning("error occurred during drain, to skip drain use '--drain=false' flag")
 			return err
 		}
 	}


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

We drain nodegroups prior to deleting them individually but not prior to deleting them when we delete the whole cluster. Draining nodegroups before deleting them is important so that pods can be evicted (and not scheduled on those pods again) and resources, such as IP addresses, can be released. Not draining nodes before deleting them may block the deletion of some resources and cause leftover resources such as IP addresses.

This PR focuses on unmanaged nodegroups because managed nodegroups get drained by EKS anyway.

I tried to do a bit of refactoring to backfill tests. I also extracted the CF call that gets `allStacks` since it was used elsewhere in the code where we delete `unowned` clusters. 

Related issues: #1849, #536, https://github.com/weaveworks/eksctl/pull/523, #3726

### Demo
The following demo is for a eksctl-created cluster with unmanaged nodegroups.

```
./eksctl delete cluster --name drain-unmanaged
2021-09-13 11:19:04 [ℹ]  eksctl version 0.68.0-dev+fbe5484e.2021-09-13T10:40:28Z
2021-09-13 11:19:04 [ℹ]  using region us-west-2
2021-09-13 11:19:04 [ℹ]  deleting EKS cluster "drain-unmanaged"
2021-09-13 11:19:07 [ℹ]  will drain 1 nodegroup(s) in cluster "drain-unmanaged"
2021-09-13 11:19:11 [ℹ]  cordon node "ip-192-168-25-121.us-west-2.compute.internal"
2021-09-13 11:19:11 [ℹ]  cordon node "ip-192-168-94-224.us-west-2.compute.internal"
2021-09-13 11:19:12 [!]  ignoring DaemonSet-managed Pods: kube-system/aws-node-shq67, kube-system/kube-proxy-jl5g2
2021-09-13 11:19:13 [!]  ignoring DaemonSet-managed Pods: kube-system/aws-node-s2nm4, kube-system/kube-proxy-2jnjc
2021-09-13 11:19:15 [!]  ignoring DaemonSet-managed Pods: kube-system/aws-node-shq67, kube-system/kube-proxy-jl5g2
2021-09-13 11:19:16 [!]  ignoring DaemonSet-managed Pods: kube-system/aws-node-s2nm4, kube-system/kube-proxy-2jnjc
2021-09-13 11:19:17 [!]  pod eviction error ("error evicting pod: kube-system/coredns-86d9946576-9n75b: pods \"coredns-86d9946576-9n75b\" not found") on node ip-192-168-94-224.us-west-2.compute.internal
2021-09-13 11:19:22 [!]  ignoring DaemonSet-managed Pods: kube-system/aws-node-shq67, kube-system/kube-proxy-jl5g2
2021-09-13 11:19:24 [!]  ignoring DaemonSet-managed Pods: kube-system/aws-node-s2nm4, kube-system/kube-proxy-2jnjc
2021-09-13 11:19:24 [✔]  drained all nodes: [ip-192-168-25-121.us-west-2.compute.internal ip-192-168-94-224.us-west-

[etc]
```

Manually tested it for an unowned cluster with unmanaged nodegroups as well.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:

