### PR TITLE
Increase timeout and added more debug information for karpenter test

### DIFF
--- a/pkg/karpenter/providers/helm/helm.go
+++ b/pkg/karpenter/providers/helm/helm.go
@@ -89,7 +89,7 @@ func (i *Installer) InstallChart(ctx context.Context, opts providers.InstallChar
 	client.ReleaseName = opts.ReleaseName
 	client.Version = opts.Version
 	client.CreateNamespace = opts.CreateNamespace
-	client.Timeout = 30 * time.Second
+	client.Timeout = 10 * time.Minute
 
 	chartPath, err := client.ChartPathOptions.LocateChart(opts.ChartName, i.Settings)
 	if err != nil {


### PR DESCRIPTION
### Description

Closes #4633 

Events are empty... looking into that.

```log
karpenter=webhook events:
container logs for container webhook in deployment karpenter=webhook: 2022/01/17 07:39:01 Registering 1 clients
2022/01/17 07:39:01 Registering 2 informer factories
2022/01/17 07:39:01 Registering 3 informers
2022/01/17 07:39:01 Registering 4 controllers
2022-01-17T07:39:01.371Z        INFO    Successfully created the logger.
...
karpenter=controller events:
container logs for container manager in deployment karpenter=controller: 2022-01-17T07:39:01.131Z       INFO    Successfully created the logger.
2022-01-17T07:39:01.131Z        INFO    Logging level set to: info
{"level":"info","ts":1642405141.2355907,"logger":"fallback","caller":"injection/injection.go:61","msg":"Starting informers..."}
2022-01-17T07:39:01.266Z        INFO    controller      starting metrics server {"commit": "dc47849", "path": "/metrics"}
I0117 07:39:01.366643       1 leaderelection.go:243] attempting to acquire leader lease karpenter/karpenter-leader-election..
...
```

Relevant events and information are all displayed correctly.

Okay, got all event information now as well as the logs:

```
all events:
name: karpenter-controller-69fdd55566-x9zgl.16cb0913966f3e96, message: Successfully assigned karpenter/karpenter-controller-69fdd55566-x9zgl to ip-192-168-94-127.us-west-2.compute.internal
name: karpenter-controller-69fdd55566-x9zgl.16cb0913cb2420f0, message: Pulling image "public.ecr.aws/karpenter/controller:v0.4.3@sha256:c10e7804ac763ce34ddfda09d1bb0501026aaf6520bc72d0aed05aab4c4ecf6f"
name: karpenter-controller-69fdd55566-x9zgl.16cb0919b9d474f3, message: Successfully pulled image "public.ecr.aws/karpenter/controller:v0.4.3@sha256:c10e7804ac763ce34ddfda09d1bb0501026aaf6520bc72d0aed05aab4c4ecf6f" in 25.479339623s
name: karpenter-controller-69fdd55566-x9zgl.16cb0919c32b4693, message: Created container manager
name: karpenter-controller-69fdd55566-x9zgl.16cb0919cfa38785, message: Started container manager
name: karpenter-controller-69fdd55566-x9zgl.16cb091a0db4a4c2, message: Container image "public.ecr.aws/karpenter/controller:v0.4.3@sha256:c10e7804ac763ce34ddfda09d1bb0501026aaf6520bc72d0aed05aab4c4ecf6f" already present on machine
name: karpenter-controller-69fdd55566.16cb0913954fc281, message: Created pod: karpenter-controller-69fdd55566-x9zgl
name: karpenter-controller.16cb091386d43516, message: Scaled up replica set karpenter-controller-69fdd55566 to 1
name: karpenter-leader-election.16cb0919e072cd28, message: karpenter-controller-69fdd55566-x9zgl_b2e76aa9-46a1-45e4-aff3-c043449fef3e became leader
name: karpenter-leader-election.16cb0919e072ee5e, message: karpenter-controller-69fdd55566-x9zgl_b2e76aa9-46a1-45e4-aff3-c043449fef3e became leader
name: karpenter-webhook-965766d67-4tqmj.16cb09139633d610, message: Successfully assigned karpenter/karpenter-webhook-965766d67-4tqmj to ip-192-168-94-127.us-west-2.compute.internal
name: karpenter-webhook-965766d67-4tqmj.16cb09142a3c6dc3, message: Pulling image "public.ecr.aws/karpenter/webhook:v0.4.3@sha256:576628e37932715cdef2d5bc4bc641a255803b81a2ffb104d674f9f996b10936"
name: karpenter-webhook-965766d67-4tqmj.16cb0919a19fd852, message: Successfully pulled image "public.ecr.aws/karpenter/webhook:v0.4.3@sha256:576628e37932715cdef2d5bc4bc641a255803b81a2ffb104d674f9f996b10936" in 23.477826241s
name: karpenter-webhook-965766d67-4tqmj.16cb0919c31fa815, message: Created container webhook
name: karpenter-webhook-965766d67-4tqmj.16cb0919cea16265, message: Started container webhook
name: karpenter-webhook-965766d67.16cb09139555bd8d, message: Created pod: karpenter-webhook-965766d67-4tqmj
name: karpenter-webhook.16cb091384f4dd6b, message: Scaled up replica set karpenter-webhook-965766d67 to 1
```

This should give us some information on what the heck is going on in the test account. I suspect the resource name will be too long.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

