### PR TITLE
Fix `get clusters --all-regions`

### DIFF
--- a/pkg/ctl/get/cluster.go
+++ b/pkg/ctl/get/cluster.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kris-nova/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 )
@@ -100,7 +101,7 @@ func getAndPrinterClusters(ctl *eks.ClusterProvider, params *getCmdParams, listA
 		addGetClustersSummaryTableColumns(printer.(*printers.TablePrinter))
 	}
 
-	clusters, err := ctl.ListClusters(params.chunkSize, listAllRegions)
+	clusters, err := ctl.ListClusters(params.chunkSize, listAllRegions, eks.New)
 	if err != nil {
 		return err
 	}

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -329,7 +329,7 @@ func (c *ClusterProvider) loadClusterKubernetesNetworkConfig(spec *api.ClusterCo
 }
 
 // ListClusters returns a list of the EKS cluster in your account
-func (c *ClusterProvider) ListClusters(chunkSize int, listAllRegions bool) ([]*api.ClusterConfig, error) {
+func (c *ClusterProvider) ListClusters(chunkSize int, listAllRegions bool, newProviderForConfig func(*api.ProviderConfig, *api.ClusterConfig) (*ClusterProvider, error)) ([]*api.ClusterConfig, error) {
 	if !listAllRegions {
 		return c.listClusters(int64(chunkSize))
 	}
@@ -349,13 +349,12 @@ func (c *ClusterProvider) ListClusters(chunkSize int, listAllRegions bool) ([]*a
 			continue
 		}
 		// Reset region and recreate the client.
-		spec := &api.ProviderConfig{
+		ctl, err := newProviderForConfig(&api.ProviderConfig{
 			Region:      region,
 			Profile:     c.Provider.Profile(),
 			WaitTimeout: c.Provider.WaitTimeout(),
-		}
+		}, nil)
 
-		ctl, err := New(spec, nil)
 		if err != nil {
 			logger.Critical("error creating provider in %q region: %v", region, err)
 			continue

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -330,38 +330,46 @@ func (c *ClusterProvider) loadClusterKubernetesNetworkConfig(spec *api.ClusterCo
 
 // ListClusters returns a list of the EKS cluster in your account
 func (c *ClusterProvider) ListClusters(chunkSize int, listAllRegions bool) ([]*api.ClusterConfig, error) {
-	if listAllRegions {
-		var clusters []*api.ClusterConfig
-		// reset region and re-create the client, then make a recursive call
-		authorizedRegions, err := c.Provider.EC2().DescribeRegions(&ec2.DescribeRegionsInput{})
-		if err != nil {
-			return nil, err
-		}
-
-		for _, region := range authorizedRegions.Regions {
-			spec := &api.ProviderConfig{
-				Region:      *region.RegionName,
-				Profile:     c.Provider.Profile(),
-				WaitTimeout: c.Provider.WaitTimeout(),
-			}
-
-			ctl, err := New(spec, nil)
-			if err != nil {
-				logger.Critical("error creating provider in %q region: %s", region, err.Error())
-				continue
-			}
-
-			newClusters, err := ctl.listClusters(int64(chunkSize))
-			if err != nil {
-				logger.Critical("error listing clusters in %q region: %s", region, err.Error())
-			}
-
-			clusters = append(clusters, newClusters...)
-		}
-		return clusters, nil
+	if !listAllRegions {
+		return c.listClusters(int64(chunkSize))
 	}
 
-	return c.listClusters(int64(chunkSize))
+	var clusters []*api.ClusterConfig
+	authorizedRegionsList, err := c.Provider.EC2().DescribeRegions(&ec2.DescribeRegionsInput{})
+	if err != nil {
+		return nil, err
+	}
+	authorizedRegions := map[string]struct{}{}
+	for _, r := range authorizedRegionsList.Regions {
+		authorizedRegions[*r.RegionName] = struct{}{}
+	}
+
+	for _, region := range api.SupportedRegions() {
+		if _, authorized := authorizedRegions[region]; !authorized {
+			continue
+		}
+		// Reset region and recreate the client.
+		spec := &api.ProviderConfig{
+			Region:      region,
+			Profile:     c.Provider.Profile(),
+			WaitTimeout: c.Provider.WaitTimeout(),
+		}
+
+		ctl, err := New(spec, nil)
+		if err != nil {
+			logger.Critical("error creating provider in %q region: %v", region, err)
+			continue
+		}
+
+		newClusters, err := ctl.listClusters(int64(chunkSize))
+		if err != nil {
+			logger.Critical("error listing clusters in %q region: %v", region, err)
+			continue
+		}
+
+		clusters = append(clusters, newClusters...)
+	}
+	return clusters, nil
 }
 
 func (c *ClusterProvider) listClusters(chunkSize int64) ([]*api.ClusterConfig, error) {


### PR DESCRIPTION
### Description

When an AWS account has access to a region not supported by EKS, `get clusters --all-regions` attempts to query that region for EKS clusters, which fails. This changelist ensures only regions supported by EKS are queried for clusters.

Fixes  #4560 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

