### PR TITLE
Move some validation functions to standard `ValidateClusterConfig` validation function

### DIFF
--- a/pkg/actions/nodegroup/create.go
+++ b/pkg/actions/nodegroup/create.go
@@ -72,10 +72,6 @@ func (m *Manager) Create(options CreateOpts, nodegroupFilter filter.NodegroupFil
 		return errors.New("Managed Nodegroups are not supported for this cluster version. Please update the cluster before adding managed nodegroups")
 	}
 
-	if err := eks.ValidateBottlerocketSupport(ctl.ControlPlaneVersion(), cmdutils.ToKubeNodeGroups(cfg)); err != nil {
-		return err
-	}
-
 	m.init.NewAWSSelectorSession(ctl.Provider)
 	nodePools := cmdutils.ToNodePools(cfg)
 

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -806,7 +806,6 @@ func NewClusterVPC(ipv6Enabled bool) *ClusterVPC {
 		ManageSharedNodeSecurityGroupRules: Enabled(),
 		NAT:                                nat,
 		AutoAllocateIPv6:                   Disabled(),
-		ClusterEndpoints:                   &ClusterEndpoints{},
 	}
 }
 

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -195,6 +195,15 @@ func (c *ClusterConfig) ValidateVPCConfig() error {
 	if c.VPC == nil {
 		return nil
 	}
+
+	if err := c.ValidatePrivateCluster(); err != nil {
+		return err
+	}
+
+	if err := c.ValidateClusterEndpointConfig(); err != nil {
+		return err
+	}
+
 	if len(c.VPC.ExtraCIDRs) > 0 {
 		cidrs, err := validateCIDRs(c.VPC.ExtraCIDRs)
 		if err != nil {
@@ -315,12 +324,15 @@ func (c *ClusterConfig) addonContainsManagedAddons(addons []string) []string {
 
 // ValidateClusterEndpointConfig checks the endpoint configuration for potential issues
 func (c *ClusterConfig) ValidateClusterEndpointConfig() error {
-	if !c.HasClusterEndpointAccess() {
-		return ErrClusterEndpointNoAccess
-	}
-	endpts := c.VPC.ClusterEndpoints
-	if noAccess(endpts) {
-		return ErrClusterEndpointNoAccess
+	if c.VPC.ClusterEndpoints != nil {
+		if !c.HasClusterEndpointAccess() {
+			return ErrClusterEndpointNoAccess
+		}
+		endpts := c.VPC.ClusterEndpoints
+
+		if noAccess(endpts) {
+			return ErrClusterEndpointNoAccess
+		}
 	}
 	return nil
 }

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -141,6 +141,10 @@ func ValidateClusterConfig(cfg *ClusterConfig) error {
 		return fmt.Errorf("failed to validate karpenter config: %w", err)
 	}
 
+	if err := ValidateSecretsEncryption(cfg); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -1289,4 +1293,15 @@ func validateAvailabilityZones(azList []string) error {
 
 func ErrTooFewAvailabilityZones(azs []string) error {
 	return fmt.Errorf("only %d zone(s) specified %v, %d are required (can be non-unique)", len(azs), azs, MinRequiredAvailabilityZones)
+}
+
+func ValidateSecretsEncryption(clusterConfig *ClusterConfig) error {
+	if clusterConfig.SecretsEncryption == nil {
+		return nil
+	}
+
+	if _, err := arn.Parse(clusterConfig.SecretsEncryption.KeyARN); err != nil {
+		return errors.Wrapf(err, "invalid ARN in secretsEncryption.keyARN: %q", clusterConfig.SecretsEncryption.KeyARN)
+	}
+	return nil
 }

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -133,16 +133,12 @@ func ValidateClusterConfig(cfg *ClusterConfig) error {
 		return err
 	}
 
-	if cfg.SecretsEncryption != nil && cfg.SecretsEncryption.KeyARN == "" {
-		return errors.New("field secretsEncryption.keyARN is required for enabling secrets encryption")
+	if err := ValidateSecretsEncryption(cfg); err != nil {
+		return err
 	}
 
 	if err := validateKarpenterConfig(cfg); err != nil {
 		return fmt.Errorf("failed to validate karpenter config: %w", err)
-	}
-
-	if err := ValidateSecretsEncryption(cfg); err != nil {
-		return err
 	}
 
 	return nil
@@ -1298,6 +1294,10 @@ func ErrTooFewAvailabilityZones(azs []string) error {
 func ValidateSecretsEncryption(clusterConfig *ClusterConfig) error {
 	if clusterConfig.SecretsEncryption == nil {
 		return nil
+	}
+
+	if clusterConfig.SecretsEncryption.KeyARN == "" {
+		return errors.New("field secretsEncryption.keyARN is required for enabling secrets encryption")
 	}
 
 	if _, err := arn.Parse(clusterConfig.SecretsEncryption.KeyARN); err != nil {

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -1812,6 +1812,36 @@ var _ = Describe("ClusterConfig validation", func() {
 			})
 		})
 	})
+
+	Describe("Validate SecretsEncryption", func() {
+		var cfg *api.ClusterConfig
+
+		BeforeEach(func() {
+			cfg = api.NewClusterConfig()
+		})
+
+		When("a SecretsEncryption is set", func() {
+			When("the key is valid", func() {
+				It("does not return an error", func() {
+					cfg.SecretsEncryption = &api.SecretsEncryption{
+						KeyARN: "arn:aws:kms:us-west-2:000000000000:key/12345-12345",
+					}
+					err := api.ValidateClusterConfig(cfg)
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+
+			When("the key is invalid", func() {
+				It("returns an error", func() {
+					cfg.SecretsEncryption = &api.SecretsEncryption{
+						KeyARN: "invalid:arn",
+					}
+					err := api.ValidateClusterConfig(cfg)
+					Expect(err).To(MatchError(ContainSubstring("invalid ARN")))
+				})
+			})
+		})
+	})
 })
 
 func newInt(value int) *int {

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -582,44 +582,60 @@ var _ = Describe("ClusterConfig validation", func() {
 		}),
 	)
 
-	Describe("cluster endpoint access config", func() {
-		var (
-			cfg *api.ClusterConfig
-			vpc *api.ClusterVPC
-			err error
-		)
+	Describe("Cluster Endpoint access", func() {
+		var cfg *api.ClusterConfig
 
 		BeforeEach(func() {
 			cfg = api.NewClusterConfig()
-			vpc = api.NewClusterVPC(false)
-			cfg.VPC = vpc
 		})
 
-		It("should not error on private=true, public=true", func() {
-			cfg.VPC.ClusterEndpoints =
-				&api.ClusterEndpoints{PrivateAccess: api.Enabled(), PublicAccess: api.Enabled()}
-			err = cfg.ValidateClusterEndpointConfig()
-			Expect(err).NotTo(HaveOccurred())
+		When("VPC is not set", func() {
+			It("should have cluster endpoint access", func() {
+				err := api.ValidateClusterConfig(cfg)
+				Expect(err).NotTo(HaveOccurred())
+			})
 		})
 
-		It("should not error on private=false, public=true", func() {
-			cfg.VPC.ClusterEndpoints =
-				&api.ClusterEndpoints{PrivateAccess: api.Disabled(), PublicAccess: api.Enabled()}
-			err = cfg.ValidateClusterEndpointConfig()
-			Expect(err).NotTo(HaveOccurred())
-		})
+		When("VPC is set", func() {
+			BeforeEach(func() {
+				cfg.VPC = &api.ClusterVPC{}
+			})
 
-		It("should not error on private=true, public=false", func() {
-			cfg.VPC.ClusterEndpoints =
-				&api.ClusterEndpoints{PrivateAccess: api.Enabled(), PublicAccess: api.Disabled()}
-			err = cfg.ValidateClusterEndpointConfig()
-			Expect(err).NotTo(HaveOccurred())
-		})
+			When("no cluster endpoint config is set", func() {
+				It("should not error", func() {
+					err := api.ValidateClusterConfig(cfg)
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
 
-		It("should error on private=false, public=false", func() {
-			cfg.VPC.ClusterEndpoints = &api.ClusterEndpoints{PrivateAccess: api.Disabled(), PublicAccess: api.Disabled()}
-			err = cfg.ValidateClusterEndpointConfig()
-			Expect(err).To(BeIdenticalTo(api.ErrClusterEndpointNoAccess))
+			When("cluster endpoint config exists", func() {
+				It("should not error on private=true, public=true", func() {
+					cfg.VPC.ClusterEndpoints =
+						&api.ClusterEndpoints{PrivateAccess: api.Enabled(), PublicAccess: api.Enabled()}
+					err := api.ValidateClusterConfig(cfg)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should not error on private=false, public=true", func() {
+					cfg.VPC.ClusterEndpoints =
+						&api.ClusterEndpoints{PrivateAccess: api.Disabled(), PublicAccess: api.Enabled()}
+					err := api.ValidateClusterConfig(cfg)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should not error on private=true, public=false", func() {
+					cfg.VPC.ClusterEndpoints =
+						&api.ClusterEndpoints{PrivateAccess: api.Enabled(), PublicAccess: api.Disabled()}
+					err := api.ValidateClusterConfig(cfg)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should error on private=false, public=false", func() {
+					cfg.VPC.ClusterEndpoints = &api.ClusterEndpoints{PrivateAccess: api.Disabled(), PublicAccess: api.Disabled()}
+					err := api.ValidateClusterConfig(cfg)
+					Expect(err).To(MatchError(api.ErrClusterEndpointNoAccess))
+				})
+			})
 		})
 	})
 
@@ -639,7 +655,7 @@ var _ = Describe("ClusterConfig validation", func() {
 		})
 		When("private cluster is enabled", func() {
 			It("validates the config", func() {
-				err := cfg.ValidatePrivateCluster()
+				err := api.ValidateClusterConfig(cfg)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -647,7 +663,7 @@ var _ = Describe("ClusterConfig validation", func() {
 			It("fails the validation", func() {
 				cfg.VPC.Subnets = &api.ClusterSubnets{}
 				cfg.VPC.ID = "id"
-				err := cfg.ValidatePrivateCluster()
+				err := api.ValidateClusterConfig(cfg)
 				Expect(err).To(MatchError(ContainSubstring("vpc.subnets.private must be specified in a fully-private cluster when a pre-existing VPC is supplied")))
 			})
 		})
@@ -655,28 +671,28 @@ var _ = Describe("ClusterConfig validation", func() {
 			It("fails the validation", func() {
 				cfg.PrivateCluster.AdditionalEndpointServices = []string{api.EndpointServiceCloudFormation}
 				cfg.PrivateCluster.SkipEndpointCreation = true
-				err := cfg.ValidatePrivateCluster()
+				err := api.ValidateClusterConfig(cfg)
 				Expect(err).To(MatchError(ContainSubstring("privateCluster.additionalEndpointServices cannot be set when privateCluster.skipEndpointCreation is true")))
 			})
 		})
 		When("additional endpoints are defined", func() {
 			It("validates the endpoint configuration", func() {
 				cfg.PrivateCluster.AdditionalEndpointServices = []string{api.EndpointServiceCloudFormation}
-				err := cfg.ValidatePrivateCluster()
+				err := api.ValidateClusterConfig(cfg)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 		When("additional endpoints are defined incorrectly", func() {
 			It("fails the endpoint validation", func() {
 				cfg.PrivateCluster.AdditionalEndpointServices = []string{"unknown"}
-				err := cfg.ValidatePrivateCluster()
+				err := api.ValidateClusterConfig(cfg)
 				Expect(err).To(MatchError(ContainSubstring("invalid value in privateCluster.additionalEndpointServices")))
 			})
 		})
 		When("private cluster is enabled with skip endpoints", func() {
 			It("does not fail the validation", func() {
 				cfg.PrivateCluster.SkipEndpointCreation = true
-				err := cfg.ValidatePrivateCluster()
+				err := api.ValidateClusterConfig(cfg)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -1780,6 +1780,22 @@ var _ = Describe("ClusterConfig validation", func() {
 			},
 		}),
 	)
+
+	Describe("Availability Zones", func() {
+		When("the config file does not specify any AZ", func() {
+			It("skips validation", func() {
+				Expect(api.ValidateClusterConfig(api.NewClusterConfig())).NotTo(HaveOccurred())
+			})
+		})
+
+		When("the config file contains too few availability zones", func() {
+			It("returns an error", func() {
+				cfg := api.NewClusterConfig()
+				cfg.AvailabilityZones = append(cfg.AvailabilityZones, "az-1")
+				Expect(api.ValidateClusterConfig(cfg)).To(MatchError("only 1 zone(s) specified [az-1], 2 are required (can be non-unique)"))
+			})
+		})
+	})
 })
 
 func newInt(value int) *int {

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -1820,7 +1820,7 @@ var _ = Describe("ClusterConfig validation", func() {
 			cfg = api.NewClusterConfig()
 		})
 
-		When("a SecretsEncryption is set", func() {
+		When("a key ARN is set", func() {
 			When("the key is valid", func() {
 				It("does not return an error", func() {
 					cfg.SecretsEncryption = &api.SecretsEncryption{
@@ -1839,6 +1839,14 @@ var _ = Describe("ClusterConfig validation", func() {
 					err := api.ValidateClusterConfig(cfg)
 					Expect(err).To(MatchError(ContainSubstring("invalid ARN")))
 				})
+			})
+		})
+
+		When("a key ARN is not set", func() {
+			It("returns an error", func() {
+				cfg.SecretsEncryption = &api.SecretsEncryption{}
+				err := api.ValidateClusterConfig(cfg)
+				Expect(err).To(MatchError(ContainSubstring("field secretsEncryption.keyARN is required for enabling secrets encryption")))
 			})
 		})
 	})

--- a/pkg/apis/eksctl.io/v1alpha5/vpc.go
+++ b/pkg/apis/eksctl.io/v1alpha5/vpc.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"reflect"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/pkg/errors"
 
 	"github.com/weaveworks/eksctl/pkg/utils/ipnet"
@@ -406,10 +407,8 @@ func EndpointsEqual(a, b ClusterEndpoints) bool {
 //HasClusterEndpointAccess determines if endpoint access was configured in config file or not
 func (c *ClusterConfig) HasClusterEndpointAccess() bool {
 	if c.VPC != nil && c.VPC.ClusterEndpoints != nil {
-		pubAccess := c.VPC.ClusterEndpoints.PublicAccess
-		privAccess := c.VPC.ClusterEndpoints.PrivateAccess
-		hasPublicAccess := pubAccess != nil && *pubAccess
-		hasPrivateAccess := privAccess != nil && *privAccess
+		hasPublicAccess := aws.BoolValue(c.VPC.ClusterEndpoints.PublicAccess)
+		hasPrivateAccess := aws.BoolValue(c.VPC.ClusterEndpoints.PrivateAccess)
 		return hasPublicAccess || hasPrivateAccess
 	}
 	return true

--- a/pkg/cfn/manager/create_tasks.go
+++ b/pkg/cfn/manager/create_tasks.go
@@ -22,7 +22,7 @@ const (
 // NewTasksToCreateClusterWithNodeGroups defines all tasks required to create a cluster along
 // with some nodegroups; see CreateAllNodeGroups for how onlyNodeGroupSubset works
 func (c *StackCollection) NewTasksToCreateClusterWithNodeGroups(nodeGroups []*api.NodeGroup,
-	managedNodeGroups []*api.ManagedNodeGroup, supportsManagedNodes bool, postClusterCreationTasks ...tasks.Task) *tasks.TaskTree {
+	managedNodeGroups []*api.ManagedNodeGroup, postClusterCreationTasks ...tasks.Task) *tasks.TaskTree {
 
 	taskTree := tasks.TaskTree{Parallel: false}
 
@@ -30,7 +30,7 @@ func (c *StackCollection) NewTasksToCreateClusterWithNodeGroups(nodeGroups []*ap
 		&createClusterTask{
 			info:                 fmt.Sprintf("create cluster control plane %q", c.spec.Metadata.Name),
 			stackCollection:      c,
-			supportsManagedNodes: supportsManagedNodes,
+			supportsManagedNodes: true,
 		},
 	)
 

--- a/pkg/cfn/manager/fakes/fake_stack_manager.go
+++ b/pkg/cfn/manager/fakes/fake_stack_manager.go
@@ -562,13 +562,12 @@ type FakeStackManager struct {
 	newTaskToDeleteUnownedNodeGroupReturnsOnCall map[int]struct {
 		result1 tasks.Task
 	}
-	NewTasksToCreateClusterWithNodeGroupsStub        func([]*v1alpha5.NodeGroup, []*v1alpha5.ManagedNodeGroup, bool, ...tasks.Task) *tasks.TaskTree
+	NewTasksToCreateClusterWithNodeGroupsStub        func([]*v1alpha5.NodeGroup, []*v1alpha5.ManagedNodeGroup, ...tasks.Task) *tasks.TaskTree
 	newTasksToCreateClusterWithNodeGroupsMutex       sync.RWMutex
 	newTasksToCreateClusterWithNodeGroupsArgsForCall []struct {
 		arg1 []*v1alpha5.NodeGroup
 		arg2 []*v1alpha5.ManagedNodeGroup
-		arg3 bool
-		arg4 []tasks.Task
+		arg3 []tasks.Task
 	}
 	newTasksToCreateClusterWithNodeGroupsReturns struct {
 		result1 *tasks.TaskTree
@@ -3385,7 +3384,7 @@ func (fake *FakeStackManager) NewTaskToDeleteUnownedNodeGroupReturnsOnCall(i int
 	}{result1}
 }
 
-func (fake *FakeStackManager) NewTasksToCreateClusterWithNodeGroups(arg1 []*v1alpha5.NodeGroup, arg2 []*v1alpha5.ManagedNodeGroup, arg3 bool, arg4 ...tasks.Task) *tasks.TaskTree {
+func (fake *FakeStackManager) NewTasksToCreateClusterWithNodeGroups(arg1 []*v1alpha5.NodeGroup, arg2 []*v1alpha5.ManagedNodeGroup, arg3 ...tasks.Task) *tasks.TaskTree {
 	var arg1Copy []*v1alpha5.NodeGroup
 	if arg1 != nil {
 		arg1Copy = make([]*v1alpha5.NodeGroup, len(arg1))
@@ -3401,15 +3400,14 @@ func (fake *FakeStackManager) NewTasksToCreateClusterWithNodeGroups(arg1 []*v1al
 	fake.newTasksToCreateClusterWithNodeGroupsArgsForCall = append(fake.newTasksToCreateClusterWithNodeGroupsArgsForCall, struct {
 		arg1 []*v1alpha5.NodeGroup
 		arg2 []*v1alpha5.ManagedNodeGroup
-		arg3 bool
-		arg4 []tasks.Task
-	}{arg1Copy, arg2Copy, arg3, arg4})
+		arg3 []tasks.Task
+	}{arg1Copy, arg2Copy, arg3})
 	stub := fake.NewTasksToCreateClusterWithNodeGroupsStub
 	fakeReturns := fake.newTasksToCreateClusterWithNodeGroupsReturns
-	fake.recordInvocation("NewTasksToCreateClusterWithNodeGroups", []interface{}{arg1Copy, arg2Copy, arg3, arg4})
+	fake.recordInvocation("NewTasksToCreateClusterWithNodeGroups", []interface{}{arg1Copy, arg2Copy, arg3})
 	fake.newTasksToCreateClusterWithNodeGroupsMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4...)
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
@@ -3423,17 +3421,17 @@ func (fake *FakeStackManager) NewTasksToCreateClusterWithNodeGroupsCallCount() i
 	return len(fake.newTasksToCreateClusterWithNodeGroupsArgsForCall)
 }
 
-func (fake *FakeStackManager) NewTasksToCreateClusterWithNodeGroupsCalls(stub func([]*v1alpha5.NodeGroup, []*v1alpha5.ManagedNodeGroup, bool, ...tasks.Task) *tasks.TaskTree) {
+func (fake *FakeStackManager) NewTasksToCreateClusterWithNodeGroupsCalls(stub func([]*v1alpha5.NodeGroup, []*v1alpha5.ManagedNodeGroup, ...tasks.Task) *tasks.TaskTree) {
 	fake.newTasksToCreateClusterWithNodeGroupsMutex.Lock()
 	defer fake.newTasksToCreateClusterWithNodeGroupsMutex.Unlock()
 	fake.NewTasksToCreateClusterWithNodeGroupsStub = stub
 }
 
-func (fake *FakeStackManager) NewTasksToCreateClusterWithNodeGroupsArgsForCall(i int) ([]*v1alpha5.NodeGroup, []*v1alpha5.ManagedNodeGroup, bool, []tasks.Task) {
+func (fake *FakeStackManager) NewTasksToCreateClusterWithNodeGroupsArgsForCall(i int) ([]*v1alpha5.NodeGroup, []*v1alpha5.ManagedNodeGroup, []tasks.Task) {
 	fake.newTasksToCreateClusterWithNodeGroupsMutex.RLock()
 	defer fake.newTasksToCreateClusterWithNodeGroupsMutex.RUnlock()
 	argsForCall := fake.newTasksToCreateClusterWithNodeGroupsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeStackManager) NewTasksToCreateClusterWithNodeGroupsReturns(result1 *tasks.TaskTree) {

--- a/pkg/cfn/manager/interface.go
+++ b/pkg/cfn/manager/interface.go
@@ -77,7 +77,7 @@ type StackManager interface {
 	NewManagedNodeGroupTask(nodeGroups []*v1alpha5.ManagedNodeGroup, forceAddCNIPolicy bool, importer vpc.Importer) *tasks.TaskTree
 	NewTaskToDeleteAddonIAM(wait bool) (*tasks.TaskTree, error)
 	NewTaskToDeleteUnownedNodeGroup(clusterName, nodegroup string, eksAPI eksiface.EKSAPI, waitCondition *DeleteWaitCondition) tasks.Task
-	NewTasksToCreateClusterWithNodeGroups(nodeGroups []*v1alpha5.NodeGroup, managedNodeGroups []*v1alpha5.ManagedNodeGroup, supportsManagedNodes bool, postClusterCreationTasks ...tasks.Task) *tasks.TaskTree
+	NewTasksToCreateClusterWithNodeGroups(nodeGroups []*v1alpha5.NodeGroup, managedNodeGroups []*v1alpha5.ManagedNodeGroup, postClusterCreationTasks ...tasks.Task) *tasks.TaskTree
 	NewTasksToCreateIAMServiceAccounts(serviceAccounts []*v1alpha5.ClusterIAMServiceAccount, oidc *iamoidc.OpenIDConnectManager, clientSetGetter kubernetes.ClientSetGetter) *tasks.TaskTree
 	NewTasksToDeleteClusterWithNodeGroups(stack *Stack, stacks []NodeGroupStack, deleteOIDCProvider bool, oidc *iamoidc.OpenIDConnectManager, clientSetGetter kubernetes.ClientSetGetter, wait bool, cleanup func(chan error, string) error) (*tasks.TaskTree, error)
 	NewTasksToDeleteIAMServiceAccounts(serviceAccounts []string, clientSetGetter kubernetes.ClientSetGetter, wait bool) (*tasks.TaskTree, error)

--- a/pkg/cfn/manager/tasks_test.go
+++ b/pkg/cfn/manager/tasks_test.go
@@ -90,7 +90,7 @@ var _ = Describe("StackCollection Tasks", func() {
 				Expect(tasks.Describe()).To(Equal(`no tasks`))
 			}
 			{
-				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar", "foo"), nil, true)
+				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar", "foo"), nil)
 				Expect(tasks.Describe()).To(Equal(`
 2 sequential tasks: { create cluster control plane "test-cluster", 
     2 parallel sub-tasks: { 
@@ -101,18 +101,18 @@ var _ = Describe("StackCollection Tasks", func() {
 `))
 			}
 			{
-				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar"), nil, false)
+				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar"), nil)
 				Expect(tasks.Describe()).To(Equal(`
 2 sequential tasks: { create cluster control plane "test-cluster", create nodegroup "bar" 
 }
 `))
 			}
 			{
-				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(nil, nil, true)
+				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(nil, nil)
 				Expect(tasks.Describe()).To(Equal(`1 task: { create cluster control plane "test-cluster" }`))
 			}
 			{
-				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar", "foo"), makeManagedNodeGroups("m1", "m2"), false)
+				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar", "foo"), makeManagedNodeGroups("m1", "m2"))
 				Expect(tasks.Describe()).To(Equal(`
 2 sequential tasks: { create cluster control plane "test-cluster", 
     4 parallel sub-tasks: { 
@@ -125,7 +125,7 @@ var _ = Describe("StackCollection Tasks", func() {
 `))
 			}
 			{
-				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("foo"), makeManagedNodeGroups("m1"), true)
+				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("foo"), makeManagedNodeGroups("m1"))
 				Expect(tasks.Describe()).To(Equal(`
 2 sequential tasks: { create cluster control plane "test-cluster", 
     2 parallel sub-tasks: { 
@@ -136,7 +136,7 @@ var _ = Describe("StackCollection Tasks", func() {
 `))
 			}
 			{
-				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar"), nil, false, &task{id: 1})
+				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar"), nil, &task{id: 1})
 				Expect(tasks.Describe()).To(Equal(`
 2 sequential tasks: { create cluster control plane "test-cluster", 
     2 sequential sub-tasks: { 
@@ -153,7 +153,7 @@ var _ = Describe("StackCollection Tasks", func() {
 				cfg.KubernetesNetworkConfig.IPFamily = api.IPV6Family
 			})
 			It("appends the AssignIpv6AddressOnCreation task to occur after the cluster creation", func() {
-				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar", "foo"), nil, true)
+				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(makeNodeGroups("bar", "foo"), nil)
 				Expect(tasks.Describe()).To(Equal(`
 3 sequential tasks: { create cluster control plane "test-cluster", set AssignIpv6AddressOnCreation to true for public subnets, 
     2 parallel sub-tasks: { 

--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -254,8 +254,8 @@ func NewCreateClusterLoader(cmd *Cmd, ngFilter *filter.NodeGroupFilter, ng *api.
 
 		api.SetClusterEndpointAccessDefaults(clusterConfig.VPC)
 
-		if !clusterConfig.HasClusterEndpointAccess() {
-			return api.ErrClusterEndpointNoAccess
+		if err := clusterConfig.ValidateClusterEndpointConfig(); err != nil {
+			return err
 		}
 
 		if clusterConfig.HasAnySubnets() && len(clusterConfig.AvailabilityZones) != 0 {

--- a/pkg/ctl/cmdutils/filter/nodegroup_filter_test.go
+++ b/pkg/ctl/cmdutils/filter/nodegroup_filter_test.go
@@ -353,8 +353,7 @@ const expected = `
 			"autoAllocateIPv6": false,
 			"nat": {
 				"gateway": "Single"
-			  },
-             "clusterEndpoints": {}
+			  }
 		},
 		"cloudWatch": {
 		  "clusterLogging": {}

--- a/pkg/ctl/utils/enable_secrets_encryption.go
+++ b/pkg/ctl/utils/enable_secrets_encryption.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/pflag"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
-	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/kubernetes"
 )
 
@@ -67,7 +66,7 @@ func doEnableSecretsEncryption(cmd *cmdutils.Cmd, encryptExistingSecrets bool) e
 		return err
 	}
 
-	if err := eks.ValidateKMSSupport(clusterConfig, ctl.ControlPlaneVersion()); err != nil {
+	if err := api.ValidateSecretsEncryption(clusterConfig); err != nil {
 		return err
 	}
 

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -367,24 +367,13 @@ func ResolveAMI(provider api.ClusterProvider, version string, np api.NodePool) e
 	return nil
 }
 
-func errTooFewAvailabilityZones(azs []string) error {
-	return fmt.Errorf("only %d zones specified %v, %d are required (can be non-unique)", len(azs), azs, api.MinRequiredAvailabilityZones)
-}
-
 // SetAvailabilityZones sets the given (or chooses) the availability zones
 func (c *ClusterProvider) SetAvailabilityZones(spec *api.ClusterConfig, given []string) error {
 	if count := len(given); count != 0 {
 		if count < api.MinRequiredAvailabilityZones {
-			return errTooFewAvailabilityZones(given)
+			return api.ErrTooFewAvailabilityZones(given)
 		}
 		spec.AvailabilityZones = given
-		return nil
-	}
-
-	if count := len(spec.AvailabilityZones); count != 0 {
-		if count < api.MinRequiredAvailabilityZones {
-			return errTooFewAvailabilityZones(spec.AvailabilityZones)
-		}
 		return nil
 	}
 

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -86,23 +86,6 @@ func isNonEKSCluster(cluster *awseks.Cluster) bool {
 
 // ClusterSupportsManagedNodes reports whether the EKS cluster supports managed nodes
 func ClusterSupportsManagedNodes(cluster *awseks.Cluster) (bool, error) {
-	supportsManagedNodes, err := utils.IsMinVersion(api.Version1_15, *cluster.Version)
-	if err != nil {
-		return false, err
-	}
-	if supportsManagedNodes {
-		return true, nil
-	}
-
-	versionSupportsManagedNodes, err := VersionSupportsManagedNodes(*cluster.Version)
-	if err != nil {
-		return false, err
-	}
-
-	if !versionSupportsManagedNodes {
-		return false, nil
-	}
-
 	if cluster.PlatformVersion == nil {
 		logger.Warning("could not find cluster's platform version")
 		return false, nil

--- a/pkg/eks/eks_test.go
+++ b/pkg/eks/eks_test.go
@@ -405,47 +405,4 @@ var _ = Describe("EKS API wrapper", func() {
 			platformVersion: "eks.invalid", expectedVersion: -1, expectError: true,
 		}),
 	)
-
-	type kmsSupportCase struct {
-		key               string
-		errSubstr         string
-		kubernetesVersion string
-	}
-
-	DescribeTable("KMS validation", func(k kmsSupportCase) {
-		clusterConfig := api.NewClusterConfig()
-		clusterConfig.Metadata.Version = k.kubernetesVersion
-
-		clusterConfig.SecretsEncryption = &api.SecretsEncryption{
-			KeyARN: k.key,
-		}
-		err := ValidateFeatureCompatibility(clusterConfig, nil)
-		if k.errSubstr != "" {
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(k.errSubstr))
-		} else {
-			Expect(err).NotTo(HaveOccurred())
-		}
-	},
-		Entry("Invalid ARN", kmsSupportCase{
-			key:               "invalid:arn",
-			errSubstr:         "invalid ARN",
-			kubernetesVersion: "1.14",
-		}),
-		Entry("Valid ARN", kmsSupportCase{
-			key:               "arn:aws:kms:us-west-2:000000000000:key/12345-12345",
-			errSubstr:         "",
-			kubernetesVersion: "1.14",
-		}),
-		Entry("Supports K8s 1.13", kmsSupportCase{
-			key:               "arn:aws:kms:us-west-2:000000000000:key/12345-12345",
-			errSubstr:         "",
-			kubernetesVersion: "1.13",
-		}),
-		Entry("Unsupported K8s version", kmsSupportCase{
-			key:               "arn:aws:kms:us-west-2:000000000000:key/12345-12345",
-			errSubstr:         "KMS is only supported for EKS version 1.13 and above",
-			kubernetesVersion: "1.12",
-		}),
-	)
 })

--- a/pkg/eks/eks_test.go
+++ b/pkg/eks/eks_test.go
@@ -230,7 +230,6 @@ var _ = Describe("EKS API wrapper", func() {
 			platform = aws.String(m.platformVersion)
 		}
 		cluster := &awseks.Cluster{
-			Version:         aws.String(m.kubernetesVersion),
 			PlatformVersion: platform,
 		}
 
@@ -240,68 +239,15 @@ var _ = Describe("EKS API wrapper", func() {
 		}
 		Expect(supportsManagedNodes).To(Equal(m.supports))
 	},
-		Entry("with minimum required versions", &managedNodesSupportCase{
-			platformVersion:   "eks.3",
-			kubernetesVersion: "1.14",
-			expectError:       false,
-			supports:          true,
-		}),
-		Entry("with newer version", &managedNodesSupportCase{
-			platformVersion:   "eks.6",
-			kubernetesVersion: "1.14",
-			expectError:       false,
-			supports:          true,
-		}),
 		Entry("with unsupported platform version", &managedNodesSupportCase{
-			platformVersion:   "eks.2",
-			kubernetesVersion: "1.14",
-			expectError:       false,
-			supports:          false,
-		}),
-		Entry("with unsupported Kubernetes version", &managedNodesSupportCase{
-			platformVersion:   "eks.3",
-			kubernetesVersion: "1.13",
-			expectError:       false,
-			supports:          false,
-		}),
-		Entry("with unsupported Kubernetes version", &managedNodesSupportCase{
-			platformVersion:   "eks.6",
-			kubernetesVersion: "1.13",
-			expectError:       false,
-			supports:          false,
+			platformVersion: "eks.2",
+			expectError:     false,
+			supports:        false,
 		}),
 		Entry("with invalid platform version", &managedNodesSupportCase{
-			platformVersion:   "eks.invalid",
-			kubernetesVersion: "1.14",
-			expectError:       true,
-			supports:          false,
-		}),
-		Entry("with invalid platform version", &managedNodesSupportCase{
-			platformVersion:   " eks.3",
-			kubernetesVersion: "1.14",
-			expectError:       true,
-			supports:          false,
-		}),
-		Entry("with invalid Kubernetes version", &managedNodesSupportCase{
-			platformVersion:   "eks.5",
-			kubernetesVersion: "1.",
-			expectError:       true,
-			supports:          false,
-		}),
-		Entry("with non-existent platform version", &managedNodesSupportCase{
-			kubernetesVersion: "1.",
-			expectError:       false,
-			supports:          false,
-		}),
-		Entry("with 1.15", &managedNodesSupportCase{
-			kubernetesVersion: "1.15",
-			expectError:       false,
-			supports:          true,
-		}),
-		Entry("with 1.16", &managedNodesSupportCase{
-			kubernetesVersion: "1.16",
-			expectError:       false,
-			supports:          true,
+			platformVersion: " eks.3",
+			expectError:     true,
+			supports:        false,
 		}),
 	)
 

--- a/pkg/eks/eks_test.go
+++ b/pkg/eks/eks_test.go
@@ -217,8 +217,7 @@ var _ = Describe("EKS API wrapper", func() {
 	})
 
 	type managedNodesSupportCase struct {
-		platformVersion   string
-		kubernetesVersion string
+		platformVersion string
 
 		expectError bool
 		supports    bool

--- a/pkg/eks/nodegroup.go
+++ b/pkg/eks/nodegroup.go
@@ -15,7 +15,6 @@ import (
 	addons "github.com/weaveworks/eksctl/pkg/addons/default"
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 	"github.com/weaveworks/eksctl/pkg/iam"
-	"github.com/weaveworks/eksctl/pkg/utils"
 	"github.com/weaveworks/eksctl/pkg/utils/tasks"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -51,82 +50,6 @@ func getNodes(clientSet kubernetes.Interface, ng KubeNodeGroup) (int, error) {
 		logger.Info("node %q is %s", node.ObjectMeta.Name, ready)
 	}
 	return counter, nil
-}
-
-// ValidateFeatureCompatibility validates whether the cluster version supports the features specified in the
-// ClusterConfig. Support for Managed Nodegroups or Windows requires the EKS cluster version to be 1.14 and above.
-// Bottlerocket nodegroups are only supported on EKS version 1.15 and above
-// If the version requirement isn't met, an error is returned
-func ValidateFeatureCompatibility(clusterConfig *api.ClusterConfig, kubeNodeGroups []KubeNodeGroup) error {
-	if err := ValidateManagedNodesSupport(clusterConfig); err != nil {
-		return err
-	}
-	if err := ValidateBottlerocketSupport(clusterConfig.Metadata.Version, kubeNodeGroups); err != nil {
-		return err
-	}
-
-	return ValidateWindowsCompatibility(kubeNodeGroups, clusterConfig.Metadata.Version)
-}
-
-// ValidateBottlerocketSupport validates support for Bottlerocket nodegroups
-func ValidateBottlerocketSupport(controlPlaneVersion string, kubeNodeGroups []KubeNodeGroup) error {
-	const minSupportedVersion = api.Version1_15
-
-	supportsBottlerocket, err := utils.IsMinVersion(minSupportedVersion, controlPlaneVersion)
-	if err != nil {
-		return err
-	}
-	if supportsBottlerocket {
-		return nil
-	}
-
-	for _, ng := range kubeNodeGroups {
-		if ng.GetAMIFamily() == api.NodeImageFamilyBottlerocket {
-			return errors.Errorf("Bottlerocket is only supported on EKS version %s and above", minSupportedVersion)
-		}
-	}
-	return nil
-}
-
-// ValidateManagedNodesSupport validates support for Managed Nodegroups
-func ValidateManagedNodesSupport(clusterConfig *api.ClusterConfig) error {
-	if len(clusterConfig.ManagedNodeGroups) > 0 {
-		minRequiredVersion := api.Version1_14
-		supportsManagedNodes, err := VersionSupportsManagedNodes(clusterConfig.Metadata.Version)
-		if err != nil {
-			return err
-		}
-		if !supportsManagedNodes {
-			return fmt.Errorf("Managed Nodegroups are only supported on EKS version %s and above", minRequiredVersion)
-		}
-	}
-	return nil
-}
-
-// VersionSupportsManagedNodes reports whether the control plane version can support Managed Nodes
-func VersionSupportsManagedNodes(controlPlaneVersion string) (bool, error) {
-	minRequiredVersion := api.Version1_14
-	supportsManagedNodes, err := utils.IsMinVersion(minRequiredVersion, controlPlaneVersion)
-	if err != nil {
-		return false, err
-	}
-	return supportsManagedNodes, nil
-}
-
-// ValidateWindowsCompatibility validates Windows compatibility
-func ValidateWindowsCompatibility(kubeNodeGroups []KubeNodeGroup, controlPlaneVersion string) error {
-	if !hasWindowsNode(kubeNodeGroups) {
-		return nil
-	}
-
-	supportsWindows, err := utils.IsMinVersion(api.Version1_14, controlPlaneVersion)
-	if err != nil {
-		return err
-	}
-	if !supportsWindows {
-		return errors.New("Windows nodes are only supported on Kubernetes 1.14 and above")
-	}
-	return nil
 }
 
 // SupportsWindowsWorkloads reports whether nodeGroups can support running Windows workloads


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Related to #4627
This PR addresses 1/2 from [this list](https://github.com/weaveworks/eksctl/issues/4627#issuecomment-1044849491).

I started moving some validation to the standard `validation.go` file as part of #4627 but came across the pattern/issue that I outlined in [this comment](https://github.com/weaveworks/eksctl/issues/4627#issuecomment-1047916987), where I suggested the following approach: moving functions to the standard validation function should be done as part of making `ctl/` functions use the standard validation functions. 

I did try to move a few of those random validation functions and add unit tests to them, but they will continue to be in use "randomly" until we make all `ctl/` packages use `ValidateClusterConfig`/centralised validation funcs.

Also removed a bunch of funcs that were doing feature support validation for versions that EKS doesn't support anymore anyway.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:

