### PR TITLE
Validate AZ configuration correctly 

### DIFF
--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -435,7 +435,7 @@ func createOrImportVPC(cmd *cmdutils.Cmd, cfg *api.ClusterConfig, params *cmduti
 
 	subnetsGiven := cfg.HasAnySubnets() // this will be false when neither flags nor config has any subnets
 	if !subnetsGiven && params.KopsClusterNameForVPC == "" {
-		if err := ctl.SetAvailabilityZones(cfg, params.AvailabilityZones); err != nil {
+		if err := eks.SetAvailabilityZones(cfg, params.AvailabilityZones, ctl.Provider.EC2(), ctl.Provider.Region()); err != nil {
 			return err
 		}
 

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -377,6 +377,13 @@ func (c *ClusterProvider) SetAvailabilityZones(spec *api.ClusterConfig, given []
 		return nil
 	}
 
+	if count := len(spec.AvailabilityZones); count != 0 {
+		if count < api.MinRequiredAvailabilityZones {
+			return api.ErrTooFewAvailabilityZones(spec.AvailabilityZones)
+		}
+		return nil
+	}
+
 	logger.Debug("determining availability zones")
 	zones, err := az.GetAvailabilityZones(c.Provider.EC2(), c.Provider.Region())
 	if err != nil {

--- a/pkg/eks/api.go
+++ b/pkg/eks/api.go
@@ -368,7 +368,7 @@ func ResolveAMI(provider api.ClusterProvider, version string, np api.NodePool) e
 }
 
 // SetAvailabilityZones sets the given (or chooses) the availability zones
-func (c *ClusterProvider) SetAvailabilityZones(spec *api.ClusterConfig, given []string) error {
+func SetAvailabilityZones(spec *api.ClusterConfig, given []string, ec2 ec2iface.EC2API, region string) error {
 	if count := len(given); count != 0 {
 		if count < api.MinRequiredAvailabilityZones {
 			return api.ErrTooFewAvailabilityZones(given)
@@ -385,7 +385,7 @@ func (c *ClusterProvider) SetAvailabilityZones(spec *api.ClusterConfig, given []
 	}
 
 	logger.Debug("determining availability zones")
-	zones, err := az.GetAvailabilityZones(c.Provider.EC2(), c.Provider.Region())
+	zones, err := az.GetAvailabilityZones(ec2, region)
 	if err != nil {
 		return errors.Wrap(err, "getting availability zones")
 	}

--- a/pkg/eks/api_test.go
+++ b/pkg/eks/api_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Setting Availability Zones", func() {
 		When("the given params contain too few AZs", func() {
 			It("returns an error", func() {
 				err := eks.SetAvailabilityZones(cfg, []string{"us-east-2a"}, provider.EC2(), "")
-				Expect(err).To(MatchError(ContainSubstring("only 1 zone(s) specified [us-east-2a], 2 are required (can be non-unique)")))
+				Expect(err).To(MatchError("only 1 zone(s) specified [us-east-2a], 2 are required (can be non-unique)"))
 			})
 		})
 	})
@@ -197,7 +197,7 @@ var _ = Describe("Setting Availability Zones", func() {
 			It("returns an error", func() {
 				cfg.AvailabilityZones = []string{"us-east-2a"}
 				err := eks.SetAvailabilityZones(cfg, []string{}, provider.EC2(), "")
-				Expect(err).To(MatchError(ContainSubstring("only 1 zone(s) specified [us-east-2a], 2 are required (can be non-unique)")))
+				Expect(err).To(MatchError("only 1 zone(s) specified [us-east-2a], 2 are required (can be non-unique)"))
 			})
 		})
 	})
@@ -216,7 +216,7 @@ var _ = Describe("Setting Availability Zones", func() {
 					}},
 				}).Return(&ec2.DescribeAvailabilityZonesOutput{}, fmt.Errorf("err"))
 				err := eks.SetAvailabilityZones(cfg, []string{}, provider.EC2(), region)
-				Expect(err).To(MatchError(ContainSubstring("getting availability zones")))
+				Expect(err).To(MatchError("getting availability zones: error getting availability zones for region us-east-2: err"))
 			})
 		})
 

