### PR TITLE
The default service account will always be present when the namespace is created, so it will always return true

### DIFF
--- a/pkg/ctl/create/iamserviceaccount_test.go
+++ b/pkg/ctl/create/iamserviceaccount_test.go
@@ -1,6 +1,8 @@
 package create
 
 import (
+	"fmt"
+
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -10,62 +12,65 @@ import (
 )
 
 var _ = Describe("create iamserviceaccount", func() {
-	DescribeTable("create service account successfully",
-		func(args ...string) {
-			commandArgs := append([]string{"iamserviceaccount"}, args...)
-			cmd := newMockEmptyCmd(commandArgs...)
-			count := 0
-			cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
-				createIAMServiceAccountCmdWithRunFunc(cmd, func(cmd *cmdutils.Cmd, overrideExistingServiceAccounts bool) error {
-					Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
-					Expect(cmd.ClusterConfig.IAM.ServiceAccounts[0].Name).To(Equal("serviceAccountName"))
-					Expect(cmd.ClusterConfig.IAM.ServiceAccounts[0].AttachPolicyARNs).To(ContainElement("dummyPolicyArn"))
-					count++
-					return nil
+	saNames := [2]string{"sa-1", "default"}
+	for i := range saNames {
+		DescribeTable(fmt.Sprintf("create service account successfully with serviceAccountName \"%s\"", saNames[i]),
+			func(args ...string) {
+				commandArgs := append([]string{"iamserviceaccount"}, args...)
+				cmd := newMockEmptyCmd(commandArgs...)
+				count := 0
+				cmdutils.AddResourceCmd(cmdutils.NewGrouping(), cmd.parentCmd, func(cmd *cmdutils.Cmd) {
+					createIAMServiceAccountCmdWithRunFunc(cmd, func(cmd *cmdutils.Cmd, overrideExistingServiceAccounts bool) error {
+						Expect(cmd.ClusterConfig.Metadata.Name).To(Equal("clusterName"))
+						Expect(cmd.ClusterConfig.IAM.ServiceAccounts[0].Name).To(Equal(saNames[i]))
+						Expect(cmd.ClusterConfig.IAM.ServiceAccounts[0].AttachPolicyARNs).To(ContainElement("dummyPolicyArn"))
+						count++
+						return nil
+					})
 				})
-			})
-			_, err := cmd.execute()
-			Expect(err).To(Not(HaveOccurred()))
-			Expect(count).To(Equal(1))
-		},
-		Entry("with all required flags", "--cluster", "clusterName", "--name", "serviceAccountName", "--attach-policy-arn", "dummyPolicyArn"),
-		Entry("with optional flags", "--cluster", "clusterName", "--name", "serviceAccountName", "--attach-policy-arn", "dummyPolicyArn", "--override-existing-serviceaccounts", "--role-name", "custom-role-name"),
-	)
+				_, err := cmd.execute()
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(count).To(Equal(1))
+			},
+			Entry("with all required flags", "--cluster", "clusterName", "--name", saNames[i], "--attach-policy-arn", "dummyPolicyArn"),
+			Entry("with optional flags", "--cluster", "clusterName", "--name", saNames[i], "--attach-policy-arn", "dummyPolicyArn", "--override-existing-serviceaccounts", "--role-name", "custom-role-name"),
+		)
 
-	DescribeTable("invalid flags or arguments",
-		func(c invalidParamsCase) {
-			cmd := newDefaultCmd(c.args...)
-			_, err := cmd.execute()
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(ContainSubstring(c.error)))
-		},
-		Entry("without cluster name", invalidParamsCase{
-			args:  []string{"iamserviceaccount", "--name", "serviceAccountName"},
-			error: "--cluster must be set",
-		}),
-		Entry("with iamserviceaccount name as argument and flag", invalidParamsCase{
-			args:  []string{"iamserviceaccount", "--cluster", "clusterName", "--name", "serviceAccountName", "serviceAccountName"},
-			error: "--name=serviceAccountName and argument serviceAccountName cannot be used at the same time",
-		}),
-		Entry("without required flags --attach-policy-arn or --attach-policy-role", invalidParamsCase{
-			args:  []string{"iamserviceaccount", "--cluster", "clusterName", "serviceAccountName"},
-			error: "--attach-policy-arn or --attach-role-arn must be set",
-		}),
-		Entry("with --attach-role-arn and --role-name", invalidParamsCase{
-			args:  []string{"iamserviceaccount", "--cluster", "clusterName", "serviceAccountName", "--role-name", "foo", "--attach-role-arn", "123"},
-			error: "cannot provde --role-name or --role-only when --attach-role-arn is configured",
-		}),
-		Entry("with --attach-policy-role and --role-only", invalidParamsCase{
-			args:  []string{"iamserviceaccount", "--cluster", "clusterName", "serviceAccountName", "--role-only", "--attach-role-arn", "123"},
-			error: "cannot provde --role-name or --role-only when --attach-role-arn is configured",
-		}),
-		Entry("with --attach-role-arn and --attach-policy-arns", invalidParamsCase{
-			args:  []string{"iamserviceaccount", "--cluster", "clusterName", "serviceAccountName", "--attach-policy-arn", "123", "--attach-role-arn", "123"},
-			error: "cannot provide --attach-role-arn and specify polices to attach",
-		}),
-		Entry("with invalid flags", invalidParamsCase{
-			args:  []string{"iamserviceaccount", "--invalid", "dummy"},
-			error: "unknown flag: --invalid",
-		}),
-	)
+		DescribeTable(fmt.Sprintf("invalid flags or arguments with serviceAccountName \"%s\"", saNames[i]),
+			func(c invalidParamsCase) {
+				cmd := newDefaultCmd(c.args...)
+				_, err := cmd.execute()
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring(c.error)))
+			},
+			Entry("without cluster name", invalidParamsCase{
+				args:  []string{"iamserviceaccount", "--name", saNames[i]},
+				error: "--cluster must be set",
+			}),
+			Entry("with iamserviceaccount name as argument and flag", invalidParamsCase{
+				args:  []string{"iamserviceaccount", "--cluster", "clusterName", "--name", saNames[i], saNames[i]},
+				error: fmt.Sprintf("--name=%s and argument %s cannot be used at the same time", saNames[i], saNames[i]),
+			}),
+			Entry("without required flags --attach-policy-arn or --attach-policy-role", invalidParamsCase{
+				args:  []string{"iamserviceaccount", "--cluster", "clusterName", saNames[i]},
+				error: "--attach-policy-arn or --attach-role-arn must be set",
+			}),
+			Entry("with --attach-role-arn and --role-name", invalidParamsCase{
+				args:  []string{"iamserviceaccount", "--cluster", "clusterName", saNames[i], "--role-name", "foo", "--attach-role-arn", "123"},
+				error: "cannot provde --role-name or --role-only when --attach-role-arn is configured",
+			}),
+			Entry("with --attach-policy-role and --role-only", invalidParamsCase{
+				args:  []string{"iamserviceaccount", "--cluster", "clusterName", saNames[i], "--role-only", "--attach-role-arn", "123"},
+				error: "cannot provde --role-name or --role-only when --attach-role-arn is configured",
+			}),
+			Entry("with --attach-role-arn and --attach-policy-arns", invalidParamsCase{
+				args:  []string{"iamserviceaccount", "--cluster", "clusterName", saNames[i], "--attach-policy-arn", "123", "--attach-role-arn", "123"},
+				error: "cannot provide --attach-role-arn and specify polices to attach",
+			}),
+			Entry("with invalid flags", invalidParamsCase{
+				args:  []string{"iamserviceaccount", "--invalid", "dummy"},
+				error: "unknown flag: --invalid",
+			}),
+		)
+	}
 })

