### PR TITLE
wait for karpenter stack to be deleted

### DIFF
--- a/pkg/actions/cluster/owned.go
+++ b/pkg/actions/cluster/owned.go
@@ -180,8 +180,7 @@ func (c *OwnedCluster) deleteKarpenterStackIfExists() error {
 
 	if stack != nil {
 		logger.Info("deleting karpenter stack")
-		_, err = c.stackManager.DeleteStackBySpec(stack)
-		return err
+		return c.stackManager.DeleteStackByNameSync(*stack.StackName)
 	}
 
 	return nil

--- a/pkg/actions/cluster/owned_test.go
+++ b/pkg/actions/cluster/owned_test.go
@@ -125,8 +125,8 @@ var _ = Describe("Delete", func() {
 			Expect(ranDeleteDeprecatedTasks).To(BeTrue())
 			Expect(fakeStackManager.NewTasksToDeleteClusterWithNodeGroupsCallCount()).To(Equal(1))
 			Expect(ranDeleteClusterTasks).To(BeTrue())
-			Expect(fakeStackManager.DeleteStackBySpecCallCount()).To(Equal(1))
-			Expect(fakeStackManager.DeleteStackBySpecArgsForCall(0)).To(Equal(karpenterStack))
+			Expect(fakeStackManager.DeleteStackByNameSyncCallCount()).To(Equal(1))
+			Expect(fakeStackManager.DeleteStackByNameSyncArgsForCall(0)).To(Equal("karpenter"))
 		})
 
 		When("force flag is set to true", func() {


### PR DESCRIPTION
### Description

Should fix flakely integration test https://github.com/weaveworks/eksctl-ci/actions/runs/1775593219:
```
[11] 2022-02-01 00:46:34 [ℹ]  waiting for CloudFormation stack "eksctl-it-exist-vpc-fabulous-rainbow-1643674705-cluster"
[18] 2022-02-01 00:46:34 [!]  found the following undeleted stacks: eksctl-it-karp-scrumptious-unicorn-1643674700-karpenter
[18] Error: failed to delete all resources
[18] 
[18] • Failure in Spec Teardown (AfterEach) [1694.819 seconds]
[18] (Integration) Karpenter
[18] /__w/eksctl-ci/eksctl-ci/eksctl/integration/tests/karpenter/karpenter_test.go:38
[18]   Creating a cluster with Karpenter [AfterEach]
[18]   /__w/eksctl-ci/eksctl-ci/eksctl/integration/tests/karpenter/karpenter_test.go:47
[18]     should support karpenter
[18]     /__w/eksctl-ci/eksctl-ci/eksctl/integration/tests/karpenter/karpenter_test.go:48
[18] 
[18]     Expected '../../../eksctl "--region" "us-west-2" "delete" "cluster" "it-karp-scrumptious-unicorn-1643674700" "--verbose" "4"' to succeed, got return code 1
[18] 
[18]     /__w/eksctl-ci/eksctl-ci/eksctl/integration/tests/karpenter/karpenter_test.go:44
```

