### PR TITLE
Fix checking cluster stack for owned clusters

### DIFF
--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -558,7 +558,7 @@ func (c *StackCollection) GetClusterStackIfExists() (*Stack, error) {
 	if err != nil {
 		return nil, err
 	}
-	return c.getClusterStackFromList(clusterStackNames, "")
+	return c.getClusterStackFromList(clusterStackNames, c.spec.Metadata.Name)
 }
 
 func (c *StackCollection) HasClusterStackFromList(clusterStackNames []string, clusterName string) (bool, error) {

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -375,7 +375,7 @@ func (c *StackCollection) ListStacksMatching(nameRegex string, statusFilters ...
 
 // ListClusterStackNames gets all stack names matching regex
 func (c *StackCollection) ListClusterStackNames() ([]string, error) {
-	stacks := []string{}
+	var stacks []string
 	re, err := regexp.Compile(clusterStackRegex)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot list stacks")

--- a/pkg/cfn/manager/api_test.go
+++ b/pkg/cfn/manager/api_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -10,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"

--- a/pkg/cfn/manager/api_test.go
+++ b/pkg/cfn/manager/api_test.go
@@ -328,12 +328,14 @@ var _ = Describe("StackCollection", func() {
 			cfg = api.NewClusterConfig()
 			cfg.Metadata.Name = "confirm-this"
 		})
+
 		It("can retrieve stacks", func() {
 			sm := NewStackCollection(p, cfg)
 			stack, err := sm.GetClusterStackIfExists()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stack).NotTo(BeNil())
 		})
+
 		When("the config stack doesn't match", func() {
 			It("returns no stack", func() {
 				cfg.Metadata.Name = "not-this"


### PR DESCRIPTION
### Description

PR https://github.com/weaveworks/eksctl/pull/4911 fixed a bug where the `clusterName` parameter was not being used when obtaining a cluster's ownership for `get clusters`. The logic for checking owned clusters, however, relied on this behaviour, breaking the check for cluster ownership. 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

