### PR TITLE
publish releases on pushes to the v prefixed tag

### DIFF
--- a/.github/workflows/publish-release-candidate.yaml
+++ b/.github/workflows/publish-release-candidate.yaml
@@ -2,7 +2,7 @@ name: publish-release-candidate
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+-rc.[0-9]'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]'
 
 jobs:
   test-and-build:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -2,7 +2,7 @@ name: publish-release
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   test-and-build:

--- a/build/scripts/do-release-candidate.sh
+++ b/build/scripts/do-release-candidate.sh
@@ -5,6 +5,8 @@ if [ -z "${GITHUB_REF_NAME}" ] || [ "${GITHUB_REF_TYPE}" != "tag" ] ; then
   exit 1
 fi
 
+tag="${GITHUB_REF_NAME}"
+
 RELEASE_NOTES_FILE="docs/release_notes/${GITHUB_REF_NAME/-rc.*}.md"
 
 if [ ! -f "${RELEASE_NOTES_FILE}" ]; then
@@ -12,6 +14,6 @@ if [ ! -f "${RELEASE_NOTES_FILE}" ]; then
     exit 1
 fi
 
-export RELEASE_DESCRIPTION="${GITHUB_REF_NAME}"
+export RELEASE_DESCRIPTION="${tag}"
 
-goreleaser release --rm-dist --timeout 60m --skip-validate --config=./.goreleaser.yml --release-notes="${RELEASE_NOTES_FILE}"
+GORELEASER_CURRENT_TAG=${tag} goreleaser release --rm-dist --timeout 60m --skip-validate --config=./.goreleaser.yml --release-notes="${RELEASE_NOTES_FILE}"

--- a/build/scripts/do-release.sh
+++ b/build/scripts/do-release.sh
@@ -16,4 +16,4 @@ if [ ! -f "${RELEASE_NOTES_FILE}" ]; then
 fi
 
 cat ./.goreleaser.yml ./.goreleaser.brew.yml > .goreleaser.brew.combined.yml
-goreleaser release --rm-dist --timeout 60m --skip-validate --config=./.goreleaser.brew.combined.yml --release-notes="${RELEASE_NOTES_FILE}"
+GORELEASER_CURRENT_TAG=${tag} goreleaser release --rm-dist --timeout 60m --skip-validate --config=./.goreleaser.brew.combined.yml --release-notes="${RELEASE_NOTES_FILE}"


### PR DESCRIPTION
### Description
Closes https://github.com/weaveworks/eksctl/issues/4858

This fix is broken into two parts:
## part 1- changing the tag the workflows run on
When this workflow runs, it triggers the `do-release.sh` script https://github.com/weaveworks/eksctl/blob/main/build/scripts/do-release.sh#L8

This fetches the tag name, which is equal to the name of the branch/tag the workflow is running on. Example https://github.com/weaveworks/eksctl/runs/5339216464?check_suite_focus=true#step:6:7. This should get changed tot he `v` prefix'd tag now.

## part 2- specifying what the tag should be via the environment variable
its super unclear how `goreleaser` decides what tag to use for the release. You can however use an environment variable to configure this `GORELEASER_CURRENT_TAG` https://goreleaser.com/customization/build/?h=goreleaser_current_tag#define-build-tag.

Combined with the changes in part 1 we can set this environment variable to ensure the version is correct