### PR TITLE
Fix integration test timeout

### DIFF
--- a/integration/tests/params.go
+++ b/integration/tests/params.go
@@ -94,7 +94,7 @@ func (p *Params) GenerateCommands() {
 
 	p.EksctlGetCmd = p.EksctlCmd.
 		WithArgs("get").
-		WithTimeout(1 * time.Minute)
+		WithTimeout(2 * time.Minute)
 
 	p.EksctlSetLabelsCmd = p.EksctlCmd.
 		WithArgs("set", "labels").


### PR DESCRIPTION
### Description

Integration test got throttled into oblivion. This is a "fix" to let `get` work longer if necessary. There is a separate issue dealing with reducing the number of API calls to reduce the number of throttled errors.

https://github.com/weaveworks/eksctl/runs/3970454584?check_suite_focus=true

Details:

```
2021-10-22T00:44:39.8940443Z [7] starting '../../../eksctl "--region" "us-west-2" "get" "clusters" "--all-regions"'
...
2021-10-22T00:45:10.7563729Z [7] 2021-10-22 00:45:10 [!]  retryable error (Throttling: Rate exceeded
2021-10-22T00:45:10.7565578Z [7] 	status code: 400, request id: 4a9ab488-3326-4dcb-8453-b02dad63e59f) from cloudformation/DescribeStacks - will retry after delay of 9.230354528s
...
2021-10-22T00:45:20.2032565Z [7] 2021-10-22 00:45:20 [!]  retryable error (Throttling: Rate exceeded
2021-10-22T00:45:20.2034240Z [7] 	status code: 400, request id: 579eaa91-ee6b-4841-ab77-eaa9a96467b2) from cloudformation/DescribeStacks - will retry after delay of 18.834357766s
...
2021-10-22T00:45:39.2705314Z [7] 
2021-10-22T00:45:39.2707340Z [7] ‚Ä¢ Failure [60.002 seconds]
```

It got throttled too often and then slept for too long and timed out.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

