### PR TITLE
Add support for Bottlerocket nodgroups with NVIDIA accelerated hardware

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -488,8 +488,14 @@ func validateNodeGroupBase(np NodePool, path string) error {
 		}
 	}
 
-	if instanceutils.IsGPUInstanceType(SelectInstanceType(np)) && (ng.AMIFamily != NodeImageFamilyAmazonLinux2 && ng.AMIFamily != "") {
-		return errors.Errorf("GPU instance types are not supported for %s", ng.AMIFamily)
+	// Only AmazonLinux2 and Bottlerocket support NVIDIA GPUs
+	if instanceutils.IsNvidiaInstanceType(SelectInstanceType(np)) && (ng.AMIFamily != NodeImageFamilyAmazonLinux2 && ng.AMIFamily != NodeImageFamilyBottlerocket && ng.AMIFamily != "") {
+		return errors.Errorf("NVIDIA GPU instance types are not supported for %s", ng.AMIFamily)
+	}
+
+	// Bottlerocket doesn't support Inferentia hosts
+	if instanceutils.IsInferentiaInstanceType(SelectInstanceType(np)) && ng.AMIFamily == NodeImageFamilyBottlerocket {
+		return errors.Errorf("Inferentia instance types are not supported for %s", ng.AMIFamily)
 	}
 
 	return nil

--- a/pkg/utils/instance/instance.go
+++ b/pkg/utils/instance/instance.go
@@ -20,13 +20,18 @@ func IsARMInstanceType(instanceType string) bool {
 
 // IsGPUInstanceType returns true if the instance type is GPU optimised
 func IsGPUInstanceType(instanceType string) bool {
+	return IsNvidiaInstanceType(instanceType) ||
+		IsInferentiaInstanceType(instanceType)
+}
+
+// IsNvidiaInstanceType returns true if the instance type has NVIDIA accelerated hardware
+func IsNvidiaInstanceType(instanceType string) bool {
 	return strings.HasPrefix(instanceType, "p2") ||
 		strings.HasPrefix(instanceType, "p3") ||
 		strings.HasPrefix(instanceType, "p4") ||
 		strings.HasPrefix(instanceType, "g3") ||
 		strings.HasPrefix(instanceType, "g4") ||
-		strings.HasPrefix(instanceType, "g5") ||
-		strings.HasPrefix(instanceType, "inf1")
+		strings.HasPrefix(instanceType, "g5")
 }
 
 // IsInferentiaInstanceType returns true if the instance type requires AWS Neuron

--- a/userdocs/src/usage/gpu-support.md
+++ b/userdocs/src/usage/gpu-support.md
@@ -24,3 +24,6 @@ eksctl create cluster --node-type=p2.xlarge --install-nvidia-plugin=false
 
 kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/<VERSION>/nvidia-device-plugin.yml
 ```
+
+The installation of the [NVIDIA Kubernetes device plugin](https://github.com/NVIDIA/k8s-device-plugin) will be skipped if the cluster only includes Bottlerocket nodegroups, since Bottlerocket already handles the execution of the device plugin.
+If you use different AMI families in your cluster's configurations, you may need to use taints and tolerations to keep the device plugin from running on Bottlerocket nodes.


### PR DESCRIPTION
### Description
Closes #4760

This pull request adds support for Bottlerocket nodegroups with NVIDIA accelerated hardware, the changes are as follows:

```
    Differentiate among accelerated hardware providers

    `IsGPUInstanceType` groups all together NVIDIA and inferentia instances
    which makes it difficult to reuse for OS'es that don't vend one image
    with support for multiple accelerated hardware.

    With this change, the instances with support for NVIDIA GPUs are
    separated in its own function (like inferentia instances), which is
    called by `IsGPUInstanceType`.
```

```
    Autoresolve SSM parameters for Bottlerocket GPU nodegroups

    This ensures that the correct SSM parameter is used to fetch the AMI id
    for Bottlerocket nodegroups with NVIDIA hardware.
```

```
    Skip NVIDIA device plugin daemonset in Bottlerocket node groups

    The Bottlerocket NVIDIA AMI already provides the NVIDIA device plugin,
    so Bottlerocket node groups don't require the NVIDIA device plugin
    daemonset.

    This change makes sure that clusters with only Bottlerocket nodegroups
    don't get the NVIDIA device plugin daemonset. If any of the nodegroups
    in the cluster's configuration uses an OS that requires the device
    plugin, it will be installed.
```

### Manual testing

- With the following configuration file, I verified that the correct AMI was auto resolved based on the `amiFamily` and the `instanceType`, and that the device plugin daemonset wasn't installed:

```yaml
---
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: bottlerocket-1-21
  region: us-west-2
  version: '1.21'

nodeGroups:
  - name: al2-without-plugin-ng
    instanceType: m5.large
    desiredCapacity: 1
  - name: br-without-plugin
    instanceType: p3.2xlarge
    desiredCapacity: 1
    amiFamily: Bottlerocket
    iam:
       attachPolicyARNs:
          - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
          - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
          - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
          - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
    ssh:
        allow: true
        publicKeyName: <>
    bottlerocket:
      settings:
        motd: "Hello from eksctl!"
        host-containers:
          admin:
            enabled: true
```

```sh
~ ❯ eksctl get nodegroup --cluster bottlerocket-1-21 -o json | jq '.[].Name, .[].Type, .[].ImageID' -r
br-without-plugin
unmanaged
ami-06e0114f5eb33d00c
~ ❯ kubectl get daemonsets -A | grep nvidia
 # returns empty
```

- With the following configuration file, I verified that the correct AMI was auto resolved based on the `amiFamily` and the `instanceType`, and that the device plugin daemonset was installed since I included an AL2 nodegroup:

```yaml
---
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: bottlerocket-1-21
  region: us-west-2
  version: '1.21'

nodeGroups:
  - name: br-with-plugin
    instanceType: p3.2xlarge
    desiredCapacity: 1
    amiFamily: Bottlerocket
    iam:
       attachPolicyARNs:
          - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
          - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
          - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
          - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
    ssh:
        allow: true
        publicKeyName: <>
    bottlerocket:
      settings:
        motd: "Hello from eksctl!"
        host-containers:
          admin:
            enabled: true
  - name: al2-with-plugin
    instanceType: p3.2xlarge
    desiredCapacity: 1
    iam:
       attachPolicyARNs:
          - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
          - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
          - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
          - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
    ssh:
        allow: true
        publicKeyName: <>
```

```sh
❯ eksctl get nodegroup --cluster bottlerocket-1-21 -o json | jq '.[].Name, .[].Type, .[].ImageID' -r
al2-with-plugin
br-with-plugin
br-without-plugin
unmanaged
unmanaged
unmanaged
ami-0a2fbc9dc946cfc58
ami-06e0114f5eb33d00c
ami-06e0114f5eb33d00c

~ ❯ kubectl get daemonsets -A | grep nvidia
kube-system   nvidia-device-plugin-daemonset   3         3         3       3            3           <none>          6m30s
```

### Checklist
- [X] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
