### PR TITLE
Parse task log to be more human readable

### DIFF
--- a/pkg/cfn/manager/tasks_test.go
+++ b/pkg/cfn/manager/tasks_test.go
@@ -95,8 +95,10 @@ var _ = Describe("StackCollection Tasks", func() {
 				// in these tests
 				{
 					tasks := stackManager.NewUnmanagedNodeGroupTask(makeNodeGroups("bar", "foo"), false, fakeVPCImporter)
-					Expect(tasks.Describe()).To(Equal(`2 parallel tasks: { create nodegroup "bar", create nodegroup "foo" 
-}`))
+					Expect(tasks.Describe()).To(Equal(`
+2 parallel tasks: { create nodegroup "bar", create nodegroup "foo" 
+}
+`))
 				}
 				{
 					tasks := stackManager.NewUnmanagedNodeGroupTask(makeNodeGroups("bar"), false, fakeVPCImporter)
@@ -112,17 +114,21 @@ var _ = Describe("StackCollection Tasks", func() {
 				}
 				{
 					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar", "foo"), nil, true)
-					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 
+					Expect(tasks.Describe()).To(Equal(`
+2 sequential tasks: { create cluster control plane "test-cluster", 
     2 parallel sub-tasks: { 
         create nodegroup "bar",
         create nodegroup "foo",
     } 
-}`))
+}
+`))
 				}
 				{
 					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar"), nil, false)
-					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", create nodegroup "bar" 
-}`))
+					Expect(tasks.Describe()).To(Equal(`
+2 sequential tasks: { create cluster control plane "test-cluster", create nodegroup "bar" 
+}
+`))
 				}
 				{
 					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(nil, nil, true)
@@ -130,32 +136,38 @@ var _ = Describe("StackCollection Tasks", func() {
 				}
 				{
 					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar", "foo"), makeManagedNodeGroups("m1", "m2"), false)
-					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 
+					Expect(tasks.Describe()).To(Equal(`
+2 sequential tasks: { create cluster control plane "test-cluster", 
     4 parallel sub-tasks: { 
         create nodegroup "bar",
         create nodegroup "foo",
         create managed nodegroup "m1",
         create managed nodegroup "m2",
     } 
-}`))
+}
+`))
 				}
 				{
 					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("foo"), makeManagedNodeGroups("m1"), true)
-					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 
+					Expect(tasks.Describe()).To(Equal(`
+2 sequential tasks: { create cluster control plane "test-cluster", 
     2 parallel sub-tasks: { 
         create nodegroup "foo",
         create managed nodegroup "m1",
     } 
-}`))
+}
+`))
 				}
 				{
 					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar"), nil, false, &task{id: 1})
-					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 
+					Expect(tasks.Describe()).To(Equal(`
+2 sequential tasks: { create cluster control plane "test-cluster", 
     2 sequential sub-tasks: { 
         task 1,
         create nodegroup "bar",
     } 
-}`))
+}
+`))
 				}
 			})
 		})

--- a/pkg/cfn/manager/tasks_test.go
+++ b/pkg/cfn/manager/tasks_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
 	vpcfakes "github.com/weaveworks/eksctl/pkg/vpc/fakes"
@@ -94,7 +95,8 @@ var _ = Describe("StackCollection Tasks", func() {
 				// in these tests
 				{
 					tasks := stackManager.NewUnmanagedNodeGroupTask(makeNodeGroups("bar", "foo"), false, fakeVPCImporter)
-					Expect(tasks.Describe()).To(Equal(`2 parallel tasks: { create nodegroup "bar", create nodegroup "foo" }`))
+					Expect(tasks.Describe()).To(Equal(`2 parallel tasks: { create nodegroup "bar", create nodegroup "foo" 
+}`))
 				}
 				{
 					tasks := stackManager.NewUnmanagedNodeGroupTask(makeNodeGroups("bar"), false, fakeVPCImporter)
@@ -110,11 +112,17 @@ var _ = Describe("StackCollection Tasks", func() {
 				}
 				{
 					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar", "foo"), nil, true)
-					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 2 parallel sub-tasks: { create nodegroup "bar", create nodegroup "foo" } }`))
+					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 
+    2 parallel sub-tasks: { 
+        create nodegroup "bar",
+        create nodegroup "foo",
+    } 
+}`))
 				}
 				{
 					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar"), nil, false)
-					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", create nodegroup "bar" }`))
+					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", create nodegroup "bar" 
+}`))
 				}
 				{
 					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(nil, nil, true)
@@ -122,15 +130,32 @@ var _ = Describe("StackCollection Tasks", func() {
 				}
 				{
 					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar", "foo"), makeManagedNodeGroups("m1", "m2"), false)
-					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 4 parallel sub-tasks: { create nodegroup "bar", create nodegroup "foo", create managed nodegroup "m1", create managed nodegroup "m2" } }`))
+					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 
+    4 parallel sub-tasks: { 
+        create nodegroup "bar",
+        create nodegroup "foo",
+        create managed nodegroup "m1",
+        create managed nodegroup "m2",
+    } 
+}`))
 				}
 				{
 					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("foo"), makeManagedNodeGroups("m1"), true)
-					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 2 parallel sub-tasks: { create nodegroup "foo", create managed nodegroup "m1" } }`))
+					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 
+    2 parallel sub-tasks: { 
+        create nodegroup "foo",
+        create managed nodegroup "m1",
+    } 
+}`))
 				}
 				{
 					tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar"), nil, false, &task{id: 1})
-					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 2 sequential sub-tasks: { task 1, create nodegroup "bar" } }`))
+					Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { create cluster control plane "test-cluster", 
+    2 sequential sub-tasks: { 
+        task 1,
+        create nodegroup "bar",
+    } 
+}`))
 				}
 			})
 		})

--- a/pkg/utils/tasks/tasks.go
+++ b/pkg/utils/tasks/tasks.go
@@ -62,36 +62,69 @@ func (t *TaskTree) Len() int {
 	return len(t.Tasks)
 }
 
-// Describe the set
+// Describe collects all tasks which have been added to the task tree.
+// This is a lazy tree which does not track its nodes in any form. This function
+// is recursively called from the rest of the task Describes and eventually
+// returns a collection of all the tasks' `Info` value.
 func (t *TaskTree) Describe() string {
-	descriptions := []string{}
+	if t.Len() == 0 {
+		return "no tasks"
+	}
+	var descriptions []string
 	for _, task := range t.Tasks {
 		descriptions = append(descriptions, task.Describe())
 	}
-	mode := "sequential"
-	if t.Parallel {
-		mode = "parallel"
-	}
-	count := len(descriptions)
-	var msg string
 	noun := "task"
 	if t.IsSubTask {
 		noun = "sub-task"
 	}
-	switch count {
-	case 0:
-		msg = "no tasks"
-	case 1:
-		msg = fmt.Sprintf("1 %s: { %s }", noun, descriptions[0])
+	if len(descriptions) == 1 {
+		msg := fmt.Sprintf("1 %s: { %s }", noun, descriptions[0])
 		if t.IsSubTask {
-			msg = descriptions[0] // simple description for single sub-task
+			msg = descriptions[0]
 		}
-	default:
-		noun += "s"
-		msg = fmt.Sprintf("%d %s %s: { %s }", count, mode, noun, strings.Join(descriptions, ", "))
+		return msg
 	}
+	count := len(descriptions)
+	mode := "sequential"
+	if t.Parallel {
+		mode = "parallel"
+	}
+	noun += "s"
+	head := fmt.Sprintf("%d %s %s: { ", count, mode, noun)
+	var tail string
+	if t.IsSubTask {
+		head = fmt.Sprintf("\n%s%d %s %s: { ", strings.Repeat(" ", 4), count, mode, noun)
+		tail = "\n"
+		for _, d := range descriptions {
+			// all tasks are sub-tasks if they are inside a task.
+			// which means we don't have to care about sequential tasks.
+			if strings.Contains(d, "sub-task") {
+				// trim the previous leading tail new line...
+				d = strings.TrimPrefix(d, "\n")
+				split := strings.Split(d, "\n")
+				// indent all lines of the subtask one deepness more
+				var result []string
+				for _, s := range split {
+					result = append(result, strings.Repeat(" ", 4)+s)
+				}
+				// join it back up with line breaks
+				d = strings.Join(result, "\n")
+			} else {
+				d = strings.Repeat(" ", 8) + d
+			}
+			tail += fmt.Sprintf("%s,\n", d)
+		}
+		// closing the final bracket
+		tail += fmt.Sprintf("%s}", strings.Repeat(" ", 4))
+	} else {
+		// if it isn't a subtask, we just add the descriptions as is joined by new line.
+		// this results in line like `1 task: { t1.1 }` which are more readable this way.
+		tail = fmt.Sprintf("%s \n}", strings.Join(descriptions, ", "))
+	}
+	msg := head + tail
 	if t.PlanMode {
-		return "(plan) " + msg
+		msg = "(plan) " + msg
 	}
 	return msg
 }

--- a/pkg/utils/tasks/tasks.go
+++ b/pkg/utils/tasks/tasks.go
@@ -72,7 +72,7 @@ func (t *TaskTree) Describe() string {
 	}
 	var descriptions []string
 	for _, task := range t.Tasks {
-		descriptions = append(descriptions, task.Describe())
+		descriptions = append(descriptions, strings.TrimSuffix(task.Describe(), "\n"))
 	}
 	noun := "task"
 	if t.IsSubTask {
@@ -91,9 +91,11 @@ func (t *TaskTree) Describe() string {
 		mode = "parallel"
 	}
 	noun += "s"
-	head := fmt.Sprintf("%d %s %s: { ", count, mode, noun)
+	head := fmt.Sprintf("\n%d %s %s: { ", count, mode, noun)
 	var tail string
 	if t.IsSubTask {
+		// Only add a linebreak at the end if we have multiple subtasks as well. Otherwise, leave it
+		// as single line.
 		head = fmt.Sprintf("\n%s%d %s %s: { ", strings.Repeat(" ", 4), count, mode, noun)
 		tail = "\n"
 		for _, d := range descriptions {
@@ -126,7 +128,7 @@ func (t *TaskTree) Describe() string {
 	if t.PlanMode {
 		msg = "(plan) " + msg
 	}
-	return msg
+	return msg + "\n"
 }
 
 // Do will run through the set in the background, it may return an error immediately,

--- a/pkg/utils/tasks/tasks_test.go
+++ b/pkg/utils/tasks/tasks_test.go
@@ -21,11 +21,13 @@ var _ = Describe("TaskTree", func() {
 				tasks.IsSubTask = true
 				tasks.PlanMode = true
 				tasks.Append(&TaskTree{Parallel: false, IsSubTask: true})
+				fmt.Println(tasks.Describe())
 				expected := []byte(`(plan) 
     2 sequential sub-tasks: { 
         no tasks,
         no tasks,
-    }`)
+    }
+`)
 				Expect([]byte(tasks.Describe())).To(Equal(expected))
 			}
 			{
@@ -52,7 +54,8 @@ var _ = Describe("TaskTree", func() {
 				tasks.Append(subTask2)
 				subTask1.Append(subTask3)
 
-				Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { 
+				Expect(tasks.Describe()).To(Equal(`
+2 sequential tasks: { 
     2 sequential sub-tasks: { 
         t1.1,
         2 parallel sub-tasks: { 
@@ -60,7 +63,8 @@ var _ = Describe("TaskTree", func() {
             t3.2,
         },
     }, t2.1 
-}`))
+}
+`))
 			}
 		})
 
@@ -142,7 +146,8 @@ var _ = Describe("TaskTree", func() {
 				})
 				subTask1.Append(subTask3)
 
-				Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { 
+				Expect(tasks.Describe()).To(Equal(`
+2 sequential tasks: { 
     2 sequential sub-tasks: { 
         t1.1,
         2 parallel sub-tasks: { 
@@ -150,7 +155,8 @@ var _ = Describe("TaskTree", func() {
             t3.2,
         },
     }, t2.1 
-}`))
+}
+`))
 
 				status.startTime = time.Now()
 				errs := tasks.DoAllSync()
@@ -260,7 +266,8 @@ var _ = Describe("TaskTree", func() {
 				})
 				subTask1.Append(subTask3)
 
-				Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { 
+				Expect(tasks.Describe()).To(Equal(`
+2 sequential tasks: { 
     2 sequential sub-tasks: { 
         t1.1,
         2 parallel sub-tasks: { 
@@ -268,7 +275,8 @@ var _ = Describe("TaskTree", func() {
             t3.2,
         },
     }, t2.1 
-}`))
+}
+`))
 
 				status.startTime = time.Now()
 				errs := tasks.DoAllSync()

--- a/pkg/utils/tasks/tasks_test.go
+++ b/pkg/utils/tasks/tasks_test.go
@@ -21,9 +21,13 @@ var _ = Describe("TaskTree", func() {
 				tasks.IsSubTask = true
 				tasks.PlanMode = true
 				tasks.Append(&TaskTree{Parallel: false, IsSubTask: true})
-				Expect(tasks.Describe()).To(Equal("(plan) 2 sequential sub-tasks: { no tasks, no tasks }"))
+				expected := []byte(`(plan) 
+    2 sequential sub-tasks: { 
+        no tasks,
+        no tasks,
+    }`)
+				Expect([]byte(tasks.Describe())).To(Equal(expected))
 			}
-
 			{
 				tasks := &TaskTree{Parallel: false}
 				subTask1 := &TaskTree{Parallel: false, IsSubTask: true}
@@ -48,7 +52,15 @@ var _ = Describe("TaskTree", func() {
 				tasks.Append(subTask2)
 				subTask1.Append(subTask3)
 
-				Expect(tasks.Describe()).To(Equal("2 sequential tasks: { 2 sequential sub-tasks: { t1.1, 2 parallel sub-tasks: { t3.1, t3.2 } }, t2.1 }"))
+				Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { 
+    2 sequential sub-tasks: { 
+        t1.1,
+        2 parallel sub-tasks: { 
+            t3.1,
+            t3.2,
+        },
+    }, t2.1 
+}`))
 			}
 		})
 