--- a/pkg/eks/api_test.go
+++ b/pkg/eks/api_test.go
@@ -1,6 +1,8 @@
 package eks_test
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -8,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 	"github.com/stretchr/testify/mock"
+	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -153,3 +156,97 @@ func mockDescribeImages(p *mockprovider.MockProvider, amiID string, matcher func
 			},
 		}, nil)
 }
+
+var _ = Describe("Setting Availability Zones", func() {
+	var (
+		provider *mockprovider.MockProvider
+		cfg      *api.ClusterConfig
+	)
+
+	BeforeEach(func() {
+		cfg = api.NewClusterConfig()
+		provider = mockprovider.NewMockProvider()
+	})
+
+	When("the AZs were set as CLI params", func() {
+		When("the given params contain enough AZs", func() {
+			It("sets them as the AZs to be used", func() {
+				err := eks.SetAvailabilityZones(cfg, []string{"us-east-2a", "us-east-2b"}, provider.EC2(), "")
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		When("the given params contain too few AZs", func() {
+			It("returns an error", func() {
+				err := eks.SetAvailabilityZones(cfg, []string{"us-east-2a"}, provider.EC2(), "")
+				Expect(err).To(MatchError(ContainSubstring("only 1 zone(s) specified [us-east-2a], 2 are required (can be non-unique)")))
+			})
+		})
+	})
+
+	When("the AZs were set in the config file", func() {
+		When("the config file contains enough AZs", func() {
+			It("sets them as the AZs to be used", func() {
+				cfg.AvailabilityZones = []string{"us-east-2a", "us-east-2b"}
+				err := eks.SetAvailabilityZones(cfg, []string{}, provider.EC2(), "")
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		When("the config file contains too few AZs", func() {
+			It("returns an error", func() {
+				cfg.AvailabilityZones = []string{"us-east-2a"}
+				err := eks.SetAvailabilityZones(cfg, []string{}, provider.EC2(), "")
+				Expect(err).To(MatchError(ContainSubstring("only 1 zone(s) specified [us-east-2a], 2 are required (can be non-unique)")))
+			})
+		})
+	})
+
+	When("no AZs were set", func() {
+		When("the call to fetch AZs fails", func() {
+			It("returns an error", func() {
+				region := "us-east-2"
+				provider.MockEC2().On("DescribeAvailabilityZones", &ec2.DescribeAvailabilityZonesInput{
+					Filters: []*ec2.Filter{{
+						Name:   aws.String("region-name"),
+						Values: []*string{aws.String(region)},
+					}, {
+						Name:   aws.String("state"),
+						Values: []*string{aws.String(ec2.AvailabilityZoneStateAvailable)},
+					}},
+				}).Return(&ec2.DescribeAvailabilityZonesOutput{}, fmt.Errorf("err"))
+				err := eks.SetAvailabilityZones(cfg, []string{}, provider.EC2(), region)
+				Expect(err).To(MatchError(ContainSubstring("getting availability zones")))
+			})
+		})
+
+		When("the call to fetch AZs succeeds", func() {
+			It("sets random AZs", func() {
+				region := "us-east-2"
+				provider.MockEC2().On("DescribeAvailabilityZones", &ec2.DescribeAvailabilityZonesInput{
+					Filters: []*ec2.Filter{{
+						Name:   aws.String("region-name"),
+						Values: []*string{aws.String(region)},
+					}, {
+						Name:   aws.String("state"),
+						Values: []*string{aws.String(ec2.AvailabilityZoneStateAvailable)},
+					}},
+				}).Return(&ec2.DescribeAvailabilityZonesOutput{
+					AvailabilityZones: []*ec2.AvailabilityZone{
+						{
+							GroupName: aws.String("name"),
+							ZoneName:  aws.String(region),
+							ZoneId:    aws.String("id"),
+						},
+						{
+							GroupName: aws.String("name"),
+							ZoneName:  aws.String(region),
+							ZoneId:    aws.String("id"),
+						}},
+				}, nil)
+				err := eks.SetAvailabilityZones(cfg, []string{}, provider.EC2(), region)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+})


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Closes #4891

During some refactoring, the AZ validation that returned early if AZs were set was accidentally removed, so the AZ configuration was not respected. Reinstating this to fix that bug :) + adding unit-tests so that hopefully it doesn't happen again 😬 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:

