### PR TITLE
ensure vpc-cni version is atleast 1.10.0 when ipv6 is configured

### DIFF
--- a/examples/29-vpc-with-ip-family.yaml
+++ b/examples/29-vpc-with-ip-family.yaml
@@ -14,8 +14,11 @@ vpc:
 
 addons:
   - name: vpc-cni
+    version: latest
   - name: coredns
+    version: latest
   - name: kube-proxy
+    version: latest
 
 iam:
   withOIDC: true

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -325,9 +325,10 @@ const (
 
 // Values for core addons
 const (
-	VPCCNIAddon    = "vpc-cni"
-	KubeProxyAddon = "kube-proxy"
-	CoreDNSAddon   = "coredns"
+	VPCCNIAddon                 = "vpc-cni"
+	KubeProxyAddon              = "kube-proxy"
+	CoreDNSAddon                = "coredns"
+	minimumVPCCNIVersionForIPv6 = "1.10.0"
 )
 
 var (

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -234,7 +234,11 @@ func (c *ClusterConfig) ValidateVPCConfig() error {
 func (c *ClusterConfig) unsupportedVPCCNIAddonVersion() (bool, error) {
 	for _, addon := range c.Addons {
 		if addon.Name == VPCCNIAddon {
-			if addon.Version == "latest" || addon.Version == "" {
+			if addon.Version == "" {
+				addon.Version = minimumVPCCNIVersionForIPv6
+				return false, nil
+			}
+			if addon.Version == "latest" {
 				return false, nil
 			}
 

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/hashicorp/go-version"
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
 
@@ -184,6 +185,16 @@ func (c *ClusterConfig) ValidateVPCConfig() error {
 		if missing := c.addonContainsManagedAddons([]string{VPCCNIAddon, CoreDNSAddon, KubeProxyAddon}); len(missing) != 0 {
 			return fmt.Errorf("the default core addons must be defined in case of IPv6; missing addon(s): %s", strings.Join(missing, ", "))
 		}
+
+		unsupportedVersion, err := c.unsupportedVPCCNIAddonVersion()
+		if err != nil {
+			return err
+		}
+
+		if unsupportedVersion {
+			return fmt.Errorf("vpc-cni version must be at least version 1.10.0 for IPv6")
+		}
+
 		if c.IAM == nil || c.IAM != nil && IsDisabled(c.IAM.WithOIDC) {
 			return fmt.Errorf("oidc needs to be enabled if IPv6 is set")
 		}
@@ -218,6 +229,39 @@ func (c *ClusterConfig) ValidateVPCConfig() error {
 		return errors.New("vpc.manageSharedNodeSecurityGroupRules must be enabled when using ekstcl-managed security groups")
 	}
 	return nil
+}
+
+func (c *ClusterConfig) unsupportedVPCCNIAddonVersion() (bool, error) {
+	for _, addon := range c.Addons {
+		if addon.Name == VPCCNIAddon {
+			if addon.Version == "latest" || addon.Version == "" {
+				return false, nil
+			}
+
+			return versionLessThan(addon.Version, minimumVPCCNIVersionForIPv6)
+		}
+	}
+	return false, nil
+}
+
+func versionLessThan(v1, v2 string) (bool, error) {
+	v1Version, err := parseVersion(v1)
+	if err != nil {
+		return false, err
+	}
+	v2Version, err := parseVersion(v2)
+	if err != nil {
+		return false, err
+	}
+	return v1Version.LessThan(v2Version), nil
+}
+
+func parseVersion(v string) (*version.Version, error) {
+	version, err := version.NewVersion(v)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse version %q: %w", v, err)
+	}
+	return version, nil
 }
 
 func (c *ClusterConfig) ipv6CidrsValid() error {

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -192,7 +192,7 @@ func (c *ClusterConfig) ValidateVPCConfig() error {
 		}
 
 		if unsupportedVersion {
-			return fmt.Errorf("vpc-cni version must be at least version 1.10.0 for IPv6")
+			return fmt.Errorf("vpc-cni version must be at least version %s for IPv6", minimumVPCCNIVersionForIPv6)
 		}
 
 		if c.IAM == nil || c.IAM != nil && IsDisabled(c.IAM.WithOIDC) {

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -637,6 +637,25 @@ var _ = Describe("ClusterConfig validation", func() {
 					})
 				})
 
+				When("the version of the vpc-cni is not configured", func() {
+					It("does not error", func() {
+						cfg.Metadata.Version = api.Version1_22
+						cfg.VPC.IPFamily = api.IPV6Family
+						cfg.IAM = &api.ClusterIAM{
+							WithOIDC: api.Enabled(),
+						}
+						cfg.Addons = append(cfg.Addons,
+							&api.Addon{Name: api.KubeProxyAddon},
+							&api.Addon{Name: api.CoreDNSAddon},
+							&api.Addon{Name: api.VPCCNIAddon},
+						)
+						cfg.VPC.NAT = nil
+						err = cfg.ValidateVPCConfig()
+						Expect(err).NotTo(HaveOccurred())
+						Expect(cfg.Addons[2].Version).To(Equal("1.10.0"))
+					})
+				})
+
 				When("the version of the vpc-cni is latest", func() {
 					It("does not error", func() {
 						cfg.Metadata.Version = api.Version1_22

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -542,6 +542,7 @@ var _ = Describe("ClusterConfig validation", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cfg.VPC.IPFamily).To(Equal(api.IPV4Family))
 			})
+
 			When("ipFamily is set to IPv6", func() {
 				It("accepts that setting", func() {
 					cfg.VPC.NAT = nil
@@ -564,6 +565,7 @@ var _ = Describe("ClusterConfig validation", func() {
 					Expect(err).ToNot(HaveOccurred())
 				})
 			})
+
 			When("ipFamily is set ot IPv6 but version is not or too low", func() {
 				It("returns an error", func() {
 					cfg.VPC.IPFamily = api.IPV6Family
@@ -584,6 +586,7 @@ var _ = Describe("ClusterConfig validation", func() {
 					Expect(err).To(MatchError(ContainSubstring("cluster version must be >= 1.21")))
 				})
 			})
+
 			When("ipFamily is set ot IPv6 but no managed addons are provided", func() {
 				It("it returns an error including which addons are missing", func() {
 					cfg.VPC.NAT = nil
@@ -596,6 +599,81 @@ var _ = Describe("ClusterConfig validation", func() {
 					Expect(err).To(MatchError(ContainSubstring("the default core addons must be defined in case of IPv6; missing addon(s): vpc-cni, coredns")))
 				})
 			})
+
+			When("the vpc-cni version is configured", func() {
+				When("the version of the vpc-cni is too low", func() {
+					It("returns an error", func() {
+						cfg.Metadata.Version = api.Version1_22
+						cfg.VPC.IPFamily = api.IPV6Family
+						cfg.IAM = &api.ClusterIAM{
+							WithOIDC: api.Enabled(),
+						}
+						cfg.Addons = append(cfg.Addons,
+							&api.Addon{Name: api.KubeProxyAddon},
+							&api.Addon{Name: api.CoreDNSAddon},
+							&api.Addon{Name: api.VPCCNIAddon, Version: "1.9.0"},
+						)
+						cfg.VPC.NAT = nil
+						err = cfg.ValidateVPCConfig()
+						Expect(err).To(MatchError(ContainSubstring("vpc-cni version must be at least version 1.10.0 for IPv6")))
+					})
+				})
+
+				When("the version of the vpc-cni is supported", func() {
+					It("does not error", func() {
+						cfg.Metadata.Version = api.Version1_22
+						cfg.VPC.IPFamily = api.IPV6Family
+						cfg.IAM = &api.ClusterIAM{
+							WithOIDC: api.Enabled(),
+						}
+						cfg.Addons = append(cfg.Addons,
+							&api.Addon{Name: api.KubeProxyAddon},
+							&api.Addon{Name: api.CoreDNSAddon},
+							&api.Addon{Name: api.VPCCNIAddon, Version: "1.10"},
+						)
+						cfg.VPC.NAT = nil
+						err = cfg.ValidateVPCConfig()
+						Expect(err).NotTo(HaveOccurred())
+					})
+				})
+
+				When("the version of the vpc-cni is latest", func() {
+					It("does not error", func() {
+						cfg.Metadata.Version = api.Version1_22
+						cfg.VPC.IPFamily = api.IPV6Family
+						cfg.IAM = &api.ClusterIAM{
+							WithOIDC: api.Enabled(),
+						}
+						cfg.Addons = append(cfg.Addons,
+							&api.Addon{Name: api.KubeProxyAddon},
+							&api.Addon{Name: api.CoreDNSAddon},
+							&api.Addon{Name: api.VPCCNIAddon, Version: "latest"},
+						)
+						cfg.VPC.NAT = nil
+						err = cfg.ValidateVPCConfig()
+						Expect(err).NotTo(HaveOccurred())
+					})
+				})
+
+				When("the version of the vpc-cni is invalid", func() {
+					It("it returns an error", func() {
+						cfg.Metadata.Version = api.Version1_22
+						cfg.VPC.IPFamily = api.IPV6Family
+						cfg.IAM = &api.ClusterIAM{
+							WithOIDC: api.Enabled(),
+						}
+						cfg.Addons = append(cfg.Addons,
+							&api.Addon{Name: api.KubeProxyAddon},
+							&api.Addon{Name: api.CoreDNSAddon},
+							&api.Addon{Name: api.VPCCNIAddon, Version: "1.invalid!semver"},
+						)
+						cfg.VPC.NAT = nil
+						err = cfg.ValidateVPCConfig()
+						Expect(err).To(MatchError(ContainSubstring("failed to parse version")))
+					})
+				})
+			})
+
 			When("iam is not set", func() {
 				It("returns an error", func() {
 					cfg.VPC.IPFamily = api.IPV6Family
@@ -608,6 +686,7 @@ var _ = Describe("ClusterConfig validation", func() {
 					Expect(err).To(MatchError(ContainSubstring("oidc needs to be enabled if IPv6 is set")))
 				})
 			})
+
 			When("iam is set but OIDC is disabled", func() {
 				It("returns an error", func() {
 					cfg.VPC.IPFamily = api.IPV6Family
@@ -623,6 +702,7 @@ var _ = Describe("ClusterConfig validation", func() {
 					Expect(err).To(MatchError(ContainSubstring("oidc needs to be enabled if IPv6 is set")))
 				})
 			})
+
 			When("ipFamily isn't IPv4 or IPv6", func() {
 				It("returns an error", func() {
 					cfg.VPC.IPFamily = "invalid"
@@ -630,6 +710,7 @@ var _ = Describe("ClusterConfig validation", func() {
 					Expect(err).To(MatchError(ContainSubstring("invalid value invalid for ipFamily; allowed are IPv4 and IPv6")))
 				})
 			})
+
 			When("ipFamily is set to IPv6 and vpc.NAT is defined", func() {
 				It("it returns an error", func() {
 					cfg.VPC.IPFamily = api.IPV6Family
@@ -647,6 +728,7 @@ var _ = Describe("ClusterConfig validation", func() {
 					Expect(err).To(MatchError(ContainSubstring("setting NAT is not supported with IPv6")))
 				})
 			})
+
 			When("ipFamily is set to IPv6 and serviceIPv4CIDR is not empty", func() {
 				It("it returns an error", func() {
 					cfg.VPC.IPFamily = api.IPV6Family
@@ -667,6 +749,7 @@ var _ = Describe("ClusterConfig validation", func() {
 					Expect(err).To(MatchError(ContainSubstring("service ipv4 cidr is not supported with IPv6")))
 				})
 			})
+
 			When("ipFamily is set to IPv6 and AutoAllocateIPv6 is set", func() {
 				It("it returns an error", func() {
 					cfg.VPC.IPFamily = api.IPV6Family
@@ -694,6 +777,7 @@ var _ = Describe("ClusterConfig validation", func() {
 				err = cfg.ValidateVPCConfig()
 				Expect(err).ToNot(HaveOccurred())
 			})
+
 			When("extraCIDRs has an invalid cidr", func() {
 				It("returns an error", func() {
 					cfg.VPC.ExtraCIDRs = []string{"not-a-cidr"}
@@ -701,6 +785,7 @@ var _ = Describe("ClusterConfig validation", func() {
 					Expect(err).To(HaveOccurred())
 				})
 			})
+
 			When("public access cidrs has an invalid cidr", func() {
 				It("returns an error", func() {
 					cfg.VPC.PublicAccessCIDRs = []string{"48.58.68/24"}

--- a/pkg/cfn/builder/vpc_existing_test.go
+++ b/pkg/cfn/builder/vpc_existing_test.go
@@ -112,15 +112,17 @@ var _ = Describe("Existing VPC", func() {
 
 			By("outputting the public subnets on the stack")
 			Expect(vpcTemplate.Outputs).To(HaveKey(outputs.ClusterSubnetsPublic))
-			Expect(vpcTemplate.Outputs.(map[string]interface{})[outputs.ClusterSubnetsPublic].(map[string]interface{})["Value"]).To(Equal(map[string]interface{}{
-				"Fn::Join": []interface{}{
-					",",
-					[]interface{}{
-						publicSubnet2,
-						publicSubnet1,
-					},
-				},
-			}))
+			// 	"Fn::Join": []interface{}{
+			// 		",",
+			// 		[]interface{}{
+			//      //this list order isn't guaranteed
+			// 			publicSubnet2,
+			// 			publicSubnet1,
+			// 		},
+			// 	},
+			publicSubnets := vpcTemplate.Outputs.(map[string]interface{})[outputs.ClusterSubnetsPublic].(map[string]interface{})["Value"].(map[string]interface{})["Fn::Join"]
+			Expect(publicSubnets.([]interface{})[0]).To(Equal(","))
+			Expect(publicSubnets.([]interface{})[1]).To(ConsistOf(publicSubnet1, publicSubnet2))
 			Expect(vpcTemplate.Outputs.(map[string]interface{})[outputs.ClusterSubnetsPublic].(map[string]interface{})["Export"]).To(Equal(map[string]interface{}{
 				"Name": map[string]interface{}{
 					"Fn::Sub": fmt.Sprintf("${AWS::StackName}::%s", outputs.ClusterSubnetsPublic),
@@ -129,15 +131,17 @@ var _ = Describe("Existing VPC", func() {
 
 			By("outputting the private subnets on the stack")
 			Expect(vpcTemplate.Outputs).To(HaveKey(outputs.ClusterSubnetsPrivate))
-			Expect(vpcTemplate.Outputs.(map[string]interface{})[outputs.ClusterSubnetsPrivate].(map[string]interface{})["Value"]).To(Equal(map[string]interface{}{
-				"Fn::Join": []interface{}{
-					",",
-					[]interface{}{
-						privateSubnet2,
-						privateSubnet1,
-					},
-				},
-			}))
+			// "Fn::Join": []interface{}{
+			// 	",",
+			// 	[]interface{}{
+			//      //this list order isn't guaranteed
+			// 		privateSubnet2,
+			// 		privateSubnet1,
+			// 	},
+			// },
+			privateSubnets := vpcTemplate.Outputs.(map[string]interface{})[outputs.ClusterSubnetsPrivate].(map[string]interface{})["Value"].(map[string]interface{})["Fn::Join"]
+			Expect(privateSubnets.([]interface{})[0]).To(Equal(","))
+			Expect(privateSubnets.([]interface{})[1]).To(ConsistOf(privateSubnet1, privateSubnet2))
 			Expect(vpcTemplate.Outputs.(map[string]interface{})[outputs.ClusterSubnetsPrivate].(map[string]interface{})["Export"]).To(Equal(map[string]interface{}{
 				"Name": map[string]interface{}{
 					"Fn::Sub": fmt.Sprintf("${AWS::StackName}::%s", outputs.ClusterSubnetsPrivate),

--- a/userdocs/src/usage/vpc-networking.md
+++ b/userdocs/src/usage/vpc-networking.md
@@ -55,7 +55,8 @@ This is an in config file setting only. When IPv6 is set, the following restrict
 
 - OIDC is enabled
 - managed addons are defined as shows above
-- version must be => 1.21
+- cluster version must be => 1.21
+- vpc-cni addon version must be => 1.10.0
 - unmanaged nodegroups are not yet supported with IPv6 clusters
 - managed nodegroup creation is not supported with un-owned IPv6 clusters
 - `vpc.NAT` and `serviceIPv4CIDR` fields are created by eksctl for ipv6 clusters and thus, are not supported configuration options


### PR DESCRIPTION
### Description

Closes #4463

## Problem
When version is not configured, we default to the EKS API to pick the latest version. For example:
```
2021-11-18 12:04:30 [ℹ]  describing addon versions for addon: vpc-cni
{
  Addons: [{
      AddonName: "vpc-cni",
      AddonVersions: [
        {
          AddonVersion: "v1.10.0-eksbuild.1",
          Architecture: ["amd64","arm64"],
          Compatibilities: [{
              ClusterVersion: "1.21",
              DefaultVersion: false,
              PlatformVersions: ["*"]
            }]
        },
        {
          AddonVersion: "v1.7.5-eksbuild.2",
          Architecture: ["amd64","arm64"],
          Compatibilities: [{
              ClusterVersion: "1.21",
              DefaultVersion: true,
              PlatformVersions: ["*"]
            }]
        },
```

atm `1.7.5` is the default, which wouldn't work for us. But this will probably change soon/before/with the ipv6 release if I was to guess. We can either:
1. Query the API, discover the default version, and then error if the default is not a good enough version. Adds a lot of complexity to the code, as well as doing API calls in the validation code, which we don't normally do AFAIK.
2. Do nothing. 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

