### PR TITLE
Add support for Windows IPAM

### DIFF
--- a/examples/14-windows-nodes.yaml
+++ b/examples/14-windows-nodes.yaml
@@ -1,5 +1,5 @@
 # An example of ClusterConfig containing Windows and Linux node groups to support Windows workloads
-# This example should be run with `eksctl create cluster -f 14-windows-nodes.yaml --install-vpc-controllers`
+# This example should be run with `eksctl create cluster -f 14-windows-nodes.yaml`
 ---
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
@@ -13,6 +13,8 @@ nodeGroups:
     amiFamily: WindowsServer2019FullContainer
     minSize: 2
     maxSize: 3
+
+managedNodeGroups:
   - name: linux-ng
     instanceType: t2.large
     minSize: 2

--- a/integration/tests/windows/windows_test.go
+++ b/integration/tests/windows/windows_test.go
@@ -70,7 +70,6 @@ var _ = Describe("(Integration) [Windows Nodegroups]", func() {
 				"--config-file", "-",
 				"--verbose", "4",
 				"--kubeconfig", params.KubeconfigPath,
-				"--install-vpc-controllers",
 			).
 			WithoutArg("--region", params.Region).
 			WithStdin(bytes.NewReader(data))

--- a/pkg/apis/eksctl.io/v1alpha5/nodegroups.go
+++ b/pkg/apis/eksctl.io/v1alpha5/nodegroups.go
@@ -94,3 +94,13 @@ func (c *ClusterConfig) AllNodeGroups() []*NodeGroupBase {
 	}
 	return baseNodeGroups
 }