@@ -130,7 +142,15 @@ var _ = Describe("TaskTree", func() {
 				})
 				subTask1.Append(subTask3)
 
-				Expect(tasks.Describe()).To(Equal("2 sequential tasks: { 2 sequential sub-tasks: { t1.1, 2 parallel sub-tasks: { t3.1, t3.2 } }, t2.1 }"))
+				Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { 
+    2 sequential sub-tasks: { 
+        t1.1,
+        2 parallel sub-tasks: { 
+            t3.1,
+            t3.2,
+        },
+    }, t2.1 
+}`))
 
 				status.startTime = time.Now()
 				errs := tasks.DoAllSync()
@@ -240,7 +260,15 @@ var _ = Describe("TaskTree", func() {
 				})
 				subTask1.Append(subTask3)
 
-				Expect(tasks.Describe()).To(Equal("2 sequential tasks: { 2 sequential sub-tasks: { t1.1, 2 parallel sub-tasks: { t3.1, t3.2 } }, t2.1 }"))
+				Expect(tasks.Describe()).To(Equal(`2 sequential tasks: { 
+    2 sequential sub-tasks: { 
+        t1.1,
+        2 parallel sub-tasks: { 
+            t3.1,
+            t3.2,
+        },
+    }, t2.1 
+}`))
 
 				status.startTime = time.Now()
 				errs := tasks.DoAllSync()


### PR DESCRIPTION
### Description

Closes #1275.

New task log's appearance:

```
2021-10-04 11:50:49 [ℹ]  CloudWatch logging will not be enabled for cluster "log-formatting-test" in "us-west-2"
2021-10-04 11:50:49 [ℹ]  you can enable it with 'eksctl utils update-cluster-logging --enable-types={SPECIFY-YOUR-LOG-TYPES-HERE (e.g. all)} --region=us-west-2 --cluster=log-formatting-test'
2021-10-04 11:50:49 [ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "log-formatting-test" in "us-west-2"
2021-10-04 11:50:49 [ℹ]  2 sequential tasks: { create cluster control plane "log-formatting-test",
    2 sequential sub-tasks: {
        wait for control plane to become ready,
        create managed nodegroup "managed-ng-1",
    }
}2021-10-04 11:50:49 [ℹ]  building cluster stack "eksctl-log-formatting-test-cluster"
2021-10-04 11:50:51 [ℹ]  deploying stack "eksctl-log-formatting-test-cluster"
2021-10-04 11:51:21 [ℹ]  waiting for CloudFormation stack "eksctl-log-formatting-test-cluster"
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

