### PR TITLE
Add ec2:DescribeInstanceTypes to autoScaler policy statements

### DIFF
--- a/pkg/cfn/builder/statement.go
+++ b/pkg/cfn/builder/statement.go
@@ -262,6 +262,7 @@ func autoScalerStatements() []cft.MapOfInterfaces {
 				"autoscaling:DescribeTags",
 				"autoscaling:SetDesiredCapacity",
 				"autoscaling:TerminateInstanceInAutoScalingGroup",
+				"ec2:DescribeInstanceTypes",
 				"ec2:DescribeLaunchTemplateVersions",
 			},
 		},


### PR DESCRIPTION
### Description

Add `ec2:DescribeInstanceTypes` to autoScaler statements which is required by cluster-autoscaler 1.23.0

https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.23.0

> **Note**: The merging of #4468 means that the default configuration of the CA will now require an extra IAM permission - ec2:DescribeInstanceTypes

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

