### PR TITLE
docs: added missing --region flag in the for nodegroup and iamidentitymapping pages

### DIFF
--- a/userdocs/src/usage/iam-identity-mappings.md
+++ b/userdocs/src/usage/iam-identity-mappings.md
@@ -6,25 +6,25 @@ called `aws-auth`. `eksctl` provides commands to read and edit this config map.
 Get all identity mappings:
 
 ```bash
-eksctl get iamidentitymapping --cluster my-cluster-1
+eksctl get iamidentitymapping --cluster <clusterName> --region=<region>
 ```
 
 Get all identity mappings matching an arn:
 
 ```bash
-eksctl get iamidentitymapping --cluster my-cluster-1 --arn arn:aws:iam::123456:role/testing-role
+eksctl get iamidentitymapping --cluster <clusterName> --region=<region> --arn arn:aws:iam::123456:role/testing-role
 ```
 
 Create an identity mapping:
 
 ```bash
- eksctl create iamidentitymapping --cluster  my-cluster-1 --arn arn:aws:iam::123456:role/testing --group system:masters --username admin
+ eksctl create iamidentitymapping --cluster  <clusterName> --region=<region> --arn arn:aws:iam::123456:role/testing --group system:masters --username admin
 ```
 
 Delete an identity mapping:
 
 ```bash
-eksctl delete iamidentitymapping --cluster  my-cluster-1 --arn arn:aws:iam::123456:role/testing
+eksctl delete iamidentitymapping --cluster  <clusterName> --region=<region> --arn arn:aws:iam::123456:role/testing
 ```
 
 !!!note
@@ -34,11 +34,11 @@ more mappings matching this role are found.
 Create an account mapping:
 
 ```bash
- eksctl create iamidentitymapping --cluster  my-cluster-1 --account user-account
+ eksctl create iamidentitymapping --cluster  <clusterName> --region=<region> --account user-account
 ```
 
 Delete an account mapping:
 
 ```bash
- eksctl delete iamidentitymapping --cluster  my-cluster-1 --account user-account
+ eksctl delete iamidentitymapping --cluster  <clusterName> --region=<region> --account user-account
 ```

--- a/userdocs/src/usage/nodegroup-upgrade.md
+++ b/userdocs/src/usage/nodegroup-upgrade.md
@@ -12,7 +12,7 @@ If you have a simple cluster with just an initial nodegroup (i.e. created with
 Get the name of old nodegroup:
 
 ```
-eksctl get nodegroups --cluster=<clusterName>
+eksctl get nodegroups --cluster=<clusterName> --region=<region>
 ```
 
 !!!note
@@ -21,13 +21,13 @@ eksctl get nodegroups --cluster=<clusterName>
 Create new nodegroup:
 
 ```
-eksctl create nodegroup --cluster=<clusterName> --managed=false
+eksctl create nodegroup --cluster=<clusterName> --region=<region> --managed=false
 ```
 
 Delete old nodegroup:
 
 ```
-eksctl delete nodegroup --cluster=<clusterName> --name=<oldNodeGroupName>
+eksctl delete nodegroup --cluster=<clusterName> --region=<region> --name=<oldNodeGroupName>
 ```
 
 !!!note
@@ -47,13 +47,13 @@ In general terms, you are looking to:
 To create a new nodegroup:
 
 ```
-eksctl create nodegroup --cluster=<clusterName> --name=<newNodeGroupName> --managed=false
+eksctl create nodegroup --cluster=<clusterName> --region=<region> --name=<newNodeGroupName> --managed=false
 ```
 
 To delete old nodegroup:
 
 ```
-eksctl delete nodegroup --cluster=<clusterName> --name=<oldNodeGroupName>
+eksctl delete nodegroup --cluster=<clusterName> --region=<region> --name=<oldNodeGroupName>
 ```
 
 ## Updating multiple nodegroups with config file


### PR DESCRIPTION
### Description

I added the missing `--region` flag in the docs page for `nodegroup` and also `iamidentitymapping`. As pointed in the issue [iamidentitymapping](https://github.com/weaveworks/eksctl/issues/2883) by @todd-dsm

### Checklist
- [ ] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

