### PR TITLE
Avoid force-pushing to `docs` branch to publish docs

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -45,7 +45,7 @@ jobs:
         run: make install-site-deps
       - name: Build docs for link check
         run: make build-pages
-        # Using liche action to check generated HTML site
+        # Using link-checker action to check generated HTML site
       - name: Link Checker (generated site)
         id: lc
         uses: peter-evans/link-checker@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,3 +27,7 @@ jobs:
           token: "${{ secrets.WEAVEWORKSBOT_TOKEN }}"
       - name: Open PRs to release branch and default branch
         run: make prepare-release
+      - name: Publish docs to Netlify
+        run: make publish-docs
+        env:
+          NETLIFY_BUILD_HOOK_URL: ${{ secrets.NETLIFY_BUILD_HOOK_URL }}

--- a/Makefile.docs
+++ b/Makefile.docs
@@ -15,3 +15,7 @@ serve-pages: ## Serve the site locally
 .PHONY: build-pages
 build-pages: userdocs/src/usage/schema.json ## Generate the site
 	cd userdocs/ && mkdocs build
+
+.PHONY: publish-docs
+publish-docs:
+	build/scripts/publish-docs.sh

--- a/build/scripts/publish-docs.sh
+++ b/build/scripts/publish-docs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -ex
+
+DIR="${BASH_SOURCE%/*}"
+
+if [ -z "${NETLIFY_BUILD_HOOK_URL}" ] ; then
+  echo "NETLIFY_BUILD_HOOK_URL is required"
+  exit 1
+fi
+
+# shellcheck source=tag-common.sh
+. "${DIR}/tag-common.sh"
+
+release_branch=$(release_branch)
+
+curl -X POST -d "trigger_branch=${release_branch}" -d "trigger_title=Triggered+by+Release+action" "${NETLIFY_BUILD_HOOK_URL}"

--- a/build/scripts/tag-release.sh
+++ b/build/scripts/tag-release.sh
@@ -28,9 +28,6 @@ commit "${m}" "${release_notes_file}"
 
 tag_version_and_latest "${m}" "${release_version}"
 
-# Update the site by putting everything from the release into the docs branch
-git push --force origin "${release_branch}":docs
-
 make_pr "${release_branch}"
 
 # Make PR to update default branch if necessary


### PR DESCRIPTION
### Description

This changelist eliminates the need to force-push to `docs` and to have a dedicated branch for publishing docs, by using Netlify's build hooks feature. Rather than asking Netlify to trigger deployments by monitoring changes to a branch (`docs`), this changelist triggers deployment as part of the release workflow by sending an HTTP request to the build hook URL specifying the release branch. 

There are some GitHub actions for Netlify but they seem complicated for this task and require more configuration than our current setup. A build hook URL seems like the best fit for triggering deployments on a specific branch, while still being able to use the existing `netlify.toml` file.

Closes #4575 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

