### PR TITLE
Fix types for Ipv6CidrBlock and Ipv6Pool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -295,7 +295,7 @@ require (
 	github.com/uudashr/gocognit v1.0.5 // indirect
 	github.com/vektra/mockery v1.1.2
 	github.com/voxelbrain/goptions v0.0.0-20180630082107-58cddc247ea2 // indirect
-	github.com/weaveworks/goformation/v4 v4.10.2-0.20211028132421-158884031b1b
+	github.com/weaveworks/goformation/v4 v4.10.2-0.20211207112218-8bde16a86f4c
 	github.com/weaveworks/launcher v0.0.2-0.20200715141516-1ca323f1de15
 	github.com/weaveworks/schemer v0.0.0-20210802122110-338b258ad2ca
 	github.com/whilp/git-urls v0.0.0-20191001220047-6db9661140c0

--- a/go.sum
+++ b/go.sum
@@ -1669,8 +1669,8 @@ github.com/voxelbrain/goptions v0.0.0-20180630082107-58cddc247ea2 h1:txplJASvd6b
 github.com/voxelbrain/goptions v0.0.0-20180630082107-58cddc247ea2/go.mod h1:DGCIhurYgnLz8J9ga1fMV/fbLDyUvTyrWXVWUIyJon4=
 github.com/weaveworks/aws-sdk-go v0.0.0-20211026093156-d6e6822f58db h1:K6lacvb3qzF/bHvx2RsPDw8cYA8VccOecn9e6xDEBY0=
 github.com/weaveworks/aws-sdk-go v0.0.0-20211026093156-d6e6822f58db/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
-github.com/weaveworks/goformation/v4 v4.10.2-0.20211028132421-158884031b1b h1:VZPFl/yFhgVjlzsTNU4/5nZlxr4zyf3l5CFXZgG/rr8=
-github.com/weaveworks/goformation/v4 v4.10.2-0.20211028132421-158884031b1b/go.mod h1:x92o12+Azh6DQ4yoXT5oEuE7dhQHR5V2vy/fmZ6pO7k=
+github.com/weaveworks/goformation/v4 v4.10.2-0.20211207112218-8bde16a86f4c h1:73KpSffTZKAwH2SQnJMe/76oZ2tX5MEPMj/lcEYUi88=
+github.com/weaveworks/goformation/v4 v4.10.2-0.20211207112218-8bde16a86f4c/go.mod h1:x92o12+Azh6DQ4yoXT5oEuE7dhQHR5V2vy/fmZ6pO7k=
 github.com/weaveworks/launcher v0.0.2-0.20200715141516-1ca323f1de15 h1:i/RhLevywqC6cuUWtGdoaNrsJd+/zWh3PXbkXZIyZsU=
 github.com/weaveworks/launcher v0.0.2-0.20200715141516-1ca323f1de15/go.mod h1:w9Z1vnQmPobkEZ0F3oyiqRYP+62qDqTGnK6t5uhe1kg=
 github.com/weaveworks/mesh v0.0.0-20170419100114-1f158d31de55/go.mod h1:mcON9Ws1aW0crSErpXWp7U1ErCDEKliDX2OhVlbWRKk=

--- a/pkg/cfn/builder/vpc_ipv6.go
+++ b/pkg/cfn/builder/vpc_ipv6.go
@@ -160,8 +160,8 @@ func (v *IPv6VPCResourceSet) addIpv6CidrBlock() {
 	if v.clusterConfig.VPC.IPv6Cidr != "" {
 		v.rs.newResource(IPv6CIDRBlockKey, &gfnec2.VPCCidrBlock{
 			AmazonProvidedIpv6CidrBlock: gfnt.False(),
-			Ipv6CidrBlock:               v.clusterConfig.VPC.IPv6Cidr,
-			Ipv6Pool:                    v.clusterConfig.VPC.IPv6Pool,
+			Ipv6CidrBlock:               gfnt.NewString(v.clusterConfig.VPC.IPv6Cidr),
+			Ipv6Pool:                    gfnt.NewString(v.clusterConfig.VPC.IPv6Pool),
 			VpcId:                       gfnt.MakeRef(VPCResourceKey),
 		})
 		return


### PR DESCRIPTION
### Description

The fields should be of type `*types.Value`. The build will fail because this [PR](https://github.com/weaveworks/goformation/pull/43) needs to be merged first.


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

