### PR TITLE
Fix GitHub Actions caching

### DIFF
--- a/.github/workflows/cache-dependencies.yaml
+++ b/.github/workflows/cache-dependencies.yaml
@@ -16,4 +16,4 @@ jobs:
             ~/go/pkg/mod/
           key: go-${{ hashFiles('go.sum') }}
           restore-keys: |
-            - go-
+            go-

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,6 +24,6 @@ jobs:
             ~/go/pkg/mod/
           key: go-${{ hashFiles('go.sum') }}
           restore-keys: |
-            - go-
+            go-
       - name: Lint
         run: make lint

--- a/.github/workflows/publish-release-type.yaml
+++ b/.github/workflows/publish-release-type.yaml
@@ -23,7 +23,7 @@ jobs:
             ~/go/pkg/mod/
           key: go-${{ hashFiles('go.sum') }}
           restore-keys: |
-            - go-
+            go-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -22,7 +22,7 @@ jobs:
             ~/go/pkg/mod/
           key: go-${{ hashFiles('go.sum') }}
           restore-keys: |
-            - go-
+            go-
       - name: Setup identity as weaveworksbot
         uses: ./.github/actions/setup-identity
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
             ~/go/pkg/mod/
           key: go-${{ hashFiles('go.sum') }}
           restore-keys: |
-            - go-
+            go-
       - name: Setup identity as weaveworksbot
         uses: ./.github/actions/setup-identity
         with:

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -33,7 +33,7 @@ jobs:
             ~/go/pkg/mod/
           key: go-${{ hashFiles('go.sum') }}
           restore-keys: |
-            - go-
+            go-
       - name: Tag from version
         run: |
           version=$(go run pkg/version/generate/release_generate.go full-version)

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -21,7 +21,7 @@ jobs:
             ~/go/pkg/mod/
           key: go-${{ hashFiles('go.sum') }}
           restore-keys: |
-            - go-
+            go-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -49,7 +49,7 @@ jobs:
             ~/go/pkg/mod/
           key: go-${{ hashFiles('go.sum') }}
           restore-keys: |
-            - go-
+            go-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -76,7 +76,7 @@ jobs:
             ~/go/pkg/mod/
           key: go-${{ hashFiles('go.sum') }}
           restore-keys: |
-            - go-
+            go-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/update-generated.yaml
+++ b/.github/workflows/update-generated.yaml
@@ -72,7 +72,7 @@ jobs:
             ~/go/pkg/mod/
           key: go-${{ hashFiles('go.sum') }}
           restore-keys: |
-            - go-
+            go-
       - name: Update aws-node
         run: make update-aws-node
       - name: Commit changes


### PR DESCRIPTION
### Description

The syntax used for `restore-keys` was invalid. The `restore-keys` field must be passed a multi-line string, not an array.
GitHub Actions does not support arrays as inputs, so most actions work around this by accepting a multi-line string.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

