### PR TITLE
Fix aws-iam-authenticator api version in kube config file

### DIFF
--- a/pkg/utils/kubeconfig/export_test.go
+++ b/pkg/utils/kubeconfig/export_test.go
@@ -1,0 +1,5 @@
+package kubeconfig
+
+func SetExecCommand(f ExecCommandFunc) {
+	execCommand = f
+}

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -36,8 +36,9 @@ const (
 	betaAPIVersion  = "client.authentication.k8s.io/v1beta1"
 )
 
-// CheckAuthenticatorVersion contains the function which is responsible to detect aws-iam-authenticator version.
-var CheckAuthenticatorVersion = getAWSIAMAuthenticatorVersion
+type ExecCommandFunc func(name string, arg ...string) *exec.Cmd
+
+var execCommand = exec.Command
 
 // DefaultPath defines the default path
 func DefaultPath() string {
@@ -213,7 +214,7 @@ type AWSAuthenticatorVersionFormat struct {
 }
 
 func authenticatorIsAboveVersion(version string) (bool, error) {
-	authenticatorVersion, err := CheckAuthenticatorVersion()
+	authenticatorVersion, err := getAWSIAMAuthenticatorVersion()
 	if err != nil {
 		return false, fmt.Errorf("failed to retrieve authenticator version: %w", err)
 	}
@@ -225,7 +226,7 @@ func authenticatorIsAboveVersion(version string) (bool, error) {
 }
 
 func getAWSIAMAuthenticatorVersion() (string, error) {
-	cmd := exec.Command(AWSIAMAuthenticator, "version")
+	cmd := execCommand(AWSIAMAuthenticator, "version")
 	output, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to run aws-iam-authenticator version command: %w", err)

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -1,6 +1,7 @@
 package kubeconfig
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,10 +12,12 @@ import (
 	"github.com/gofrs/flock"
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
-	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
-	"github.com/weaveworks/eksctl/pkg/utils/file"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/utils"
+	"github.com/weaveworks/eksctl/pkg/utils/file"
 )
 
 const (
@@ -26,7 +29,15 @@ const (
 	AWSEKSAuthenticator = "aws"
 	// Shadowing the default kubeconfig path environment variable
 	RecommendedConfigPathEnvVar = clientcmd.RecommendedConfigPathEnvVar
+	// AWSIAMAuthenticatorMinimumBetaVersion this is the minimum version at which aws-iam-authenticator uses v1beta1 as APIVersion
+	AWSIAMAuthenticatorMinimumBetaVersion = "0.5.3"
+
+	alphaAPIVersion = "client.authentication.k8s.io/v1alpha1"
+	betaAPIVersion  = "client.authentication.k8s.io/v1beta1"
 )
+
+// CheckAuthenticatorVersion contains the function which is responsible to detect aws-iam-authenticator version.
+var CheckAuthenticatorVersion = getAWSIAMAuthenticatorVersion
 
 // DefaultPath defines the default path
 func DefaultPath() string {
@@ -134,7 +145,7 @@ func AppendAuthenticator(config *clientcmdapi.Config, clusterMeta *api.ClusterMe
 	)
 
 	execConfig := &clientcmdapi.ExecConfig{
-		APIVersion: "client.authentication.k8s.io/v1alpha1",
+		APIVersion: alphaAPIVersion,
 		Command:    authenticatorCMD,
 		Env: []clientcmdapi.ExecEnvVar{
 			{
@@ -146,7 +157,22 @@ func AppendAuthenticator(config *clientcmdapi.Config, clusterMeta *api.ClusterMe
 	}
 
 	switch authenticatorCMD {
-	case AWSIAMAuthenticator, HeptioAuthenticatorAWS:
+	case AWSIAMAuthenticator:
+		// if version is above or equal to v0.5.3 we change the APIVersion to v1beta1.
+		if authenticatorIsBetaVersion, err := authenticatorIsAboveVersion(AWSIAMAuthenticatorMinimumBetaVersion); err != nil {
+			logger.Warning("failed to determine authenticator version, leaving API version as default v1alpha1: %v", err)
+		} else if authenticatorIsBetaVersion {
+			execConfig.APIVersion = betaAPIVersion
+		}
+		args = []string{"token", "-i", clusterMeta.Name}
+		roleARNFlag = "-r"
+		if clusterMeta.Region != "" {
+			execConfig.Env = append(execConfig.Env, clientcmdapi.ExecEnvVar{
+				Name:  "AWS_DEFAULT_REGION",
+				Value: clusterMeta.Region,
+			})
+		}
+	case HeptioAuthenticatorAWS:
 		args = []string{"token", "-i", clusterMeta.Name}
 		roleARNFlag = "-r"
 		if clusterMeta.Region != "" {
@@ -178,6 +204,37 @@ func AppendAuthenticator(config *clientcmdapi.Config, clusterMeta *api.ClusterMe
 	config.AuthInfos[config.CurrentContext] = &clientcmdapi.AuthInfo{
 		Exec: execConfig,
 	}
+}
+
+// AWSAuthenticatorVersionFormat is the format in which aws-iam-authenticator displays version information:
+// {"Version":"0.5.5","Commit":"85e50980d9d916ae95882176c18f14ae145f916f"}
+type AWSAuthenticatorVersionFormat struct {
+	Version string `json:"Version"`
+}
+
+func authenticatorIsAboveVersion(version string) (bool, error) {
+	authenticatorVersion, err := CheckAuthenticatorVersion()
+	if err != nil {
+		return false, fmt.Errorf("failed to retrieve authenticator version: %w", err)
+	}
+	compareVersions, err := utils.CompareVersions(authenticatorVersion, version)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse versions: %w", err)
+	}
+	return compareVersions >= 0, nil
+}
+
+func getAWSIAMAuthenticatorVersion() (string, error) {
+	cmd := exec.Command(AWSIAMAuthenticator, "version")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to run aws-iam-authenticator version command: %w", err)
+	}
+	var parsedVersion AWSAuthenticatorVersionFormat
+	if err := json.Unmarshal(output, &parsedVersion); err != nil {
+		return "", fmt.Errorf("failed to parse version information: %w", err)
+	}
+	return parsedVersion.Version, nil
 }
 
 func lockFileName(filePath string) string {

--- a/pkg/utils/kubeconfig/kubeconfig_suite_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_suite_test.go
@@ -1,4 +1,4 @@
-package kubeconfig
+package kubeconfig_test
 
 import (
 	"testing"

--- a/pkg/utils/kubeconfig/testdata/aws-iam-authenticator
+++ b/pkg/utils/kubeconfig/testdata/aws-iam-authenticator
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+if [[ "${1}" == "fail" ]]; then
+  exit 1
+fi
+echo "$@"


### PR DESCRIPTION
Closes https://github.com/weaveworks/eksctl/issues/4031

Note, unit testing this is rather difficult since it requires spoofing exec.Cmd. But I'll figure something out.

Manual test:

```
➜  simple-cluster k get pods -A
Unable to connect to the server: getting credentials: exec plugin is configured to use API version client.authentication.k8s.io/v1alpha1, plugin returned version client.authentication.k8s.io/v1beta1
➜  simple-cluster aws-iam-authenticator version
{"Version":"0.5.5","Commit":"85e50980d9d916ae95882176c18f14ae145f916f"}
➜  simple-cluster k get pods -A
➜  simple-cluster
➜  simple-cluster
➜  simple-cluster eksctl utils write-kubeconfig --cluster test-kube-config-1
2022-02-24 11:08:49 [ℹ]  eksctl version 0.86.0-dev+57d0afb2.2022-02-24T11:07:28Z
2022-02-24 11:08:49 [ℹ]  using region us-west-2
2022-02-24 11:08:50 [✔]  saved kubeconfig as "/Users/skarlso/.kube/config"
➜  simple-cluster k get pods -A
NAMESPACE     NAME                       READY   STATUS    RESTARTS   AGE
kube-system   aws-node-mp94q             1/1     Running   1          153m
kube-system   coredns-85d5b4454c-99tpf   1/1     Running   1          162m
kube-system   coredns-85d5b4454c-v29fq   1/1     Running   1          162m
kube-system   kube-proxy-wzvq

// incoming test with previous version of authenticator to see if that still works

➜  bin aws-iam-authenticator version
{"Version":"v0.5.3","Commit":"4c933f86b1dd7e9b7124542987b4eabb45eaa727","Date":"2022-02-24T10:28:29Z"}

➜  simple-cluster rm /Users/skarlso/.kube/config

➜  simple-cluster aws-iam-authenticator version
{"Version":"git-292b9b82","Commit":"292b9b82df69b87af962b92485b254d9f4b10f00"} // this is version 0.5.2
➜  simple-cluster k get pods -A
NAMESPACE     NAME                       READY   STATUS    RESTARTS   AGE
kube-system   aws-node-mp94q             1/1     Running   1          3h22m
kube-system   coredns-85d5b4454c-99tpf   1/1     Running   1          3h31m
kube-system   coredns-85d5b4454c-v29fq   1/1     Running   1          3h31m
kube-system   kube-proxy-wzvqv           1/1     Running   1          3h22m
```