### PR TITLE
update ipv6 integration check to create & test managed nodegroup

### DIFF
--- a/integration/tests/ipv6/ipv6_test.go
+++ b/integration/tests/ipv6/ipv6_test.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +20,7 @@ import (
 	. "github.com/weaveworks/eksctl/integration/matchers"
 	. "github.com/weaveworks/eksctl/integration/runner"
 	"github.com/weaveworks/eksctl/integration/tests"
+	"github.com/weaveworks/eksctl/integration/utilities/kube"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/cfn/builder"
 	"github.com/weaveworks/eksctl/pkg/eks"
@@ -52,6 +55,11 @@ var _ = Describe("(Integration) [EKS IPv6 test]", func() {
 		clusterName := params.NewClusterName("ipv6")
 
 		BeforeSuite(func() {
+			f, err := ioutil.TempFile("", "kubeconfig-")
+			Expect(err).NotTo(HaveOccurred())
+			params.KubeconfigPath = f.Name()
+			params.KubeconfigTemp = true
+
 			clusterConfig = api.NewClusterConfig()
 			clusterConfig.Metadata.Name = clusterName
 			clusterConfig.Metadata.Version = "1.21"
@@ -70,6 +78,13 @@ var _ = Describe("(Integration) [EKS IPv6 test]", func() {
 					Name: api.CoreDNSAddon,
 				},
 			}
+			clusterConfig.ManagedNodeGroups = []*api.ManagedNodeGroup{
+				{
+					NodeGroupBase: &api.NodeGroupBase{
+						Name: "mng-1",
+					},
+				},
+			}
 
 			data, err := json.Marshal(clusterConfig)
 			Expect(err).ToNot(HaveOccurred())
@@ -79,6 +94,7 @@ var _ = Describe("(Integration) [EKS IPv6 test]", func() {
 					"cluster",
 					"--config-file", "-",
 					"--verbose", "4",
+					"--kubeconfig", params.KubeconfigPath,
 				).
 				WithoutArg("--region", params.Region).
 				WithStdin(bytes.NewReader(data))
@@ -91,6 +107,10 @@ var _ = Describe("(Integration) [EKS IPv6 test]", func() {
 				"--verbose", "2",
 			)
 			Expect(cmd).To(RunSuccessfully())
+
+			if params.KubeconfigTemp {
+				os.Remove(params.KubeconfigPath)
+			}
 		})
 
 		It("should support ipv6", func() {
@@ -171,6 +191,29 @@ var _ = Describe("(Integration) [EKS IPv6 test]", func() {
 				}
 				return svcIP.Version()
 			}, 5*time.Second, time.Minute).Should(Equal(6))
+
+			By("ensuring workloads can run successfully")
+			test, err := kube.NewTest(params.KubeconfigPath)
+			Expect(err).ShouldNot(HaveOccurred())
+			d := test.CreateDeploymentFromFile(test.Namespace, "../../data/podinfo.yaml")
+			test.WaitForDeploymentReady(d, 10*time.Minute)
+
+			pods := test.ListPodsFromDeployment(d)
+			Expect(len(pods.Items)).To(Equal(2))
+
+			// For each pod of the Deployment, check we receive a sensible response to a
+			// GET request on /version.
+			for _, pod := range pods.Items {
+				Expect(pod.Namespace).To(Equal(test.Namespace))
+
+				req := test.PodProxyGet(&pod, "", "/version")
+				fmt.Fprintf(GinkgoWriter, "url = %#v", req.URL())
+
+				var js interface{}
+				test.PodProxyGetJSON(&pod, "", "/version", &js)
+
+				Expect(js.(map[string]interface{})).To(HaveKeyWithValue("version", "1.5.1"))
+			}
 		})
 	})
 })

--- a/integration/tests/ipv6/ipv6_test.go
+++ b/integration/tests/ipv6/ipv6_test.go
@@ -69,13 +69,16 @@ var _ = Describe("(Integration) [EKS IPv6 test]", func() {
 			clusterConfig.IAM.WithOIDC = api.Enabled()
 			clusterConfig.Addons = []*api.Addon{
 				{
-					Name: api.VPCCNIAddon,
+					Name:    api.VPCCNIAddon,
+					Version: "latest",
 				},
 				{
-					Name: api.KubeProxyAddon,
+					Name:    api.KubeProxyAddon,
+					Version: "latest",
 				},
 				{
-					Name: api.CoreDNSAddon,
+					Name:    api.CoreDNSAddon,
+					Version: "latest",
 				},
 			}
 			clusterConfig.ManagedNodeGroups = []*api.ManagedNodeGroup{


### PR DESCRIPTION
### Description

```
[0] • [SLOW TEST:26.294 seconds]
[0] (Integration) [EKS IPv6 test]
[0] /home/jake/weave/eksctl/integration/tests/ipv6/ipv6_test.go:50
[0]   Creating a cluster with IPv6
[0]   /home/jake/weave/eksctl/integration/tests/ipv6/ipv6_test.go:55
[0]     should support ipv6
[0]     /home/jake/weave/eksctl/integration/tests/ipv6/ipv6_test.go:117
...
1 Passed | 0 Failed | 0 Pending | 0 Skipped
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