--- a/pkg/kubernetes/serviceaccount.go
+++ b/pkg/kubernetes/serviceaccount.go
@@ -25,6 +25,9 @@ func NewServiceAccount(meta metav1.ObjectMeta) *corev1.ServiceAccount {
 // returns boolean or an error
 func CheckServiceAccountExists(clientSet Interface, meta metav1.ObjectMeta) (bool, error) {
 	name := meta.Namespace + "/" + meta.Name
+	if meta.Name == "default" {
+		return true, nil
+	}
 	_, err := clientSet.CoreV1().ServiceAccounts(meta.Namespace).Get(context.TODO(), meta.Name, metav1.GetOptions{})
 	if err == nil {
 		return true, nil

--- a/pkg/kubernetes/serviceaccount_test.go
+++ b/pkg/kubernetes/serviceaccount_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Kubernetes serviceaccount object helpers", func() {
 				"apiVersion": "v1",
 				"kind": "ServiceAccount",
 				"metadata": {
-		  			"creationTimestamp": null,
+					"creationTimestamp": null,
 					"name": "sa-1",
 					"namespace": "ns-1"
 				}

--- a/pkg/kubernetes/serviceaccount_test.go
+++ b/pkg/kubernetes/serviceaccount_test.go
@@ -48,6 +48,31 @@ var _ = Describe("Kubernetes serviceaccount object helpers", func() {
 		Expect(js).To(MatchJSON([]byte(expected)))
 	})
 
+	It("can create a serviceaccount object even if the serviceaccount name is \"default\"", func() {
+		sa := NewServiceAccount(metav1.ObjectMeta{Name: "default", Namespace: "ns-1"})
+
+		Expect(sa.APIVersion).To(Equal("v1"))
+		Expect(sa.Kind).To(Equal("ServiceAccount"))
+		Expect(sa.Name).To(Equal("default"))
+		Expect(sa.Namespace).To(Equal("ns-1"))
+
+		Expect(sa.Labels).To(BeEmpty())
+
+		js, err := json.Marshal(sa)
+		Expect(err).NotTo(HaveOccurred())
+
+		expected := `{
+				"apiVersion": "v1",
+				"kind": "ServiceAccount",
+				"metadata": {
+					"creationTimestamp": null,
+					"name": "default",
+					"namespace": "ns-1"
+				}
+			}`
+		Expect(js).To(MatchJSON([]byte(expected)))
+	})
+
 	It("can create serviceaccount using fake client, and update it in incremental manner with overrides", func() {
 		sa := metav1.ObjectMeta{Name: "sa-1", Namespace: "ns-1"}
 


### PR DESCRIPTION
I created this to improve this issue.
https://github.com/weaveworks/eksctl/issues/4522