### PR TITLE
Add extra validation for `kubernetesNetworkConfig.IPFamily` to avoid panic

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -188,7 +188,7 @@ func (c *ClusterConfig) ValidateVPCConfig() error {
 		c.VPC.PublicAccessCIDRs = cidrs
 	}
 	if len(c.VPC.ExtraIPv6CIDRs) > 0 {
-		if c.KubernetesNetworkConfig.IPFamily != IPV6Family {
+		if c.KubernetesNetworkConfig == nil || c.KubernetesNetworkConfig.IPFamily != IPV6Family {
 			return fmt.Errorf("cannot specify vpc.extraIPv6CIDRs with an IPv4 cluster")
 		}
 		cidrs, err := validateCIDRs(c.VPC.ExtraIPv6CIDRs)
@@ -199,12 +199,12 @@ func (c *ClusterConfig) ValidateVPCConfig() error {
 	}
 
 	if c.VPC.IPv6Cidr != "" || c.VPC.IPv6Pool != "" {
-		if c.KubernetesNetworkConfig.IPFamily != IPV6Family {
+		if c.KubernetesNetworkConfig == nil || c.KubernetesNetworkConfig.IPFamily != IPV6Family {
 			return fmt.Errorf("Ipv6Cidr and Ipv6CidrPool are only supported when IPFamily is set to IPv6")
 		}
 	}
 
-	if c.KubernetesNetworkConfig.IPFamily == IPV6Family {
+	if c.KubernetesNetworkConfig != nil && c.KubernetesNetworkConfig.IPFamily == IPV6Family {
 		if IsEnabled(c.VPC.AutoAllocateIPv6) {
 			return fmt.Errorf("auto allocate ipv6 is not supported with IPv6")
 		}

--- a/pkg/cfn/manager/create_tasks.go
+++ b/pkg/cfn/manager/create_tasks.go
@@ -33,7 +33,7 @@ func (c *StackCollection) NewTasksToCreateClusterWithNodeGroups(nodeGroups []*ap
 		},
 	)
 
-	if c.spec.KubernetesNetworkConfig.IPFamily == api.IPV6Family {
+	if c.spec.KubernetesNetworkConfig != nil && c.spec.KubernetesNetworkConfig.IPFamily == api.IPV6Family {
 		taskTree.Append(
 			&UpdateSubnetsForIPv6Task{
 				ClusterConfig: c.spec,


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Some of the integration test suites panicked and failed due to some missing validation for when `kubernetesNetworkConfig` is nil (it's nil by default)!

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

