### PR TITLE
Move from io/ioutil to io and os packages

### DIFF
--- a/cmd/schema/generate.go
+++ b/cmd/schema/generate.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -48,7 +47,7 @@ func main() {
 		panic(err)
 	}
 	fmt.Println("Writing docs schema to " + outputFile)
-	if err := ioutil.WriteFile(outputFile, bytes, 0755); err != nil {
+	if err := os.WriteFile(outputFile, bytes, 0755); err != nil {
 		panic(err)
 	}
 }

--- a/integration/main.go
+++ b/integration/main.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -92,7 +91,7 @@ func listModules() []string {
 		return moduleDirs
 	}
 
-	files, err := ioutil.ReadDir(testsDir)
+	files, err := os.ReadDir(testsDir)
 	if err != nil {
 		log.Fatalf("failed to gather test suites: %v", err)
 	}

--- a/integration/matchers/flux.go
+++ b/integration/matchers/flux.go
@@ -5,7 +5,6 @@ package matchers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -61,7 +60,7 @@ func assertDoesNotContainFluxDir(dir string) {
 }
 
 func dirExists(dir string) (bool, error) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return false, err
 	}
@@ -80,7 +79,7 @@ func assertContainsFluxManifests(dir string) {
 	// API server. Hence, for now, we simply ensure that all files & objects
 	// are present, and that the main fields of these objects match expected
 	// values.
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	Expect(err).ShouldNot(HaveOccurred())
 	for _, f := range files {
 		if f.IsDir() {
@@ -115,7 +114,7 @@ func assertContainsFluxManifests(dir string) {
 }
 
 func assertValidFluxAccountManifest(fileName string) {
-	bytes, err := ioutil.ReadFile(fileName)
+	bytes, err := os.ReadFile(fileName)
 	Expect(err).ShouldNot(HaveOccurred())
 	list, err := kubernetes.NewRawExtensions(bytes)
 	Expect(err).ShouldNot(HaveOccurred())
@@ -148,7 +147,7 @@ func assertValidFluxAccountManifest(fileName string) {
 }
 
 func assertValidFluxDeploymentManifest(fileName string) {
-	bytes, err := ioutil.ReadFile(fileName)
+	bytes, err := os.ReadFile(fileName)
 	Expect(err).ShouldNot(HaveOccurred())
 	list, err := kubernetes.NewRawExtensions(bytes)
 	Expect(err).ShouldNot(HaveOccurred())
@@ -175,7 +174,7 @@ func assertValidFluxDeploymentManifest(fileName string) {
 }
 
 func assertValidFluxSecretManifest(fileName string) {
-	bytes, err := ioutil.ReadFile(fileName)
+	bytes, err := os.ReadFile(fileName)
 	Expect(err).ShouldNot(HaveOccurred())
 	list, err := kubernetes.NewRawExtensions(bytes)
 	Expect(err).ShouldNot(HaveOccurred())
@@ -196,7 +195,7 @@ func assertValidFluxSecretManifest(fileName string) {
 }
 
 func assertValidFluxMemcacheDeploymentManifest(fileName string) {
-	bytes, err := ioutil.ReadFile(fileName)
+	bytes, err := os.ReadFile(fileName)
 	Expect(err).ShouldNot(HaveOccurred())
 	list, err := kubernetes.NewRawExtensions(bytes)
 	Expect(err).ShouldNot(HaveOccurred())
@@ -224,7 +223,7 @@ func assertValidFluxMemcacheDeploymentManifest(fileName string) {
 }
 
 func assertValidFluxMemcacheServiceManifest(fileName string) {
-	bytes, err := ioutil.ReadFile(fileName)
+	bytes, err := os.ReadFile(fileName)
 	Expect(err).ShouldNot(HaveOccurred())
 	list, err := kubernetes.NewRawExtensions(bytes)
 	Expect(err).ShouldNot(HaveOccurred())
@@ -250,7 +249,7 @@ func assertValidFluxMemcacheServiceManifest(fileName string) {
 }
 
 func assertValidFluxNamespaceManifest(fileName string) {
-	bytes, err := ioutil.ReadFile(fileName)
+	bytes, err := os.ReadFile(fileName)
 	Expect(err).ShouldNot(HaveOccurred())
 	list, err := kubernetes.NewRawExtensions(bytes)
 	Expect(err).ShouldNot(HaveOccurred())
@@ -269,7 +268,7 @@ func assertValidFluxNamespaceManifest(fileName string) {
 }
 
 func assertValidFluxHelmOperatorAccount(fileName string) {
-	bytes, err := ioutil.ReadFile(fileName)
+	bytes, err := os.ReadFile(fileName)
 	Expect(err).ShouldNot(HaveOccurred())
 	list, err := kubernetes.NewRawExtensions(bytes)
 	Expect(err).ShouldNot(HaveOccurred())
@@ -302,7 +301,7 @@ func assertValidFluxHelmOperatorAccount(fileName string) {
 }
 
 func assertValidFluxHelmReleaseCRD(fileName string) {
-	bytes, err := ioutil.ReadFile(fileName)
+	bytes, err := os.ReadFile(fileName)
 	Expect(err).ShouldNot(HaveOccurred())
 	list, err := kubernetes.NewRawExtensions(bytes)
 	Expect(err).ShouldNot(HaveOccurred())
@@ -323,7 +322,7 @@ func assertValidFluxHelmReleaseCRD(fileName string) {
 }
 
 func assertValidHelmOperatorDeployment(fileName string) {
-	bytes, err := ioutil.ReadFile(fileName)
+	bytes, err := os.ReadFile(fileName)
 	Expect(err).ShouldNot(HaveOccurred())
 	list, err := kubernetes.NewRawExtensions(bytes)
 	Expect(err).ShouldNot(HaveOccurred())

--- a/integration/tests/anywhere/anywhere_run_test.go
+++ b/integration/tests/anywhere/anywhere_run_test.go
@@ -5,7 +5,6 @@ package anywhere
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -51,7 +50,7 @@ var _ = Describe("(Integration) [EKS Anywhere]", func() {
 
 		BeforeEach(func() {
 			var err error
-			tmpDir, err = ioutil.TempDir("", "anywhere-command")
+			tmpDir, err = os.MkdirTemp("", "anywhere-command")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -63,7 +62,7 @@ var _ = Describe("(Integration) [EKS Anywhere]", func() {
 			var originalPath string
 
 			BeforeEach(func() {
-				err := ioutil.WriteFile(filepath.Join(tmpDir, anywhere.BinaryFileName), []byte(`#!/usr/bin/env sh
+				err := os.WriteFile(filepath.Join(tmpDir, anywhere.BinaryFileName), []byte(`#!/usr/bin/env sh
 echo "you called?"
 exit 0`), 0777)
 				Expect(err).NotTo(HaveOccurred())

--- a/integration/tests/backwards_compat/backwards_compatibility_test.go
+++ b/integration/tests/backwards_compat/backwards_compatibility_test.go
@@ -6,7 +6,6 @@ package backwards_compat
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -54,7 +53,7 @@ var _ = Describe("(Integration) [Backwards compatibility test]", func() {
 		}
 
 		By("downloading a previous release")
-		eksctlDir, err := ioutil.TempDir(os.TempDir(), "eksctl")
+		eksctlDir, err := os.MkdirTemp(os.TempDir(), "eksctl")
 		Expect(err).ToNot(HaveOccurred())
 
 		defer func() {

--- a/integration/tests/caching/credential_caching_test.go
+++ b/integration/tests/caching/credential_caching_test.go
@@ -4,7 +4,6 @@
 package caching
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,7 +34,7 @@ var _ = Describe("", func() {
 		When("credential caching is disabled", func() {
 			var tmp string
 			BeforeEach(func() {
-				tmp, err := ioutil.TempDir("", "caching_creds")
+				tmp, err := os.MkdirTemp("", "caching_creds")
 				Expect(err).NotTo(HaveOccurred())
 				_ = os.Setenv(credentials.EksctlCacheFilenameEnvName, filepath.Join(tmp, "credentials.yaml"))
 				// Make sure the environment property is not set on the running environment.
@@ -60,7 +59,7 @@ var _ = Describe("", func() {
 		XWhen("credential caching is enabled", func() {
 			var tmp string
 			BeforeEach(func() {
-				tmp, err := ioutil.TempDir("", "caching_creds")
+				tmp, err := os.MkdirTemp("", "caching_creds")
 				Expect(err).NotTo(HaveOccurred())
 				_ = os.Setenv(credentials.EksctlCacheFilenameEnvName, filepath.Join(tmp, "credentials.yaml"))
 				_ = os.Setenv(credentials.EksctlGlobalEnableCachingEnvName, "1")
@@ -74,7 +73,7 @@ var _ = Describe("", func() {
 				).WithoutArg("--region", params.Region)
 				Expect(cmd).Should(RunSuccessfully())
 
-				content, err := ioutil.ReadFile(filepath.Join(tmp, "credentials.yaml"))
+				content, err := os.ReadFile(filepath.Join(tmp, "credentials.yaml"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(content).NotTo(BeEmpty())
 			})

--- a/integration/tests/cluster_api/cluster_api_endpoints_test.go
+++ b/integration/tests/cluster_api/cluster_api_endpoints_test.go
@@ -6,7 +6,6 @@ package cluster_api
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -84,7 +83,7 @@ var _ = Describe("(Integration) Create and Update Cluster with Endpoint Configs"
 			bytes, err := json.Marshal(cfg)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(bytes)).ToNot(BeZero())
-			tmpfile, err := ioutil.TempFile("", "clusterendpointtests")
+			tmpfile, err := os.CreateTemp("", "clusterendpointtests")
 			Expect(err).ToNot(HaveOccurred())
 
 			defer os.Remove(tmpfile.Name())

--- a/integration/tests/crud/creategetdelete_test.go
+++ b/integration/tests/crud/creategetdelete_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -77,7 +76,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 		params.KubeconfigTemp = false
 		if params.KubeconfigPath == "" {
 			wd, _ := os.Getwd()
-			f, _ := ioutil.TempFile(wd, "kubeconfig-")
+			f, _ := os.CreateTemp(wd, "kubeconfig-")
 			params.KubeconfigPath = f.Name()
 			params.KubeconfigTemp = true
 		}

--- a/integration/tests/eks_connector/eks_connector_test.go
+++ b/integration/tests/eks_connector/eks_connector_test.go
@@ -5,7 +5,6 @@ package eks_connector_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -87,7 +86,7 @@ var _ = Describe("(Integration) [EKS Connector test]", func() {
 
 			rawClient := getRawClient(params.ClusterName, params.Region)
 			for _, f := range resourcePaths {
-				bytes, err := ioutil.ReadFile(f)
+				bytes, err := os.ReadFile(f)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(rawClient.CreateOrReplace(bytes, false)).To(Succeed())
 			}

--- a/integration/tests/gitops/flux_test.go
+++ b/integration/tests/gitops/flux_test.go
@@ -5,7 +5,6 @@ package integration_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -90,9 +89,9 @@ var _ = Describe("Enable GitOps", func() {
 		}
 		configData, err := json.Marshal(&cfg)
 		Expect(err).NotTo(HaveOccurred())
-		configFile, err = ioutil.TempFile("", "")
+		configFile, err = os.CreateTemp("", "")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ioutil.WriteFile(configFile.Name(), configData, 0755)).To(Succeed())
+		Expect(os.WriteFile(configFile.Name(), configData, 0755)).To(Succeed())
 	})
 
 	AfterEach(func() {

--- a/integration/tests/inferentia/inferentia_test.go
+++ b/integration/tests/inferentia/inferentia_test.go
@@ -5,7 +5,6 @@ package inferentia
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -52,7 +51,7 @@ var _ = Describe("(Integration) Inferentia nodes", func() {
 		params.KubeconfigTemp = false
 		if params.KubeconfigPath == "" {
 			wd, _ := os.Getwd()
-			f, _ := ioutil.TempFile(wd, "kubeconfig-")
+			f, _ := os.CreateTemp(wd, "kubeconfig-")
 			params.KubeconfigPath = f.Name()
 			params.KubeconfigTemp = true
 		}

--- a/integration/tests/unowned_cluster/unowned_cluster_test.go
+++ b/integration/tests/unowned_cluster/unowned_cluster_test.go
@@ -6,7 +6,6 @@ package unowned_clusters
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -70,7 +69,7 @@ var _ = Describe("(Integration) [non-eksctl cluster & nodegroup support]", func(
 		}
 
 		var err error
-		configFile, err = ioutil.TempFile("", "")
+		configFile, err = os.CreateTemp("", "")
 		Expect(err).NotTo(HaveOccurred())
 
 		if !params.SkipCreate {
@@ -112,7 +111,7 @@ var _ = Describe("(Integration) [non-eksctl cluster & nodegroup support]", func(
 		// write config file so that the nodegroup creates have access to the vpc spec
 		configData, err := json.Marshal(&cfg)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ioutil.WriteFile(configFile.Name(), configData, 0755)).To(Succeed())
+		Expect(os.WriteFile(configFile.Name(), configData, 0755)).To(Succeed())
 		cmd := params.EksctlCreateNodegroupCmd.
 			WithArgs(
 				"--config-file", configFile.Name(),
@@ -130,7 +129,7 @@ var _ = Describe("(Integration) [non-eksctl cluster & nodegroup support]", func(
 		// write config file so that the nodegroup creates have access to the vpc spec
 		configData, err := json.Marshal(&cfg)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ioutil.WriteFile(configFile.Name(), configData, 0755)).To(Succeed())
+		Expect(os.WriteFile(configFile.Name(), configData, 0755)).To(Succeed())
 		cmd := params.EksctlCreateNodegroupCmd.
 			WithArgs(
 				"--config-file", configFile.Name(),
@@ -484,7 +483,7 @@ func createClusterWithNodeGroup(clusterName, stackName, ng1, version string, ctl
 }
 
 func createVPCAndRole(stackName string, ctl api.ClusterProvider) ([]string, []string, string, string, string, string) {
-	templateBody, err := ioutil.ReadFile("cf-template.yaml")
+	templateBody, err := os.ReadFile("cf-template.yaml")
 	Expect(err).NotTo(HaveOccurred())
 	createStackInput := &cfn.CreateStackInput{
 		StackName: &stackName,

--- a/integration/tests/update/update_cluster_test.go
+++ b/integration/tests/update/update_cluster_test.go
@@ -6,7 +6,6 @@ package update
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -64,7 +63,7 @@ var _ = Describe("(Integration) Update addons", func() {
 		params.KubeconfigTemp = false
 		if params.KubeconfigPath == "" {
 			wd, _ := os.Getwd()
-			f, _ := ioutil.TempFile(wd, "kubeconfig-")
+			f, _ := os.CreateTemp(wd, "kubeconfig-")
 			params.KubeconfigPath = f.Name()
 			params.KubeconfigTemp = true
 		}

--- a/pkg/actions/anywhere/anywhere_test.go
+++ b/pkg/actions/anywhere/anywhere_test.go
@@ -2,7 +2,7 @@ package anywhere_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,9 +53,9 @@ var _ = Describe("Anywhere", func() {
 		)
 		BeforeEach(func() {
 			var err error
-			tmpDir, err = ioutil.TempDir("", "anywhere-command")
+			tmpDir, err = os.MkdirTemp("", "anywhere-command")
 			Expect(err).NotTo(HaveOccurred())
-			err = ioutil.WriteFile(filepath.Join(tmpDir, anywhere.BinaryFileName), []byte(`#!/usr/bin/env sh
+			err = os.WriteFile(filepath.Join(tmpDir, anywhere.BinaryFileName), []byte(`#!/usr/bin/env sh
 echo $@
 echo "EKSCTL_VERSION=$EKSCTL_VERSION"
 >&2 echo "stderr outputted"
@@ -91,11 +91,11 @@ exit 0`), 0777)
 			newStderrWriter.Close()
 
 			By("printing the binary stderr to os.Stderr")
-			stderr, _ := ioutil.ReadAll(newStderrReader)
+			stderr, _ := io.ReadAll(newStderrReader)
 			Expect(string(stderr)).To(Equal("stderr outputted\n"))
 
 			By("printing the binary stdout to os.Stdout and passing the args to the binary")
-			stdout, _ := ioutil.ReadAll(newStdoutReader)
+			stdout, _ := io.ReadAll(newStdoutReader)
 			stdoutLines := strings.Split(strings.TrimSuffix(string(stdout), "\n"), "\n")
 			Expect(stdoutLines).To(HaveLen(2))
 			Expect(stdoutLines[0]).To(Equal("--do something"))
@@ -106,7 +106,7 @@ exit 0`), 0777)
 
 		When("the binary exits non-zero", func() {
 			BeforeEach(func() {
-				err := ioutil.WriteFile(filepath.Join(tmpDir, anywhere.BinaryFileName), []byte(`#!/usr/bin/env sh
+				err := os.WriteFile(filepath.Join(tmpDir, anywhere.BinaryFileName), []byte(`#!/usr/bin/env sh
 exit 33`), 0777)
 				Expect(err).NotTo(HaveOccurred())
 			})

--- a/pkg/actions/irsa/update.go
+++ b/pkg/actions/irsa/update.go
@@ -2,14 +2,13 @@ package irsa
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 
 	"github.com/kris-nova/logger"
 
 	"github.com/weaveworks/eksctl/pkg/utils/tasks"
-
-	"strings"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 )

--- a/pkg/actions/repo/enable.go
+++ b/pkg/actions/repo/enable.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -289,7 +288,7 @@ func writeFluxManifests(baseDir string, manifests map[string][]byte) error {
 	}
 	for fileName, contents := range manifests {
 		fullPath := filepath.Join(baseDir, fileName)
-		if err := ioutil.WriteFile(fullPath, contents, 0600); err != nil {
+		if err := os.WriteFile(fullPath, contents, 0600); err != nil {
 			return errors.Wrapf(err, "failed to write Flux manifest file %s", fullPath)
 		}
 	}

--- a/pkg/actions/repo/enable_test.go
+++ b/pkg/actions/repo/enable_test.go
@@ -2,7 +2,6 @@
 package repo_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/instrumenta/kubeval/kubeval"
@@ -46,7 +45,7 @@ var _ = Describe("Installer", func() {
 		}
 
 		var err error
-		tmpDir, err = ioutil.TempDir(os.TempDir(), "getmanifestsandsecrets")
+		tmpDir, err = os.MkdirTemp(os.TempDir(), "getmanifestsandsecrets")
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/pkg/cfn/builder/managed_launch_template_test.go
+++ b/pkg/cfn/builder/managed_launch_template_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -77,7 +77,7 @@ var _ = Describe("ManagedNodeGroup builder", func() {
 		actual, err := json.Marshal(template.Resources)
 		Expect(err).ToNot(HaveOccurred())
 
-		expected, err := ioutil.ReadFile(path.Join("testdata", "launch_template", m.resourcesFilename))
+		expected, err := os.ReadFile(path.Join("testdata", "launch_template", m.resourcesFilename))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(actual).To(MatchOrderedJSON(expected, WithUnorderedListKeys("Tags")))
 

--- a/pkg/cfn/builder/vpc_endpoint_test.go
+++ b/pkg/cfn/builder/vpc_endpoint_test.go
@@ -3,7 +3,7 @@ package builder
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -80,7 +80,7 @@ var _ = Describe("VPC Endpoint Builder", func() {
 		resourceJSON, err := rs.template.JSON()
 		Expect(err).ToNot(HaveOccurred())
 
-		expectedJSON, err := ioutil.ReadFile("testdata/" + vc.expectedFile)
+		expectedJSON, err := os.ReadFile("testdata/" + vc.expectedFile)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resourceJSON).To(MatchJSON(expectedJSON))
 	},

--- a/pkg/cfn/template/matchers/matchers.go
+++ b/pkg/cfn/template/matchers/matchers.go
@@ -3,7 +3,7 @@ package template
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
@@ -60,7 +60,7 @@ func (m *Loader) Match(actualTemplate interface{}) (bool, error) {
 	}
 
 	if m.templatePath != "" {
-		js, err := ioutil.ReadFile(m.templatePath)
+		js, err := os.ReadFile(m.templatePath)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/cloudconfig/cloudconfig.go
+++ b/pkg/cloudconfig/cloudconfig.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"path"
 
 	"github.com/kris-nova/logger"
@@ -136,12 +135,12 @@ func DecodeCloudConfig(s string) (*CloudConfig, error) {
 		return nil, err
 	}
 
-	gr, err := gzip.NewReader(ioutil.NopCloser(bytes.NewBuffer(data)))
+	gr, err := gzip.NewReader(io.NopCloser(bytes.NewBuffer(data)))
 	if err != nil {
 		return nil, err
 	}
 	defer safeClose(gr)
-	data, err = ioutil.ReadAll(gr)
+	data, err = io.ReadAll(gr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/connector_test.go
+++ b/pkg/connector/connector_test.go
@@ -1,7 +1,7 @@
 package connector_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -27,7 +27,7 @@ type connectorCase struct {
 
 var _ = Describe("EKS Connector", func() {
 	readManifest := func(filename string) (connector.ManifestFile, error) {
-		data, err := ioutil.ReadFile(path.Join("testdata", filename))
+		data, err := os.ReadFile(path.Join("testdata", filename))
 		if err != nil {
 			return connector.ManifestFile{}, nil
 		}
@@ -100,7 +100,7 @@ var _ = Describe("EKS Connector", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		assertManifestEquals := func(m connector.ManifestFile, expectedFile string) {
-			expected, err := ioutil.ReadFile(path.Join("testdata", expectedFile))
+			expected, err := os.ReadFile(path.Join("testdata", expectedFile))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(m.Data).To(Equal(expected), m.Filename)
 		}

--- a/pkg/connector/kubernetes.go
+++ b/pkg/connector/kubernetes.go
@@ -1,7 +1,7 @@
 package connector
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -72,7 +72,7 @@ func getResource(client *http.Client, url string) (ManifestFile, error) {
 		return ManifestFile{}, errors.Errorf("expected status code %d; got %d", http.StatusOK, resp.StatusCode)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return ManifestFile{}, err
 	}

--- a/pkg/credentials/filecache_test.go
+++ b/pkg/credentials/filecache_test.go
@@ -2,7 +2,6 @@ package credentials_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -47,7 +46,7 @@ var _ = Describe("filecache", func() {
 			err error
 		)
 		BeforeEach(func() {
-			tmp, err = ioutil.TempDir("", "filecache")
+			tmp, err = os.MkdirTemp("", "filecache")
 			Expect(err).ToNot(HaveOccurred())
 			_ = os.Setenv(EksctlCacheFilenameEnvName, filepath.Join(tmp, "credentials.yaml"))
 		})
@@ -75,7 +74,7 @@ var _ = Describe("filecache", func() {
 			Expect(value.SecretAccessKey).To(Equal("secret"))
 			Expect(value.SessionToken).To(Equal("token"))
 			Expect(p.IsExpired()).NotTo(BeTrue())
-			content, err := ioutil.ReadFile(filepath.Join(tmp, "credentials.yaml"))
+			content, err := os.ReadFile(filepath.Join(tmp, "credentials.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(content)).To(Equal(`profiles:
   profile:
@@ -117,7 +116,7 @@ var _ = Describe("filecache", func() {
       providername: stubProvider
     expiration: 0001-01-01T00:00:00Z
 `)
-				err := ioutil.WriteFile(filepath.Join(tmp, "credentials.yaml"), content, 0700)
+				err := os.WriteFile(filepath.Join(tmp, "credentials.yaml"), content, 0700)
 				Expect(err).ToNot(HaveOccurred())
 				c := credentials.NewCredentials(&stubProviderExpirer{})
 				fakeClock := &fakes.FakeClock{}
@@ -153,7 +152,7 @@ var _ = Describe("filecache", func() {
 		When("the cache file's permission is too broad", func() {
 			It("will refuse to use that file", func() {
 				content := []byte(`test:`)
-				err := ioutil.WriteFile(filepath.Join(tmp, "credentials.yaml"), content, 0777)
+				err := os.WriteFile(filepath.Join(tmp, "credentials.yaml"), content, 0777)
 				Expect(err).ToNot(HaveOccurred())
 				c := credentials.NewCredentials(&stubProviderExpirer{})
 				fakeClock := &fakes.FakeClock{}
@@ -164,7 +163,7 @@ var _ = Describe("filecache", func() {
 		When("the cache data has been corrupted", func() {
 			It("will return an appropriate error", func() {
 				content := []byte(`not valid yaml`)
-				err := ioutil.WriteFile(filepath.Join(tmp, "credentials.yaml"), content, 0600)
+				err := os.WriteFile(filepath.Join(tmp, "credentials.yaml"), content, 0600)
 				Expect(err).ToNot(HaveOccurred())
 				c := credentials.NewCredentials(&stubProviderExpirer{})
 				fakeClock := &fakes.FakeClock{}

--- a/pkg/ctl/cmdutils/filter/iamserviceaccount_filter_test.go
+++ b/pkg/ctl/cmdutils/filter/iamserviceaccount_filter_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	kubernetes "github.com/weaveworks/eksctl/pkg/kubernetes"
+	"github.com/weaveworks/eksctl/pkg/kubernetes"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 

--- a/pkg/ctl/ctltest/utils.go
+++ b/pkg/ctl/ctltest/utils.go
@@ -2,8 +2,8 @@ package ctltest
 
 import (
 	"bytes"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
@@ -51,7 +51,7 @@ func CreateConfigFile(cfg *api.ClusterConfig) string {
 	if err != nil {
 		log.Fatalf("unable to marshal object: %s", err.Error())
 	}
-	file, err := ioutil.TempFile("", "enable-test-config-file")
+	file, err := os.CreateTemp("", "enable-test-config-file")
 	if err != nil {
 		log.Fatalf("unable to create temp config file: %s", err.Error())
 	}

--- a/pkg/ctl/enable/flux.go
+++ b/pkg/ctl/enable/flux.go
@@ -1,7 +1,6 @@
 package enable
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/kris-nova/logger"
@@ -58,7 +57,7 @@ func flux2Install(cmd *cmdutils.Cmd) error {
 			return err
 		}
 
-		kubeCfgPath, err := ioutil.TempFile("", cmd.ClusterConfig.Metadata.Name)
+		kubeCfgPath, err := os.CreateTemp("", cmd.ClusterConfig.Metadata.Name)
 		if err != nil {
 			return err
 		}

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -2,7 +2,7 @@ package eks
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -278,9 +278,9 @@ func LoadConfigFromFile(configFile string) (*api.ClusterConfig, error) {
 
 func readConfig(configFile string) ([]byte, error) {
 	if configFile == "-" {
-		return ioutil.ReadAll(os.Stdin)
+		return io.ReadAll(os.Stdin)
 	}
-	return ioutil.ReadFile(configFile)
+	return os.ReadFile(configFile)
 }
 
 // IsSupportedRegion check if given region is supported

--- a/pkg/flux/flux_test.go
+++ b/pkg/flux/flux_test.go
@@ -2,7 +2,6 @@ package flux_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -34,7 +33,7 @@ var _ = Describe("Flux", func() {
 		fluxClient.SetExecutor(fakeExecutor)
 		fakeExecutor.ExecWithOutReturns([]byte("flux version 0.13.3\n"), nil)
 
-		binDir, err := ioutil.TempDir("", "bin")
+		binDir, err := os.MkdirTemp("", "bin")
 		Expect(err).NotTo(HaveOccurred())
 		f, err := os.Create(filepath.Join(binDir, "flux"))
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -3,7 +3,6 @@ package git
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -83,7 +82,7 @@ func (git *Client) WithDir(dir string) {
 
 // CloneRepoInTmpDir clones a repo specified in the gitURL in a temporary directory and checks out the specified branch
 func (git *Client) CloneRepoInTmpDir(tmpDirPrefix string, options CloneOptions) (string, error) {
-	cloneDir, err := ioutil.TempDir(os.TempDir(), tmpDirPrefix)
+	cloneDir, err := os.MkdirTemp(os.TempDir(), tmpDirPrefix)
 	if err != nil {
 		return "", fmt.Errorf("cannot create temporary directory: %s", err)
 	}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -2,7 +2,6 @@
 package git_test
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -183,7 +182,7 @@ var _ = Describe("git", func() {
 		})
 
 		It("succeeds when a valid path is provided", func() {
-			privateSSHKey, err := ioutil.TempFile("", "fake_id_rsa")
+			privateSSHKey, err := os.CreateTemp("", "fake_id_rsa")
 			Expect(err).To(Not(HaveOccurred()))
 			defer os.Remove(privateSSHKey.Name()) // clean up
 

--- a/pkg/gitops/profile.go
+++ b/pkg/gitops/profile.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -52,7 +51,7 @@ func (p *Profile) Install(clusterConfig *api.ClusterConfig) error {
 	if err != nil {
 		return err
 	}
-	usersRepoDir, err := ioutil.TempDir("", usersRepoName+"-")
+	usersRepoDir, err := os.MkdirTemp("", usersRepoName+"-")
 	if err != nil {
 		return errors.Wrapf(err, "unable to create temporary directory for %q", usersRepoName)
 	}

--- a/pkg/iam/oidc/api_test.go
+++ b/pkg/iam/oidc/api_test.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -29,7 +29,7 @@ var _ = BeforeSuite(func() {
 	session, err := gexec.Start(exec.Command("make", "-C", "testdata", "all"), GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
 	Eventually(session, 3).Should(gexec.Exit())
-	rawCert, err := ioutil.ReadFile("testdata/test-server.pem")
+	rawCert, err := os.ReadFile("testdata/test-server.pem")
 	Expect(err).NotTo(HaveOccurred())
 	block, rest := pem.Decode(rawCert)
 	Expect(rest).To(BeEmpty())

--- a/pkg/info/info_test.go
+++ b/pkg/info/info_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	semver "github.com/Masterminds/semver/v3"
+	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/pkg/kubernetes/manifests_test.go
+++ b/pkg/kubernetes/manifests_test.go
@@ -1,7 +1,7 @@
 package kubernetes_test
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -15,7 +15,7 @@ var _ = Describe("Kubernetes client toolkit", func() {
 
 		Context("can load and flatten deeply nested lists", func() {
 			It("loads all items into flattened list without errors", func() {
-				jb, err := ioutil.ReadFile("testdata/misc-sample-nested-list-1.json")
+				jb, err := os.ReadFile("testdata/misc-sample-nested-list-1.json")
 				Expect(err).To(Not(HaveOccurred()))
 
 				list, err := NewList(jb)
@@ -27,7 +27,7 @@ var _ = Describe("Kubernetes client toolkit", func() {
 
 		Context("can load and flatten deeply nested lists", func() {
 			It("flatten all items into an empty list without errors", func() {
-				jb, err := ioutil.ReadFile("testdata/misc-sample-empty-list-1.json")
+				jb, err := os.ReadFile("testdata/misc-sample-empty-list-1.json")
 				Expect(err).To(Not(HaveOccurred()))
 
 				list, err := NewList(jb)
@@ -39,7 +39,7 @@ var _ = Describe("Kubernetes client toolkit", func() {
 
 		Context("can combine empty nested lists from a multidoc", func() {
 			It("can load without errors", func() {
-				yb, err := ioutil.ReadFile("testdata/misc-sample-multidoc-empty-lists-1.yaml")
+				yb, err := os.ReadFile("testdata/misc-sample-multidoc-empty-lists-1.yaml")
 				Expect(err).To(Not(HaveOccurred()))
 
 				list, err := NewList(yb)
@@ -52,7 +52,7 @@ var _ = Describe("Kubernetes client toolkit", func() {
 		Context("can combine two empty lists from a multidoc", func() {
 
 			It("can load without errors", func() {
-				yb, err := ioutil.ReadFile("testdata/misc-sample-multidoc-empty-lists-2.yaml")
+				yb, err := os.ReadFile("testdata/misc-sample-multidoc-empty-lists-2.yaml")
 				Expect(err).To(Not(HaveOccurred()))
 
 				list, err := NewList(yb)
@@ -64,7 +64,7 @@ var _ = Describe("Kubernetes client toolkit", func() {
 
 		Context("can combine empty and non-empty lists from a multidoc", func() {
 			It("can load without errors", func() {
-				yb, err := ioutil.ReadFile("testdata/misc-sample-multidoc-nested-lists-1.yaml")
+				yb, err := os.ReadFile("testdata/misc-sample-multidoc-nested-lists-1.yaml")
 				Expect(err).To(Not(HaveOccurred()))
 
 				list, err := NewList(yb)
@@ -76,7 +76,7 @@ var _ = Describe("Kubernetes client toolkit", func() {
 
 		Context("can handle comment nodes", func() {
 			It("should be able to parse lists with comment nodes", func() {
-				bytes, err := ioutil.ReadFile("testdata/list-with-comment-nodes.yaml")
+				bytes, err := os.ReadFile("testdata/list-with-comment-nodes.yaml")
 				Expect(err).ToNot(HaveOccurred())
 				list, err := NewList(bytes)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/nodebootstrap/legacy/maxpods_generate.go
+++ b/pkg/nodebootstrap/legacy/maxpods_generate.go
@@ -1,15 +1,14 @@
+//go:build ignore
 //+build ignore
 
 package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"net/http"
 	"strconv"
 	"strings"
-
-	"net/http"
 
 	. "github.com/dave/jennifer/jen"
 )
@@ -30,7 +29,7 @@ func generateMap() map[string]int {
 		log.Fatal(err.Error())
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/pkg/nodebootstrap/legacy/reserved_generate.go
+++ b/pkg/nodebootstrap/legacy/reserved_generate.go
@@ -1,3 +1,4 @@
+//go:build ignore
 //+build ignore
 
 // Fetches AWS instance type data such as memory, cpus, and

--- a/pkg/printers/json_test.go
+++ b/pkg/printers/json_test.go
@@ -3,7 +3,7 @@ package printers_test
 import (
 	"bufio"
 	"bytes"
-	"io/ioutil"
+	"os"
 	"time"
 
 	. "github.com/weaveworks/eksctl/pkg/printers"
@@ -69,7 +69,7 @@ var _ = Describe("JSON Printer", func() {
 			})
 
 			It("the output should equal the golden file jsontest_single.golden", func() {
-				g, err := ioutil.ReadFile("testdata/jsontest_single.golden")
+				g, err := os.ReadFile("testdata/jsontest_single.golden")
 				if err != nil {
 					GinkgoT().Fatalf("failed reading .golden: %s", err)
 				}
@@ -126,7 +126,7 @@ var _ = Describe("JSON Printer", func() {
 			})
 
 			It("the output should equal the golden file jsontest_2clusters.golden", func() {
-				g, err := ioutil.ReadFile("testdata/jsontest_2clusters.golden")
+				g, err := os.ReadFile("testdata/jsontest_2clusters.golden")
 				if err != nil {
 					GinkgoT().Fatalf("failed reading .golden: %s", err)
 				}

--- a/pkg/printers/table_test.go
+++ b/pkg/printers/table_test.go
@@ -3,7 +3,7 @@ package printers_test
 import (
 	"bufio"
 	"bytes"
-	"io/ioutil"
+	"os"
 	"time"
 
 	. "github.com/weaveworks/eksctl/pkg/printers"
@@ -97,7 +97,7 @@ var _ = Describe("Table Printer", func() {
 			})
 
 			It("the output should equal the golden file tabletest_emptyslicegolden", func() {
-				g, err := ioutil.ReadFile("testdata/tabletest_emptyslice.golden")
+				g, err := os.ReadFile("testdata/tabletest_emptyslice.golden")
 				if err != nil {
 					GinkgoT().Fatalf("failed reading .golden: %s", err)
 				}
@@ -142,7 +142,7 @@ var _ = Describe("Table Printer", func() {
 			})
 
 			It("the output should equal the golden file tabletest_single.golden", func() {
-				g, err := ioutil.ReadFile("testdata/tabletest_single.golden")
+				g, err := os.ReadFile("testdata/tabletest_single.golden")
 				if err != nil {
 					GinkgoT().Fatalf("failed reading .golden: %s", err)
 				}
@@ -199,7 +199,7 @@ var _ = Describe("Table Printer", func() {
 			})
 
 			It("the output should equal the golden file tabletest_2clusters.golden", func() {
-				g, err := ioutil.ReadFile("testdata/tabletest_2clusters.golden")
+				g, err := os.ReadFile("testdata/tabletest_2clusters.golden")
 				if err != nil {
 					GinkgoT().Fatalf("failed reading .golden: %s", err)
 				}

--- a/pkg/printers/yaml_test.go
+++ b/pkg/printers/yaml_test.go
@@ -1,12 +1,9 @@
 package printers_test
 
 import (
-
-	//"reflect"
-	//"fmt"
 	"bufio"
 	"bytes"
-	"io/ioutil"
+	"os"
 	"time"
 
 	. "github.com/weaveworks/eksctl/pkg/printers"
@@ -72,7 +69,7 @@ var _ = Describe("YAML Printer", func() {
 			})
 
 			It("the output should equal the golden file yamltest_single.golden", func() {
-				g, err := ioutil.ReadFile("testdata/yamltest_single.golden")
+				g, err := os.ReadFile("testdata/yamltest_single.golden")
 				if err != nil {
 					GinkgoT().Fatalf("failed reading .golden: %s", err)
 				}
@@ -129,7 +126,7 @@ var _ = Describe("YAML Printer", func() {
 			})
 
 			It("the output should equal the golden file yamltest_2clusters.golden", func() {
-				g, err := ioutil.ReadFile("testdata/yamltest_2clusters.golden")
+				g, err := os.ReadFile("testdata/yamltest_2clusters.golden")
 				if err != nil {
 					GinkgoT().Fatalf("failed reading .golden: %s", err)
 				}

--- a/pkg/ssh/client/ssh.go
+++ b/pkg/ssh/client/ssh.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -172,7 +172,7 @@ func findKeyInEc2(name string, ec2API ec2iface.EC2API) (*ec2.KeyPairInfo, error)
 }
 
 func readFileContents(filePath string) ([]byte, error) {
-	fileContents, err := ioutil.ReadFile(filePath)
+	fileContents, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("reading SSH public key file %q", filePath))
 	}

--- a/pkg/testutils/client.go
+++ b/pkg/testutils/client.go
@@ -3,8 +3,9 @@ package testutils
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 
 	. "github.com/onsi/gomega"
 
@@ -27,7 +28,7 @@ func LoadSamples(manifest string) []runtime.Object {
 		samples []runtime.Object
 	)
 
-	samplesData, err := ioutil.ReadFile(manifest)
+	samplesData, err := os.ReadFile(manifest)
 	Expect(err).ToNot(HaveOccurred())
 	samplesList, err := kubernetes.NewList(samplesData)
 	Expect(err).ToNot(HaveOccurred())
@@ -207,7 +208,7 @@ func NewFakeRawResource(item runtime.Object, missing, unionised bool, ct *Collec
 		collection: ct,
 	}
 
-	emptyBody := ioutil.NopCloser(bytes.NewReader([]byte{}))
+	emptyBody := io.NopCloser(bytes.NewReader([]byte{}))
 	notFound := http.Response{StatusCode: http.StatusNotFound, Body: emptyBody}
 	conflict := http.Response{StatusCode: http.StatusConflict, Body: emptyBody}
 
@@ -218,7 +219,7 @@ func NewFakeRawResource(item runtime.Object, missing, unionised bool, ct *Collec
 	asResult := func(req *http.Request) (*http.Response, error) {
 		data, err := runtime.Encode(unstructured.UnstructuredJSONScheme, item)
 		Expect(err).To(Not(HaveOccurred()))
-		res := &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(bytes.NewReader(data))}
+		res := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(data))}
 		return res, nil
 	}
 

--- a/pkg/utils/dir/dir_test.go
+++ b/pkg/utils/dir/dir_test.go
@@ -1,7 +1,6 @@
 package dir_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +17,7 @@ func TestUtilsDir(t *testing.T) {
 
 var _ = Describe("dir.IsEmpty", func() {
 	It("should return true when passed an empty directory", func() {
-		d, err := ioutil.TempDir("", "test_dir_isempty")
+		d, err := os.MkdirTemp("", "test_dir_isempty")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.RemoveAll(d) // clean up.
 
@@ -28,7 +27,7 @@ var _ = Describe("dir.IsEmpty", func() {
 	})
 
 	It("should return false when passed a directory containing another directory", func() {
-		d, err := ioutil.TempDir("", "test_dir_isempty")
+		d, err := os.MkdirTemp("", "test_dir_isempty")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.RemoveAll(d) // clean up.
 		err = os.Mkdir(filepath.Join(d, "subdir"), 0755)
@@ -40,7 +39,7 @@ var _ = Describe("dir.IsEmpty", func() {
 	})
 
 	It("should return false when passed a directory containing a file", func() {
-		d, err := ioutil.TempDir("", "test_dir_isempty")
+		d, err := os.MkdirTemp("", "test_dir_isempty")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.RemoveAll(d) // clean up.
 		f, err := os.OpenFile(filepath.Join(d, "file.tmp"), os.O_CREATE, 0755)

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -3,11 +3,10 @@ package kubeconfig
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
-
-	"os/exec"
 
 	"github.com/gofrs/flock"
 	"github.com/kris-nova/logger"

--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -1,7 +1,6 @@
 package kubeconfig_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"sync"
@@ -32,7 +31,7 @@ var _ = Describe("Kubeconfig", func() {
 	var exampleSSHKeyPath = "~/.ssh/id_rsa.pub"
 
 	BeforeEach(func() {
-		configFile, _ = ioutil.TempFile("", "")
+		configFile, _ = os.CreateTemp("", "")
 	})
 
 	AfterEach(func() {
@@ -40,12 +39,12 @@ var _ = Describe("Kubeconfig", func() {
 	})
 
 	var writeConfig = func(filename string) error {
-		minikubeSample, err := ioutil.ReadFile("testdata/minikube_sample.golden")
+		minikubeSample, err := os.ReadFile("testdata/minikube_sample.golden")
 		if err != nil {
 			GinkgoT().Fatalf("failed reading .golden: %s", err)
 		}
 
-		return ioutil.WriteFile(filename, minikubeSample, os.FileMode(0755))
+		return os.WriteFile(filename, minikubeSample, os.FileMode(0755))
 	}
 
 	It("creating new Kubeconfig", func() {
@@ -72,7 +71,7 @@ var _ = Describe("Kubeconfig", func() {
 	})
 
 	It("creating new Kubeconfig in non-existent directory", func() {
-		tempDir, _ := ioutil.TempDir("", "")
+		tempDir, _ := os.MkdirTemp("", "")
 		filename, err := kubeconfig.Write(path.Join(tempDir, "nonexistentdir", "kubeconfig"), testConfig, false)
 		Expect(err).To(BeNil())
 		Expect(filename).ToNot(BeEmpty())
@@ -229,23 +228,23 @@ var _ = Describe("Kubeconfig", func() {
 
 			var err error
 
-			if emptyClusterAsBytes, err = ioutil.ReadFile("testdata/empty_cluster.golden"); err != nil {
+			if emptyClusterAsBytes, err = os.ReadFile("testdata/empty_cluster.golden"); err != nil {
 				GinkgoT().Fatalf("failed reading .golden: %v", err)
 			}
 
-			if oneClusterAsBytes, err = ioutil.ReadFile("testdata/one_cluster.golden"); err != nil {
+			if oneClusterAsBytes, err = os.ReadFile("testdata/one_cluster.golden"); err != nil {
 				GinkgoT().Fatalf("failed reading .golden: %v", err)
 			}
 
-			if twoClustersAsBytes, err = ioutil.ReadFile("testdata/two_clusters.golden"); err != nil {
+			if twoClustersAsBytes, err = os.ReadFile("testdata/two_clusters.golden"); err != nil {
 				GinkgoT().Fatalf("failed reading .golden: %v", err)
 			}
 
-			if oneClusterWithoutContextAsBytes, err = ioutil.ReadFile("testdata/one_cluster_without_context.golden"); err != nil {
+			if oneClusterWithoutContextAsBytes, err = os.ReadFile("testdata/one_cluster_without_context.golden"); err != nil {
 				GinkgoT().Fatalf("failed reading .golden: %v", err)
 			}
 
-			if oneClusterWithStaleContextAsBytes, err = ioutil.ReadFile("testdata/one_cluster_with_stale_context.golden"); err != nil {
+			if oneClusterWithStaleContextAsBytes, err = os.ReadFile("testdata/one_cluster_with_stale_context.golden"); err != nil {
 				GinkgoT().Fatalf("failed reading .golden: %v", err)
 			}
 
@@ -264,7 +263,7 @@ var _ = Describe("Kubeconfig", func() {
 			existingClusterConfig := GetClusterConfig("cluster-one")
 			kubeconfig.MaybeDeleteConfig(existingClusterConfig.Metadata)
 
-			configFileAsBytes, err := ioutil.ReadFile(configFile.Name())
+			configFileAsBytes, err := os.ReadFile(configFile.Name())
 			Expect(err).To(BeNil())
 			Expect(configFileAsBytes).To(MatchYAML(emptyClusterAsBytes), "Failed to delete cluster from config")
 		})
@@ -273,7 +272,7 @@ var _ = Describe("Kubeconfig", func() {
 			existingClusterConfig := GetClusterConfig("cluster-one")
 			kubeconfig.MaybeDeleteConfig(existingClusterConfig.Metadata)
 
-			configFileAsBytes, err := ioutil.ReadFile(configFile.Name())
+			configFileAsBytes, err := os.ReadFile(configFile.Name())
 			Expect(err).To(BeNil())
 			Expect(configFileAsBytes).To(MatchYAML(oneClusterWithoutContextAsBytes), "Failed to delete cluster from config")
 		})
@@ -285,7 +284,7 @@ var _ = Describe("Kubeconfig", func() {
 			existingClusterConfig := GetClusterConfig("cluster-one")
 			kubeconfig.MaybeDeleteConfig(existingClusterConfig.Metadata)
 
-			configFileAsBytes, err := ioutil.ReadFile(configFile.Name())
+			configFileAsBytes, err := os.ReadFile(configFile.Name())
 			Expect(err).To(BeNil())
 			Expect(configFileAsBytes).To(MatchYAML(oneClusterWithoutContextAsBytes), "Updated config")
 
@@ -295,7 +294,7 @@ var _ = Describe("Kubeconfig", func() {
 			existingClusterConfig := GetClusterConfig("cluster-two")
 			kubeconfig.MaybeDeleteConfig(existingClusterConfig.Metadata)
 
-			configFileAsBytes, err := ioutil.ReadFile(configFile.Name())
+			configFileAsBytes, err := os.ReadFile(configFile.Name())
 			Expect(err).To(BeNil())
 			Expect(configFileAsBytes).To(MatchYAML(oneClusterAsBytes), "Failed to delete cluster from config")
 		})
@@ -304,7 +303,7 @@ var _ = Describe("Kubeconfig", func() {
 			nonExistentClusterConfig := GetClusterConfig("not-a-cluster")
 			kubeconfig.MaybeDeleteConfig(nonExistentClusterConfig.Metadata)
 
-			configFileAsBytes, err := ioutil.ReadFile(configFile.Name())
+			configFileAsBytes, err := os.ReadFile(configFile.Name())
 			Expect(err).To(BeNil())
 			Expect(configFileAsBytes).To(MatchYAML(twoClustersAsBytes), "Should not change")
 		})
@@ -318,7 +317,7 @@ var _ = Describe("Kubeconfig", func() {
 		ChangeKubeconfig()
 
 		var err error
-		tmp, err := ioutil.TempFile("", "")
+		tmp, err := os.CreateTemp("", "")
 		Expect(err).To(BeNil())
 
 		{


### PR DESCRIPTION
### Description

The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since eksctl has been upgraded to Go 1.17 (#4165), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:

