### PR TITLE
Add --config-flag to get labels

### DIFF
--- a/pkg/ctl/get/labels.go
+++ b/pkg/ctl/get/labels.go
@@ -34,6 +34,7 @@ func getLabelsCmd(cmd *cmdutils.Cmd) {
 
 		cmdutils.AddRegionFlag(fs, &cmd.ProviderConfig)
 		cmdutils.AddTimeoutFlag(fs, &cmd.ProviderConfig.WaitTimeout)
+		cmdutils.AddConfigFileFlag(fs, &cmd.ClusterConfigFile)
 	})
 
 	cmdutils.AddCommonFlagsForAWS(cmd.FlagSetGroup, &cmd.ProviderConfig, false)
@@ -41,17 +42,10 @@ func getLabelsCmd(cmd *cmdutils.Cmd) {
 }
 
 func getLabels(cmd *cmdutils.Cmd, nodeGroupName string) error {
+	if err := cmdutils.NewGetLabelsLoader(cmd, nodeGroupName).Load(); err != nil {
+		return err
+	}
 	cfg := cmd.ClusterConfig
-	if cfg.Metadata.Name == "" {
-		return cmdutils.ErrMustBeSet(cmdutils.ClusterNameFlag(cmd))
-	}
-	if nodeGroupName == "" {
-		return cmdutils.ErrMustBeSet("--nodegroup")
-	}
-
-	if cmd.NameArg != "" {
-		return cmdutils.ErrUnsupportedNameArg()
-	}
 
 	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {

--- a/pkg/ctl/get/labels_test.go
+++ b/pkg/ctl/get/labels_test.go
@@ -1,6 +1,8 @@
 package get
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -34,5 +36,24 @@ var _ = Describe("get", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Error: name argument is not supported"))
 		})
+
+		It("setting --cluster and --config-file at the same time", func() {
+			f, err := os.CreateTemp("", "configfile")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = f.WriteString(labelsGetConfigFile)
+			Expect(err).NotTo(HaveOccurred())
+			cmd := newMockCmd("labels", "--cluster", "name", "--nodegroup", "name", "--config-file", f.Name())
+			_, err = cmd.execute()
+			Expect(err).To(MatchError(ContainSubstring("Error: cannot use --cluster when --config-file/-f is set")))
+		})
 	})
 })
+
+var labelsGetConfigFile = `apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: test-nodegroup-cluster-config
+  region: us-west-2
+  version: '1.20'
+`

--- a/pkg/ctl/get/nodegroup.go
+++ b/pkg/ctl/get/nodegroup.go
@@ -45,28 +45,10 @@ func getNodeGroupCmd(cmd *cmdutils.Cmd) {
 }
 
 func doGetNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *getCmdParams) error {
-	if err := cmdutils.NewMetadataLoader(cmd).Load(); err != nil {
+	if err := cmdutils.NewGetNodegroupLoader(cmd, ng).Load(); err != nil {
 		return err
 	}
 	cfg := cmd.ClusterConfig
-
-	// TODO: move this into a loader when --config-file gets added to this command
-	if cfg.Metadata.Name == "" {
-		return cmdutils.ErrMustBeSet(cmdutils.ClusterNameFlag(cmd))
-	}
-
-	if ng.Name != "" && cmd.NameArg != "" {
-		return cmdutils.ErrFlagAndArg("--name", ng.Name, cmd.NameArg)
-	}
-
-	if cmd.NameArg != "" {
-		ng.Name = cmd.NameArg
-	}
-
-	// prevent creation of invalid config object with unnamed nodegroup
-	if ng.Name != "" {
-		cfg.NodeGroups = append(cfg.NodeGroups, ng)
-	}
 
 	ctl, err := cmd.NewProviderForExistingCluster()
 	if err != nil {

--- a/pkg/ctl/get/nodegroup_test.go
+++ b/pkg/ctl/get/nodegroup_test.go
@@ -15,14 +15,8 @@ var _ = Describe("get", func() {
 			Expect(err).To(MatchError(ContainSubstring("Error: --cluster must be set")))
 		})
 
-		It("setting --name and argument at the same time", func() {
-			cmd := newMockCmd("nodegroup", "ng", "--name", "ng")
-			_, err := cmd.execute()
-			Expect(err).To(MatchError(ContainSubstring("Error: --name=ng and argument ng cannot be used at the same time")))
-		})
-
 		It("setting --cluster and argument at the same time", func() {
-			cmd := newMockCmd("nodegroup", "ng", "--cluster", "name")
+			cmd := newMockCmd("nodegroup", "ng", "--cluster", "name", "--name", "ng")
 			_, err := cmd.execute()
 			Expect(err).To(MatchError(ContainSubstring("Error: --cluster=name and argument ng cannot be used at the same time")))
 		})


### PR DESCRIPTION
### Description

Added `--config-file` to `get labels` for https://github.com/weaveworks/eksctl/issues/1126.
And fix the config file loading added in https://github.com/weaveworks/eksctl/pull/4465

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

