### PR TITLE
Check InstanceRoleARN exists before deleting authconfigmap entry

### DIFF
--- a/pkg/ctl/delete/nodegroup.go
+++ b/pkg/ctl/delete/nodegroup.go
@@ -139,8 +139,10 @@ func doDeleteNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, updateAuthConfigMap
 		cmdutils.LogIntendedAction(cmd.Plan, "delete %d nodegroups from auth ConfigMap in cluster %q", len(cfg.NodeGroups), cfg.Metadata.Name)
 		if !cmd.Plan {
 			for _, ng := range cfg.NodeGroups {
-				if err := authconfigmap.RemoveNodeGroup(clientSet, ng); err != nil {
-					logger.Warning(err.Error())
+				if ng.IAM != nil && ng.IAM.InstanceRoleARN != "" {
+					if err := authconfigmap.RemoveNodeGroup(clientSet, ng); err != nil {
+						logger.Warning(err.Error())
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Description
Closes https://github.com/weaveworks/eksctl/issues/4555

[Here](https://github.com/weaveworks/eksctl/blob/main/pkg/ctl/delete/nodegroup.go#L109-L118) we populate the InstaceRoleArn if possible- and print a warning if we can't. But we never checked it was set when proceeding to delete. This PR updates it so we check it was updated before deleting.

Before:
```
eksctl delete nodegroup --cluster jk --wait --name ng-2

2021-12-22 12:08:14 [ℹ]  eksctl version 0.79.0-dev+8ed86d65.2021-12-22T12:06:43Z
2021-12-22 12:08:14 [ℹ]  using region us-west-2
2021-12-22 12:08:16 [ℹ]  1 nodegroup (ng-2) was included (based on the include/exclude rules)
2021-12-22 12:08:17 [!]  stack's status of nodegroup named eksctl-jk-nodegroup-ng-2 is DELETE_FAILED
2021-12-22 12:08:17 [!]  continuing with deletion, error occurred: error getting instance role ARN for nodegroup "ng-2": stack not found for nodegroup "ng-2"
2021-12-22 12:08:17 [ℹ]  will drain 1 nodegroup(s) in cluster "jk"
2021-12-22 12:08:18 [!]  no nodes found in nodegroup "ng-2" (label selector: "alpha.eksctl.io/nodegroup-name=ng-2")
2021-12-22 12:08:18 [ℹ]  will delete 1 nodegroups from cluster "jk"
2021-12-22 12:08:19 [!]  stack's status of nodegroup named eksctl-jk-nodegroup-ng-2 is DELETE_FAILED
2021-12-22 12:08:19 [ℹ]  1 task: { no tasks }
&{0xc000702d00 <nil> [] <nil> [] [] [] <nil>  <nil> <nil>}
2021-12-22 12:08:19 [ℹ]  will delete 1 nodegroups from auth ConfigMap in cluster "jk"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x1e2e10b]

goroutine 1 [running]:
github.com/weaveworks/eksctl/pkg/authconfigmap.RemoveNodeGroup({0x343b0d0, 0xc0006a6f20}, 0xc000d841e0)
        /home/jake/weave/eksctl/pkg/authconfigmap/authconfigmap.go:319 +0x4b
github.com/weaveworks/eksctl/pkg/ctl/delete.doDeleteNodeGroup(0xc000897290, 0xc000c56280, 0x1, 0x1, 0x0, 0x15, 0x80)
        /home/jake/weave/eksctl/pkg/ctl/delete/nodegroup.go:144 +0xa93
github.com/weaveworks/eksctl/pkg/ctl/delete.deleteNodeGroupCmd.func1(0xc0005b60a0, 0xc000cbfce0, 0x7, 0x0, 0x0, 0xc000897290, 0x69)
        /home/jake/weave/eksctl/pkg/ctl/delete/nodegroup.go:21 +0x19
github.com/weaveworks/eksctl/pkg/ctl/delete.deleteNodeGroupWithRunFunc.func1(0xc000c52f00, {0xc0005b60a0, 0x5, 0x5})
        /home/jake/weave/eksctl/pkg/ctl/delete/nodegroup.go:38 +0xdd
github.com/spf13/cobra.(*Command).execute(0xc000c52f00, {0xc0005b6050, 0x5, 0x5})
        /home/jake/workspace/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0xc00013bb80)
        /home/jake/workspace/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
        /home/jake/workspace/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
main.main()
        /home/jake/weave/eksctl/cmd/eksctl/main.go:97 +0x525
```

After:
```
eksctl delete nodegroup --cluster jk --wait --name ng-2

2021-12-22 12:13:37 [ℹ]  eksctl version 0.79.0-dev+8ed86d65.2021-12-22T12:12:50Z
2021-12-22 12:13:37 [ℹ]  using region us-west-2
2021-12-22 12:13:38 [ℹ]  1 nodegroup (ng-2) was included (based on the include/exclude rules)
2021-12-22 12:13:39 [!]  stack's status of nodegroup named eksctl-jk-nodegroup-ng-2 is DELETE_FAILED
2021-12-22 12:13:39 [!]  continuing with deletion, error occurred: error getting instance role ARN for nodegroup "ng-2": stack not found for nodegroup "ng-2"
2021-12-22 12:13:39 [ℹ]  will drain 1 nodegroup(s) in cluster "jk"
2021-12-22 12:13:40 [!]  no nodes found in nodegroup "ng-2" (label selector: "alpha.eksctl.io/nodegroup-name=ng-2")
2021-12-22 12:13:40 [ℹ]  will delete 1 nodegroups from cluster "jk"
2021-12-22 12:13:41 [!]  stack's status of nodegroup named eksctl-jk-nodegroup-ng-2 is DELETE_FAILED
2021-12-22 12:13:41 [ℹ]  1 task: { no tasks }
2021-12-22 12:13:41 [ℹ]  will delete 1 nodegroups from auth ConfigMap in cluster "jk"
2021-12-22 12:13:41 [✔]  deleted 1 nodegroup(s) from cluster "jk"
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

