### PR TITLE
Updated the deprecated link checker

### DIFF
--- a/.github/workflows/exclude-file.txt
+++ b/.github/workflows/exclude-file.txt
@@ -8,3 +8,4 @@ eksctl-handbook
 github.com
 weave.works
 config.site_url
+eks.amazonaws.com

--- a/.github/workflows/exclude-file.txt
+++ b/.github/workflows/exclude-file.txt
@@ -1,0 +1,5 @@
+twitter.com
+.svg
+fonts.gstatic.com
+127.0.0.1:8000
+www.w3.org/2000/svg

--- a/.github/workflows/exclude-file.txt
+++ b/.github/workflows/exclude-file.txt
@@ -11,3 +11,4 @@ config.site_url
 eks.amazonaws.com
 raw.githubusercontent.com
 creating-and-managing-clusters
+schema.js

--- a/.github/workflows/exclude-file.txt
+++ b/.github/workflows/exclude-file.txt
@@ -9,3 +9,5 @@ github.com
 weave.works
 config.site_url
 eks.amazonaws.com
+raw.githubusercontent.com
+creating-and-managing-clusters

--- a/.github/workflows/exclude-file.txt
+++ b/.github/workflows/exclude-file.txt
@@ -3,3 +3,8 @@ twitter.com
 fonts.gstatic.com
 127.0.0.1:8000
 www.w3.org/2000/svg
+eksctl.io
+eksctl-handbook
+github.com
+weave.works
+config.site_url

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -35,5 +35,3 @@ jobs:
         with:
           fail: true
           args: --exclude-all-private --exclude-file .github/workflows/exclude-file.txt --verbose --no-progress './**/*.md' './**/*.html'
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -5,16 +5,12 @@ on:
     paths:
       - 'userdocs/**'
       - '**.md'
-      - '.github/workflows/markdown-link-check-config.json'
-      - '.github/workflows/check-links.yaml'
   push:
     branches:
       - main
     paths:
       - 'userdocs/**'
       - '**.md'
-      - '.github/workflows/markdown-link-check-config.json'
-      - '.github/workflows/check-links.yaml'
 
 jobs:
   link-checker:
@@ -38,5 +34,6 @@ jobs:
         uses: lycheeverse/lychee-action@768a13171aff975543be1d2f2dd740bc3dcd113c #v1.2.1
         with:
           fail: true
+          exclude-file: '.github/workflows/exclude-file.txt'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -17,19 +17,7 @@ on:
       - '.github/workflows/check-links.yaml'
 
 jobs:
-  markdown-link-checker:
-    name: Check markdown links
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      # Using markdown-link-check to check markdown docs
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          use-verbose-mode: 'yes'
-          config-file: '.github/workflows/markdown-link-check-config.json'
-          max-depth: 1
-
-  site-link-checker:
+  link-checker:
     name: Check site links
     runs-on: ubuntu-latest
     strategy:
@@ -45,11 +33,10 @@ jobs:
         run: make install-site-deps
       - name: Build docs for link check
         run: make build-pages
-        # Using link-checker action to check generated HTML site
-      - name: Link Checker (generated site)
-        id: lc
-        uses: peter-evans/link-checker@v1
+        # Using link-checker action to check links in Markdown, HTML files
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@768a13171aff975543be1d2f2dd740bc3dcd113c #v1.2.1
         with:
-          args: -d userdocs/site -r userdocs/site -x https://twitter.com|https://www.weave.works
-      - name: Fail if there were link errors
-        run: exit ${{ steps.lc.outputs.exit_code }}
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -34,6 +34,6 @@ jobs:
         uses: lycheeverse/lychee-action@768a13171aff975543be1d2f2dd740bc3dcd113c #v1.2.1
         with:
           fail: true
