### PR TITLE
error when creating managed bottlerocket GPU instances

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -847,7 +847,7 @@ func ValidateManagedNodeGroup(index int, ng *ManagedNodeGroup) error {
 	}
 
 	if instanceutils.IsNvidiaInstanceType(SelectInstanceType(ng)) && ng.AMIFamily == NodeImageFamilyBottlerocket {
-		logger.Info("Bottlerocket GPU support is for unmanaged nodegroups only. If your using cli flags pass --managed=false")
+		logger.Info("Bottlerocket GPU support is for unmanaged nodegroups only. If you're using CLI flags pass --managed=false")
 		return errors.Errorf("NVIDIA GPU instance types are not supported for managed nodegroups with AMIFamily %s", ng.AMIFamily)
 	}
 

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -489,7 +489,8 @@ func validateNodeGroupBase(np NodePool, path string) error {
 	}
 
 	// Only AmazonLinux2 and Bottlerocket support NVIDIA GPUs
-	if instanceutils.IsNvidiaInstanceType(SelectInstanceType(np)) && (ng.AMIFamily != NodeImageFamilyAmazonLinux2 && ng.AMIFamily != NodeImageFamilyBottlerocket && ng.AMIFamily != "") {
+	if instanceutils.IsNvidiaInstanceType(SelectInstanceType(np)) &&
+		(ng.AMIFamily != NodeImageFamilyAmazonLinux2 && ng.AMIFamily != NodeImageFamilyBottlerocket && ng.AMIFamily != "") {
 		return errors.Errorf("NVIDIA GPU instance types are not supported for %s", ng.AMIFamily)
 	}
 
@@ -843,6 +844,11 @@ func ValidateManagedNodeGroup(index int, ng *ManagedNodeGroup) error {
 
 	if err := validateNodeGroupBase(ng, path); err != nil {
 		return err
+	}
+
+	if instanceutils.IsNvidiaInstanceType(SelectInstanceType(ng)) && ng.AMIFamily == NodeImageFamilyBottlerocket {
+		logger.Info("Bottlerocket GPU support is for unmanaged nodegroups only. If your using cli flags pass --managed=false")
+		return errors.Errorf("NVIDIA GPU instance types are not supported for managed nodegroups with AMIFamily %s", ng.AMIFamily)
 	}
 
 	if ng.IAM != nil {


### PR DESCRIPTION
### Description
Does option 1 from https://github.com/weaveworks/eksctl/issues/4863#issuecomment-1055609051

Before:
```
./eksctl create nodegroup --cluster jk --name br-new --instance-types g4dn.xlarge --node-ami-family Bottlerocket --node-zones us-west-2b
2022-03-01 16:45:32 [ℹ]  eksctl version 0.87.0-dev+ffed567d.2022-03-01T16:45:23Z
2022-03-01 16:45:32 [ℹ]  using region us-west-2
2022-03-01 16:45:33 [ℹ]  will use version 1.21 for new nodegroup(s) based on control plane version
2022-03-01 16:45:39 [ℹ]  nodegroup "br-new" will use "" [Bottlerocket/1.21]
2022-03-01 16:45:42 [ℹ]  3 existing nodegroup(s) (br-new-mg,br-old,ng-1) will be excluded
2022-03-01 16:45:42 [ℹ]  1 nodegroup (br-new) was included (based on the include/exclude rules)
2022-03-01 16:45:42 [ℹ]  will create a CloudFormation stack for each of 1 managed nodegroups in cluster "jk"
2022-03-01 16:45:42 [ℹ]
2 sequential tasks: { fix cluster compatibility, 1 task: { 1 task: { create managed nodegroup "br-new" } }
}
2022-03-01 16:45:42 [ℹ]  checking cluster stack for missing resources
2022-03-01 16:45:44 [ℹ]  cluster stack has all required resources
2022-03-01 16:45:45 [ℹ]  building managed nodegroup stack "eksctl-jk-nodegroup-br-new"
2022-03-01 16:45:45 [ℹ]  deploying stack "eksctl-jk-nodegroup-br-new"
2022-03-01 16:45:45 [ℹ]  waiting for CloudFormation stack "eksctl-jk-nodegroup-br-new"
2022-03-01 16:46:01 [ℹ]  waiting for CloudFormation stack "eksctl-jk-nodegroup-br-new"
2022-03-01 16:46:20 [ℹ]  waiting for CloudFormation stack "eksctl-jk-nodegroup-br-new"
2022-03-01 16:46:36 [ℹ]  waiting for CloudFormation stack "eksctl-jk-nodegroup-br-new"
2022-03-01 16:46:54 [ℹ]  waiting for CloudFormation stack "eksctl-jk-nodegroup-br-new"
2022-03-01 16:47:13 [ℹ]  waiting for CloudFormation stack "eksctl-jk-nodegroup-br-new"
2022-03-01 16:47:14 [✖]  unexpected status "ROLLBACK_IN_PROGRESS" while waiting for CloudFormation stack "eksctl-jk-nodegroup-br-new"
2022-03-01 16:47:14 [ℹ]  fetching stack events in attempt to troubleshoot the root cause of the failure
2022-03-01 16:47:14 [!]  AWS::EKS::Nodegroup/ManagedNodeGroup: DELETE_IN_PROGRESS
2022-03-01 16:47:14 [✖]  AWS::EKS::Nodegroup/ManagedNodeGroup: CREATE_FAILED – "Resource handler returned message: \"[Issue(Code=Ec2LaunchTemplateInvalidConfiguration, Message=User data was not in the MIME multipart format.)] (Service: null, Status Code: 0, Request ID: null, Extended Request ID: null)\" (RequestToken: da1b33ab-cfae-bac5-bb6d-ac01fc0757cb, HandlerErrorCode: GeneralServiceException)"
2022-03-01 16:47:14 [ℹ]  1 error(s) occurred and nodegroups haven't been created properly, you may wish to check CloudFormation console
2022-03-01 16:47:14 [ℹ]  to cleanup resources, run 'eksctl delete nodegroup --region=us-west-2 --cluster=jk --name=<name>' for each of the failed nodegroup
2022-03-01 16:47:14 [✖]  waiting for CloudFormation stack "eksctl-jk-nodegroup-br-new": ResourceNotReady: failed waiting for successful resource state
Error: failed to create nodegroups for cluster "jk"
```

After:
```
./eksctl create nodegroup --cluster jk --name br-new --instance-types g4dn.xlarge --node-ami-family Bottlerocket --node-zones us-west-2b
2022-03-01 16:44:49 [ℹ]  Bottlerocket GPU support is for unmanaged nodegroups only. If your using cli flags pass --managed=false
Error: couldn't create cluster provider from options: NVIDIA GPU instance types are not supported for managed nodegroups with AMIFamily Bottlerocket
```