### PR TITLE
Increase timeout for associate and disassociate commands

### DIFF
--- a/integration/tests/identity_provider/identity_provider_test.go
+++ b/integration/tests/identity_provider/identity_provider_test.go
@@ -101,7 +101,7 @@ var _ = Describe("(Integration) [Identity Provider]", func() {
 		).
 			WithStdin(strings.NewReader(identityProviderClusterConfig)).
 			WithoutArg("--region", params.Region).
-			WithTimeout(40 * time.Minute)
+			WithTimeout(1 * time.Hour)
 
 		Expect(cmd).To(RunSuccessfully())
 
@@ -159,7 +159,7 @@ var _ = Describe("(Integration) [Identity Provider]", func() {
 			).
 			WithStdin(strings.NewReader(identityProviderClusterConfig)).
 			WithoutArg("--region", params.Region).
-			WithTimeout(45 * time.Minute)
+			WithTimeout(1 * time.Hour)
 
 		Expect(cmd).To(RunSuccessfully())
 


### PR DESCRIPTION
### Description

In the last integration test run, the `disassociate` command timed out. This changelist increases the timeout for both `associate` and `disassociate` commands.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

