### PR TITLE
Removed misleading keywords under the schema.json

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -895,17 +895,14 @@
         },
         "amiFamily": {
           "type": "string",
-          "description": "Valid variants are: `\"AmazonLinux2\"` (default), `\"Ubuntu2004\"`, `\"Ubuntu1804\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2004CoreContainer\"`.",
-          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2&quot;</code> (default), <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Ubuntu1804&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2004CoreContainer&quot;</code>.",
+          "description": "Valid variants are: `\"AmazonLinux2\"` (default), `\"Ubuntu2004\"`, `\"Ubuntu1804\"`, `\"Bottlerocket\"`.",
+          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2&quot;</code> (default), <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Ubuntu1804&quot;</code>, <code>&quot;Bottlerocket&quot;</code>.",
           "default": "AmazonLinux2",
           "enum": [
             "AmazonLinux2",
             "Ubuntu2004",
             "Ubuntu1804",
-            "Bottlerocket",
-            "WindowsServer2019CoreContainer",
-            "WindowsServer2019FullContainer",
-            "WindowsServer2004CoreContainer"
+            "Bottlerocket"
           ]
         },
         "asgSuspendProcesses": {


### PR DESCRIPTION

### Description

It is misleading to see Windows types under Managed node groups 'https://eksctl.io/usage/schema/#managedNodeGroups-amiFamily' when in fact they are not supported:

$  eksctl create cluster -f cluster.yaml
Error: "WindowsServer2019CoreContainer" is not supported for managed nodegroups

The file:

managedNodeGroups:
  - name: bmc-autodev-eks-node-group-win
    amiFamily: WindowsServer2019CoreContainer
    instanceType: m5.xlarge


### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

