### PR TITLE
Fix bug causing the identityProviders to be marshalled incorrectly

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/identity_provider.go
+++ b/pkg/apis/eksctl.io/v1alpha5/identity_provider.go
@@ -2,6 +2,7 @@ package v1alpha5
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/pkg/errors"
 )
@@ -46,6 +47,26 @@ func FromIdentityProvider(idp IdentityProviderInterface) IdentityProvider {
 	return IdentityProvider{
 		type_: string(idp.Type()),
 		Inner: idp,
+	}
+}
+
+func (ip *IdentityProvider) MarshalJSON() ([]byte, error) {
+	switch ip.Inner.Type() {
+	case OIDCIdentityProviderType:
+		oidc, ok := ip.Inner.(*OIDCIdentityProvider)
+		if !ok {
+			return nil, fmt.Errorf("failed to cast oidc of type %s into OIDCIdentityProvider", OIDCIdentityProviderType)
+		}
+		return json.Marshal(struct {
+			*OIDCIdentityProvider
+			Type string `json:"type"`
+		}{
+			Type:                 string(OIDCIdentityProviderType),
+			OIDCIdentityProvider: oidc,
+		})
+
+	default:
+		return nil, errors.New("couldn't marshal to IdentityProvider, invalid type")
 	}
 }
 

--- a/pkg/apis/eksctl.io/v1alpha5/identity_provider_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/identity_provider_test.go
@@ -1,0 +1,58 @@
+package v1alpha5_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/eks"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+const identityProviders = `apiVersion: eksctl.io/v1alpha5
+identityProviders:
+- clientID: client
+  issuerURL: example.com
+  name: name
+  type: oidc
+  usernameClaim: email
+kind: ClusterConfig
+metadata:
+  name: ip
+  region: us-west-2
+`
+
+var _ = Describe("IdentityProvider", func() {
+	It("can be Unmarshaled and marshaled", func() {
+		Expect(api.Register()).To(Succeed())
+		cfg, err := eks.ParseConfig([]byte(identityProviders))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(*cfg).To(Equal(api.ClusterConfig{
+			Metadata: &api.ClusterMeta{
+				Name:   "ip",
+				Region: "us-west-2",
+			},
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "eksctl.io/v1alpha5",
+				Kind:       "ClusterConfig",
+			},
+			IdentityProviders: []api.IdentityProvider{
+				{
+					Inner: &api.OIDCIdentityProvider{
+						ClientID:      "client",
+						IssuerURL:     "example.com",
+						Name:          "name",
+						UsernameClaim: "email",
+					},
+				},
+			},
+		}))
+
+		data, err := yaml.Marshal(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		fmt.Println(string(data))
+		Expect(string(data)).To(Equal(identityProviders))
+	})
+})


### PR DESCRIPTION
### Description

Closes #4500

input:
```
---
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: cluster-26
  region: us-west-2

identityProviders:
  - name: cognito-user-pool-1
    issuerURL: https://cognito-idp.us-west-2.amazonaws.com/us-west-2_Ur78RxTra
    clientID: 10basodnbu3gs9b1bf9r566btu
    usernameClaim: email
    type: oidc
```

Before `eksctl create cluster -f examples/27-oidc-provider.yaml --dry-run` would output:
```
identityProviders:
- Inner:
    clientID: 10basodnbu3gs9b1bf9r566btu
    issuerURL: https://cognito-idp.us-west-2.amazonaws.com/us-west-2_Ur78RxTra
    name: cognito-user-pool-1
    usernameClaim: email
```

After:
```
identityProviders:
- clientID: 10basodnbu3gs9b1bf9r566btu
  issuerURL: https://cognito-idp.us-west-2.amazonaws.com/us-west-2_Ur78RxTra
  name: cognito-user-pool-1
  type: oidc
  usernameClaim: email
```