-          args: --exclude-all-private --exclude-file '.github/workflows/exclude-file.txt'
+          args: --exclude-all-private --exclude-file .github/workflows/exclude-file.txt --verbose --no-progress './**/*.md' './**/*.html'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -34,6 +34,6 @@ jobs:
         uses: lycheeverse/lychee-action@768a13171aff975543be1d2f2dd740bc3dcd113c #v1.2.1
         with:
           fail: true
-          exclude-file: '.github/workflows/exclude-file.txt'
+          args: --exclude-all-private --exclude-file '.github/workflows/exclude-file.txt'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -1,8 +1,0 @@
-{
-    "ignorePatterns": [
-        { "pattern": "^https://github.com/\\S+/\\S+/(issues|pull)/[0-9]+" },
-        { "pattern": "^mailto:" },
-        { "pattern": "^https://circleci.com/workflow-run/02d8b5fb-bc7f-404c-9051-68307c124649" },
-        { "pattern": "^https://github.com/weaveworks/eksctl-handbook" }
-    ]
-}

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -18,7 +18,7 @@ The core team of maintainers are Chetan Patwal ([@cPu1](https://github.com/cPu1)
 Jake Klein ([@aclevername](https://github.com/aclevername)),
 Niki Manoledaki ([@nikimanoledaki](https://github.com/nikimanoledaki)),
 Gergely Brautigam ([@Skarlso](https://github.com/Skarlso)),
-and Claudia Beresford ([@Callisto13](https://github.com/Callisto13)).
+and Himangini Daware ([@Himangini](https://github.com/Himangini)).
 
 ## Join us!
 

--- a/docs/guidelines/design-conventions.md
+++ b/docs/guidelines/design-conventions.md
@@ -43,6 +43,6 @@ General conventions followed when developing in eksctl:
   - eksctl does not use arguments except when used for the name of the resource (e.g.: `eksctl create nodegroup ng-1`). This is what we call `nameArg` in the code. The reason for this is that users get very easily confused when arguments are used and what their meaning is, and relative position with respect to flags. The name of the resource will also have the option to pass it as part of the flag called `--name` (e.g.: `eksctl create nodegroup --name ng-1`).
   - when the main resource is not the cluster, the cluster will be set in the `--cluster` flag (e.g.: `eksctl create nodegroup --cluster clus1 ng-1`)
   - for boolean flags, use `*bool` so that eksctl can know if a flag was explicitly enabled or disabled by the user
-  - add unit tests for the flags and config file parsing. These are tedious to manual test. See [profile_test.go](pkg/ctl/enable/profile_test.go) as an example
+  - add unit tests for the flags and config file parsing. These are tedious to manual test.
   - keep the number of CLI flags small. Not all options should have flags, but rather have a way to use them through the config file. In general, basic use cases can be covered by flags but more advanced options should only live in the config file.
   

--- a/docs/proposal-008-flux2.md
+++ b/docs/proposal-008-flux2.md
@@ -101,7 +101,7 @@ The unofficial motivations of this proposal are:
 ### Linked Docs
 
 [Original PR](https://github.com/weaveworks/eksctl/pull/3066).
-[Current eksctl docs](https://eksctl.io/usage/gitops-v2/#installing-flux-v2-gitops-toolkit).
+[Current eksctl docs](https://eksctl.io/usage/gitops-v2/#experimental-installing-flux-v2-gitops-toolkit).
 [Current Flux api object in eksctl](https://github.com/weaveworks/eksctl/blob/ab702daa671a87dc926b70348481ce336638f064/pkg/apis/eksctl.io/v1alpha5/types.go#L901-L937).
 [Expansion issue](https://github.com/weaveworks/eksctl/issues/3238).
 
@@ -208,7 +208,7 @@ not possible then we would have to change `flags` to be a `[]string`.
 Update: a PR has been opened to do this: [fluxcd/flux2#1390](https://github.com/fluxcd/flux2/pull/1390).
 
 Even if we were able to change that flag in Flux cli, we would have to hope that they didn't
-use `StringArrayVar` for bootstrap flags again (at least for a year, see future work [below](future-work)).
+use `StringArrayVar` for bootstrap flags again (at least for a year, see future work [below](#future-work)).
 
 See more on alternatives [below](#alternatives).
 

--- a/docs/proposal-008-flux2.md
+++ b/docs/proposal-008-flux2.md
@@ -101,7 +101,7 @@ The unofficial motivations of this proposal are:
 ### Linked Docs
 
 [Original PR](https://github.com/weaveworks/eksctl/pull/3066).
-[Current eksctl docs](https://eksctl.io/usage/gitops/#experimental-installing-flux-v2-gitops-toolkit).
+[Current eksctl docs](https://eksctl.io/usage/gitops-v2/#installing-flux-v2-gitops-toolkit).
 [Current Flux api object in eksctl](https://github.com/weaveworks/eksctl/blob/ab702daa671a87dc926b70348481ce336638f064/pkg/apis/eksctl.io/v1alpha5/types.go#L901-L937).
 [Expansion issue](https://github.com/weaveworks/eksctl/issues/3238).
 

--- a/docs/proposal-008-flux2.md
+++ b/docs/proposal-008-flux2.md
@@ -101,7 +101,7 @@ The unofficial motivations of this proposal are:
 ### Linked Docs
 
 [Original PR](https://github.com/weaveworks/eksctl/pull/3066).
-[Current eksctl docs](https://eksctl.io/usage/gitops-v2/#experimental-installing-flux-v2-gitops-toolkit).
+[Current eksctl docs](https://eksctl.io/usage/gitops/#experimental-installing-flux-v2-gitops-toolkit).
 [Current Flux api object in eksctl](https://github.com/weaveworks/eksctl/blob/ab702daa671a87dc926b70348481ce336638f064/pkg/apis/eksctl.io/v1alpha5/types.go#L901-L937).
 [Expansion issue](https://github.com/weaveworks/eksctl/issues/3238).
 

--- a/userdocs/src/index.md
+++ b/userdocs/src/index.md
@@ -91,7 +91,7 @@ able to use `kubectl`. You will need to make sure to use the same AWS API creden
 dependencies installed already.
 
 To learn more about how to create clusters and other features continue reading the
-[usage section](usage/creating-and-managing-clusters/).
+[usage section](usage/creating-and-managing-clusters).
 
 [ekskubectl]: https://docs.aws.amazon.com/eks/latest/userguide/configure-kubectl.html
 

--- a/userdocs/src/index.md
+++ b/userdocs/src/index.md
@@ -91,7 +91,7 @@ able to use `kubectl`. You will need to make sure to use the same AWS API creden
 dependencies installed already.
 
 To learn more about how to create clusters and other features continue reading the
-[usage section](usage/creating-and-managing-clusters).
+[usage section](creating-and-managing-clusters.md).
 
 [ekskubectl]: https://docs.aws.amazon.com/eks/latest/userguide/configure-kubectl.html
 

--- a/userdocs/src/index.md
+++ b/userdocs/src/index.md
@@ -91,7 +91,7 @@ able to use `kubectl`. You will need to make sure to use the same AWS API creden
 dependencies installed already.
 
 To learn more about how to create clusters and other features continue reading the
-[usage section](creating-and-managing-clusters.md).
+[Creating and Managing Clusters section](usage/creating-and-managing-clusters).
 
 [ekskubectl]: https://docs.aws.amazon.com/eks/latest/userguide/configure-kubectl.html
 

--- a/userdocs/src/usage/nodegroup-customize-dns.md
+++ b/userdocs/src/usage/nodegroup-customize-dns.md
@@ -3,7 +3,7 @@
 There are two ways of overwriting the DNS server IP address used for all the internal and external DNS lookups. This
 is the equivalent of the `--cluster-dns` flag for the `kubelet`.
 
-The first, is through the `clusterDNS` field. [Config files](../usage/schema) accepts a `string` field called
+The first, is through the `clusterDNS` field. [Config files](schema.md) accepts a `string` field called
 `clusterDNS` with the IP address of the DNS server to use.
 This will be passed to the `kubelet` that in turn will pass it to the pods through the `/etc/resolv.conf` file.
 
@@ -21,7 +21,7 @@ nodeGroups:
 ```
 
 Note that this configuration only accepts one IP address. To specify more than one address, use the
-[`kubeletExtraConfig` parameter](../usage/customizing-the-kubelet):
+[`kubeletExtraConfig` parameter](customizing-the-kubelet.md):
 
 ```yaml
 apiVersion: eksctl.io/v1alpha5

--- a/userdocs/src/usage/nodegroup-customize-dns.md
+++ b/userdocs/src/usage/nodegroup-customize-dns.md
@@ -3,7 +3,7 @@
 There are two ways of overwriting the DNS server IP address used for all the internal and external DNS lookups. This
 is the equivalent of the `--cluster-dns` flag for the `kubelet`.
 
-The first, is through the `clusterDNS` field. [Config files](../schema) accepts a `string` field called
+The first, is through the `clusterDNS` field. [Config files](../usage/schema) accepts a `string` field called
 `clusterDNS` with the IP address of the DNS server to use.
 This will be passed to the `kubelet` that in turn will pass it to the pods through the `/etc/resolv.conf` file.
 
@@ -21,7 +21,7 @@ nodeGroups:
 ```
 
 Note that this configuration only accepts one IP address. To specify more than one address, use the
-[`kubeletExtraConfig` parameter](../customizing-the-kubelet):
+[`kubeletExtraConfig` parameter](../usage/customizing-the-kubelet):
 
 ```yaml
 apiVersion: eksctl.io/v1alpha5

--- a/userdocs/src/usage/schema.md
+++ b/userdocs/src/usage/schema.md
@@ -1,6 +1,6 @@
 # Config file schema
 Use `eksctl utils schema` to get the raw JSON schema.
-<script type="module" src="schema.js"></script>
+<script type="module" src="../schema.js"></script>
 
 <table id="config"></table>
 

--- a/userdocs/src/usage/schema.md
+++ b/userdocs/src/usage/schema.md
@@ -1,6 +1,6 @@
 # Config file schema
 Use `eksctl utils schema` to get the raw JSON schema.
-<script type="module" src="../schema.js"></script>
+<script type="module" src="../usage/schema.js"></script>
 
 <table id="config"></table>
 

--- a/userdocs/src/usage/schema.md
+++ b/userdocs/src/usage/schema.md
@@ -1,6 +1,6 @@
 # Config file schema
 Use `eksctl utils schema` to get the raw JSON schema.
-<script type="module" src="../usage/schema.js"></script>
+<script type="module" src="schema.js"></script>
 
 <table id="config"></table>
 

--- a/userdocs/src/usage/vpc-networking.md
+++ b/userdocs/src/usage/vpc-networking.md
@@ -21,7 +21,7 @@ The nodegroup by default allows inbound traffic from the control plane security 
 
 If the default functionality doesn't suit you, the following sections explain how to customize VPC configuration further:
 
-- [VPC Configuration](../vpc-configuration)
-- [Subnet Settings](../vpc-subnet-settings)
-- [Cluster Access](../vpc-cluster-access)
-- [IP Family](../vpc-ip-family)
+- [VPC Configuration](vpc-configuration.md)
+- [Subnet Settings](vpc-subnet-settings.md)
+- [Cluster Access](vpc-cluster-access.md)
+- [IP Family](vpc-ip-family.md)


### PR DESCRIPTION
### Description
Following the suggestion here https://github.com/peter-evans/link-checker#warning-this-action-is-deprecated-please-consider-using-lychee-action
Updated the link checker to use lychee action

Closes https://github.com/weaveworks/eksctl-private/issues/422

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

