### PR TITLE
pend flakely ipv6 test

### DIFF
--- a/integration/tests/ipv6/ipv6_test.go
+++ b/integration/tests/ipv6/ipv6_test.go
@@ -46,7 +46,7 @@ func TestIPv6(t *testing.T) {
 	testutils.RegisterAndRun(t)
 }
 
-var _ = Describe("(Integration) [EKS IPv6 test]", func() {
+var _ = PDescribe("(Integration) [EKS IPv6 test]", func() {
 	var (
 		clusterConfig *api.ClusterConfig
 	)


### PR DESCRIPTION
### Description

The following flake is occurring more often than not https://github.com/weaveworks/eksctl/issues/4700. Lets pend the test until its fixed.