### PR TITLE
Fix missing stack name in case only the stack is provided.

### DIFF
--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -248,9 +248,11 @@ func (c *StackCollection) UpdateStack(options UpdateStackOptions) error {
 			return err
 		}
 		options.Stack = s
+	} else {
+		options.StackName = *options.Stack.StackName
 	}
 	if err := c.doCreateChangeSetRequest(
-		*options.Stack.StackName,
+		options.StackName,
 		options.ChangeSetName,
 		options.Description,
 		options.TemplateData,


### PR DESCRIPTION
### Description

Closes https://github.com/weaveworks/eksctl/issues/4821

Fixed missing stack name from options.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

