### PR TITLE
Set volume size in data volume for Bottlerocket

### DIFF
--- a/pkg/ami/api.go
+++ b/pkg/ami/api.go
@@ -21,13 +21,6 @@ const (
 	ImageClassARM
 )
 
-const (
-	// used by kubelet
-	bottlerocketDataDisk = "/dev/xvdb"
-	// used by OS
-	bottlerocketOSDisk = "/dev/xvda"
-)
-
 // ImageClasses is a list of image class names
 var ImageClasses = []string{
 	"ImageClassGeneral",
@@ -59,12 +52,9 @@ func Use(ec2api ec2iface.EC2API, ng *api.NodeGroupBase) error {
 		return fmt.Errorf("%q is an instance-store AMI and EBS block device mappings are not supported for instance-store AMIs", ng.AMI)
 
 	case "ebs":
-		if !api.IsSetAndNonEmptyString(ng.VolumeName) {
+		if ng.AMIFamily != api.NodeImageFamilyBottlerocket && !api.IsSetAndNonEmptyString(ng.VolumeName) {
+			// Volume name is preset for Bottlerocket.
 			ng.VolumeName = image.RootDeviceName
-			if ng.AMIFamily == api.NodeImageFamilyBottlerocket {
-				ng.VolumeName = aws.String(bottlerocketDataDisk)
-				ng.AdditionalEncryptedVolume = bottlerocketOSDisk
-			}
 		}
 		rootDeviceMapping, err := findRootDeviceMapping(image)
 		if err != nil {

--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -15,6 +15,13 @@ const (
 	IAMPolicyAmazonEKSCNIPolicy = "AmazonEKS_CNI_Policy"
 )
 
+const (
+	// Data volume, used by kubelet
+	bottlerocketDataDisk = "/dev/xvdb"
+	// OS volume
+	bottlerocketOSDisk = "/dev/xvda"
+)
+
 var (
 	AWSNodeMeta = ClusterIAMMeta{
 		Name:      "aws-node",
@@ -188,6 +195,10 @@ func setVolumeDefaults(ng *NodeGroupBase, template *LaunchTemplate) {
 	}
 	if *ng.VolumeType == NodeVolumeTypeIO1 && ng.VolumeIOPS == nil {
 		ng.VolumeIOPS = aws.Int(DefaultNodeVolumeIO1IOPS)
+	}
+	if ng.AMIFamily == NodeImageFamilyBottlerocket && !IsSetAndNonEmptyString(ng.VolumeName) {
+		ng.AdditionalEncryptedVolume = bottlerocketOSDisk
+		ng.VolumeName = aws.String(bottlerocketDataDisk)
 	}
 }
 

--- a/pkg/cfn/builder/block_device_mapping.go
+++ b/pkg/cfn/builder/block_device_mapping.go
@@ -43,7 +43,7 @@ func makeBlockDeviceMappings(ng *api.NodeGroupBase) []gfnec2.LaunchTemplate_Bloc
 
 	mappings := []gfnec2.LaunchTemplate_BlockDeviceMapping{mapping}
 
-	if ng.AdditionalEncryptedVolume != "" {
+	if api.IsEnabled(ng.VolumeEncrypted) && ng.AdditionalEncryptedVolume != "" {
 		mappings = append(mappings, gfnec2.LaunchTemplate_BlockDeviceMapping{
 			DeviceName: gfnt.NewString(ng.AdditionalEncryptedVolume),
 			Ebs: &gfnec2.LaunchTemplate_Ebs{

--- a/pkg/cfn/builder/managed_launch_template_test.go
+++ b/pkg/cfn/builder/managed_launch_template_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+
 	. "github.com/benjamintf1/unmarshalledmatchers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -268,6 +269,17 @@ API_SERVER_URL=https://test.com
 				UserData: aws.String("bootstrap.sh"),
 			}),
 			resourcesFilename: "lt_instance_types.json",
+		}),
+
+		Entry("Bottlerocket AMI Family with defaults", &mngCase{
+			ng: &api.ManagedNodeGroup{
+				NodeGroupBase: &api.NodeGroupBase{
+					Name:         "bottlerocket",
+					AMIFamily:    api.NodeImageFamilyBottlerocket,
+					InstanceType: "m5.xlarge",
+				},
+			},
+			resourcesFilename: "bottlerocket.json",
 		}),
 
 		Entry("Bottlerocket with volumeSize set", &mngCase{

--- a/pkg/cfn/builder/managed_launch_template_test.go
+++ b/pkg/cfn/builder/managed_launch_template_test.go
@@ -269,6 +269,18 @@ API_SERVER_URL=https://test.com
 			}),
 			resourcesFilename: "lt_instance_types.json",
 		}),
+
+		Entry("Bottlerocket with volumeSize set", &mngCase{
+			ng: &api.ManagedNodeGroup{
+				NodeGroupBase: &api.NodeGroupBase{
+					Name:         "bottlerocket-volume",
+					AMIFamily:    api.NodeImageFamilyBottlerocket,
+					InstanceType: "m5.xlarge",
+					VolumeSize:   aws.Int(142),
+				},
+			},
+			resourcesFilename: "bottlerocket_volume.json",
+		}),
 	)
 })
 

--- a/pkg/cfn/builder/nodegroup_test.go
+++ b/pkg/cfn/builder/nodegroup_test.go
@@ -994,13 +994,14 @@ var _ = Describe("Unmanaged NodeGroup Template Builder", func() {
 				Context("ng.AdditionalEncryptedVolume is set", func() {
 					BeforeEach(func() {
 						ng.AdditionalEncryptedVolume = "/foo/bar"
+						ng.VolumeEncrypted = aws.Bool(true)
 					})
 
 					It("the volume is added to the launch template block device mappings", func() {
 						Expect(ngTemplate.Resources["NodeGroupLaunchTemplate"].Properties.LaunchTemplateData.BlockDeviceMappings).To(HaveLen(2))
 						mapping := ngTemplate.Resources["NodeGroupLaunchTemplate"].Properties.LaunchTemplateData.BlockDeviceMappings[1]
 						Expect(mapping.DeviceName).To(Equal("/foo/bar"))
-						Expect(mapping.Ebs["Encrypted"]).To(Equal(false))
+						Expect(mapping.Ebs["Encrypted"]).To(Equal(true))
 					})
 				})
 			})

--- a/pkg/cfn/builder/testdata/launch_template/bottlerocket.json
+++ b/pkg/cfn/builder/testdata/launch_template/bottlerocket.json
@@ -1,0 +1,178 @@
+{
+    "LaunchTemplate": {
+        "Type": "AWS::EC2::LaunchTemplate",
+        "Properties": {
+            "LaunchTemplateData": {
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvdb",
+                        "Ebs": {
+                            "Iops": 3000,
+                            "Throughput": 125,
+                            "VolumeSize": 80,
+                            "VolumeType": "gp3"
+                        }
+                    }
+                ],
+                "MetadataOptions": {
+                    "HttpPutResponseHopLimit": 2,
+                    "HttpTokens": "optional"
+                },
+                "SecurityGroupIds": [
+                    {
+                        "Fn::ImportValue": "eksctl-lt::ClusterSecurityGroupId"
+                    }
+                ],
+                "TagSpecifications": [
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [
+                            {
+                                "Key": "Name",
+                                "Value": "lt-bottlerocket-Node"
+                            },
+                            {
+                                "Key": "alpha.eksctl.io/nodegroup-name",
+                                "Value": "bottlerocket"
+                            },
+                            {
+                                "Key": "alpha.eksctl.io/nodegroup-type",
+                                "Value": "managed"
+                            }
+                        ]
+                    },
+                    {
+                        "ResourceType": "volume",
+                        "Tags": [
+                        {
+                            "Key": "Name",
+                            "Value": "lt-bottlerocket-Node"
+                        },
+                        {
+                            "Key": "alpha.eksctl.io/nodegroup-name",
+                            "Value": "bottlerocket"
+                        },
+                        {
+                            "Key": "alpha.eksctl.io/nodegroup-type",
+                            "Value": "managed"
+                        }
+                        ]
+                    },
+                    {
+                        "ResourceType": "network-interface",
+                        "Tags": [
+                        {
+                            "Key": "Name",
+                            "Value": "lt-bottlerocket-Node"
+                        },
+                        {
+                            "Key": "alpha.eksctl.io/nodegroup-name",
+                            "Value": "bottlerocket"
+                        },
+                        {
+                            "Key": "alpha.eksctl.io/nodegroup-type",
+                            "Value": "managed"
+                        }
+                        ]
+                    }
+                ]
+            },
+            "LaunchTemplateName": {
+                "Fn::Sub": "${AWS::StackName}"
+            }
+        }
+    },
+    "ManagedNodeGroup": {
+        "Type": "AWS::EKS::Nodegroup",
+        "Properties": {
+            "AmiType": "BOTTLEROCKET_x86_64",
+            "ClusterName": "lt",
+            "Labels": {
+                "alpha.eksctl.io/cluster-name": "lt",
+                "alpha.eksctl.io/nodegroup-name": "bottlerocket"
+            },
+            "InstanceTypes": ["m5.xlarge"],
+            "NodeRole": {
+                "Fn::GetAtt": [
+                    "NodeInstanceRole",
+                    "Arn"
+                ]
+            },
+            "NodegroupName": "bottlerocket",
+            "ScalingConfig": {
+                "DesiredSize": 2,
+                "MaxSize": 2,
+                "MinSize": 2
+            },
+            "Subnets": {
+                "Fn::Split": [
+                    ",",
+                    {
+                        "Fn::ImportValue": "eksctl-lt::SubnetsPublic"
+                    }
+                ]
+            },
+            "Tags": {
+                "alpha.eksctl.io/nodegroup-name": "bottlerocket",
+                "alpha.eksctl.io/nodegroup-type": "managed"
+            },
+            "LaunchTemplate": {
+                "Id": {
+                    "Ref": "LaunchTemplate"
+                }
+            }
+        }
+    },
+    "NodeInstanceRole": {
+        "Type": "AWS::IAM::Role",
+        "Properties": {
+            "AssumeRolePolicyDocument": {
+                "Statement": [
+                    {
+                        "Action": [
+                            "sts:AssumeRole"
+                        ],
+                        "Effect": "Allow",
+                        "Principal": {
+                            "Service": [
+                                {
+                                    "Fn::FindInMap": [
+                                        "ServicePrincipalPartitionMap",
+                                        {
+                                            "Ref": "AWS::Partition"
+                                        },
+                                        "EC2"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "Version": "2012-10-17"
+            },
+            "ManagedPolicyArns": [
+                {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+                },
+                {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+                },
+                {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+                },
+                {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+                }
+            ],
+            "Path": "/",
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": {
+                        "Fn::Sub": "${AWS::StackName}/NodeInstanceRole"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/pkg/cfn/builder/testdata/launch_template/bottlerocket_volume.json
+++ b/pkg/cfn/builder/testdata/launch_template/bottlerocket_volume.json
@@ -1,0 +1,178 @@
+{
+    "LaunchTemplate": {
+        "Type": "AWS::EC2::LaunchTemplate",
+        "Properties": {
+            "LaunchTemplateData": {
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvdb",
+                        "Ebs": {
+                            "Iops": 3000,
+                            "Throughput": 125,
+                            "VolumeSize": 142,
+                            "VolumeType": "gp3"
+                        }
+                    }
+                ],
+                "MetadataOptions": {
+                    "HttpPutResponseHopLimit": 2,
+                    "HttpTokens": "optional"
+                },
+                "SecurityGroupIds": [
+                    {
+                        "Fn::ImportValue": "eksctl-lt::ClusterSecurityGroupId"
+                    }
+                ],
+                "TagSpecifications": [
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [
+                            {
+                                "Key": "Name",
+                                "Value": "lt-bottlerocket-volume-Node"
+                            },
+                            {
+                                "Key": "alpha.eksctl.io/nodegroup-name",
+                                "Value": "bottlerocket-volume"
+                            },
+                            {
+                                "Key": "alpha.eksctl.io/nodegroup-type",
+                                "Value": "managed"
+                            }
+                        ]
+                    },
+                    {
+                        "ResourceType": "volume",
+                        "Tags": [
+                        {
+                            "Key": "Name",
+                            "Value": "lt-bottlerocket-volume-Node"
+                        },
+                        {
+                            "Key": "alpha.eksctl.io/nodegroup-name",
+                            "Value": "bottlerocket-volume"
+                        },
+                        {
+                            "Key": "alpha.eksctl.io/nodegroup-type",
+                            "Value": "managed"
+                        }
+                        ]
+                    },
+                    {
+                        "ResourceType": "network-interface",
+                        "Tags": [
+                        {
+                            "Key": "Name",
+                            "Value": "lt-bottlerocket-volume-Node"
+                        },
+                        {
+                            "Key": "alpha.eksctl.io/nodegroup-name",
+                            "Value": "bottlerocket-volume"
+                        },
+                        {
+                            "Key": "alpha.eksctl.io/nodegroup-type",
+                            "Value": "managed"
+                        }
+                        ]
+                    }
+                ]
+            },
+            "LaunchTemplateName": {
+                "Fn::Sub": "${AWS::StackName}"
+            }
+        }
+    },
+    "ManagedNodeGroup": {
+        "Type": "AWS::EKS::Nodegroup",
+        "Properties": {
+            "AmiType": "BOTTLEROCKET_x86_64",
+            "ClusterName": "lt",
+            "Labels": {
+                "alpha.eksctl.io/cluster-name": "lt",
+                "alpha.eksctl.io/nodegroup-name": "bottlerocket-volume"
+            },
+            "InstanceTypes": ["m5.xlarge"],
+            "NodeRole": {
+                "Fn::GetAtt": [
+                    "NodeInstanceRole",
+                    "Arn"
+                ]
+            },
+            "NodegroupName": "bottlerocket-volume",
+            "ScalingConfig": {
+                "DesiredSize": 2,
+                "MaxSize": 2,
+                "MinSize": 2
+            },
+            "Subnets": {
+                "Fn::Split": [
+                    ",",
+                    {
+                        "Fn::ImportValue": "eksctl-lt::SubnetsPublic"
+                    }
+                ]
+            },
+            "Tags": {
+                "alpha.eksctl.io/nodegroup-name": "bottlerocket-volume",
+                "alpha.eksctl.io/nodegroup-type": "managed"
+            },
+            "LaunchTemplate": {
+                "Id": {
+                    "Ref": "LaunchTemplate"
+                }
+            }
+        }
+    },
+    "NodeInstanceRole": {
+        "Type": "AWS::IAM::Role",
+        "Properties": {
+            "AssumeRolePolicyDocument": {
+                "Statement": [
+                    {
+                        "Action": [
+                            "sts:AssumeRole"
+                        ],
+                        "Effect": "Allow",
+                        "Principal": {
+                            "Service": [
+                                {
+                                    "Fn::FindInMap": [
+                                        "ServicePrincipalPartitionMap",
+                                        {
+                                            "Ref": "AWS::Partition"
+                                        },
+                                        "EC2"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "Version": "2012-10-17"
+            },
+            "ManagedPolicyArns": [
+                {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+                },
+                {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+                },
+                {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+                },
+                {
+                    "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+                }
+            ],
+            "Path": "/",
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": {
+                        "Fn::Sub": "${AWS::StackName}/NodeInstanceRole"
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
### Description

The volume size was being set for the OS volume, instead of the data volume for Bottlerocket nodegroups.

Fixes https://github.com/weaveworks/eksctl/issues/4434


<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