+
+// HasWindowsNodeGroup returns true if an unmanaged Windows nodegroup exists.
+func (c *ClusterConfig) HasWindowsNodeGroup() bool {
+	for _, ng := range c.NodeGroups {
+		if IsWindowsImage(ng.AMIFamily) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -32,6 +32,14 @@ import (
 	"github.com/weaveworks/eksctl/pkg/vpc"
 )
 
+const (
+	vpcControllerInfoMessage = "you no longer need to install the VPC resource controller on Linux worker nodes to run " +
+		"Windows workloads in EKS clusters created after Oct 22, 2021. You can enable Windows IP address management on the EKS control plane via " +
+		"a ConﬁgMap setting (see https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html for details). eksctl will automatically patch the ConfigMap to enable " +
+		"Windows IP address management when a Windows nodegroup is created. For existing clusters, you can enable it manually " +
+		"and run `eksctl utils install-vpc-controllers` with the --delete ﬂag to remove the worker node installation of the VPC resource controller"
+)
+
 func createClusterCmd(cmd *cmdutils.Cmd) {
 	createClusterCmdWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params *cmdutils.CreateClusterCmdParams) error {
 		return doCreateCluster(cmd, ngFilter, params)
@@ -71,6 +79,8 @@ func createClusterCmdWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.C
 		fs.BoolVarP(&params.InstallWindowsVPCController, "install-vpc-controllers", "", false, "Install VPC controller that's required for Windows workloads")
 		fs.BoolVarP(&params.Fargate, "fargate", "", false, "Create a Fargate profile scheduling pods in the default and kube-system namespaces onto Fargate")
 		fs.BoolVarP(&params.DryRun, "dry-run", "", false, "Dry-run mode that skips cluster creation and outputs a ClusterConfig")
+
+		_ = fs.MarkDeprecated("install-vpc-controllers", vpcControllerInfoMessage)
 	})
 
 	cmd.FlagSetGroup.InFlagSet("Initial nodegroup", func(fs *pflag.FlagSet) {
@@ -190,6 +200,7 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 		if !eks.SupportsWindowsWorkloads(kubeNodeGroups) {
 			return errors.New("running Windows workloads requires having both Windows and Linux (AmazonLinux2) node groups")
 		}
+		logger.Warning(vpcControllerInfoMessage)
 	} else {
 		eks.LogWindowsCompatibility(kubeNodeGroups, cfg.Metadata)
 	}
@@ -248,7 +259,7 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 	if err != nil {
 		return err
 	}
-	postClusterCreationTasks := ctl.CreateExtraClusterConfigTasks(cfg, params.InstallWindowsVPCController)
+	postClusterCreationTasks := ctl.CreateExtraClusterConfigTasks(cfg)
 
 	supported, err := utils.IsMinVersion(api.Version1_18, cfg.Metadata.Version)
 	if err != nil {

--- a/pkg/windows/ipam.go
+++ b/pkg/windows/ipam.go
@@ -1,0 +1,86 @@
+package windows
+
+import (
+	"context"
+	"encoding/json"
+
+	jsonpatch "github.com/evanphx/json-patch/v5"
+	"github.com/kris-nova/logger"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+const (
+	vpcCNIName       = "amazon-vpc-cni"
+	vpcCNINamespace  = metav1.NamespaceSystem
+	windowsIPAMField = "enable-windows-ipam"
+)
+
+// IPAM enables Windows IPAM in the VPC CNI ConfigMap.
+type IPAM struct {
+	Clientset kubernetes.Interface
+}
+
+// Enable enables Windows IPAM in the VPC CNI ConfigMap.
+func (w *IPAM) Enable(ctx context.Context) error {
+	configMaps := w.Clientset.CoreV1().ConfigMaps(metav1.NamespaceSystem)
+	vpcCNIConfig, err := configMaps.Get(ctx, vpcCNIName, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return errors.Wrapf(err, "error getting ConfigMap %q", vpcCNIName)
+		}
+		return createConfigMap(ctx, configMaps)
+	}
+
+	if val, ok := vpcCNIConfig.Data[windowsIPAMField]; ok && val == "true" {
+		logger.Info("Windows IPAM is already enabled")
+		return nil
+	}
+
+	patch, err := createPatch(vpcCNIConfig)
+	if err != nil {
+		return errors.Wrap(err, "error creating merge patch")
+	}
+
+	_, err = configMaps.Patch(ctx, vpcCNIName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to patch resource %q", vpcCNIName)
+	}
+	return nil
+}
+
+func createPatch(cm *corev1.ConfigMap) ([]byte, error) {
+	oldData, err := json.Marshal(cm)
+	if err != nil {
+		return nil, err
+	}
+	cm.Data[windowsIPAMField] = "true"
+	modifiedData, err := json.Marshal(cm)
+	if err != nil {
+		return nil, err
+	}
+	return jsonpatch.CreateMergePatch(oldData, modifiedData)
+}
+
+func createConfigMap(ctx context.Context, configMaps corev1client.ConfigMapInterface) error {
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vpcCNIName,
+			Namespace: vpcCNINamespace,
+		},
+		Data: map[string]string{
+			windowsIPAMField: "true",
+		},
+	}
+	_, err := configMaps.Create(ctx, cm, metav1.CreateOptions{})
+	return err
+}

--- a/pkg/windows/ipam_test.go
+++ b/pkg/windows/ipam_test.go
@@ -1,0 +1,97 @@
+package windows_test
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/gomega"
+
+	. "github.com/onsi/ginkgo/extensions/table"
+	"github.com/weaveworks/eksctl/pkg/windows"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type ipamEntry struct {
+	existingConfigMapData map[string]string
+
+	expectedConfigMapData map[string]string
+}
+
+var _ = DescribeTable("Windows IPAM", func(e ipamEntry) {
+	var clientset *fake.Clientset
+	if e.existingConfigMapData != nil {
+		clientset = fake.NewSimpleClientset(&v1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "amazon-vpc-cni",
+				Namespace: "kube-system",
+			},
+			Data: e.existingConfigMapData,
+		})
+	} else {
+		clientset = fake.NewSimpleClientset()
+	}
+
+	ipam := &windows.IPAM{
+		Clientset: clientset,
+	}
+	ctx := context.Background()
+	err := ipam.Enable(ctx)
+	Expect(err).ToNot(HaveOccurred())
+
+	cm, err := clientset.CoreV1().ConfigMaps("kube-system").Get(ctx, "amazon-vpc-cni", metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cm.Data).To(Equal(e.expectedConfigMapData))
+
+},
+	Entry("VPC CNI ConfigMap is missing", ipamEntry{
+		expectedConfigMapData: map[string]string{
+			"enable-windows-ipam": "true",
+		},
+	}),
+
+	Entry("VPC CNI ConfigMap has data", ipamEntry{
+		existingConfigMapData: map[string]string{
+			"VPC_CNI_1": "yes",
+			"VPC_CNI_2": "no",
+			"other":     "true",
+		},
+		expectedConfigMapData: map[string]string{
+			"VPC_CNI_1":           "yes",
+			"VPC_CNI_2":           "no",
+			"other":               "true",
+			"enable-windows-ipam": "true",
+		},
+	}),
+
+	Entry("VPC CNI ConfigMap has Windows IPAM already enabled", ipamEntry{
+		existingConfigMapData: map[string]string{
+			"VPC_CNI_1":           "yes",
+			"VPC_CNI_2":           "no",
+			"enable-windows-ipam": "true",
+		},
+		expectedConfigMapData: map[string]string{
+			"VPC_CNI_1":           "yes",
+			"VPC_CNI_2":           "no",
+			"enable-windows-ipam": "true",
+		},
+	}),
+
+	Entry("VPC CNI ConfigMap has Windows IPAM explicitly disabled", ipamEntry{
+		existingConfigMapData: map[string]string{
+			"VPC_CNI_1":           "yes",
+			"VPC_CNI_2":           "no",
+			"enable-windows-ipam": "false",
+		},
+		expectedConfigMapData: map[string]string{
+			"VPC_CNI_1":           "yes",
+			"VPC_CNI_2":           "no",
+			"enable-windows-ipam": "true",
+		},
+	}),
+)


### PR DESCRIPTION
### Description

This changelist adds support for Windows IPAM for new clusters. 

EKS will eliminate the need to install the VPC controller on worker nodes to run Windows clusters for new clusters. For existing clusters, this functionality will be available later. When it's out, eksctl will 
1. Add a new flag `--delete` to `eksctl utils install-vpc-controllers` to allow deleting an existing installation of VPC controller
2. Automatically patch the ConfigMap to enable Windows IPAM support when a Windows nodegroup is created

Partially addresses #2401


<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x]   Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

