### PR TITLE
Add config-file option to get nodegroup

### DIFF
--- a/pkg/ctl/get/nodegroup.go
+++ b/pkg/ctl/get/nodegroup.go
@@ -38,15 +38,18 @@ func getNodeGroupCmd(cmd *cmdutils.Cmd) {
 		cmdutils.AddRegionFlag(fs, &cmd.ProviderConfig)
 		cmdutils.AddCommonFlagsForGetCmd(fs, &params.chunkSize, &params.output)
 		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
+		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 	})
 
 	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, &cmd.ProviderConfig, false)
 }
 
 func doGetNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *getCmdParams) error {
+	if err := cmdutils.NewMetadataLoader(cmd).Load(); err != nil {
+		return err
+	}
 	cfg := cmd.ClusterConfig
 
-	// TODO: move this into a loader when --config-file gets added to this command
 	if cfg.Metadata.Name == "" {
 		return cmdutils.ErrMustBeSet(cmdutils.ClusterNameFlag(cmd))
 	}


### PR DESCRIPTION
### Description

Does the `nodegroup` part of https://github.com/weaveworks/eksctl/issues/1126.

```
eksctl get nodegroup -f cluster-managed.yaml
2021-11-16 16:03:36 [ℹ]  eksctl version 0.75.0-dev+c5f6d0ef.2021-11-16T15:10:41Z
2021-11-16 16:03:36 [ℹ]  using region us-west-2
CLUSTER                         NODEGROUP       STATUS  CREATED                 MIN SIZE        MAX SIZE        DESIRED CAPACITY     INSTANCE TYPE    IMAGE ID        ASG NAME
test-nodegroup-cluster-config   managed-ng-1    ACTIVE  2021-11-16T12:02:30Z    1               2               1                    m5.large AL2_x86_64      eks-52be9450-42a1-0ff9-b901-3b51d3bda8d3
test-nodegroup-cluster-config   managed-ng-2    ACTIVE  2021-11-16T14:56:25Z    1               2               1                    m5.large AL2_x86_64      eks-f8be949f-df08-fa4e-4e46-2590f597f474
```

It's not allowed to define `--name` with `--config-file`. I'm on the fence with that. Like, it would be nice to define which nodegroup you are interested in... But then again, if you use the config-file you want to see all of the things the config-file provides and this behaviour is mimicked with others. 

This was easier since nodegroup already was using the config thing to load in data, so it was easy to just overwrite it if the setting is set. I tried without, with and only name and only name argument.

### Testing

- [x] with `--config-file`
- [x] with named argument
- [x] with `--cluster` + `--name`
- [x] with `--config-file` + `--name`
- [x] without anything

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

