### PR TITLE
Revert "Tag 0.73.0-rc.0 release candidate"

### DIFF
--- a/pkg/version/release.go
+++ b/pkg/version/release.go
@@ -6,7 +6,7 @@ package version
 var Version = "0.73.0"
 
 // PreReleaseID can be empty for releases, "rc.X" for release candidates and "dev" for snapshots
-var PreReleaseID = "rc.0"
+var PreReleaseID = "dev"
 
 // gitCommit is the short commit hash. It will be set by the linker.
 var gitCommit = ""


### PR DESCRIPTION
Reverts weaveworks/eksctl#4420

The workflow to create a 0.73.0 RC failed because a tag wasn't created.

Reverting this PR to follow the [steps](https://github.com/weaveworks/eksctl-handbook#re-run-a-failed-release-candidate-job) in the handbook for when a RC fails.