### PR TITLE
Add tests for eks client config with embedded token

### DIFF
--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -235,7 +235,7 @@ func New(spec *api.ProviderConfig, clusterSpec *api.ClusterConfig) (*ClusterProv
 		clusterSpec.Metadata.Region = c.Provider.Region()
 	}
 
-	return c, c.checkAuth()
+	return c, c.CheckAuth()
 }
 
 // ParseConfig parses data into a ClusterConfig
@@ -305,9 +305,8 @@ func (c *ClusterProvider) GetCredentialsEnv() ([]string, error) {
 	}, nil
 }
 
-// checkAuth checks the AWS authentication
-func (c *ClusterProvider) checkAuth() error {
-
+// CheckAuth checks the AWS authentication
+func (c *ClusterProvider) CheckAuth() error {
 	input := &sts.GetCallerIdentityInput{}
 	output, err := c.Provider.STS().GetCallerIdentity(input)
 	if err != nil {

--- a/pkg/eks/client.go
+++ b/pkg/eks/client.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
-	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
 
@@ -72,7 +71,7 @@ func (c *Client) useEmbeddedToken(spec *api.ClusterConfig, stsclient stsiface.ST
 		return errors.Wrap(err, "could not get token generator")
 	}
 
-	tok, err := gen.GetWithSTS(spec.Metadata.Name, stsclient.(*sts.STS))
+	tok, err := gen.GetWithSTS(spec.Metadata.Name, stsclient)
 	if err != nil {
 		return errors.Wrap(err, "could not get token")
 	}


### PR DESCRIPTION
### Description
Add tests for eks client config with embedded token using a mocked AWS provider and STS interface after removing the explicit cast in the token generation code.

Also exports `CheckAuth()` from `ClusterProvider` to populate private `Cluster.Status.iamRoleARN` field in struct via STS mocking.

### Checklist
- [x] Added tests that cover your change (if possible)
- [N/A] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

