### PR TITLE
Fix validation for ipFamily when serviceIPv4CIDR is set

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -340,13 +340,15 @@ func (c *ClusterConfig) validateKubernetesNetworkConfig() error {
 			}
 		}
 
-		if c.KubernetesNetworkConfig.IPFamily != IPV4Family && c.KubernetesNetworkConfig.IPFamily != IPV6Family {
-			return fmt.Errorf("invalid value %s for ipFamily; allowed are %s and %s", c.KubernetesNetworkConfig.IPFamily, IPV4Family, IPV6Family)
-		}
+		switch c.KubernetesNetworkConfig.IPFamily {
+		case IPV4Family, "":
 
-		if c.KubernetesNetworkConfig.IPFamily == IPV6Family {
+		default:
+			return fmt.Errorf("invalid value %q for ipFamily; allowed are %s and %s", c.KubernetesNetworkConfig.IPFamily, IPV4Family, IPV6Family)
+
+		case IPV6Family:
 			if missing := c.addonContainsManagedAddons([]string{VPCCNIAddon, CoreDNSAddon, KubeProxyAddon}); len(missing) != 0 {
-				return fmt.Errorf("the default core addons must be defined in case of IPv6; missing addon(s): %s", strings.Join(missing, ", "))
+				return fmt.Errorf("the default core addons must be defined for IPv6; missing addon(s): %s", strings.Join(missing, ", "))
 			}
 
 			unsupportedVersion, err := c.unsupportedVPCCNIAddonVersion()

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -676,6 +676,13 @@ var _ = Describe("ClusterConfig validation", func() {
 				})
 			})
 
+			When("ipFamily is empty", func() {
+				It("treats it as IPv4 and does not return an error", func() {
+					cfg.KubernetesNetworkConfig.IPFamily = ""
+					Expect(api.ValidateClusterConfig(cfg)).To(Succeed())
+				})
+			})
+
 			When("ipFamily is set to IPv6", func() {
 				JustBeforeEach(func() {
 					cfg.KubernetesNetworkConfig.IPFamily = api.IPV6Family

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -672,7 +672,7 @@ var _ = Describe("ClusterConfig validation", func() {
 				It("returns an error", func() {
 					cfg.KubernetesNetworkConfig.IPFamily = "invalid"
 					err = api.ValidateClusterConfig(cfg)
-					Expect(err).To(MatchError(ContainSubstring("invalid value invalid for ipFamily; allowed are IPv4 and IPv6")))
+					Expect(err).To(MatchError(ContainSubstring(`invalid value "invalid" for ipFamily; allowed are IPv4 and IPv6`)))
 				})
 			})
 
@@ -736,7 +736,7 @@ var _ = Describe("ClusterConfig validation", func() {
 						}
 						cfg.Addons = append(cfg.Addons, &api.Addon{Name: api.KubeProxyAddon})
 						err = api.ValidateClusterConfig(cfg)
-						Expect(err).To(MatchError(ContainSubstring("the default core addons must be defined in case of IPv6; missing addon(s): vpc-cni, coredns")))
+						Expect(err).To(MatchError(ContainSubstring("the default core addons must be defined for IPv6; missing addon(s): vpc-cni, coredns")))
 					})
 				})
 


### PR DESCRIPTION
### Description

This changelist fixes the validation for `ipFamily` when `kubernetesNetworkConfig` is non-nil. 

Fixes https://github.com/weaveworks/eksctl/issues/4580

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

