### PR TITLE
Scale managed nodegroup with --name flag

### DIFF
--- a/pkg/actions/nodegroup/scale.go
+++ b/pkg/actions/nodegroup/scale.go
@@ -16,7 +16,7 @@ import (
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 )
 
-func (m *Manager) Scale(ng *api.NodeGroup) error {
+func (m *Manager) Scale(ng *api.NodeGroupBase) error {
 	logger.Info("scaling nodegroup %q in cluster %s", ng.Name, m.cfg.Metadata.Name)
 
 	nodegroupStackInfos, err := m.stackManager.DescribeNodeGroupStacksAndResources()
@@ -48,7 +48,7 @@ func (m *Manager) Scale(ng *api.NodeGroup) error {
 	return nil
 }
 
-func (m *Manager) scaleUnmanagedNodeGroup(ng *api.NodeGroup, stackInfo manager.StackInfo) error {
+func (m *Manager) scaleUnmanagedNodeGroup(ng *api.NodeGroupBase, stackInfo manager.StackInfo) error {
 	asgName := ""
 	for _, resource := range stackInfo.Resources {
 		if *resource.LogicalResourceId == "NodeGroup" {
@@ -86,7 +86,7 @@ func (m *Manager) scaleUnmanagedNodeGroup(ng *api.NodeGroup, stackInfo manager.S
 	return nil
 }
 
-func (m *Manager) scaleManagedNodeGroup(ng *api.NodeGroup) error {
+func (m *Manager) scaleManagedNodeGroup(ng *api.NodeGroupBase) error {
 	scalingConfig := &eks.NodegroupScalingConfig{}
 
 	if ng.MaxSize != nil {

--- a/pkg/actions/nodegroup/scale_test.go
+++ b/pkg/actions/nodegroup/scale_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Scale", func() {
 		clusterName, ngName string
 		p                   *mockprovider.MockProvider
 		cfg                 *api.ClusterConfig
-		ng                  *api.NodeGroup
+		ng                  *api.NodeGroupBase
 		m                   *nodegroup.Manager
 		fakeStackManager    *fakes.FakeStackManager
 	)
@@ -37,13 +37,11 @@ var _ = Describe("Scale", func() {
 		cfg = api.NewClusterConfig()
 		cfg.Metadata.Name = clusterName
 
-		ng = &api.NodeGroup{
-			NodeGroupBase: &api.NodeGroupBase{
-				Name: ngName,
-				ScalingConfig: &api.ScalingConfig{
-					MinSize:         aws.Int(1),
-					DesiredCapacity: aws.Int(3),
-				},
+		ng = &api.NodeGroupBase{
+			Name: ngName,
+			ScalingConfig: &api.ScalingConfig{
+				MinSize:         aws.Int(1),
+				DesiredCapacity: aws.Int(3),
 			},
 		}
 		m = nodegroup.New(cfg, &eks.ClusterProvider{Provider: p}, nil)

--- a/pkg/ctl/cmdutils/scale.go
+++ b/pkg/ctl/cmdutils/scale.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewScaleNodeGroupLoader will load config or use flags for 'eksctl scale nodegroup'
-func NewScaleNodeGroupLoader(cmd *Cmd, ng *api.NodeGroup) ClusterConfigLoader {
+func NewScaleNodeGroupLoader(cmd *Cmd, ng *api.NodeGroupBase) ClusterConfigLoader {
 	l := newCommonClusterConfigLoader(cmd)
 
 	l.flagsIncompatibleWithConfigFile.Insert(
@@ -22,9 +22,9 @@ func NewScaleNodeGroupLoader(cmd *Cmd, ng *api.NodeGroup) ClusterConfigLoader {
 			return err
 		}
 
-		loadedNG := l.ClusterConfig.FindNodegroup(ng.Name)
-		if loadedNG == nil {
-			return fmt.Errorf("node group %s not found", ng.Name)
+		loadedNG, err := l.ClusterConfig.FindNodegroup(ng.Name)
+		if err != nil {
+			return err
 		}
 
 		if err := validateNumberOfNodes(loadedNG); err != nil {
@@ -54,7 +54,7 @@ func NewScaleNodeGroupLoader(cmd *Cmd, ng *api.NodeGroup) ClusterConfigLoader {
 	return l
 }
 
-func validateNameArgument(cmd *Cmd, ng *api.NodeGroup) error {
+func validateNameArgument(cmd *Cmd, ng *api.NodeGroupBase) error {
 	if ng.Name != "" && cmd.NameArg != "" {
 		return ErrFlagAndArg("--name", ng.Name, cmd.NameArg)
 	}
@@ -70,7 +70,7 @@ func validateNameArgument(cmd *Cmd, ng *api.NodeGroup) error {
 	return nil
 }
 
-func validateNumberOfNodes(ng *api.NodeGroup) error {
+func validateNumberOfNodes(ng *api.NodeGroupBase) error {
 	if ng.ScalingConfig == nil {
 		ng.ScalingConfig = &api.ScalingConfig{}
 	}
@@ -103,7 +103,7 @@ func validateNumberOfNodes(ng *api.NodeGroup) error {
 }
 
 //only 1 of desired/min/max has to be set on the cli
-func validateNumberOfNodesCLI(ng *api.NodeGroup) error {
+func validateNumberOfNodesCLI(ng *api.NodeGroupBase) error {
 	if ng.ScalingConfig == nil {
 		ng.ScalingConfig = &api.ScalingConfig{}
 	}

--- a/pkg/ctl/scale/nodegroup.go
+++ b/pkg/ctl/scale/nodegroup.go
@@ -11,14 +11,14 @@ import (
 )
 
 func scaleNodeGroupCmd(cmd *cmdutils.Cmd) {
-	scaleNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *api.NodeGroup) error {
+	scaleNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *api.NodeGroupBase) error {
 		return doScaleNodeGroup(cmd, ng)
 	})
 }
 
-func scaleNodeGroupWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, ng *api.NodeGroup) error) {
+func scaleNodeGroupWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd, ng *api.NodeGroupBase) error) {
 	cfg := api.NewClusterConfig()
-	ng := cfg.NewNodeGroup()
+	ng := cfg.NewNodeGroup().BaseNodeGroup()
 	cmd.ClusterConfig = cfg
 
 	cmd.SetDescription("nodegroup", "Scale a nodegroup", "", "ng")
@@ -56,7 +56,7 @@ func scaleNodeGroupWithRunFunc(cmd *cmdutils.Cmd, runFunc func(cmd *cmdutils.Cmd
 	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, &cmd.ProviderConfig, true)
 }
 
-func doScaleNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup) error {
+func doScaleNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroupBase) error {
 	if err := cmdutils.NewScaleNodeGroupLoader(cmd, ng).Load(); err != nil {
 		return err
 	}

--- a/pkg/ctl/scale/nodegroup_test.go
+++ b/pkg/ctl/scale/nodegroup_test.go
@@ -13,12 +13,12 @@ import (
 
 var _ = Describe("scale", func() {
 	Describe("nodegroup", func() {
-		DescribeTable("create cluster successfully",
+		DescribeTable("scales  a nodegroup successfully",
 			func(args ...string) {
 				cmd := newMockEmptyCmd(args...)
 				count := 0
 				cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
-					scaleNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *v1alpha5.NodeGroup) error {
+					scaleNodeGroupWithRunFunc(cmd, func(cmd *cmdutils.Cmd, ng *v1alpha5.NodeGroupBase) error {
 						if len(ng.Name) != 0 {
 							Expect(ng.Name).To(Or(Equal("nodeGroup"), Equal("")))
 						} else {


### PR DESCRIPTION
### Description

Fixes bug in #2655

The issue was that when a user was doing `eksctl scale nodegroup --config-file x --name y`, eksctl was not looking in the config file for managed nodegroups. This only worked for unmanaged nodegroups. 

Iterating over `managedNodeGroups` as well and then returning the nodegroup base (which is common to both types of ng) fixes this issue.

A separate PR will address scaling all nodegroups in the config file if the name flag is not provided.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:

