### PR TITLE
Unset kubernetesNetworkConfig for `create nodegroup` test

### DIFF
--- a/integration/tests/dry_run/dry_run_test.go
+++ b/integration/tests/dry_run/dry_run_test.go
@@ -354,6 +354,7 @@ var _ = Describe("(Integration) [Dry-Run test]", func() {
 				c.PrivateCluster = nil
 				c.NodeGroups = nil
 				c.AvailabilityZones = nil
+				c.KubernetesNetworkConfig = nil
 
 				ng := c.ManagedNodeGroups[0]
 				actualNG := actual.ManagedNodeGroups[0]


### PR DESCRIPTION
### Description

`kubernetesNetworkConfig` is not set to a default value in `create nodegroup`, so it needs to be unset. 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

