### PR TITLE
Add `list-integration-suites` make command for listing integration suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,13 +120,8 @@ integration-test-focus: build
 	echo "ran with args: ${TEST_SUITE_DIRS}"
 	./eksctl get clusters
 
-integration-count:
-	tree integration/tests/ | grep _test.go | wc -l
-
 integration-dirs:
-	@ ls -A1d integration/tests/*/ | cut -b 19- | rev | cut -c 2- | rev > integration/dirs.json
-	@ truncate -s -1 integration/dirs.json
-	@ cat integration/dirs.json | jq -R -s -c 'split("\n")'
+	@ find integration/tests/ -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | head -c -1 | jq -R -s -c 'split("\n")'
 
 
 TEST_CLUSTER ?= integration-test-dev

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,13 @@ integration-test: build build-integration-test ## Run the integration tests (wit
 integration-test-focus:
 	echo "ran with args: ${TEST_SUITE_DIRS}"
 
+integration-count:
+	tree integration/tests/ | grep _test.go | wc -l
+
+integration-dirs:
+	@ ls -A1d integration/tests/*/ | cut -b 19- | rev | cut -c 3- | rev > integration/dirs.json
+	@ cat integration/dirs.json | jq -R -s -c 'split("\n")'
+
 
 TEST_CLUSTER ?= integration-test-dev
 .PHONY: integration-test-dev

--- a/Makefile
+++ b/Makefile
@@ -116,14 +116,16 @@ build-integration-test: $(all_generated_code) ## Ensure integration tests compil
 integration-test: build build-integration-test ## Run the integration tests (with cluster creation and cleanup)
 	JUNIT_REPORT_DIR=$(git_toplevel)/test-results ./eksctl-integration-test $(INTEGRATION_TEST_ARGS)
 
-integration-test-focus:
+integration-test-focus: build
 	echo "ran with args: ${TEST_SUITE_DIRS}"
+	./eksctl get clusters
 
 integration-count:
 	tree integration/tests/ | grep _test.go | wc -l
 
 integration-dirs:
-	@ ls -A1d integration/tests/*/ | cut -b 19- | rev | cut -c 3- | rev > integration/dirs.json
+	@ ls -A1d integration/tests/*/ | cut -b 19- | rev | cut -c 2- | rev > integration/dirs.json
+	@ truncate -s -1 integration/dirs.json
 	@ cat integration/dirs.json | jq -R -s -c 'split("\n")'
 
 

--- a/Makefile
+++ b/Makefile
@@ -116,13 +116,8 @@ build-integration-test: $(all_generated_code) ## Ensure integration tests compil
 integration-test: build build-integration-test ## Run the integration tests (with cluster creation and cleanup)
 	JUNIT_REPORT_DIR=$(git_toplevel)/test-results ./eksctl-integration-test $(INTEGRATION_TEST_ARGS)
 
-integration-test-focus: build
-	echo "ran with args: ${TEST_SUITE_DIRS}"
-	./eksctl get clusters
-
-integration-dirs:
+list-integration-suites:
 	@ find integration/tests/ -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | head -c -1 | jq -R -s -c 'split("\n")'
-
 
 TEST_CLUSTER ?= integration-test-dev
 .PHONY: integration-test-dev

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,10 @@ build-integration-test: $(all_generated_code) ## Ensure integration tests compil
 integration-test: build build-integration-test ## Run the integration tests (with cluster creation and cleanup)
 	JUNIT_REPORT_DIR=$(git_toplevel)/test-results ./eksctl-integration-test $(INTEGRATION_TEST_ARGS)
 
+integration-test-focus:
+	echo "ran with args: ${TEST_SUITE_DIRS}"
+
+
 TEST_CLUSTER ?= integration-test-dev
 .PHONY: integration-test-dev
 integration-test-dev: build-integration-test ## Run the integration tests without cluster teardown. For use when developing integration tests.


### PR DESCRIPTION
Used for running the integration tests

```
make list-integration-suites
["update","caching","gitops","identity_provider","instance_selector","labels","addons","crud","before_active","eks_connector","anywhere","cloudwatch_logging","windows","dry_run","existing_vpc","backwards_compat","karpenter","cluster_dns","utils","inferentia","unowned_cluster","ipv6","fargate","cluster_api","managed"]
```