### PR TITLE
Fix Karpenter integration test config

### DIFF
--- a/integration/tests/karpenter/testdata/cluster-config.yaml
+++ b/integration/tests/karpenter/testdata/cluster-config.yaml
@@ -7,6 +7,9 @@ metadata:
 karpenter:
   version: '0.4.3'
 
+iam:
+  withOIDC: true
+
 managedNodeGroups:
   - name: managed-ng-1
     minSize: 1


### PR DESCRIPTION
### Description

Fixes the config for the Karpenter integration test.

Running the test:

```

• [SLOW TEST:1700.599 seconds]
(Integration) Karpenter
/Users/skarlso/goprojects/weaveworks/eksctl/integration/tests/karpenter/karpenter_test.go:35
  Creating a cluster with Karpenter
  /Users/skarlso/goprojects/weaveworks/eksctl/integration/tests/karpenter/karpenter_test.go:54
    should support karpenter
    /Users/skarlso/goprojects/weaveworks/eksctl/integration/tests/karpenter/karpenter_test.go:55
------------------------------

Ran 1 of 1 Specs in 1700.599 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped

```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

