### PR TITLE
Fix ASG names in `get nodegroup`

### DIFF
--- a/pkg/actions/nodegroup/get.go
+++ b/pkg/actions/nodegroup/get.go
@@ -11,6 +11,7 @@ import (
 	awseks "github.com/aws/aws-sdk-go/service/eks"
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
+
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 	kubewrapper "github.com/weaveworks/eksctl/pkg/kubernetes"
 )
@@ -106,10 +107,10 @@ func (m *Manager) Get(name string) (*manager.NodeGroupSummary, error) {
 		return nil, err
 	}
 
-	var asg string
+	var asgs []string
 	if describeOutput.Nodegroup.Resources != nil {
-		for _, v := range describeOutput.Nodegroup.Resources.AutoScalingGroups {
-			asg = aws.StringValue(v.Name)
+		for _, asg := range describeOutput.Nodegroup.Resources.AutoScalingGroups {
+			asgs = append(asgs, aws.StringValue(asg.Name))
 		}
 	}
 
@@ -124,7 +125,7 @@ func (m *Manager) Get(name string) (*manager.NodeGroupSummary, error) {
 		ImageID:              *describeOutput.Nodegroup.AmiType,
 		CreationTime:         describeOutput.Nodegroup.CreatedAt,
 		NodeInstanceRoleARN:  *describeOutput.Nodegroup.NodeRole,
-		AutoScalingGroupName: asg,
+		AutoScalingGroupName: strings.Join(asgs, ","),
 		Version:              getOptionalValue(describeOutput.Nodegroup.Version),
 	}, nil
 }


### PR DESCRIPTION
`Nodegroup.Resources.AutoScalingGroups` is a slice but the code incorrectly shows only one ASG name in the output of `get nodegroup`.

I'm also working on another PR that refactors `pkg/actions/nodegroup/get.go`. 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

