### PR TITLE
Use correct kubeconfig for karpenter install

### DIFF
--- a/integration/main.go
+++ b/integration/main.go
@@ -97,7 +97,7 @@ func listModules() []string {
 	}
 	var moduleDirs []string
 	for _, f := range files {
-		if f.IsDir() {
+		if f.IsDir() && strings.Contains(f.Name(), "karp") {
 			moduleDirs = append(moduleDirs, path.Join(testsDir, f.Name()))
 		}
 	}

--- a/integration/main.go
+++ b/integration/main.go
@@ -97,7 +97,7 @@ func listModules() []string {
 	}
 	var moduleDirs []string
 	for _, f := range files {
-		if f.IsDir() && strings.Contains(f.Name(), "karp") {
+		if f.IsDir() {
 			moduleDirs = append(moduleDirs, path.Join(testsDir, f.Name()))
 		}
 	}

--- a/integration/tests/karpenter/karpenter_test.go
+++ b/integration/tests/karpenter/karpenter_test.go
@@ -5,7 +5,6 @@ package karpenter
 
 import (
 	"fmt"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	. "github.com/weaveworks/eksctl/integration/runner"
 	"github.com/weaveworks/eksctl/integration/tests"
 	clusterutils "github.com/weaveworks/eksctl/integration/utilities/cluster"
 	"github.com/weaveworks/eksctl/integration/utilities/kube"
@@ -36,13 +36,13 @@ func TestKarpenter(t *testing.T) {
 }
 
 var _ = Describe("(Integration) Karpenter", func() {
-	// AfterEach(func() {
-	// 	cmd := params.EksctlDeleteCmd.WithArgs(
-	// 		"cluster", params.ClusterName,
-	// 		"--verbose", "4",
-	// 	)
-	// 	Expect(cmd).To(RunSuccessfully())
-	// })
+	AfterEach(func() {
+		cmd := params.EksctlDeleteCmd.WithArgs(
+			"cluster", params.ClusterName,
+			"--verbose", "4",
+		)
+		Expect(cmd).To(RunSuccessfully())
+	})
 
 	Context("Creating a cluster with Karpenter", func() {
 		It("should support karpenter", func() {
@@ -55,17 +55,7 @@ var _ = Describe("(Integration) Karpenter", func() {
 				).
 				WithoutArg("--region", params.Region).
 				WithStdin(clusterutils.ReaderFromFile(params.ClusterName, params.Region, "testdata/cluster-config.yaml"))
-			// For dumping information, we need the kubeconfig. We just log the error here to
-			// know that it failed for debugging then carry on.
-			session := cmd.Run()
-			if session.ExitCode() != 0 {
-				fmt.Fprintf(GinkgoWriter, "cluster create command failed:")
-				fmt.Fprint(GinkgoWriter, string(session.Out.Contents()))
-				fmt.Fprint(GinkgoWriter, string(session.Err.Contents()))
-			}
-			if session.ExitCode() != 0 {
-				describeKarpenterResources([]string{"karpenter-webhook", "karpenter-controller"})
-			}
+			Expect(cmd).To(RunSuccessfully())
 
 			kubeTest, err := kube.NewTest(params.KubeconfigPath)
 			Expect(err).NotTo(HaveOccurred())
@@ -80,19 +70,3 @@ var _ = Describe("(Integration) Karpenter", func() {
 		})
 	})
 })
-
-// not using kubeTest since kubeTest fatals on error, and we don't want that.
-func describeKarpenterResources(names []string) {
-	for _, name := range names {
-		cmd := exec.Command("kubectl", "--kubeconfig", params.KubeconfigPath, "describe", "replicaset", name, "-n", karpenter.DefaultNamespace)
-		output, err := cmd.Output()
-		Expect(err).NotTo(HaveOccurred())
-		fmt.Fprintf(GinkgoWriter, "describe replicaset %s", name)
-		fmt.Fprint(GinkgoWriter, string(output))
-		cmd = exec.Command("kubectl", "--kubeconfig", params.KubeconfigPath, "describe", "deployment", name, "-n", karpenter.DefaultNamespace)
-		output, err = cmd.Output()
-		Expect(err).NotTo(HaveOccurred())
-		fmt.Fprintf(GinkgoWriter, "describe deployment %s", name)
-		fmt.Fprint(GinkgoWriter, string(output))
-	}
-}

--- a/integration/tests/karpenter/karpenter_test.go
+++ b/integration/tests/karpenter/karpenter_test.go
@@ -13,7 +13,6 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	. "github.com/weaveworks/eksctl/integration/runner"
 	"github.com/weaveworks/eksctl/integration/tests"
 	clusterutils "github.com/weaveworks/eksctl/integration/utilities/cluster"
 	"github.com/weaveworks/eksctl/integration/utilities/kube"
@@ -37,13 +36,13 @@ func TestKarpenter(t *testing.T) {
 }
 
 var _ = Describe("(Integration) Karpenter", func() {
-	AfterEach(func() {
-		cmd := params.EksctlDeleteCmd.WithArgs(
-			"cluster", params.ClusterName,
-			"--verbose", "4",
-		)
-		Expect(cmd).To(RunSuccessfully())
-	})
+	// AfterEach(func() {
+	// 	cmd := params.EksctlDeleteCmd.WithArgs(
+	// 		"cluster", params.ClusterName,
+	// 		"--verbose", "4",
+	// 	)
+	// 	Expect(cmd).To(RunSuccessfully())
+	// })
 
 	Context("Creating a cluster with Karpenter", func() {
 		It("should support karpenter", func() {

--- a/integration/tests/karpenter/karpenter_test.go
+++ b/integration/tests/karpenter/karpenter_test.go
@@ -35,7 +35,7 @@ func TestKarpenter(t *testing.T) {
 	testutils.RegisterAndRun(t)
 }
 
-var _ = PDescribe("(Integration) Karpenter", func() {
+var _ = Describe("(Integration) Karpenter", func() {
 	AfterEach(func() {
 		cmd := params.EksctlDeleteCmd.WithArgs(
 			"cluster", params.ClusterName,

--- a/pkg/actions/karpenter/karpenter.go
+++ b/pkg/actions/karpenter/karpenter.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/kris-nova/logger"
+	"helm.sh/helm/v3/pkg/kube"
 	kubeclient "k8s.io/client-go/kubernetes"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -33,9 +34,11 @@ type Installer struct {
 type WaitFunc func(name, msg string, acceptors []request.WaiterAcceptor, newRequest func() *request.Request, waitTimeout time.Duration, troubleshoot func(string) error) error
 
 // NewInstaller creates a new Karpenter installer.
-func NewInstaller(cfg *api.ClusterConfig, ctl *eks.ClusterProvider, stackManager manager.StackManager, clientSet kubeclient.Interface) (*Installer, error) {
+func NewInstaller(cfg *api.ClusterConfig, ctl *eks.ClusterProvider, stackManager manager.StackManager, clientSet kubeclient.Interface, kubeConfig string) (*Installer, error) {
+	restClientGetter := kube.GetConfig(kubeConfig, "", "karpenter")
 	helmInstaller, err := helm.NewInstaller(helm.Options{
-		Namespace: karpenter.DefaultNamespace,
+		Namespace:        karpenter.DefaultNamespace,
+		RESTClientGetter: restClientGetter,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/actions/karpenter/karpenter.go
+++ b/pkg/actions/karpenter/karpenter.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/kris-nova/logger"
-	"helm.sh/helm/v3/pkg/kube"
 	kubeclient "k8s.io/client-go/kubernetes"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -34,8 +33,7 @@ type Installer struct {
 type WaitFunc func(name, msg string, acceptors []request.WaiterAcceptor, newRequest func() *request.Request, waitTimeout time.Duration, troubleshoot func(string) error) error
 
 // NewInstaller creates a new Karpenter installer.
-func NewInstaller(cfg *api.ClusterConfig, ctl *eks.ClusterProvider, stackManager manager.StackManager, clientSet kubeclient.Interface, kubeConfig string) (*Installer, error) {
-	restClientGetter := kube.GetConfig(kubeConfig, "", "karpenter")
+func NewInstaller(cfg *api.ClusterConfig, ctl *eks.ClusterProvider, stackManager manager.StackManager, clientSet kubeclient.Interface, restClientGetter *kubernetes.SimpleRESTClientGetter) (*Installer, error) {
 	helmInstaller, err := helm.NewInstaller(helm.Options{
 		Namespace:        karpenter.DefaultNamespace,
 		RESTClientGetter: restClientGetter,

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -12,7 +12,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/runtime"
 	kubeclient "k8s.io/client-go/kubernetes"
+	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
 
 	"github.com/weaveworks/eksctl/pkg/actions/addon"
 	"github.com/weaveworks/eksctl/pkg/actions/flux"
@@ -24,6 +26,7 @@ import (
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils/filter"
 	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/kops"
+	"github.com/weaveworks/eksctl/pkg/kubernetes"
 	"github.com/weaveworks/eksctl/pkg/printers"
 	"github.com/weaveworks/eksctl/pkg/utils"
 	"github.com/weaveworks/eksctl/pkg/utils/kubeconfig"
@@ -367,16 +370,13 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 				return fmt.Errorf("failed to create addons")
 			}
 		}
-		kubectlConfig := kubeconfig.NewForKubectl(cfg, ctl.GetUsername(), params.AuthenticatorRoleARN, ctl.Provider.Profile())
-		_, err = kubeconfig.Write("/tmp/kube-config", *kubectlConfig, true)
+		config := kubeconfig.NewForKubectl(cfg, ctl.GetUsername(), params.AuthenticatorRoleARN, ctl.Provider.Profile())
+		kubeConfigBytes, err := runtime.Encode(clientcmdlatest.Codec, config)
 		if err != nil {
-			return errors.Wrap(err, "writing kubeconfig")
+			return errors.Wrap(err, "generating kubeconfig")
 		}
-
-		defer os.RemoveAll("/tmp/kube-config")
-
 		// After we have the cluster config and all the nodes are done, we install Karpenter if necessary.
-		if err := installKarpenter(ctl, cfg, stackManager, clientSet, "/tmp/kube-config"); err != nil {
+		if err := installKarpenter(ctl, cfg, stackManager, clientSet, kubernetes.NewRESTClientGetter("karpenter", string(kubeConfigBytes))); err != nil {
 			return err
 		}
 
@@ -425,12 +425,12 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 // - service account
 // - identity mapping
 // then proceeds with installing Karpenter using Helm.
-func installKarpenter(ctl *eks.ClusterProvider, cfg *api.ClusterConfig, stackManager manager.StackManager, clientSet *kubeclient.Clientset, kubeConfig string) error {
+func installKarpenter(ctl *eks.ClusterProvider, cfg *api.ClusterConfig, stackManager manager.StackManager, clientSet *kubeclient.Clientset, restClientGetter *kubernetes.SimpleRESTClientGetter) error {
 	if cfg.Karpenter == nil {
 		return nil
 	}
 
-	installer, err := karpenteractions.NewInstaller(cfg, ctl, stackManager, clientSet, kubeConfig)
+	installer, err := karpenteractions.NewInstaller(cfg, ctl, stackManager, clientSet, restClientGetter)
 	if err != nil {
 		return fmt.Errorf("failed to create installer: %w", err)
 	}

--- a/pkg/karpenter/providers/helm/helm.go
+++ b/pkg/karpenter/providers/helm/helm.go
@@ -86,7 +86,7 @@ func (i *Installer) AddRepo(repoURL, release string) error {
 // it will install into that namespace and create the namespace. Version is required.
 func (i *Installer) InstallChart(ctx context.Context, opts providers.InstallChartOpts) error {
 	client := action.NewInstall(i.ActionConfig)
-	client.Wait = false
+	client.Wait = true
 	client.Namespace = opts.Namespace
 	client.ReleaseName = opts.ReleaseName
 	client.Version = opts.Version

--- a/pkg/karpenter/providers/helm/helm.go
+++ b/pkg/karpenter/providers/helm/helm.go
@@ -84,7 +84,7 @@ func (i *Installer) AddRepo(repoURL, release string) error {
 // it will install into that namespace and create the namespace. Version is required.
 func (i *Installer) InstallChart(ctx context.Context, opts providers.InstallChartOpts) error {
 	client := action.NewInstall(i.ActionConfig)
-	client.Wait = true
+	client.Wait = false
 	client.Namespace = opts.Namespace
 	client.ReleaseName = opts.ReleaseName
 	client.Version = opts.Version

--- a/pkg/karpenter/providers/helm/helm.go
+++ b/pkg/karpenter/providers/helm/helm.go
@@ -15,13 +15,15 @@ import (
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/repo"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/weaveworks/eksctl/pkg/karpenter/providers"
 )
 
 // Options defines options for the Helm Installer.
 type Options struct {
-	Namespace string
+	Namespace        string
+	RESTClientGetter genericclioptions.RESTClientGetter
 }
 
 // Installer implement the HelmInstaller interface.
@@ -35,7 +37,7 @@ type Installer struct {
 func NewInstaller(opts Options) (*Installer, error) {
 	settings := cli.New()
 	actionConfig := new(action.Configuration)
-	if err := actionConfig.Init(settings.RESTClientGetter(), opts.Namespace, "", logger.Debug); err != nil {
+	if err := actionConfig.Init(opts.RESTClientGetter, opts.Namespace, "", logger.Debug); err != nil {
 		return nil, fmt.Errorf("failed to initialize action config: %w", err)
 	}
 	return &Installer{

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -19,10 +19,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Interface is an alias to avoid having to import k8s.io/client-go/kubernetes
@@ -475,4 +478,63 @@ func (r *RawResource) Get() (runtime.Object, bool, error) {
 		return nil, false, err
 	}
 	return obj, true, nil
+}
+
+//Credit https://github.com/helm/helm/issues/6910#issuecomment-601277026
+type SimpleRESTClientGetter struct {
+	Namespace  string
+	KubeConfig string
+}
+
+func NewRESTClientGetter(namespace, kubeConfig string) *SimpleRESTClientGetter {
+	return &SimpleRESTClientGetter{
+		Namespace:  namespace,
+		KubeConfig: kubeConfig,
+	}
+}
+
+func (c *SimpleRESTClientGetter) ToRESTConfig() (*rest.Config, error) {
+	config, err := clientcmd.RESTConfigFromKubeConfig([]byte(c.KubeConfig))
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+func (c *SimpleRESTClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	config, err := c.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// The more groups you have, the more discovery requests you need to make.
+	// given 25 groups (our groups + a few custom conf) with one-ish version each, discovery needs to make 50 requests
+	// double it just so we don't end up here again for a while.  This config is only used for discovery.
+	config.Burst = 100
+
+	discoveryClient, _ := discovery.NewDiscoveryClientForConfig(config)
+	return memory.NewMemCacheClient(discoveryClient), nil
+}
+
+func (c *SimpleRESTClientGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	discoveryClient, err := c.ToDiscoveryClient()
+	if err != nil {
+		return nil, err
+	}
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
+	expander := restmapper.NewShortcutExpander(mapper, discoveryClient)
+	return expander, nil
+}
+
+func (c *SimpleRESTClientGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	// use the standard defaults for this client command
+	// DEPRECATED: remove and replace with something more accurate
+	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+
+	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clientcmd.ClusterDefaults}
+	overrides.Context.Namespace = c.Namespace
+
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
 }


### PR DESCRIPTION
### Description

Before this PR we would use the default kubeconfig `~/.kube/config` to try and install karpenter into. This makes sure that we use the kubeconfig belonging to the cluster when installing karpenter
```
[0] JUnit report was created: /home/jake/weave/eksctl/test-results/__home__jake__weave__eksctl__integration__tests__karpenter__karpenter__test__go_1.xml
[0]
[0] Ran 1 of 1 Specs in 1665.298 seconds
[0] SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[0] PASS
[0]
```