### PR TITLE
check if ClusterEndpoint is set before mutating

### DIFF
--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -561,6 +561,9 @@ func NewUtilsEnableEndpointAccessLoader(cmd *Cmd, privateAccess, publicAccess bo
 			return err
 		}
 
+		if cmd.ClusterConfig.VPC.ClusterEndpoints == nil {
+			cmd.ClusterConfig.VPC.ClusterEndpoints = api.ClusterEndpointAccessDefaults()
+		}
 		if flag := l.CobraCommand.Flag("private-access"); flag != nil && flag.Changed {
 			cmd.ClusterConfig.VPC.ClusterEndpoints.PrivateAccess = &privateAccess
 		} else {


### PR DESCRIPTION
### Description
Running the integration test locally to see if it fails, should fail fairly quickly if its still broken