### PR TITLE
Wait for addons to be healthy only if there are nodegroups when creating a cluster

### DIFF
--- a/pkg/actions/addon/tasks.go
+++ b/pkg/actions/addon/tasks.go
@@ -31,6 +31,7 @@ func CreateAddonTasks(cfg *api.ClusterConfig, clusterProvider *eks.ClusterProvid
 			clusterProvider: clusterProvider,
 			forceAll:        forceAll,
 			timeout:         timeout,
+			wait:            false,
 		},
 	)
 
@@ -42,6 +43,7 @@ func CreateAddonTasks(cfg *api.ClusterConfig, clusterProvider *eks.ClusterProvid
 			clusterProvider: clusterProvider,
 			forceAll:        forceAll,
 			timeout:         timeout,
+			wait:            len(cfg.NodeGroups) > 0 || len(cfg.ManagedNodeGroups) > 0,
 		},
 	)
 	return preTasks, postTasks
@@ -52,7 +54,7 @@ type createAddonTask struct {
 	cfg             *api.ClusterConfig
 	clusterProvider *eks.ClusterProvider
 	addons          []*api.Addon
-	forceAll        bool
+	forceAll, wait  bool
 	timeout         time.Duration
 }
 
@@ -89,7 +91,7 @@ func (t *createAddonTask) Do(errorCh chan error) error {
 		if t.forceAll {
 			a.Force = true
 		}
-		err := addonManager.Create(a, true)
+		err := addonManager.Create(a, t.wait)
 		if err != nil {
 			go func() {
 				errorCh <- err


### PR DESCRIPTION
### Description
If you create a cluster with addons, and no nodegroups the create cluster command fails. This is because the `coredns` addon is unhealthy according to the EKS API, this is because it has 0 replicas, because there are no nodegroups. We cannot fix this if a user creates a cluster with no nodegroups, so instead of checking the health of the addon we instead just skip the check.
### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

