### PR TITLE
only set 2 AZ's when using us-west-1

### DIFF
--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -385,7 +385,7 @@ func (c *ClusterProvider) SetAvailabilityZones(spec *api.ClusterConfig, given []
 
 	logger.Debug("determining availability zones")
 	var azSelector *az.AvailabilityZoneSelector
-	if c.Provider.Region() == api.RegionUSEast1 {
+	if c.Provider.Region() == api.RegionUSEast1 || c.Provider.Region() == api.RegionUSWest1 {
 		azSelector = az.NewSelectorWithMinRequired(c.Provider.EC2(), c.Provider.Region())
 	} else {
 		azSelector = az.NewSelectorWithDefaults(c.Provider.EC2(), c.Provider.Region())


### PR DESCRIPTION
### Description

Before the cluster template would contain duplicates:
```
    },
    "SubnetsPrivate": {
      "Value": {
        "Fn::Join": [
          ",",
          [
            {
              "Ref": "PrivateSubnetUSWEST1B"
            },
            {
              "Ref": "PrivateSubnetUSWEST1A"
            },
            {
              "Ref": "PrivateSubnetUSWEST1A"
            }
          ]
        ]
      },
      "Export": {
        "Name": {
          "Fn::Sub": "${AWS::StackName}::SubnetsPrivate"
        }
      }
    },
    "SubnetsPublic": {
      "Value": {
        "Fn::Join": [
          ",",
          [
            {
              "Ref": "PublicSubnetUSWEST1B"
            },
            {
              "Ref": "PublicSubnetUSWEST1A"
            },
            {
              "Ref": "PublicSubnetUSWEST1A"
            }
          ]
        ]
      },
```

After this change:
```
  "SubnetsPrivate": {
      "Value": {
        "Fn::Join": [
          ",",
          [
            {
              "Ref": "PrivateSubnetUSWEST1B"
            },
            {
              "Ref": "PrivateSubnetUSWEST1A"
            }
          ]
        ]
      },
      "Export": {
        "Name": {
          "Fn::Sub": "${AWS::StackName}::SubnetsPrivate"
        }
      }
    },
    "SubnetsPublic": {
      "Value": {
        "Fn::Join": [
          ",",
          [
            {
              "Ref": "PublicSubnetUSWEST1B"
            },
            {
              "Ref": "PublicSubnetUSWEST1A"
            }
          ]
        ]
      },
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

