### PR TITLE
Pass GitHub token to release scripts

### DIFF
--- a/.github/workflows/publish-release-type.yaml
+++ b/.github/workflows/publish-release-type.yaml
@@ -28,9 +28,13 @@ jobs:
           make install-build-deps
       - name: Publish release
         if: ${{ !inputs.isReleaseCandidate }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.WEAVEWORKSBOT_TOKEN }}
         run: |
           ./build/scripts/do-release.sh
       - name: Publish release candidate
         if: ${{ inputs.isReleaseCandidate }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.WEAVEWORKSBOT_TOKEN }}
         run: |
           ./build/scripts/do-release-candidate.sh


### PR DESCRIPTION
### Description

The GitHub token is required to publish releases, but it wasn't being passed to the release scripts. 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

