### PR TITLE
Increase lint timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ endif
 
 .PHONY: lint
 lint: ## Run linter over the codebase
-	golangci-lint run
+	golangci-lint run --timeout=30m
 	@for config_file in $(shell ls .goreleaser*); do goreleaser check -f $${config_file} || exit 1; done
 
 .PHONY: test


### PR DESCRIPTION
Closes https://github.com/weaveworks/eksctl/issues/4589

## Delete the job

We can't. This is the only job testing if eksctl can build on all platforms.

## Why the timeout increase

On my machine, which isn't a bad machine, now-a-days, linter runs in 12 minutes! The CI isn't always faster than that. It times out before that.