### PR TITLE
Unpend and fix Windows integration tests

### DIFF
--- a/integration/tests/windows/windows_test.go
+++ b/integration/tests/windows/windows_test.go
@@ -52,12 +52,6 @@ var _ = Describe("(Integration) [Windows Nodegroups]", func() {
 					AMIFamily: api.NodeImageFamilyWindowsServer2019FullContainer,
 				},
 			},
-			{
-				NodeGroupBase: &api.NodeGroupBase{
-					Name:      "windows20h2",
-					AMIFamily: api.NodeImageFamilyWindowsServer20H2CoreContainer,
-				},
-			},
 		}
 		clusterConfig.ManagedNodeGroups = []*api.ManagedNodeGroup{
 			{
@@ -97,8 +91,8 @@ var _ = Describe("(Integration) [Windows Nodegroups]", func() {
 			createCluster(withOIDC)
 			runWindowsPod()
 		},
-			PEntry("when withOIDC is disabled", false),
-			PEntry("when withOIDC is enabled", true),
+			Entry("when withOIDC is disabled", false),
+			Entry("when withOIDC is enabled", true),
 		)
 	})
 


### PR DESCRIPTION
### Description
The workload being deployed is not compatible with `WindowsServer20H2CoreContainer` and that was preventing the pod from starting. I have opened a separate [issue](https://github.com/weaveworks/eksctl/issues/4441
) to test workloads on `WindowsServer20H2CoreContainer`.

Closes #4414 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

