### PR TITLE
Allow AWS_PROFILE env var to be used write-kubeconig

### DIFF
--- a/pkg/ctl/cmdutils/cmdutils.go
+++ b/pkg/ctl/cmdutils/cmdutils.go
@@ -107,7 +107,7 @@ func GetNameArg(args []string) string {
 // AddCommonFlagsForAWS adds common flags for api.ProviderConfig
 func AddCommonFlagsForAWS(group *NamedFlagSetGroup, p *api.ProviderConfig, addCfnOptions bool) {
 	group.InFlagSet("AWS client", func(fs *pflag.FlagSet) {
-		fs.StringVarP(&p.Profile, "profile", "p", "", "AWS credentials profile to use (overrides the AWS_PROFILE environment variable)")
+		fs.StringVarP(&p.Profile, "profile", "p", os.Getenv("AWS_PROFILE"), "AWS credentials profile to use (defaults to value of the AWS_PROFILE environment variable)")
 
 		if addCfnOptions {
 			fs.StringVar(&p.CloudFormationRoleARN, "cfn-role-arn", "", "IAM role used by CloudFormation to call AWS API on your behalf")


### PR DESCRIPTION
### Description

Closes #4483

Before value was being correctly set with flag, but not set when using an env var:
```bash
./eksctl utils write-kubeconfig --profile jake --cluster cp7
2022-02-23 15:42:48 [ℹ]  eksctl version 0.81.0-rc.0
2022-02-23 15:42:48 [ℹ]  using region us-west-2
2022-02-23 15:42:48 [✔]  saved kubeconfig as "/home/jake/.kube/config"

cat ~/.kube/config
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data:
    ...
      - name: AWS_PROFILE
        value: jake
      provideClusterInfo: false
      
AWS_PROFILE=jake ./eksctl utils write-kubeconfig --cluster cp7
2022-02-23 15:43:50 [ℹ]  eksctl version 0.81.0-rc.0
2022-02-23 15:43:50 [ℹ]  using region us-west-2
2022-02-23 15:43:50 [✔]  saved kubeconfig as "/home/jake/.kube/config"

 cat ~/.kube/config
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: 
      ...
      - name: AWS_STS_REGIONAL_ENDPOINTS
        value: regional
      provideClusterInfo: false
```

value was unset when using env var

after:
```bash
AWS_PROFILE=jake ./eksctl utils write-kubeconfig --cluster cp7
2022-02-23 15:46:01 [ℹ]  eksctl version 0.86.0-dev+87ef00a0.2022-02-23T15:44:43Z
2022-02-23 15:46:01 [ℹ]  using region us-west-2
cat2022-02-23 15:46:02 [✔]  saved kubeconfig as "/home/jake/.kube/config"
jake@jake-weave [15:46:02] [~/weave/eksctl] [AWS_PROFILE]
-> % cat ~/.kube/config
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: 
    ...
      - name: AWS_PROFILE
        value: jake
      provideClusterInfo: false
```