### PR TITLE
Fix integration tests for `get cluster`

### DIFF
--- a/integration/matchers/cluster.go
+++ b/integration/matchers/cluster.go
@@ -19,8 +19,9 @@ func AssertContainsCluster(cmd runner.Cmd, out GetClusterOutput) {
 	Expect(cmd).To(runner.RunSuccessfullyWithOutputStringLines(
 		ContainElement(WithTransform(func(line string) GetClusterOutput {
 			fields := strings.Fields(line)
-			const expectedColumns = 3
-			Expect(fields).To(HaveLen(expectedColumns), "Expected `get clusters` to return %d columns", expectedColumns)
+			if len(fields) != 3 {
+				return GetClusterOutput{}
+			}
 			return GetClusterOutput{
 				ClusterName:   fields[0],
 				Region:        fields[1],


### PR DESCRIPTION
### Description

This changelist fixes the integration tests for `get clusters`. The tests were failing because, as of a few releases ago, `eksctl get cluster` logs the version and region, but this wasn't taken into account when the assertions were added. 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

