### PR TITLE
Increase delete wait time

### DIFF
--- a/integration/tests/params.go
+++ b/integration/tests/params.go
@@ -110,7 +110,7 @@ func (p *Params) GenerateCommands() {
 
 	p.EksctlDeleteCmd = p.EksctlCmd.
 		WithArgs("delete").
-		WithTimeout(15 * time.Minute)
+		WithTimeout(30 * time.Minute)
 
 	p.EksctlDeleteClusterCmd = p.EksctlDeleteCmd.
 		WithArgs("cluster", "--verbose", "4").


### PR DESCRIPTION
### Description

Following the failure here: https://github.com/weaveworks/eksctl-ci/runs/4560062147?check_suite_focus=true

Log:

```
2021-12-17T12:44:41.1250860Z [0] 2021-12-17 12:44:41 [!]  retryable error (Throttling: Rate exceeded
2021-12-17T12:44:41.1253245Z [0] 	status code: 400, request id: c373a035-eca0-4e89-b5d3-78094d1ab5b4) from cloudformation/DescribeStacks - will retry after delay of 6.713243581s
2021-12-17T12:48:56.0293813Z [0] 2021-12-17 12:48:56 [!]  retryable error (Throttling: Rate exceeded
2021-12-17T12:48:56.0296666Z [0] 	status code: 400, request id: 40c6add8-49e6-483e-b4a6-1864643f99ca) from cloudformation/DescribeStacks - will retry after delay of 9.338821934s
2021-12-17T12:49:05.4914286Z [0] Error: failed to delete all resources
```

Reached the maximum wait while being throtteled.
### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

