### PR TITLE
Fix karpenter v0.6.3 install

### DIFF
--- a/examples/29-cluster-with-karpenter.yaml
+++ b/examples/29-cluster-with-karpenter.yaml
@@ -10,7 +10,7 @@ iam:
   withOIDC: true
 
 karpenter:
-  version: '0.5.6'
+  version: '0.6.3'
   createServiceAccount: true # default is false
 
 managedNodeGroups:

--- a/pkg/karpenter/karpenter.go
+++ b/pkg/karpenter/karpenter.go
@@ -19,7 +19,6 @@ const (
 	aws                      = "aws"
 	clusterEndpoint          = "clusterEndpoint"
 	clusterName              = "clusterName"
-	controller               = "controller"
 	create                   = "create"
 	defaultInstanceProfile   = "defaultInstanceProfile"
 	helmChartName            = "karpenter/karpenter"
@@ -71,10 +70,8 @@ func (k *Installer) Install(ctx context.Context, serviceAccountRoleARN string, i
 		}
 	}
 	values := map[string]interface{}{
-		controller: map[string]interface{}{
-			clusterName:     k.ClusterConfig.Metadata.Name,
-			clusterEndpoint: k.ClusterConfig.Status.Endpoint,
-		},
+		clusterName:     k.ClusterConfig.Metadata.Name,
+		clusterEndpoint: k.ClusterConfig.Status.Endpoint,
 		aws: map[string]interface{}{
 			defaultInstanceProfile: instanceProfileName,
 		},

--- a/pkg/karpenter/karpenter_test.go
+++ b/pkg/karpenter/karpenter_test.go
@@ -47,10 +47,8 @@ var _ = Describe("Install", func() {
 			Expect(installerUnderTest.Install(context.Background(), "", "role/profile")).To(Succeed())
 			_, args := fakeHelmInstaller.InstallChartArgsForCall(0)
 			values := map[string]interface{}{
-				controller: map[string]interface{}{
-					clusterName:     cfg.Metadata.Name,
-					clusterEndpoint: cfg.Status.Endpoint,
-				},
+				clusterName:     cfg.Metadata.Name,
+				clusterEndpoint: cfg.Status.Endpoint,
 				serviceAccount: map[string]interface{}{
 					create: api.IsEnabled(cfg.Karpenter.CreateServiceAccount),
 				},
@@ -138,10 +136,8 @@ var _ = Describe("Install", func() {
 				Expect(installerUnderTest.Install(context.Background(), "role/account", "role/profile")).To(Succeed())
 				_, opts := fakeHelmInstaller.InstallChartArgsForCall(0)
 				values := map[string]interface{}{
-					controller: map[string]interface{}{
-						clusterName:     cfg.Metadata.Name,
-						clusterEndpoint: cfg.Status.Endpoint,
-					},
+					clusterName:     cfg.Metadata.Name,
+					clusterEndpoint: cfg.Status.Endpoint,
 					serviceAccount: map[string]interface{}{
 						create: api.IsEnabled(cfg.Karpenter.CreateServiceAccount),
 						serviceAccountAnnotation: map[string]interface{}{

--- a/userdocs/src/usage/eksctl-karpenter.md
+++ b/userdocs/src/usage/eksctl-karpenter.md
@@ -15,12 +15,14 @@ metadata:
   name: cluster-with-karpenter
   region: us-west-2
   version: '1.20'
+  tags:
+    karpenter.sh/discovery: cluster-with-karpenter
 
 iam:
   withOIDC: true # required
 
 karpenter:
-  version: '0.6.0'
+  version: '0.6.3'
 
 managedNodeGroups:
   - name: managed-ng-1
@@ -34,7 +36,7 @@ to be set:
 
 ```yaml
 karpenter:
-  version: '0.6.0'
+  version: '0.6.3'
   createServiceAccount: true # default is false
   defaultInstanceProfile: 'KarpenterNodeInstanceProfile' # default is to use the IAM instance profile created by eksctl
 ```


### PR DESCRIPTION
### Description
This PR fixes the Karpenter helm installation and addresses the docs to include the `karpenter.sh/discovery` tag which was recently changed from the cluster tag:

https://github.com/weaveworks/eksctl/issues/4804
https://github.com/weaveworks/eksctl/issues/4806


<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

I did a manual test to reproduce the deployment failures which was caused by the Karpenter project changing the `controller.clusterName` and `controller.clusterEndpoint`  to just `clusterName` and `clusterEndpoint`. 

I created a new cluster with my change using the below spec and a new cluster came up with Karpenter working:

```
$ ./eksctl create cluster -f - << EOF
---
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig
metadata:
  name: ${CLUSTER_NAME}
  region: us-east-2
  version: "1.21"
  tags:
    karpenter.sh/discovery: ${CLUSTER_NAME}
managedNodeGroups:
  - instanceType: m5.large
    amiFamily: AmazonLinux2
    name: ${CLUSTER_NAME}-ng
    desiredCapacity: 1
    minSize: 1
    maxSize: 10
iam:
  withOIDC: true
karpenter:
  version: '0.6.3'
  createServiceAccount: true
EOF
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

