### PR TITLE
Gracefully delete vpc-cni during cluster deletion

### DIFF
--- a/pkg/actions/cluster/delete.go
+++ b/pkg/actions/cluster/delete.go
@@ -183,7 +183,7 @@ func drainAllNodegroups(cfg *api.ClusterConfig, ctl *eks.ClusterProvider, stackM
 // to prevent a race condition in the vpc-cni #1849
 func attemptVpcCniDeletion(clusterName string, ctl *eks.ClusterProvider, clientSet kubernetes.Interface) {
 	vpcCNI := "vpc-cni"
-	logger.Info("deleting EKS addon %q if it exists", vpcCNI)
+	logger.Debug("deleting EKS addon %q if it exists", vpcCNI)
 	_, err := ctl.Provider.EKS().DeleteAddon(&awseks.DeleteAddonInput{
 		ClusterName: &clusterName,
 		AddonName:   aws.String(vpcCNI),
@@ -191,16 +191,15 @@ func attemptVpcCniDeletion(clusterName string, ctl *eks.ClusterProvider, clientS
 
 	if err != nil {
 		if awsError, ok := err.(awserr.Error); ok && awsError.Code() == awseks.ErrCodeResourceNotFoundException {
-			logger.Info("EKS addon %q does not exist", vpcCNI)
+			logger.Debug("EKS addon %q does not exist", vpcCNI)
 		} else {
-			logger.Info("failed to delete addon %q: %v", vpcCNI, err)
-			return
+			logger.Debug("failed to delete addon %q: %v", vpcCNI, err)
 		}
 	}
 
-	logger.Info("deleting kube-system/aws-node DaemonSet")
+	logger.Debug("deleting kube-system/aws-node DaemonSet")
 	err = clientSet.AppsV1().DaemonSets("kube-system").Delete(context.TODO(), "aws-node", metav1.DeleteOptions{})
 	if err != nil {
-		logger.Info("failed to delete kube-system/aws-node DaemonSet: %w", err)
+		logger.Debug("failed to delete kube-system/aws-node DaemonSet: %w", err)
 	}
 }

--- a/pkg/actions/cluster/delete.go
+++ b/pkg/actions/cluster/delete.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/pkg/errors"
 
@@ -15,11 +17,13 @@ import (
 	"github.com/weaveworks/eksctl/pkg/fargate"
 	"github.com/weaveworks/eksctl/pkg/kubernetes"
 
+	awseks "github.com/aws/aws-sdk-go/service/eks"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/elb"
 	ssh "github.com/weaveworks/eksctl/pkg/ssh/client"
 	"github.com/weaveworks/eksctl/pkg/utils/kubeconfig"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kris-nova/logger"
 )
@@ -171,5 +175,32 @@ func drainAllNodegroups(cfg *api.ClusterConfig, ctl *eks.ClusterProvider, stackM
 	if err := nodeGroupManager.Drain(cmdutils.ToKubeNodeGroups(cfg), false, ctl.Provider.WaitTimeout(), false); err != nil {
 		return err
 	}
+	attemptVpcCniDeletion(cfg.Metadata.Name, ctl, clientSet)
 	return nil
+}
+
+// Attempts to delete the vpc-cni, and fails silently if an error occurs. This is an attempt
+// to prevent a race condition in the vpc-cni #1849
+func attemptVpcCniDeletion(clusterName string, ctl *eks.ClusterProvider, clientSet kubernetes.Interface) {
+	vpcCNI := "vpc-cni"
+	logger.Info("deleting EKS addon %q if it exists", vpcCNI)
+	_, err := ctl.Provider.EKS().DeleteAddon(&awseks.DeleteAddonInput{
+		ClusterName: &clusterName,
+		AddonName:   aws.String(vpcCNI),
+	})
+
+	if err != nil {
+		if awsError, ok := err.(awserr.Error); ok && awsError.Code() == awseks.ErrCodeResourceNotFoundException {
+			logger.Info("EKS addon %q does not exist", vpcCNI)
+		} else {
+			logger.Info("failed to delete addon %q: %v", vpcCNI, err)
+			return
+		}
+	}
+
+	logger.Info("deleting kube-system/aws-node DaemonSet")
+	err = clientSet.AppsV1().DaemonSets("kube-system").Delete(context.TODO(), "aws-node", metav1.DeleteOptions{})
+	if err != nil {
+		logger.Info("failed to delete kube-system/aws-node DaemonSet: %w", err)
+	}
 }

--- a/pkg/actions/cluster/unowned_test.go
+++ b/pkg/actions/cluster/unowned_test.go
@@ -58,6 +58,11 @@ var _ = Describe("Delete", func() {
 				Cluster: testutils.NewFakeCluster(clusterName, awseks.ClusterStatusActive),
 			}, nil)
 
+			p.MockEKS().On("DeleteAddon", &awseks.DeleteAddonInput{
+				ClusterName: strings.Pointer(clusterName),
+				AddonName:   strings.Pointer("vpc-cni"),
+			}).Return(&awseks.DeleteAddonOutput{}, nil)
+
 			p.MockEKS().On("ListFargateProfiles", &awseks.ListFargateProfilesInput{
 				ClusterName: strings.Pointer(clusterName),
 			}).Once().Return(&awseks.ListFargateProfilesOutput{FargateProfileNames: aws.StringSlice([]string{"fargate-1"})}, nil)


### PR DESCRIPTION
### Description
Closes https://github.com/weaveworks/eksctl/issues/4214

See comment: https://github.com/weaveworks/eksctl/issues/4214#issuecomment-925055655

---

Without EKS addon:
```
/eksctl delete cluster --name jk-2 --wait
2021-09-23 09:51:46 [ℹ]  eksctl version 0.68.0-dev+b4d0de23.2021-09-23T09:50:49Z
2021-09-23 09:51:46 [ℹ]  using region eu-central-1
2021-09-23 09:51:46 [ℹ]  deleting EKS cluster "jk-2"
2021-09-23 09:51:47 [ℹ]  will drain 1 unmanaged nodegroup(s) in cluster "jk-2"
2021-09-23 09:51:47 [ℹ]  cordon node "ip-192-168-16-32.eu-central-1.compute.internal"
2021-09-23 09:51:47 [ℹ]  cordon node "ip-192-168-90-19.eu-central-1.compute.internal"
2021-09-23 09:51:55 [✔]  drained all nodes: [ip-192-168-16-32.eu-central-1.compute.internal ip-192-168-90-19.eu-central-1.compute.internal]
....
2021-09-23 09:51:55 [ℹ]  deleting EKS addon "vpc-cni" if it exists
2021-09-23 09:51:55 [ℹ]  EKS addon "vpc-cni" does not exist
2021-09-23 09:51:55 [ℹ]  deleting kube-system/aws-node DaemonSet
....
2021-09-23 09:51:55 [ℹ]  deleted 0 Fargate profile(s)
2021-09-23 09:51:56 [✔]  kubeconfig has been updated
2021-09-23 09:51:56 [ℹ]  cleaning up AWS load balancers created by Kubernetes objects of Kind Service or Ingress
2021-09-23 09:51:57 [ℹ]  2 sequential tasks: { delete nodegroup "ng-af74974f", delete cluster control plane "jk-2" }
2021-09-23 09:51:58 [ℹ]  will delete stack "eksctl-jk-2-nodegroup-ng-af74974f"
2021-09-23 09:51:58 [ℹ]  waiting for stack "eksctl-jk-2-nodegroup-ng-af74974f" to get deleted
2021-09-23 09:51:58 [ℹ]  waiting for CloudFormation stack "eksctl-jk-2-nodegroup-ng-af74974f"
2021-09-23 09:52:14 [ℹ]  waiting for CloudFormation stack "eksctl-jk-2-nodegroup-ng-af74974f"
2021-09-23 09:52:31 [ℹ]  waiting for CloudFormation stack "eksctl-jk-2-nodegroup-ng-af74974f"
```

With addon:
```
eksctl delete cluster --name jk-3 --wait
2021-09-23 09:54:00 [ℹ]  eksctl version 0.68.0-dev+b4d0de23.2021-09-23T09:50:49Z
2021-09-23 09:54:00 [ℹ]  using region eu-central-1
2021-09-23 09:54:00 [ℹ]  deleting EKS cluster "jk-3"
2021-09-23 09:54:01 [ℹ]  will drain 1 unmanaged nodegroup(s) in cluster "jk-3"
2021-09-23 09:54:02 [ℹ]  cordon node "ip-192-168-52-43.eu-central-1.compute.internal"
2021-09-23 09:54:02 [ℹ]  cordon node "ip-192-168-77-3.eu-central-1.compute.internal"
2021-09-23 09:54:10 [✔]  drained all nodes: [ip-192-168-52-43.eu-central-1.compute.internal ip-192-168-77-3.eu-central-1.compute.internal]
....
2021-09-23 09:54:10 [ℹ]  deleting EKS addon "vpc-cni" if it exists
2021-09-23 09:54:10 [ℹ]  deleting kube-system/aws-node DaemonSet
2021-09-23 09:54:10 [ℹ]  deleted 0 Fargate profile(s)
2021-09-23 09:54:11 [✔]  kubeconfig has been updated
2021-09-23 09:54:11 [ℹ]  cleaning up AWS load balancers created by Kubernetes objects of Kind Service or Ingress
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

