### PR TITLE
Skip addons task when no addon is configured

### DIFF
--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -252,13 +252,13 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 		return err
 	}
 
-	var taskTree, preNodegroupAddons, postNodegroupAddons *tasks.TaskTree
-	if supported {
+	var preNodegroupAddons, postNodegroupAddons *tasks.TaskTree
+	if supported && len(cfg.Addons) > 0 {
 		preNodegroupAddons, postNodegroupAddons = addon.CreateAddonTasks(cfg, ctl, true, cmd.ProviderConfig.WaitTimeout)
-		taskTree = stackManager.NewTasksToCreateClusterWithNodeGroups(cfg.NodeGroups, cfg.ManagedNodeGroups, supportsManagedNodes, postClusterCreationTasks, preNodegroupAddons)
-	} else {
-		taskTree = stackManager.NewTasksToCreateClusterWithNodeGroups(cfg.NodeGroups, cfg.ManagedNodeGroups, supportsManagedNodes, postClusterCreationTasks)
+		postClusterCreationTasks.Append(preNodegroupAddons)
 	}
+
+	taskTree := stackManager.NewTasksToCreateClusterWithNodeGroups(cfg.NodeGroups, cfg.ManagedNodeGroups, supportsManagedNodes, postClusterCreationTasks)
 
 	logger.Info(taskTree.Describe())
 	if errs := taskTree.DoAllSync(); len(errs) > 0 {


### PR DESCRIPTION
### Description

When no addon is configured, eksctl runs the addons task which attempts to check for the existence of an OIDC provider. If the API call for this check fails (e.g., due to lack of permissions), the cluster creation itself fails. This changelist ensures the addons task is skipped if no addon is configured.

This either partially or fully addresses https://github.com/weaveworks/eksctl/issues/4251


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

