### PR TITLE
Add support for using existing VPC for ipv6 cluster

### DIFF
--- a/integration/tests/existing_vpc/cf-template.yaml
+++ b/integration/tests/existing_vpc/cf-template.yaml
@@ -1,0 +1,391 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Networking and roles for EKSCTL unowned cluster integration test'
+
+Mappings:
+  ServicePrincipalPartitionMap:
+    aws:
+      EC2: ec2.amazonaws.com
+      EKS: eks.amazonaws.com
+      EKSFargatePods: eks-fargate-pods.amazonaws.com
+
+Parameters:
+  VpcBlock:
+    Type: String
+    Default: 192.168.0.0/16
+    Description: The CIDR range for the VPC. This should be a valid private (RFC 1918) CIDR range.
+
+  Subnet01Block:
+    Type: String
+    Default: 192.168.0.0/19
+    Description: CidrBlock for subnet 01 within the VPC
+
+  Subnet02Block:
+    Type: String
+    Default: 192.168.32.0/19
+    Description: CidrBlock for subnet 02 within the VPC
+
+  Subnet03Block:
+    Type: String
+    Default: 192.168.64.0/19
+    Description: CidrBlock for subnet 03 within the VPC. This is used only if the region has more than 2 AZs.
+
+  Subnet04Block:
+    Type: String
+    Default: 192.168.96.0/19
+    Description: CidrBlock for private subnet 04 within the VPC.
+
+  Subnet05Block:
+    Type: String
+    Default: 192.168.128.0/19
+    Description: CidrBlock for private subnet 05 within the VPC.
+
+  Subnet06Block:
+    Type: String
+    Default: 192.168.160.0/19
+    Description: CidrBlock for private subnet 06 within the VPC. This is used only if the region has more than 2 AZs.
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      -
+        Label:
+          default: "Worker Network Configuration"
+        Parameters:
+          - VpcBlock
+          - Subnet01Block
+          - Subnet02Block
+          - Subnet03Block
+          - Subnet04Block
+          - Subnet05Block
+          - Subnet06Block
+
+Conditions:
+  Has2Azs:
+    Fn::Or:
+      - Fn::Equals:
+        - {Ref: 'AWS::Region'}
+        - ap-south-1
+      - Fn::Equals:
+        - {Ref: 'AWS::Region'}
+        - ap-northeast-2
+      - Fn::Equals:
+        - {Ref: 'AWS::Region'}
+        - ca-central-1
+      - Fn::Equals:
+        - {Ref: 'AWS::Region'}
+        - cn-north-1
+      - Fn::Equals:
+        - {Ref: 'AWS::Region'}
+        - sa-east-1
+      - Fn::Equals:
+        - {Ref: 'AWS::Region'}
+        - us-west-1
+
+  HasMoreThan2Azs:
+    Fn::Not:
+      - Condition: Has2Azs
+
+Resources:
+  NodeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - Fn::FindInMap:
+                    - ServicePrincipalPartitionMap
+                    - Ref: AWS::Partition
+                    - EC2
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+        - Fn::Sub: arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+        - Fn::Sub: arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy
+        - Fn::Sub: arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy
+      Path: "/"
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: "${AWS::StackName}/NodeRole"
+  ClusterRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - Fn::FindInMap:
+                    - ServicePrincipalPartitionMap
+                    - Ref: AWS::Partition
+                    - EKS
+                - Fn::FindInMap:
+                    - ServicePrincipalPartitionMap
+                    - Ref: AWS::Partition
+                    - EKSFargatePods
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+        - Fn::Sub: arn:${AWS::Partition}:iam::aws:policy/AmazonEKSClusterPolicy
+        - Fn::Sub: arn:${AWS::Partition}:iam::aws:policy/AmazonEKSVPCResourceController
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Sub: "${AWS::StackName}/ClusterRole"
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock:  !Ref VpcBlock
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+      - Key: Name
+        Value: !Sub '${AWS::StackName}-VPC'
+
+  InternetGateway:
+    Type: "AWS::EC2::InternetGateway"
+
+  VPCGatewayAttachment:
+    Type: "AWS::EC2::VPCGatewayAttachment"
+    Properties:
+      InternetGatewayId: !Ref InternetGateway
+      VpcId: !Ref VPC
+
+  RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: Public Subnets
+      - Key: Network
+        Value: Public
+
+  PrivateRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: Private Subnets
+      - Key: Network
+        Value: Private
+
+  Route:
+    DependsOn: VPCGatewayAttachment
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref RouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  Subnet01:
+    Type: AWS::EC2::Subnet
+    Metadata:
+      Comment: Subnet 01
+    Properties:
+      MapPublicIpOnLaunch: true
+      AvailabilityZone:
+        Fn::Select:
+        - '0'
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock:
+        Ref: Subnet01Block
+      VpcId:
+        Ref: VPC
+      Tags:
+      - Key: Name
+        Value: !Sub "${AWS::StackName}-Subnet01"
+      - Key: kubernetes.io/role/elb
+        Value: 1
+
+  Subnet02:
+    Type: AWS::EC2::Subnet
+    Metadata:
+      Comment: Subnet 02
+    Properties:
+      MapPublicIpOnLaunch: true
+      AvailabilityZone:
+        Fn::Select:
+        - '1'
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock:
+        Ref: Subnet02Block
+      VpcId:
+        Ref: VPC
+      Tags:
+      - Key: Name
+        Value: !Sub "${AWS::StackName}-Subnet02"
+      - Key: kubernetes.io/role/elb
+        Value: 1
+
+  Subnet03:
+    Condition: HasMoreThan2Azs
+    Type: AWS::EC2::Subnet
+    Metadata:
+      Comment: Subnet 03
+    Properties:
+      MapPublicIpOnLaunch: true
+      AvailabilityZone:
+        Fn::Select:
+        - '2'
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock:
+        Ref: Subnet03Block
+      VpcId:
+        Ref: VPC
+      Tags:
+      - Key: Name
+        Value: !Sub "${AWS::StackName}-Subnet03"
+      - Key: kubernetes.io/role/elb
+        Value: 1
+
+  Subnet04:
+    Type: AWS::EC2::Subnet
+    Metadata:
+      Comment: Subnet 04
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+        - '1'
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock:
+        Ref: Subnet04Block
+      VpcId:
+        Ref: VPC
+      Tags:
+      - Key: Name
+        Value: !Sub "${AWS::StackName}-Subnet04"
+
+  Subnet05:
+    Type: AWS::EC2::Subnet
+    Metadata:
+      Comment: Subnet 05
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+        - '1'
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock:
+        Ref: Subnet05Block
+      VpcId:
+        Ref: VPC
+      Tags:
+      - Key: Name
+        Value: !Sub "${AWS::StackName}-Subnet05"
+
+  Subnet06:
+    Condition: HasMoreThan2Azs
+    Type: AWS::EC2::Subnet
+    Metadata:
+      Comment: Subnet 06
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+        - '1'
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock:
+        Ref: Subnet06Block
+      VpcId:
+        Ref: VPC
+      Tags:
+      - Key: Name
+        Value: !Sub "${AWS::StackName}-Subnet06"
+
+  Subnet01RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref Subnet01
+      RouteTableId: !Ref RouteTable
+
+  Subnet02RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref Subnet02
+      RouteTableId: !Ref RouteTable
+
+  Subnet03RouteTableAssociation:
+    Condition: HasMoreThan2Azs
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref Subnet03
+      RouteTableId: !Ref RouteTable
+
+  Subnet04RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref Subnet04
+      RouteTableId: !Ref PrivateRouteTable
+
+  Subnet05RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref Subnet05
+      RouteTableId: !Ref PrivateRouteTable
+
+  Subnet06RouteTableAssociation:
+    Condition: HasMoreThan2Azs
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref Subnet06
+      RouteTableId: !Ref PrivateRouteTable
+
+  ControlPlaneSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Cluster communication with worker nodes
+      VpcId: !Ref VPC
+
+Outputs:
+  ClusterRoleARN:
+    Value:
+      Fn::GetAtt:
+          - "ClusterRole"
+          - "Arn"
+    Export:
+      Name:
+        Fn::Sub: "${AWS::StackName}::ClusterRoleARN"
+
+  NodeRoleARN:
+    Value:
+      Fn::GetAtt:
+        - "NodeRole"
+        - "Arn"
+    Export:
+      Name:
+        Fn::Sub: "${AWS::StackName}::NodeRoleARN"
+
+  PrivateSubnetIds:
+    Description: All private subnets in the VPC
+    Value:
+      Fn::If:
+      - HasMoreThan2Azs
+      - !Join [ ",", [ !Ref Subnet04, !Ref Subnet05, !Ref Subnet06 ] ]
+      - !Join [ ",", [ !Ref Subnet04, !Ref Subnet05 ] ]
+
+  PublicSubnetIds:
+    Description: All public subnets in the VPC
+    Value:
+      Fn::If:
+      - HasMoreThan2Azs
+      - !Join [ ",", [ !Ref Subnet01, !Ref Subnet02, !Ref Subnet03 ] ]
+      - !Join [ ",", [ !Ref Subnet01, !Ref Subnet02 ] ]
+
+  SecurityGroups:
+    Description: Security group for the cluster control plane communication with worker nodes
+    Value: !Join [ ",", [ !Ref ControlPlaneSecurityGroup ] ]
+
+  VpcId:
+    Description: The VPC Id
+    Value: !Ref VPC

