### PR TITLE
Adds instanceSelector support for allow and deny rules

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -816,6 +816,11 @@
     },
     "InstanceSelector": {
       "properties": {
+        "allow": {
+          "type": "string",
+          "description": "Allow is a regex that matching instances must meet to be selected",
+          "x-intellij-html-description": "Allow is a regex that matching instances must meet to be selected"
+        },
         "cpuArchitecture": {
           "type": "string",
           "description": "CPU Architecture of the EC2 instance type. Valid variants are: `\"x86_64\"` `\"amd64\"` `\"arm64\"`",
@@ -825,6 +830,11 @@
             "amd64",
             "arm64"
           ]
+        },
+        "deny": {
+          "type": "string",
+          "description": "Deny is a regex that prevents matching instances from being selected",
+          "x-intellij-html-description": "Deny is a regex that prevents matching instances from being selected"
         },
         "gpus": {
           "type": "integer",
@@ -846,7 +856,9 @@
         "vCPUs",
         "memory",
         "gpus",
-        "cpuArchitecture"
+        "cpuArchitecture",
+        "allow",
+        "deny"
       ],
       "additionalProperties": false,
       "description": "holds EC2 instance selector options",

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -1604,6 +1604,10 @@ type InstanceSelector struct {
 	// `"amd64"`
 	// `"arm64"`
 	CPUArchitecture string `json:"cpuArchitecture,omitempty"`
+	// Allow is a regex that matching instances must meet to be selected
+	AllowRegex string `json:"allow,omitempty"`
+	// Deny is a regex that prevents matching instances from being selected
+	DenyRegex string `json:"deny,omitempty"`
 }
 
 // IsZero returns true if all fields hold a zero value

--- a/pkg/ctl/cmdutils/nodegroup_flags.go
+++ b/pkg/ctl/cmdutils/nodegroup_flags.go
@@ -72,6 +72,8 @@ func AddInstanceSelectorOptions(flagSetGroup *NamedFlagSetGroup, ng *api.NodeGro
 		fs.IntVar(&ng.InstanceSelector.VCPUs, "instance-selector-vcpus", 0, "an integer value (2, 4 etc)")
 		fs.StringVar(&ng.InstanceSelector.Memory, "instance-selector-memory", "", "4 or 4GiB")
 		fs.StringVar(&ng.InstanceSelector.CPUArchitecture, "instance-selector-cpu-architecture", "", "x86_64, or arm64")
+		fs.StringVar(&ng.InstanceSelector.DenyRegex, "instance-selector-deny", "", "instance types which should be excluded w/ regex syntax")
+		fs.StringVar(&ng.InstanceSelector.AllowRegex, "instance-selector-allow", "", "allowed instance types to select from w/ regex syntax")
 		ng.InstanceSelector.GPUs = fs.Int("instance-selector-gpus", 0, "an integer value")
 	})
 }

--- a/userdocs/src/usage/instance-selector.md
+++ b/userdocs/src/usage/instance-selector.md
@@ -60,7 +60,7 @@ $ eksctl create cluster -f instance-selector-cluster.yaml
 
 The following instance selector CLI options are supported by `eksctl create cluster` and `eksctl create nodegroup`:
 
-`--instance-selector-vcpus`, `--instance-selector-memory`, `--instance-selector-gpus` and `instance-selector-cpu-architecture`
+`--instance-selector-vcpus`, `--instance-selector-memory`, `--instance-selector-gpus`,`--instance-selector-cpu-architecture`, `--instance-selector-allow` and `--instance-selector-deny`
 
 An example file can be found [here](https://github.com/weaveworks/eksctl/blob/main/examples/28-instance-selector.yaml).
 


### PR DESCRIPTION
### Description

Added the ability to specify `allow` and `deny` attributes as part of the instanceSelector
configuration as well as the command line arguments which allow instance types to be
filtered based on regexes. These fields behave like the `--allow-list` and `--deny-list`
arguments from https://github.com/aws/amazon-ec2-instance-selector.

Issue #3718 
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

