### PR TITLE
add ipv6 route table entry when AllocateIPV6 is enabled

### DIFF
--- a/pkg/cfn/builder/vpc_ipv4_test.go
+++ b/pkg/cfn/builder/vpc_ipv4_test.go
@@ -286,6 +286,16 @@ var _ = Describe("VPC Template Builder", func() {
 				assertIpv6CidrBlockCreatedWithSelect(vpcTemplate.Resources["PrivateUSWEST2BCIDRv6"].Properties.Ipv6CidrBlock, expectedFnCIDR)
 				assertIpv6CidrBlockCreatedWithSelect(vpcTemplate.Resources["PrivateUSWEST2ACIDRv6"].Properties.Ipv6CidrBlock, expectedFnCIDR)
 			})
+
+			It("adds the ipv6 route table entry", func() {
+				Expect(vpcTemplate.Resources).To(HaveKey(pubRouteTable))
+				Expect(vpcTemplate.Resources[pubRouteTable].Properties.VpcID).To(Equal(makeRef(vpcResourceKey)))
+
+				Expect(vpcTemplate.Resources).To(HaveKey(builder.PubSubIPv6RouteKey))
+				Expect(vpcTemplate.Resources[builder.PubSubIPv6RouteKey].Properties.RouteTableID).To(Equal(makeRef(pubRouteTable)))
+				Expect(vpcTemplate.Resources[builder.PubSubIPv6RouteKey].Properties.DestinationIpv6CidrBlock).To(Equal(builder.InternetIPv6CIDR))
+				Expect(vpcTemplate.Resources[builder.PubSubIPv6RouteKey].Properties.GatewayID).To(Equal(makeRef(igwKey)))
+			})
 		})
 
 		Context("when the vpc is fully private", func() {


### PR DESCRIPTION
### Description
Closes https://github.com/weaveworks/eksctl/issues/1464

Adds an identical route entry that we add when we are creating an `ipv6` cluster, but for when `AllocateIPv6` is enabled on an `IPv4` cluster

```
./eksctl create cluster -f cluster.yaml
2022-02-15 16:13:09 [ℹ]  eksctl version 0.84.0-dev+9551631f.2022-02-15T16:10:35Z
2022-02-15 16:13:09 [ℹ]  using region us-west-2
2022-02-15 16:13:10 [ℹ]  setting availability zones to [us-west-2d us-west-2c us-west-2a]
2022-02-15 16:13:10 [ℹ]  subnets for us-west-2d - public:192.168.0.0/19 private:192.168.96.0/19
2022-02-15 16:13:10 [ℹ]  subnets for us-west-2c - public:192.168.32.0/19 private:192.168.128.0/19
2022-02-15 16:13:10 [ℹ]  subnets for us-west-2a - public:192.168.64.0/19 private:192.168.160.0/19
2022-02-15 16:13:10 [ℹ]  using Kubernetes version 1.21
2022-02-15 16:13:10 [ℹ]  creating EKS cluster "jk-alloc" in "us-west-2" region with
...
2022-02-15 16:13:41 [ℹ]  waiting for CloudFormation stack "eksctl-jk-alloc-cluster"
2022-02-15 16:14:12 [ℹ]  waiting for CloudFormation stack "eksctl-jk-alloc-cluster"
```

![alloc](https://user-images.githubusercontent.com/19669095/154102839-f762f003-1385-471c-b820-3168fc675351.png)
