### PR TITLE
Improve ipv6 docs and link to docs in help text

### DIFF
--- a/pkg/ctl/cmdutils/group.go
+++ b/pkg/ctl/cmdutils/group.go
@@ -101,6 +101,7 @@ func (g *FlagGrouping) Usage(cmd *cobra.Command) error {
 	}
 
 	usage = append(usage, fmt.Sprintf("\nUse '%s [command] --help' for more information about a command.\n", cmd.CommandPath()))
+	usage = append(usage, "\nFor detailed docs go to https://eksctl.io/\n")
 
 	cmd.Println(strings.Join(usage, "\n"))
 

--- a/userdocs/mkdocs.yml
+++ b/userdocs/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
             - usage/vpc-configuration.md
             - usage/vpc-subnet-settings.md
             - usage/vpc-cluster-access.md
+            - usage/vpc-ip-family.md
         - IAM:
             - usage/minimum-iam-policies.md
             - usage/iam-permissions-boundary.md

--- a/userdocs/src/usage/vpc-ip-family.md
+++ b/userdocs/src/usage/vpc-ip-family.md
@@ -1,3 +1,5 @@
+# IPv6 Support
+
 ## Define IP Family
 
 When `eksctl` creates a vpc, you can define the IP version that will be used. The following options are available to be configured:


### PR DESCRIPTION
### Description
Closes https://github.com/weaveworks/eksctl/issues/4665

![docs-ipv6](https://user-images.githubusercontent.com/19669095/151154272-640b857d-f0bc-4269-89ce-5dec73847318.png)
![docs-ipv6-search](https://user-images.githubusercontent.com/19669095/151154289-c8a6a85b-db95-4df7-a0da-f01d533f1edc.png)


```
eksctl --help
The official CLI for Amazon EKS

Usage: eksctl [command] [flags]

Commands:
  eksctl anywhere                        EKS anywhere
  eksctl associate                       Associate resources with a cluster
  eksctl completion                      Generates shell completion scripts for bash, zsh or fish
...

Common flags:
  -C, --color string   toggle colorized logs (valid options: true, false, fabulous) (default "true")
  -h, --help           help for this command
  -v, --verbose int    set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging (default 3)

Use 'eksctl [command] --help' for more information about a command.


For detailed docs go to https://eksctl.io/
```

```
eksctl create cluster
Create a cluster

Usage: eksctl create cluster [flags]

General flags:
  -n, --name string           EKS cluster name (generated if unspecified, e.g. "fabulous-sheepdog-1643196264")
      --tags stringToString   Used to tag the AWS resources. List of comma separated KV pairs "k1=v1,k2=v2" (default [])
...

Common flags:
  -C, --color string   toggle colorized logs (valid options: true, false, fabulous) (default "true")
  -h, --help           help for this command
  -v, --verbose int    set log level, use 0 to silence, 4 for debugging and 5 for debugging with AWS debug logging (default 3)

Use 'eksctl create cluster [command] --help' for more information about a command.


For detailed docs go to https://eksctl.io/
```
