### PR TITLE
Fix backwards compatibility check test

### DIFF
--- a/integration/scripts/download-previous-release.sh
+++ b/integration/scripts/download-previous-release.sh
@@ -2,7 +2,7 @@
 
 
 GIT_REPO_URL="https://github.com/weaveworks/eksctl"
-RELEASE_URL_FORMAT="https://github.com/weaveworks/eksctl/releases/download/v%s/eksctl_Linux_amd64.tar.gz"
+RELEASE_URL_FORMAT="https://github.com/weaveworks/eksctl/releases/download/%s/eksctl_Linux_amd64.tar.gz"
 
 download_previous_release() {
     previous_tag=$(git ls-remote --tags $GIT_REPO_URL | grep -E -v "(refs/tags/(latest_release|v))|\-rc|\{\}" | cut -d/ -f3 | sort -Vr \


### PR DESCRIPTION
With the latest release we removed the `v` from the tag of the released version.