--- a/integration/tests/existing_vpc/existing_vpc_test.go
+++ b/integration/tests/existing_vpc/existing_vpc_test.go
@@ -82,7 +82,13 @@ var _ = Describe("(Integration) [using existing VPC]", func() {
 	})
 
 	AfterSuite(func() {
-		// deleteStack(stackName, ctl)
+		cmd := params.EksctlDeleteClusterCmd.
+			WithArgs(
+				"--config-file", configFile.Name(),
+				"--wait",
+			).WithoutArg("--region", params.Region)
+		Expect(cmd).To(RunSuccessfully())
+		deleteStack(stackName, ctl)
 		Expect(os.RemoveAll(configFile.Name())).To(Succeed())
 	})
 

--- a/integration/tests/existing_vpc/existing_vpc_test.go
+++ b/integration/tests/existing_vpc/existing_vpc_test.go
@@ -1,0 +1,207 @@
+//go:build integration
+// +build integration
+
+package unowned_clusters
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weaveworks/eksctl/pkg/eks"
+
+	cfn "github.com/aws/aws-sdk-go/service/cloudformation"
+
+	"github.com/aws/aws-sdk-go/aws"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+
+	. "github.com/weaveworks/eksctl/integration/runner"
+	"github.com/weaveworks/eksctl/integration/tests"
+	"github.com/weaveworks/eksctl/pkg/testutils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var params *tests.Params
+
+func init() {
+	// Call testing.Init() prior to tests.NewParams(), as otherwise -test.* will not be recognised. See also: https://golang.org/doc/go1.13#testing
+	testing.Init()
+	params = tests.NewParams("exist-vpc")
+}
+
+func TestVPC(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}
+
+var _ = Describe("(Integration) [using existing VPC]", func() {
+	var (
+		stackName  string
+		ng1        = "ng-1"
+		mng1       = "mng-1"
+		ctl        api.ClusterProvider
+		configFile *os.File
+		cfg        *api.ClusterConfig
+	)
+
+	BeforeSuite(func() {
+		stackName = fmt.Sprintf("eksctl-%s", params.ClusterName)
+		cfg = &api.ClusterConfig{
+			TypeMeta: api.ClusterConfigTypeMeta(),
+			Metadata: &api.ClusterMeta{
+				Name:   params.ClusterName,
+				Region: params.Region,
+			},
+		}
+
+		var err error
+		configFile, err = ioutil.TempFile("", "")
+		Expect(err).NotTo(HaveOccurred())
+
+		clusterProvider, err := eks.New(&api.ProviderConfig{Region: params.Region}, cfg)
+		Expect(err).NotTo(HaveOccurred())
+		ctl = clusterProvider.Provider
+		cfg.VPC = createVPC(stackName, ctl)
+
+		configData, err := json.Marshal(&cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ioutil.WriteFile(configFile.Name(), configData, 0755)).To(Succeed())
+		cmd := params.EksctlCreateCmd.
+			WithArgs(
+				"cluster",
+				"--config-file", configFile.Name(),
+				"--verbose", "2",
+			).WithoutArg("--region", params.Region)
+		Expect(cmd).To(RunSuccessfully())
+	})
+
+	AfterSuite(func() {
+		// deleteStack(stackName, ctl)
+		Expect(os.RemoveAll(configFile.Name())).To(Succeed())
+	})
+
+	It("supports creating managed and unmanaged nodegroups in the existing VPC", func() {
+		cfg.NodeGroups = []*api.NodeGroup{{
+			NodeGroupBase: &api.NodeGroupBase{
+				Name: ng1,
+			}},
+		}
+		cfg.ManagedNodeGroups = []*api.ManagedNodeGroup{{
+			NodeGroupBase: &api.NodeGroupBase{
+				Name: mng1,
+			}},
+		}
+		// write config file so that the nodegroup creates have access to the vpc spec
+		configData, err := json.Marshal(&cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ioutil.WriteFile(configFile.Name(), configData, 0755)).To(Succeed())
+		cmd := params.EksctlCreateCmd.
+			WithArgs(
+				"nodegroup",
+				"--config-file", configFile.Name(),
+				"--verbose", "2",
+			).WithoutArg("--region", params.Region)
+		Expect(cmd).To(RunSuccessfully())
+
+		//GetCluster shows us what subnets/vpc the EKS cluster was created with
+		cmd = params.EksctlGetCmd.WithArgs("cluster", "--name", params.ClusterName, "-o", "yaml")
+		Expect(cmd).To(RunSuccessfullyWithOutputStringLines(
+			ContainElement(ContainSubstring(cfg.VPC.ID)),
+			ContainElement(ContainSubstring(cfg.VPC.Subnets.Public["public1"].ID)),
+			ContainElement(ContainSubstring(cfg.VPC.Subnets.Public["public2"].ID)),
+			ContainElement(ContainSubstring(cfg.VPC.Subnets.Public["public3"].ID)),
+			ContainElement(ContainSubstring(cfg.VPC.Subnets.Public["private4"].ID)),
+			ContainElement(ContainSubstring(cfg.VPC.Subnets.Public["private5"].ID)),
+			ContainElement(ContainSubstring(cfg.VPC.Subnets.Public["private6"].ID)),
+		))
+	})
+})
+
+func createVPC(stackName string, ctl api.ClusterProvider) *api.ClusterVPC {
+	publicSubnets, privateSubnets, vpcID, securityGroup := createStackAndGetOutputs(stackName, ctl)
+
+	newVPC := api.NewClusterVPC()
+	newVPC.ID = vpcID
+	newVPC.SecurityGroup = securityGroup
+	newVPC.Subnets = &api.ClusterSubnets{
+		Public: api.AZSubnetMapping{
+			"public1": api.AZSubnetSpec{
+				ID: publicSubnets[0],
+			},
+			"public2": api.AZSubnetSpec{
+				ID: publicSubnets[1],
+			},
+			"public3": api.AZSubnetSpec{
+				ID: publicSubnets[2],
+			},
+		},
+		Private: api.AZSubnetMapping{
+			"private4": api.AZSubnetSpec{
+				ID: privateSubnets[0],
+			},
+			"private5": api.AZSubnetSpec{
+				ID: privateSubnets[1],
+			},
+			"private6": api.AZSubnetSpec{
+				ID: privateSubnets[2],
+			},
+		},
+	}
+
+	return newVPC
+}
+
+func createStackAndGetOutputs(stackName string, ctl api.ClusterProvider) ([]string, []string, string, string) {
+	templateBody, err := ioutil.ReadFile("cf-template.yaml")
+	Expect(err).NotTo(HaveOccurred())
+	createStackInput := &cfn.CreateStackInput{
+		StackName: &stackName,
+	}
+	createStackInput.SetTemplateBody(string(templateBody))
+	createStackInput.SetCapabilities(aws.StringSlice([]string{cfn.CapabilityCapabilityIam}))
+	createStackInput.SetCapabilities(aws.StringSlice([]string{cfn.CapabilityCapabilityNamedIam}))
+
+	_, err = ctl.CloudFormation().CreateStack(createStackInput)
+	Expect(err).NotTo(HaveOccurred())
+
+	var describeStackOut *cfn.DescribeStacksOutput
+	Eventually(func() string {
+		describeStackOut, err = ctl.CloudFormation().DescribeStacks(&cfn.DescribeStacksInput{
+			StackName: &stackName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		return *describeStackOut.Stacks[0].StackStatus
+	}, time.Minute*10, time.Second*15).Should(Equal(cfn.StackStatusCreateComplete))
+
+	var vpcID string
+	var publicSubnets, privateSubnets, securityGroups []string
+	for _, output := range describeStackOut.Stacks[0].Outputs {
+		switch *output.OutputKey {
+		case "PublicSubnetIds":
+			publicSubnets = strings.Split(*output.OutputValue, ",")
+		case "PrivateSubnetIds":
+			privateSubnets = strings.Split(*output.OutputValue, ",")
+		case "VpcId":
+			vpcID = *output.OutputValue
+		case "SecurityGroups":
+			securityGroups = strings.Split(*output.OutputValue, ",")
+		}
+	}
+
+	return publicSubnets, privateSubnets, vpcID, securityGroups[0]
+}
+
+func deleteStack(stackName string, ctl api.ClusterProvider) {
+	deleteStackInput := &cfn.DeleteStackInput{
+		StackName: &stackName,
+	}
+
+	_, err := ctl.CloudFormation().DeleteStack(deleteStackInput)
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -221,7 +221,14 @@ func (c *ClusterConfig) ValidateVPCConfig() error {
 }
 
 func (c *ClusterConfig) ipv6CidrsValid() error {
-	if (c.VPC.IPv6Cidr == "" && c.VPC.IPv6Pool == "") || (c.VPC.IPv6Cidr != "" && c.VPC.IPv6Pool != "") {
+	if c.VPC.IPv6Cidr == "" && c.VPC.IPv6Pool == "" {
+		return nil
+	}
+
+	if c.VPC.IPv6Cidr != "" && c.VPC.IPv6Pool != "" {
+		if c.VPC.ID != "" {
+			return fmt.Errorf("cannot provide VPC.IPv6Cidr when using a pre-existing VPC.ID")
+		}
 		return nil
 	}
 	return fmt.Errorf("Ipv6Cidr and Ipv6Pool must both be configured to use a custom IPv6 CIDR and address pool")

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -740,6 +740,17 @@ var _ = Describe("ClusterConfig validation", func() {
 					Expect(err).To(MatchError("Ipv6Cidr and Ipv6Pool must both be configured to use a custom IPv6 CIDR and address pool"))
 				})
 			})
+
+			When("its set alongside VPC.ID", func() {
+				It("returns an error", func() {
+					cfg.VPC.IPFamily = api.IPV6Family
+					cfg.VPC.IPv6Cidr = "foo"
+					cfg.VPC.IPv6Pool = "bar"
+					cfg.VPC.ID = "123"
+					err = cfg.ValidateVPCConfig()
+					Expect(err).To(MatchError("cannot provide VPC.IPv6Cidr when using a pre-existing VPC.ID"))
+				})
+			})
 		})
 
 		Context("extraIPv6CIDRs", func() {

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -741,7 +741,7 @@ var _ = Describe("ClusterConfig validation", func() {
 				})
 			})
 
-			When("its set alongside VPC.ID", func() {
+			When("it's set alongside VPC.ID", func() {
 				It("returns an error", func() {
 					cfg.VPC.IPFamily = api.IPV6Family
 					cfg.VPC.IPv6Cidr = "foo"

--- a/pkg/cfn/builder/cluster.go
+++ b/pkg/cfn/builder/cluster.go
@@ -38,7 +38,9 @@ func NewClusterResourceSet(ec2API ec2iface.EC2API, region string, spec *api.Clus
 	rs := newResourceSet()
 
 	var vpcResourceSet VPCResourceSet = NewIPv4VPCResourceSet(rs, spec, ec2API)
-	if spec.VPC.IPFamily == api.IPV6Family {
+	if spec.VPC.ID != "" {
+		vpcResourceSet = NewExistingVPCResourceSet(rs, spec, ec2API)
+	} else if spec.VPC.IPFamily == api.IPV6Family {
 		vpcResourceSet = NewIPv6VPCResourceSet(rs, spec, ec2API)
 	}
 	return &ClusterResourceSet{

--- a/pkg/cfn/builder/cluster_test.go
+++ b/pkg/cfn/builder/cluster_test.go
@@ -452,6 +452,7 @@ var _ = Describe("Cluster Template Builder", func() {
 	Describe("RenderJSON", func() {
 		It("returns the template rendered as JSON", func() {
 			// the work actually gets done on the internal resource set
+			Expect(crs.AddAllResources()).To(Succeed())
 			result, err := crs.RenderJSON()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(ContainSubstring(vpcResourceKey))
@@ -461,6 +462,7 @@ var _ = Describe("Cluster Template Builder", func() {
 	Describe("Template", func() {
 		It("returns the template from the inner resource set", func() {
 			// the work actually gets done on the internal resource set
+			Expect(crs.AddAllResources()).To(Succeed())
 			clusterTemplate := crs.Template()
 			Expect(clusterTemplate.Resources).To(HaveKey(vpcResourceKey))
 		})

--- a/pkg/cfn/builder/vpc_endpoint_test.go
+++ b/pkg/cfn/builder/vpc_endpoint_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	awsec2 "github.com/aws/aws-sdk-go/service/ec2"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -149,6 +150,11 @@ var _ = Describe("VPC Endpoint Builder", func() {
 				},
 				AvailabilityZones: []string{"us-west-2a", "us-west-2b"},
 			},
+			createProvider: func() api.ClusterProvider {
+				provider := mockprovider.NewMockProvider()
+				mockDescribeVPC(provider)
+				return provider
+			},
 		}),
 		Entry("Private cluster with a user-supplied VPC", vpcResourceSetCase{
 			clusterConfig: &api.ClusterConfig{
@@ -176,6 +182,7 @@ var _ = Describe("VPC Endpoint Builder", func() {
 			},
 			createProvider: func() api.ClusterProvider {
 				provider := mockprovider.NewMockProvider()
+				mockDescribeVPC(provider)
 				mockDescribeVPCEndpoints(provider, false)
 				mockDescribeRouteTables(provider, []string{"subnet-custom1", "subnet-custom2"})
 				return provider
@@ -208,6 +215,7 @@ var _ = Describe("VPC Endpoint Builder", func() {
 			},
 			createProvider: func() api.ClusterProvider {
 				provider := mockprovider.NewMockProvider()
+				mockDescribeVPC(provider)
 				mockDescribeVPCEndpoints(provider, false)
 				mockDescribeRouteTablesSame(provider, []string{"subnet-custom1", "subnet-custom2"})
 				return provider
@@ -237,6 +245,7 @@ var _ = Describe("VPC Endpoint Builder", func() {
 			},
 			createProvider: func() api.ClusterProvider {
 				provider := mockprovider.NewMockProvider()
+				mockDescribeVPC(provider)
 				output := &ec2.DescribeRouteTablesOutput{
 					RouteTables: []*ec2.RouteTable{
 						{
@@ -567,6 +576,23 @@ var serviceDetailsJSONChina = `
 }
 `
 
+func mockDescribeVPC(provider *mockprovider.MockProvider) {
+	provider.MockEC2().On("DescribeVpcs", &awsec2.DescribeVpcsInput{
+		VpcIds: aws.StringSlice([]string{"vpc-custom"}),
+	}).Return(&awsec2.DescribeVpcsOutput{
+		Vpcs: []*awsec2.Vpc{
+			{
+				VpcId: aws.String("vpc-custom"),
+				Ipv6CidrBlockAssociationSet: []*awsec2.VpcIpv6CidrBlockAssociation{
+					{
+						Ipv6CidrBlock: aws.String("foo"),
+					},
+				},
+			},
+		},
+	}, nil)
+}
+
 func mockDescribeVPCEndpoints(provider *mockprovider.MockProvider, china bool) {
 	var detailsJSON = serviceDetailsJSON
 	if china {
@@ -579,6 +605,7 @@ func mockDescribeVPCEndpoints(provider *mockprovider.MockProvider, china bool) {
 	provider.MockEC2().On("DescribeVpcEndpointServices", mock.MatchedBy(func(e *ec2.DescribeVpcEndpointServicesInput) bool {
 		return len(e.ServiceNames) == 5
 	})).Return(output, nil)
+
 }
 
 func mockDescribeRouteTables(provider *mockprovider.MockProvider, subnetIDs []string) {

--- a/pkg/cfn/builder/vpc_endpoint_test.go
+++ b/pkg/cfn/builder/vpc_endpoint_test.go
@@ -28,7 +28,6 @@ type vpcResourceSetCase struct {
 }
 
 var _ = Describe("VPC Endpoint Builder", func() {
-
 	DescribeTable("Adds resources to template", func(vc vpcResourceSetCase) {
 		api.SetClusterConfigDefaults(vc.clusterConfig)
 
@@ -54,7 +53,10 @@ var _ = Describe("VPC Endpoint Builder", func() {
 		}
 
 		rs := newResourceSet()
-		vpcResourceSet := NewIPv4VPCResourceSet(rs, vc.clusterConfig, provider.EC2())
+		var vpcResourceSet VPCResourceSet = NewIPv4VPCResourceSet(rs, vc.clusterConfig, provider.EC2())
+		if vc.clusterConfig.VPC.ID != "" {
+			vpcResourceSet = NewExistingVPCResourceSet(rs, vc.clusterConfig, provider.EC2())
+		}
 		vpcID, subnetDetails, err := vpcResourceSet.CreateTemplate()
 		if vc.err != "" {
 			Expect(err).To(HaveOccurred())

--- a/pkg/cfn/builder/vpc_existing.go
+++ b/pkg/cfn/builder/vpc_existing.go
@@ -91,8 +91,7 @@ func (v *ExistingVPCResourceSet) importExistingResources() error {
 }
 
 func makeSubnetResources(subnets map[string]api.AZSubnetSpec, subnetRoutes map[string]string) ([]SubnetResource, error) {
-	subnetResources := make([]SubnetResource, len(subnets))
-	i := 0
+	var subnetResources []SubnetResource
 	for _, network := range subnets {
 		az := network.AZ
 		sr := SubnetResource{
@@ -108,8 +107,7 @@ func makeSubnetResources(subnets map[string]api.AZSubnetSpec, subnetRoutes map[s
 			}
 			sr.RouteTable = gfnt.NewString(rt)
 		}
-		subnetResources[i] = sr
-		i++
+		subnetResources = append(subnetResources, sr)
 	}
 	return subnetResources, nil
 }

--- a/pkg/cfn/builder/vpc_existing.go
+++ b/pkg/cfn/builder/vpc_existing.go
@@ -29,13 +29,13 @@ func NewExistingVPCResourceSet(rs *resourceSet, clusterConfig *api.ClusterConfig
 }
 
 func (v *ExistingVPCResourceSet) CreateTemplate() (*gfnt.Value, *SubnetDetails, error) {
-	if err := v.importResources(); err != nil {
+	if err := v.importExistingResources(); err != nil {
 		return nil, nil, errors.Wrap(err, "error importing VPC resources")
 	}
 	return v.vpcID, v.subnetDetails, nil
 }
 
-func (v *ExistingVPCResourceSet) importResources() error {
+func (v *ExistingVPCResourceSet) importExistingResources() error {
 	if subnets := v.clusterConfig.VPC.Subnets.Private; subnets != nil {
 		var (
 			subnetRoutes map[string]string

--- a/pkg/cfn/builder/vpc_existing.go
+++ b/pkg/cfn/builder/vpc_existing.go
@@ -1,0 +1,138 @@
+package builder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/pkg/errors"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	gfnt "github.com/weaveworks/goformation/v4/cloudformation/types"
+)
+
+type ExistingVPCResourceSet struct {
+	rs            *resourceSet
+	clusterConfig *api.ClusterConfig
+	ec2API        ec2iface.EC2API
+	vpcID         *gfnt.Value
+	subnetDetails *SubnetDetails
+}
+
+// NewExistingVPCResourceSet creates and returns a new VPCResourceSet
+func NewExistingVPCResourceSet(rs *resourceSet, clusterConfig *api.ClusterConfig, ec2API ec2iface.EC2API) *ExistingVPCResourceSet {
+	return &ExistingVPCResourceSet{
+		rs:            rs,
+		clusterConfig: clusterConfig,
+		ec2API:        ec2API,
+		vpcID:         gfnt.NewString(clusterConfig.VPC.ID),
+		subnetDetails: &SubnetDetails{},
+	}
+}
+
+func (v *ExistingVPCResourceSet) CreateTemplate() (*gfnt.Value, *SubnetDetails, error) {
+	if err := v.importResources(); err != nil {
+		return nil, nil, errors.Wrap(err, "error importing VPC resources")
+	}
+	return v.vpcID, v.subnetDetails, nil
+}
+
+func (v *ExistingVPCResourceSet) importResources() error {
+	if subnets := v.clusterConfig.VPC.Subnets.Private; subnets != nil {
+		var (
+			subnetRoutes map[string]string
+			err          error
+		)
+		if v.isFullyPrivate() {
+			subnetRoutes, err = importRouteTables(v.ec2API, v.clusterConfig.VPC.Subnets.Private)
+			if err != nil {
+				return err
+			}
+		}
+
+		subnetResources, err := makeSubnetResources(subnets, subnetRoutes)
+		if err != nil {
+			return err
+		}
+		v.subnetDetails.Private = subnetResources
+	}
+
+	if subnets := v.clusterConfig.VPC.Subnets.Public; subnets != nil {
+		subnetResources, err := makeSubnetResources(subnets, nil)
+		if err != nil {
+			return err
+		}
+		v.subnetDetails.Public = subnetResources
+	}
+
+	return nil
+}
+
+func makeSubnetResources(subnets map[string]api.AZSubnetSpec, subnetRoutes map[string]string) ([]SubnetResource, error) {
+	subnetResources := make([]SubnetResource, len(subnets))
+	i := 0
+	for _, network := range subnets {
+		az := network.AZ
+		sr := SubnetResource{
+			AvailabilityZone: az,
+			Subnet:           gfnt.NewString(network.ID),
+		}
+
+		if subnetRoutes != nil {
+			rt, ok := subnetRoutes[network.ID]
+			if !ok {
+				return nil, errors.Errorf("failed to find an explicit route table associated with subnet %q; "+
+					"eksctl does not modify the main route table if a subnet is not associated with an explicit route table", network.ID)
+			}
+			sr.RouteTable = gfnt.NewString(rt)
+		}
+		subnetResources[i] = sr
+		i++
+	}
+	return subnetResources, nil
+}
+
+func importRouteTables(ec2API ec2iface.EC2API, subnets map[string]api.AZSubnetSpec) (map[string]string, error) {
+	var subnetIDs []string
+	for _, subnet := range subnets {
+		subnetIDs = append(subnetIDs, subnet.ID)
+	}
+
+	var routeTables []*ec2.RouteTable
+	var nextToken *string
+
+	for {
+		output, err := ec2API.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("association.subnet-id"),
+					Values: aws.StringSlice(subnetIDs),
+				},
+			},
+			NextToken: nextToken,
+		})
+
+		if err != nil {
+			return nil, errors.Wrap(err, "error describing route tables")
+		}
+
+		routeTables = append(routeTables, output.RouteTables...)
+
+		if nextToken = output.NextToken; nextToken == nil {
+			break
+		}
+	}
+
+	subnetRoutes := make(map[string]string)
+	for _, rt := range routeTables {
+		for _, rta := range rt.Associations {
+			if rta.Main != nil && *rta.Main {
+				return nil, errors.New("subnets must be associated with a non-main route table; eksctl does not modify the main route table")
+			}
+			subnetRoutes[*rta.SubnetId] = *rt.RouteTableId
+		}
+	}
+	return subnetRoutes, nil
+}
+
+func (v *ExistingVPCResourceSet) isFullyPrivate() bool {
+	return v.clusterConfig.PrivateCluster.Enabled
+}

--- a/pkg/cfn/builder/vpc_existing.go
+++ b/pkg/cfn/builder/vpc_existing.go
@@ -57,7 +57,7 @@ func (v *ExistingVPCResourceSet) CreateTemplate() (*gfnt.Value, *SubnetDetails, 
 
 func (v *ExistingVPCResourceSet) checkIPv6CidrBlockAssociated(describeVPCOutput *awsec2.DescribeVpcsOutput) error {
 	if len(describeVPCOutput.Vpcs[0].Ipv6CidrBlockAssociationSet) == 0 {
-		return fmt.Errorf("VPC %q does not have any associated IPv6 cidr blocks", v.clusterConfig.VPC.ID)
+		return fmt.Errorf("VPC %q does not have any associated IPv6 CIDR blocks", v.clusterConfig.VPC.ID)
 	}
 	return nil
 }

--- a/pkg/cfn/builder/vpc_existing_test.go
+++ b/pkg/cfn/builder/vpc_existing_test.go
@@ -26,6 +26,7 @@ var _ = PDescribe("Existing VPC", func() {
 		cfg = api.NewClusterConfig()
 		cfg.VPC = vpcConfig()
 		cfg.AvailabilityZones = []string{azA, azB}
+		cfg.VPC.ID = "custom-vpc"
 	})
 
 	JustBeforeEach(func() {
@@ -47,105 +48,94 @@ var _ = PDescribe("Existing VPC", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(json.Unmarshal(templateBody, vpcTemplate)).To(Succeed())
 		})
-		Context("when a custom VPC is set (vpc.ID != nil)", func() {
+
+		It("uses the existing VPC", func() {
+			By("the correct VPC resource values are loaded into the VPCResource")
+			Expect(vpcID).To(Equal(gfnt.NewString("custom-vpc")))
+
+			By("no resources are added to the set")
+			Expect(vpcTemplate.Resources).To(HaveLen(0))
+
+			By("the private subnet resource values are loaded into the VPCResource")
+			Expect(subnetDetails.Private).To(HaveLen(2))
+			Expect(subnetDetails.Private).To(ContainElement(builder.SubnetResource{
+				Subnet:           gfnt.NewString(privateSubnet2),
+				AvailabilityZone: azB,
+			}))
+			Expect(subnetDetails.Private).To(ContainElement(builder.SubnetResource{
+				Subnet:           gfnt.NewString(privateSubnet1),
+				AvailabilityZone: azA,
+			}))
+
+			By("the public subnet resource values are loaded into the VPCResource")
+			Expect(subnetDetails.Public).To(HaveLen(2))
+			Expect(subnetDetails.Public).To(ContainElement(builder.SubnetResource{
+				Subnet:           gfnt.NewString(publicSubnet2),
+				AvailabilityZone: azB,
+			}))
+			Expect(subnetDetails.Public).To(ContainElement(builder.SubnetResource{
+				Subnet:           gfnt.NewString(publicSubnet1),
+				AvailabilityZone: azA,
+			}))
+		})
+
+		Context("PrivateCluster is enabled", func() {
+			var rtOutput *ec2.DescribeRouteTablesOutput
+
 			BeforeEach(func() {
-				cfg.VPC.ID = "custom-vpc"
+				cfg.PrivateCluster.Enabled = true
+				rtOutput = makeRTOutput([]string{privateSubnet2, privateSubnet1}, false)
 			})
 
-			It("the correct VPC resource values are loaded into the VPCResource", func() {
-				Expect(vpcID).To(Equal(gfnt.NewString("custom-vpc")))
-			})
+			Context("ec2 call succeeds", func() {
+				BeforeEach(func() {
+					mockResultFn := func(_ *ec2.DescribeRouteTablesInput) *ec2.DescribeRouteTablesOutput {
+						return rtOutput
+					}
 
-			It("no resources are added to the set", func() {
-				Expect(vpcTemplate.Resources).To(HaveLen(0))
-			})
+					mockEC2.On("DescribeRouteTables", mock.MatchedBy(func(input *ec2.DescribeRouteTablesInput) bool {
+						return len(input.Filters) > 0
+					})).Return(mockResultFn, nil)
+				})
 
-			Context("private subnets are configured", func() {
-				It("the private subnet resource values are loaded into the VPCResource", func() {
+				It("the private subnet resource values are loaded into the VPCResource with route table association", func() {
 					Expect(subnetDetails.Private).To(HaveLen(2))
 					Expect(subnetDetails.Private).To(ContainElement(builder.SubnetResource{
 						Subnet:           gfnt.NewString(privateSubnet2),
+						RouteTable:       gfnt.NewString("this-is-a-route-table"),
 						AvailabilityZone: azB,
 					}))
 					Expect(subnetDetails.Private).To(ContainElement(builder.SubnetResource{
 						Subnet:           gfnt.NewString(privateSubnet1),
+						RouteTable:       gfnt.NewString("this-is-a-route-table"),
 						AvailabilityZone: azA,
 					}))
-				})
-
-				Context("PrivateCluster is enabled", func() {
-					var rtOutput *ec2.DescribeRouteTablesOutput
-
-					BeforeEach(func() {
-						cfg.PrivateCluster.Enabled = true
-						rtOutput = makeRTOutput([]string{privateSubnet2, privateSubnet1}, false)
-					})
-
-					Context("ec2 call succeeds", func() {
-						BeforeEach(func() {
-							mockResultFn := func(_ *ec2.DescribeRouteTablesInput) *ec2.DescribeRouteTablesOutput {
-								return rtOutput
-							}
-
-							mockEC2.On("DescribeRouteTables", mock.MatchedBy(func(input *ec2.DescribeRouteTablesInput) bool {
-								return len(input.Filters) > 0
-							})).Return(mockResultFn, nil)
-						})
-
-						It("the private subnet resource values are loaded into the VPCResource with route table association", func() {
-							Expect(subnetDetails.Private).To(HaveLen(2))
-							Expect(subnetDetails.Private).To(ContainElement(builder.SubnetResource{
-								Subnet:           gfnt.NewString(privateSubnet2),
-								RouteTable:       gfnt.NewString("this-is-a-route-table"),
-								AvailabilityZone: azB,
-							}))
-							Expect(subnetDetails.Private).To(ContainElement(builder.SubnetResource{
-								Subnet:           gfnt.NewString(privateSubnet1),
-								RouteTable:       gfnt.NewString("this-is-a-route-table"),
-								AvailabilityZone: azA,
-							}))
-						})
-					})
-
-					Context("importing route tables fails because the rt association points to main", func() {
-						BeforeEach(func() {
-							rtOutput.RouteTables[0].Associations[0].Main = aws.Bool(true)
-							mockEC2.On("DescribeRouteTables", mock.MatchedBy(func(input *ec2.DescribeRouteTablesInput) bool {
-								return len(input.Filters) > 0
-							})).Return(rtOutput, nil)
-						})
-
-						It("returns an error", func() {
-							Expect(addErr).To(MatchError(ContainSubstring("subnets must be associated with a non-main route table; eksctl does not modify the main route table")))
-						})
-					})
-
-					Context("adding the route table to the subnet resource fails", func() {
-						BeforeEach(func() {
-							rtOutput.RouteTables[0].Associations[0].SubnetId = aws.String("fake")
-							mockEC2.On("DescribeRouteTables", mock.MatchedBy(func(input *ec2.DescribeRouteTablesInput) bool {
-								return len(input.Filters) > 0
-							})).Return(rtOutput, nil)
-						})
-
-						It("returns an error", func() {
-							Expect(addErr).To(MatchError(ContainSubstring("failed to find an explicit route table associated with subnet \"subnet-0f98135715dfcf55a\"; eksctl does not modify the main route table if a subnet is not associated with an explicit route table")))
-						})
-					})
 				})
 			})
 
-			Context("public subnets are configured", func() {
-				It("the public subnet resource values are loaded into the VPCResource", func() {
-					Expect(subnetDetails.Public).To(HaveLen(2))
-					Expect(subnetDetails.Public).To(ContainElement(builder.SubnetResource{
-						Subnet:           gfnt.NewString(publicSubnet2),
-						AvailabilityZone: azB,
-					}))
-					Expect(subnetDetails.Public).To(ContainElement(builder.SubnetResource{
-						Subnet:           gfnt.NewString(publicSubnet1),
-						AvailabilityZone: azA,
-					}))
+			Context("importing route tables fails because the rt association points to main", func() {
+				BeforeEach(func() {
+					rtOutput.RouteTables[0].Associations[0].Main = aws.Bool(true)
+					mockEC2.On("DescribeRouteTables", mock.MatchedBy(func(input *ec2.DescribeRouteTablesInput) bool {
+						return len(input.Filters) > 0
+					})).Return(rtOutput, nil)
+				})
+
+				It("returns an error", func() {
+					Expect(addErr).To(MatchError(ContainSubstring("subnets must be associated with a non-main route table; eksctl does not modify the main route table")))
+				})
+			})
+
+			Context("adding the route table to the subnet resource fails", func() {
+				BeforeEach(func() {
+					rtOutput.RouteTables[0].Associations[0].SubnetId = aws.String("fake")
+					mockEC2.On("DescribeRouteTables", mock.MatchedBy(func(input *ec2.DescribeRouteTablesInput) bool {
+						return len(input.Filters) > 0
+					})).Return(rtOutput, nil)
+				})
+
+				It("returns an error", func() {
+					Expect(addErr).To(MatchError(ContainSubstring("failed to find an explicit route table associated with subnet \"subnet-0f98135715dfcf55a\"; eksctl does not modify the main route table if a subnet is not associated with an explicit route table")))
 				})
 			})
 		})

--- a/pkg/cfn/builder/vpc_existing_test.go
+++ b/pkg/cfn/builder/vpc_existing_test.go
@@ -1,0 +1,153 @@
+package builder_test
+
+import (
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/cfn/builder"
+	"github.com/weaveworks/eksctl/pkg/cfn/builder/fakes"
+	"github.com/weaveworks/eksctl/pkg/eks/mocks"
+	gfnt "github.com/weaveworks/goformation/v4/cloudformation/types"
+)
+
+var _ = PDescribe("Existing VPC", func() {
+	var (
+		vpcRs   *builder.IPv4VPCResourceSet
+		cfg     *api.ClusterConfig
+		mockEC2 = &mocks.EC2API{}
+	)
+
+	BeforeEach(func() {
+		cfg = api.NewClusterConfig()
+		cfg.VPC = vpcConfig()
+		cfg.AvailabilityZones = []string{azA, azB}
+	})
+
+	JustBeforeEach(func() {
+		vpcRs = builder.NewIPv4VPCResourceSet(builder.NewRS(), cfg, mockEC2)
+	})
+
+	Describe("CreateTemplate", func() {
+		var (
+			addErr        error
+			vpcID         *gfnt.Value
+			subnetDetails *builder.SubnetDetails
+			vpcTemplate   *fakes.FakeTemplate
+		)
+
+		JustBeforeEach(func() {
+			vpcID, subnetDetails, addErr = vpcRs.CreateTemplate()
+			vpcTemplate = &fakes.FakeTemplate{}
+			templateBody, err := vpcRs.RenderJSON()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(json.Unmarshal(templateBody, vpcTemplate)).To(Succeed())
+		})
+		Context("when a custom VPC is set (vpc.ID != nil)", func() {
+			BeforeEach(func() {
+				cfg.VPC.ID = "custom-vpc"
+			})
+
+			It("the correct VPC resource values are loaded into the VPCResource", func() {
+				Expect(vpcID).To(Equal(gfnt.NewString("custom-vpc")))
+			})
+
+			It("no resources are added to the set", func() {
+				Expect(vpcTemplate.Resources).To(HaveLen(0))
+			})
+
+			Context("private subnets are configured", func() {
+				It("the private subnet resource values are loaded into the VPCResource", func() {
+					Expect(subnetDetails.Private).To(HaveLen(2))
+					Expect(subnetDetails.Private).To(ContainElement(builder.SubnetResource{
+						Subnet:           gfnt.NewString(privateSubnet2),
+						AvailabilityZone: azB,
+					}))
+					Expect(subnetDetails.Private).To(ContainElement(builder.SubnetResource{
+						Subnet:           gfnt.NewString(privateSubnet1),
+						AvailabilityZone: azA,
+					}))
+				})
+
+				Context("PrivateCluster is enabled", func() {
+					var rtOutput *ec2.DescribeRouteTablesOutput
+
+					BeforeEach(func() {
+						cfg.PrivateCluster.Enabled = true
+						rtOutput = makeRTOutput([]string{privateSubnet2, privateSubnet1}, false)
+					})
+
+					Context("ec2 call succeeds", func() {
+						BeforeEach(func() {
+							mockResultFn := func(_ *ec2.DescribeRouteTablesInput) *ec2.DescribeRouteTablesOutput {
+								return rtOutput
+							}
+
+							mockEC2.On("DescribeRouteTables", mock.MatchedBy(func(input *ec2.DescribeRouteTablesInput) bool {
+								return len(input.Filters) > 0
+							})).Return(mockResultFn, nil)
+						})
+
+						It("the private subnet resource values are loaded into the VPCResource with route table association", func() {
+							Expect(subnetDetails.Private).To(HaveLen(2))
+							Expect(subnetDetails.Private).To(ContainElement(builder.SubnetResource{
+								Subnet:           gfnt.NewString(privateSubnet2),
+								RouteTable:       gfnt.NewString("this-is-a-route-table"),
+								AvailabilityZone: azB,
+							}))
+							Expect(subnetDetails.Private).To(ContainElement(builder.SubnetResource{
+								Subnet:           gfnt.NewString(privateSubnet1),
+								RouteTable:       gfnt.NewString("this-is-a-route-table"),
+								AvailabilityZone: azA,
+							}))
+						})
+					})
+
+					Context("importing route tables fails because the rt association points to main", func() {
+						BeforeEach(func() {
+							rtOutput.RouteTables[0].Associations[0].Main = aws.Bool(true)
+							mockEC2.On("DescribeRouteTables", mock.MatchedBy(func(input *ec2.DescribeRouteTablesInput) bool {
+								return len(input.Filters) > 0
+							})).Return(rtOutput, nil)
+						})
+
+						It("returns an error", func() {
+							Expect(addErr).To(MatchError(ContainSubstring("subnets must be associated with a non-main route table; eksctl does not modify the main route table")))
+						})
+					})
+
+					Context("adding the route table to the subnet resource fails", func() {
+						BeforeEach(func() {
+							rtOutput.RouteTables[0].Associations[0].SubnetId = aws.String("fake")
+							mockEC2.On("DescribeRouteTables", mock.MatchedBy(func(input *ec2.DescribeRouteTablesInput) bool {
+								return len(input.Filters) > 0
+							})).Return(rtOutput, nil)
+						})
+
+						It("returns an error", func() {
+							Expect(addErr).To(MatchError(ContainSubstring("failed to find an explicit route table associated with subnet \"subnet-0f98135715dfcf55a\"; eksctl does not modify the main route table if a subnet is not associated with an explicit route table")))
+						})
+					})
+				})
+			})
+
+			Context("public subnets are configured", func() {
+				It("the public subnet resource values are loaded into the VPCResource", func() {
+					Expect(subnetDetails.Public).To(HaveLen(2))
+					Expect(subnetDetails.Public).To(ContainElement(builder.SubnetResource{
+						Subnet:           gfnt.NewString(publicSubnet2),
+						AvailabilityZone: azB,
+					}))
+					Expect(subnetDetails.Public).To(ContainElement(builder.SubnetResource{
+						Subnet:           gfnt.NewString(publicSubnet1),
+						AvailabilityZone: azA,
+					}))
+				})
+			})
+		})
+	})
+})

--- a/pkg/cfn/builder/vpc_existing_test.go
+++ b/pkg/cfn/builder/vpc_existing_test.go
@@ -85,8 +85,7 @@ var _ = Describe("Existing VPC", func() {
 					Subnet:           gfnt.NewString(privateSubnet1),
 					AvailabilityZone: azA,
 				}),
-			)		
-
+			)
 
 			By("the public subnet resource values are loaded into the VPCResource")
 			Expect(subnetDetails.Public).To(HaveLen(2))
@@ -99,7 +98,7 @@ var _ = Describe("Existing VPC", func() {
 					Subnet:           gfnt.NewString(publicSubnet1),
 					AvailabilityZone: azA,
 				}),
-			)			
+			)
 		})
 
 		When("and the VPC does not exist", func() {
@@ -151,7 +150,7 @@ var _ = Describe("Existing VPC", func() {
 				})
 
 				It("errors", func() {
-					Expect(addErr).To(MatchError("VPC \"custom-vpc\" does not have any associated IPv6 cidr blocks"))
+					Expect(addErr).To(MatchError("VPC \"custom-vpc\" does not have any associated IPv6 CIDR blocks"))
 				})
 			})
 		})

--- a/pkg/cfn/builder/vpc_existing_test.go
+++ b/pkg/cfn/builder/vpc_existing_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Existing VPC", func() {
 			Expect(vpcID).To(Equal(gfnt.NewString("custom-vpc")))
 
 			By("no resources are added to the set")
-			Expect(vpcTemplate.Resources).To(HaveLen(0))
+			Expect(vpcTemplate.Resources).To(BeEmpty())
 
 			By("the private subnet resource values are loaded into the VPCResource")
 			Expect(subnetDetails.Private).To(HaveLen(2))

--- a/pkg/cfn/builder/vpc_existing_test.go
+++ b/pkg/cfn/builder/vpc_existing_test.go
@@ -76,14 +76,17 @@ var _ = Describe("Existing VPC", func() {
 
 			By("the private subnet resource values are loaded into the VPCResource")
 			Expect(subnetDetails.Private).To(HaveLen(2))
-			Expect(subnetDetails.Private).To(ContainElement(builder.SubnetResource{
-				Subnet:           gfnt.NewString(privateSubnet2),
-				AvailabilityZone: azB,
-			}))
-			Expect(subnetDetails.Private).To(ContainElement(builder.SubnetResource{
-				Subnet:           gfnt.NewString(privateSubnet1),
-				AvailabilityZone: azA,
-			}))
+			Expect(subnetDetails.Private).To(ContainElements(
+				builder.SubnetResource{
+					Subnet:           gfnt.NewString(privateSubnet2),
+					AvailabilityZone: azB,
+				},
+				builder.SubnetResource{
+					Subnet:           gfnt.NewString(privateSubnet1),
+					AvailabilityZone: azA,
+				}),
+			)		
+
 
 			By("the public subnet resource values are loaded into the VPCResource")
 			Expect(subnetDetails.Public).To(HaveLen(2))

--- a/pkg/cfn/builder/vpc_existing_test.go
+++ b/pkg/cfn/builder/vpc_existing_test.go
@@ -90,14 +90,16 @@ var _ = Describe("Existing VPC", func() {
 
 			By("the public subnet resource values are loaded into the VPCResource")
 			Expect(subnetDetails.Public).To(HaveLen(2))
-			Expect(subnetDetails.Public).To(ContainElement(builder.SubnetResource{
-				Subnet:           gfnt.NewString(publicSubnet2),
-				AvailabilityZone: azB,
-			}))
-			Expect(subnetDetails.Public).To(ContainElement(builder.SubnetResource{
-				Subnet:           gfnt.NewString(publicSubnet1),
-				AvailabilityZone: azA,
-			}))
+			Expect(subnetDetails.Public).To(ContainElements(
+				builder.SubnetResource{
+					Subnet:           gfnt.NewString(publicSubnet2),
+					AvailabilityZone: azB,
+				},
+				builder.SubnetResource{
+					Subnet:           gfnt.NewString(publicSubnet1),
+					AvailabilityZone: azA,
+				}),
+			)			
 		})
 
 		When("and the VPC does not exist", func() {

--- a/pkg/cfn/builder/vpc_ipv4.go
+++ b/pkg/cfn/builder/vpc_ipv4.go
@@ -4,10 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/pkg/errors"
 	gfncfn "github.com/weaveworks/goformation/v4/cloudformation/cloudformation"
 	gfnec2 "github.com/weaveworks/goformation/v4/cloudformation/ec2"
 	gfnt "github.com/weaveworks/goformation/v4/cloudformation/types"
@@ -53,7 +50,6 @@ func NewIPv4VPCResourceSet(rs *resourceSet, clusterConfig *api.ClusterConfig, ec
 			EnableDnsHostnames: gfnt.True(),
 		})
 	} else {
-		vpcRef = gfnt.NewString(clusterConfig.VPC.ID)
 	}
 
 	return &IPv4VPCResourceSet{
@@ -77,13 +73,6 @@ func (v *IPv4VPCResourceSet) CreateTemplate() (*gfnt.Value, *SubnetDetails, erro
 // AddResources adds all required resources
 func (v *IPv4VPCResourceSet) addResources() error {
 	vpc := v.clusterConfig.VPC
-	if vpc.ID != "" { // custom VPC has been set
-		if err := v.importResources(); err != nil {
-			return errors.Wrap(err, "error importing VPC resources")
-		}
-		return nil
-	}
-
 	if api.IsEnabled(vpc.AutoAllocateIPv6) {
 		v.rs.newResource("AutoAllocatedCIDRv6", &gfnec2.VPCCidrBlock{
 			VpcId:                       v.vpcID,
@@ -170,6 +159,10 @@ func (v *IPv4VPCResourceSet) addOutputs() {
 	}
 }
 
+func (v *IPv4VPCResourceSet) isFullyPrivate() bool {
+	return v.clusterConfig.PrivateCluster.Enabled
+}
+
 // RenderJSON returns the rendered JSON
 func (v *IPv4VPCResourceSet) RenderJSON() ([]byte, error) {
 	return v.rs.renderJSON()
@@ -251,108 +244,6 @@ func (v *IPv4VPCResourceSet) addNATGateways() error {
 		return fmt.Errorf("%s is not a valid NAT gateway mode", *v.clusterConfig.VPC.NAT.Gateway)
 	}
 	return nil
-}
-
-func (v *IPv4VPCResourceSet) importResources() error {
-	if subnets := v.clusterConfig.VPC.Subnets.Private; subnets != nil {
-		var (
-			subnetRoutes map[string]string
-			err          error
-		)
-		if v.isFullyPrivate() {
-			subnetRoutes, err = importRouteTables(v.ec2API, v.clusterConfig.VPC.Subnets.Private)
-			if err != nil {
-				return err
-			}
-		}
-
-		subnetResources, err := makeSubnetResources(subnets, subnetRoutes)
-		if err != nil {
-			return err
-		}
-		v.subnetDetails.Private = subnetResources
-	}
-
-	if subnets := v.clusterConfig.VPC.Subnets.Public; subnets != nil {
-		subnetResources, err := makeSubnetResources(subnets, nil)
-		if err != nil {
-			return err
-		}
-		v.subnetDetails.Public = subnetResources
-	}
-
-	return nil
-}
-
-func makeSubnetResources(subnets map[string]api.AZSubnetSpec, subnetRoutes map[string]string) ([]SubnetResource, error) {
-	subnetResources := make([]SubnetResource, len(subnets))
-	i := 0
-	for _, network := range subnets {
-		az := network.AZ
-		sr := SubnetResource{
-			AvailabilityZone: az,
-			Subnet:           gfnt.NewString(network.ID),
-		}
-
-		if subnetRoutes != nil {
-			rt, ok := subnetRoutes[network.ID]
-			if !ok {
-				return nil, errors.Errorf("failed to find an explicit route table associated with subnet %q; "+
-					"eksctl does not modify the main route table if a subnet is not associated with an explicit route table", network.ID)
-			}
-			sr.RouteTable = gfnt.NewString(rt)
-		}
-		subnetResources[i] = sr
-		i++
-	}
-	return subnetResources, nil
-}
-
-func importRouteTables(ec2API ec2iface.EC2API, subnets map[string]api.AZSubnetSpec) (map[string]string, error) {
-	var subnetIDs []string
-	for _, subnet := range subnets {
-		subnetIDs = append(subnetIDs, subnet.ID)
-	}
-
-	var routeTables []*ec2.RouteTable
-	var nextToken *string
-
-	for {
-		output, err := ec2API.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
-			Filters: []*ec2.Filter{
-				{
-					Name:   aws.String("association.subnet-id"),
-					Values: aws.StringSlice(subnetIDs),
-				},
-			},
-			NextToken: nextToken,
-		})
-
-		if err != nil {
-			return nil, errors.Wrap(err, "error describing route tables")
-		}
-
-		routeTables = append(routeTables, output.RouteTables...)
-
-		if nextToken = output.NextToken; nextToken == nil {
-			break
-		}
-	}
-
-	subnetRoutes := make(map[string]string)
-	for _, rt := range routeTables {
-		for _, rta := range rt.Associations {
-			if rta.Main != nil && *rta.Main {
-				return nil, errors.New("subnets must be associated with a non-main route table; eksctl does not modify the main route table")
-			}
-			subnetRoutes[*rta.SubnetId] = *rt.RouteTableId
-		}
-	}
-	return subnetRoutes, nil
-}
-
-func (v *IPv4VPCResourceSet) isFullyPrivate() bool {
-	return v.clusterConfig.PrivateCluster.Enabled
 }
 
 var (

--- a/pkg/cfn/builder/vpc_ipv4.go
+++ b/pkg/cfn/builder/vpc_ipv4.go
@@ -42,21 +42,10 @@ type SubnetDetails struct {
 
 // NewIPv4VPCResourceSet creates and returns a new VPCResourceSet
 func NewIPv4VPCResourceSet(rs *resourceSet, clusterConfig *api.ClusterConfig, ec2API ec2iface.EC2API) *IPv4VPCResourceSet {
-	var vpcRef *gfnt.Value
-	if clusterConfig.VPC.ID == "" {
-		vpcRef = rs.newResource("VPC", &gfnec2.VPC{
-			CidrBlock:          gfnt.NewString(clusterConfig.VPC.CIDR.String()),
-			EnableDnsSupport:   gfnt.True(),
-			EnableDnsHostnames: gfnt.True(),
-		})
-	} else {
-	}
-
 	return &IPv4VPCResourceSet{
 		rs:            rs,
 		clusterConfig: clusterConfig,
 		ec2API:        ec2API,
-		vpcID:         vpcRef,
 		subnetDetails: &SubnetDetails{},
 	}
 }
@@ -73,6 +62,13 @@ func (v *IPv4VPCResourceSet) CreateTemplate() (*gfnt.Value, *SubnetDetails, erro
 // AddResources adds all required resources
 func (v *IPv4VPCResourceSet) addResources() error {
 	vpc := v.clusterConfig.VPC
+
+	v.vpcID = v.rs.newResource("VPC", &gfnec2.VPC{
+		CidrBlock:          gfnt.NewString(vpc.CIDR.String()),
+		EnableDnsSupport:   gfnt.True(),
+		EnableDnsHostnames: gfnt.True(),
+	})
+
 	if api.IsEnabled(vpc.AutoAllocateIPv6) {
 		v.rs.newResource("AutoAllocatedCIDRv6", &gfnec2.VPCCidrBlock{
 			VpcId:                       v.vpcID,

--- a/pkg/cfn/builder/vpc_ipv4_test.go
+++ b/pkg/cfn/builder/vpc_ipv4_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/stretchr/testify/mock"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/cfn/builder"
 	"github.com/weaveworks/eksctl/pkg/cfn/builder/fakes"
@@ -262,109 +261,6 @@ var _ = Describe("VPC Template Builder", func() {
 
 			It("returns an error", func() {
 				Expect(addErr).To(MatchError("some-trash is not a valid NAT gateway mode"))
-			})
-		})
-
-		Context("when a custom VPC is set (vpc.ID != nil)", func() {
-			BeforeEach(func() {
-				cfg.VPC.ID = "custom-vpc"
-			})
-
-			It("the correct VPC resource values are loaded into the VPCResource", func() {
-				Expect(vpcID).To(Equal(gfnt.NewString("custom-vpc")))
-			})
-
-			It("no resources are added to the set", func() {
-				Expect(vpcTemplate.Resources).To(HaveLen(0))
-			})
-
-			Context("private subnets are configured", func() {
-				It("the private subnet resource values are loaded into the VPCResource", func() {
-					Expect(subnetDetails.Private).To(HaveLen(2))
-					Expect(subnetDetails.Private).To(ContainElement(builder.SubnetResource{
-						Subnet:           gfnt.NewString(privateSubnet2),
-						AvailabilityZone: azB,
-					}))
-					Expect(subnetDetails.Private).To(ContainElement(builder.SubnetResource{
-						Subnet:           gfnt.NewString(privateSubnet1),
-						AvailabilityZone: azA,
-					}))
-				})
-
-				Context("PrivateCluster is enabled", func() {
-					var rtOutput *ec2.DescribeRouteTablesOutput
-
-					BeforeEach(func() {
-						cfg.PrivateCluster.Enabled = true
-						rtOutput = makeRTOutput([]string{privateSubnet2, privateSubnet1}, false)
-					})
-
-					Context("ec2 call succeeds", func() {
-						BeforeEach(func() {
-							mockResultFn := func(_ *ec2.DescribeRouteTablesInput) *ec2.DescribeRouteTablesOutput {
-								return rtOutput
-							}
-
-							mockEC2.On("DescribeRouteTables", mock.MatchedBy(func(input *ec2.DescribeRouteTablesInput) bool {
-								return len(input.Filters) > 0
-							})).Return(mockResultFn, nil)
-						})
-
-						It("the private subnet resource values are loaded into the VPCResource with route table association", func() {
-							Expect(subnetDetails.Private).To(HaveLen(2))
-							Expect(subnetDetails.Private).To(ContainElement(builder.SubnetResource{
-								Subnet:           gfnt.NewString(privateSubnet2),
-								RouteTable:       gfnt.NewString("this-is-a-route-table"),
-								AvailabilityZone: azB,
-							}))
-							Expect(subnetDetails.Private).To(ContainElement(builder.SubnetResource{
-								Subnet:           gfnt.NewString(privateSubnet1),
-								RouteTable:       gfnt.NewString("this-is-a-route-table"),
-								AvailabilityZone: azA,
-							}))
-						})
-					})
-
-					Context("importing route tables fails because the rt association points to main", func() {
-						BeforeEach(func() {
-							rtOutput.RouteTables[0].Associations[0].Main = aws.Bool(true)
-							mockEC2.On("DescribeRouteTables", mock.MatchedBy(func(input *ec2.DescribeRouteTablesInput) bool {
-								return len(input.Filters) > 0
-							})).Return(rtOutput, nil)
-						})
-
-						It("returns an error", func() {
-							Expect(addErr).To(MatchError(ContainSubstring("subnets must be associated with a non-main route table; eksctl does not modify the main route table")))
-						})
-					})
-
-					Context("adding the route table to the subnet resource fails", func() {
-						BeforeEach(func() {
-							rtOutput.RouteTables[0].Associations[0].SubnetId = aws.String("fake")
-							mockEC2.On("DescribeRouteTables", mock.MatchedBy(func(input *ec2.DescribeRouteTablesInput) bool {
-								return len(input.Filters) > 0
-							})).Return(rtOutput, nil)
-						})
-
-						It("returns an error", func() {
-							Expect(addErr).To(MatchError(ContainSubstring("failed to find an explicit route table associated with subnet \"subnet-0f98135715dfcf55a\"; eksctl does not modify the main route table if a subnet is not associated with an explicit route table")))
-						})
-					})
-				})
-			})
-
-			Context("public subnets are configured", func() {
-				It("the public subnet resource values are loaded into the VPCResource", func() {
-					Expect(subnetDetails.Public).To(HaveLen(2))
-					Expect(subnetDetails.Public).To(ContainElement(builder.SubnetResource{
-						Subnet:           gfnt.NewString(publicSubnet2),
-						AvailabilityZone: azB,
-					}))
-					Expect(subnetDetails.Public).To(ContainElement(builder.SubnetResource{
-						Subnet:           gfnt.NewString(publicSubnet1),
-						AvailabilityZone: azA,
-					}))
-				})
 			})
 		})
 


### PR DESCRIPTION
### Description

Closes #4275

Manual test:
```
---
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: jk-existing
  region: us-west-2
  version: "1.21"

vpc:
  ipFamily: IPv6
  id: "vpc-0492baf606b68fcde"  # (optional, must match VPC ID used for each subnet below)
  subnets:
    # must provide 'private' and/or 'public' subnets by availibility zone as shown
    private:
      us-west-2a:
        id: "subnet-0937638d4685f935f"
      us-west-2c:
        id: "subnet-0f9bc36d056efab79"
      us-west-2d:
        id: "subnet-0d9d4e2b7f751bacf"
    public:
      us-west-2a:
        id: "subnet-054fc9c0692c17d47"
      us-west-2c:
        id: "subnet-0e1a368ce55b8623b"
      us-west-2d:
        id: "subnet-03d71f7ea27d5f53c"

addons:
  - name: vpc-cni
  - name: coredns
  - name: kube-proxy

iam:
  withOIDC: true

managedNodeGroups: []
```

output:
```
eksctl create cluster -f examples/29-vpc-with-ip-family.yaml
2021-11-03 13:30:34 [ℹ]  eksctl version 0.70.0-dev+884cf616.2021-11-03T13:18:52Z
2021-11-03 13:30:34 [ℹ]  using region us-west-2
2021-11-03 13:30:36 [✔]  using existing VPC (vpc-0492baf606b68fcde) and subnets (private:map[us-west-2a:{subnet-0937638d4685f935f us-west-2a 192.168.160.0/19} us-west-2c:{subnet-0f9bc36d056efab79 us-west-2c 192.168.128.0/19} us-west-2d:{subnet-0d9d4e2b7f751bacf us-west-2d 192.168.96.0/19}] public:map[us-west-2a:{subnet-054fc9c0692c17d47 us-west-2a 192.168.64.0/19} us-west-2c:{subnet-0e1a368ce55b8623b us-west-2c 192.168.32.0/19} us-west-2d:{subnet-03d71f7ea27d5f53c us-west-2d 192.168.0.0/19}])
2021-11-03 13:30:36 [!]  custom VPC/subnets will be used; if resulting cluster doesn't function as expected, make sure to review the configuration of VPC/subnets
2021-11-03 13:30:36 [ℹ]  using Kubernetes version 1.21
2021-11-03 13:30:36 [ℹ]  creating EKS cluster "jk-existing" in "us-west-2" region with
2021-11-03 13:30:36 [ℹ]  will create a CloudFormation stack for cluster itself and 0 nodegroup stack(s)
2021-11-03 13:30:36 [ℹ]  will create a CloudFormation stack for cluster itself and 0 managed nodegroup stack(s)
2021-11-03 13:30:36 [ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-west-2 --cluster=jk-existing'
2021-11-03 13:30:36 [ℹ]  CloudWatch logging will not be enabled for cluster "jk-existing" in "us-west-2"
2021-11-03 13:30:36 [ℹ]  you can enable it with 'eksctl utils update-cluster-logging --enable-types={SPECIFY-YOUR-LOG-TYPES-HERE (e.g. all)} --region=us-west-2 --cluster=jk-existing'
2021-11-03 13:30:36 [ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "jk-existing" in "us-west-2"
2021-11-03 13:30:36 [ℹ]  3 sequential tasks: { create cluster control plane "jk-existing", set AssignIpv6AddressOnCreation to true for public subnets, 5 sequential sub-tasks: { wait for control plane to become ready, associate IAM OIDC provider, no tasks, restart daemonset "kube-system/aws-node", 1 task: { create addons } } }
2021-11-03 13:30:36 [ℹ]  building cluster stack "eksctl-jk-existing-cluster"
2021-11-03 13:30:37 [ℹ]  deploying stack "eksctl-jk-existing-cluster"
2021-11-03 13:34:12 [ℹ]  waiting for CloudFormation stack "eksctl-jk-existing-cluster"
...
2021-11-03 13:46:49 [ℹ]  daemonset "kube-system/aws-node" restarted
2021-11-03 13:48:52 [ℹ]  creating role using recommended policies
2021-11-03 13:48:53 [ℹ]  deploying stack "eksctl-jk-existing-addon-vpc-cni"
2021-11-03 13:48:53 [ℹ]  waiting for CloudFormation stack "eksctl-jk-existing-addon-vpc-cni"
2021-11-03 13:49:10 [ℹ]  waiting for CloudFormation stack "eksctl-jk-existing-addon-vpc-cni"
2021-11-03 13:49:28 [ℹ]  waiting for CloudFormation stack "eksctl-jk-existing-addon-vpc-cni"
2021-11-03 13:49:30 [ℹ]  creating addon
2021-11-03 13:49:31 [ℹ]  successfully created addon
2021-11-03 13:49:31 [ℹ]  waiting for the control plane availability...
2021-11-03 13:49:31 [✔]  saved kubeconfig as "/home/jake/.kube/config"
2021-11-03 13:49:31 [ℹ]  no tasks
2021-11-03 13:49:31 [✔]  all EKS cluster resources for "jk-existing" have been created
2021-11-03 13:51:34 [ℹ]  no recommended policies found, proceeding without any IAM
2021-11-03 13:51:34 [ℹ]  creating addon
2021-11-03 13:51:35 [ℹ]  successfully created addon
2021-11-03 13:51:35 [ℹ]  no recommended policies found, proceeding without any IAM
2021-11-03 13:51:35 [ℹ]  creating addon
2021-11-03 13:51:35 [ℹ]  successfully created addon
2021-11-03 13:51:38 [ℹ]  kubectl command should work with "/home/jake/.kube/config", try 'kubectl get nodes'
2021-11-03 13:51:38 [✔]  EKS cluster "jk-existing" in "us-west-2" region is ready
```

inspecting resoures created:
```
ClusterSharedNodeSecurityGroup
ControlPlane
ControlPlaneSecurityGroup
IngressDefaultClusterToNodeSG-
IngressInterNodeGroupSG
IngressNodeToDefaultClusterSG
PolicyCloudWatchMetrics
PolicyELBPermissions
ServiceRole
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

