### PR TITLE
Add support for arm gpu instance types

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/gpu_validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/gpu_validation_test.go
@@ -51,18 +51,22 @@ var _ = Describe("GPU instance support", func() {
 			gpuInstanceType: "g5.12xlarge",
 			amiFamily:       api.NodeImageFamilyAmazonLinux2,
 		}),
-		Entry("Bottlerocket", gpuInstanceEntry{
-			amiFamily:            api.NodeImageFamilyBottlerocket,
-			gpuInstanceType:      "g4dn.xlarge",
+		Entry("AL2 ARM", gpuInstanceEntry{
+			gpuInstanceType:      "g5g.xlarge",
+			amiFamily:            api.NodeImageFamilyAmazonLinux2,
 			expectUnsupportedErr: true,
-			customErr:            fmt.Sprintf("NVIDIA GPU instance types are not supported for managed nodegroups with AMIFamily %s", api.NodeImageFamilyBottlerocket),
+			customErr:            "ARM GPU instance types are not supported for managed nodegroups with AMIFamily AmazonLinux2",
+		}),
+		Entry("Bottlerocket nvidia", gpuInstanceEntry{
+			amiFamily:       api.NodeImageFamilyBottlerocket,
+			gpuInstanceType: "g4dn.xlarge",
 		}),
 		Entry("Ubuntu2004", gpuInstanceEntry{
 			amiFamily:            api.NodeImageFamilyUbuntu2004,
 			gpuInstanceType:      "g4dn.xlarge",
 			expectUnsupportedErr: true,
 		}),
-		Entry("Bottlerocket", gpuInstanceEntry{
+		Entry("Bottlerocket inferentia", gpuInstanceEntry{
 			amiFamily:            api.NodeImageFamilyBottlerocket,
 			gpuInstanceType:      "inf1.xlarge",
 			expectUnsupportedErr: true,
@@ -86,6 +90,10 @@ var _ = Describe("GPU instance support", func() {
 		}),
 		Entry("AL2", gpuInstanceEntry{
 			gpuInstanceType: "inf1.xlarge",
+			amiFamily:       api.NodeImageFamilyAmazonLinux2,
+		}),
+		Entry("AL2 ARM", gpuInstanceEntry{
+			gpuInstanceType: "g5g.xlarge",
 			amiFamily:       api.NodeImageFamilyAmazonLinux2,
 		}),
 		Entry("AMI unset", gpuInstanceEntry{

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -856,9 +856,10 @@ func ValidateManagedNodeGroup(index int, ng *ManagedNodeGroup) error {
 		return err
 	}
 
-	if instanceutils.IsNvidiaInstanceType(SelectInstanceType(ng)) && ng.AMIFamily == NodeImageFamilyBottlerocket {
-		logger.Info("Bottlerocket GPU support is for unmanaged nodegroups only. If you're using CLI flags pass --managed=false")
-		return errors.Errorf("NVIDIA GPU instance types are not supported for managed nodegroups with AMIFamily %s", ng.AMIFamily)
+	if instanceutils.IsGPUInstanceType(SelectInstanceType(ng)) &&
+		instanceutils.IsARMInstanceType(SelectInstanceType(ng)) &&
+		ng.AMIFamily == NodeImageFamilyAmazonLinux2 {
+		return errors.Errorf("ARM GPU instance types are not supported for managed nodegroups with AMIFamily %s", ng.AMIFamily)
 	}
 
 	if ng.IAM != nil {

--- a/pkg/cfn/builder/managed_nodegroup_ami_type_test.go
+++ b/pkg/cfn/builder/managed_nodegroup_ami_type_test.go
@@ -100,6 +100,40 @@ var _ = DescribeTable("Managed Nodegroup AMI type", func(e amiTypeEntry) {
 		expectedAMIType: "AL2_ARM_64",
 	}),
 
+	//Doesn't exist yet :(
+	// Entry("AL2 ARM GPU instance type", amiTypeEntry{
+	// 	nodeGroup: &api.ManagedNodeGroup{
+	// 		NodeGroupBase: &api.NodeGroupBase{
+	// 			Name:         "test",
+	// 			AMIFamily:    api.NodeImageFamilyAmazonLinux2,
+	// 			InstanceType: "g5g.xlarge",
+	// 		},
+	// 	},
+	// 	expectedAMIType: "AL2_ARM_64_GPU",
+	// }),
+
+	Entry("Bottlerocket ARM GPU instance type", amiTypeEntry{
+		nodeGroup: &api.ManagedNodeGroup{
+			NodeGroupBase: &api.NodeGroupBase{
+				Name:         "test",
+				AMIFamily:    api.NodeImageFamilyBottlerocket,
+				InstanceType: "g5g.xlarge",
+			},
+		},
+		expectedAMIType: "BOTTLEROCKET_ARM_64_NVIDIA",
+	}),
+
+	Entry("Bottlerocket x86 Nvidia GPU instance type", amiTypeEntry{
+		nodeGroup: &api.ManagedNodeGroup{
+			NodeGroupBase: &api.NodeGroupBase{
+				Name:         "test",
+				AMIFamily:    api.NodeImageFamilyBottlerocket,
+				InstanceType: "p2.xlarge",
+			},
+		},
+		expectedAMIType: "BOTTLEROCKET_x86_64_NVIDIA",
+	}),
+
 	Entry("Bottlerocket AMI type", amiTypeEntry{
 		nodeGroup: &api.ManagedNodeGroup{
 			NodeGroupBase: &api.NodeGroupBase{


### PR DESCRIPTION
### Description
Closes https://github.com/weaveworks/eksctl/issues/4865 #4916

ARM GPU instance type: g5g.xlarge
x86 GPU instance type: g4dn.xlarge

## Before

### 1- AL2 ARM GPU managed
managed instance on G5g (ARM GPU):

```
managedNodeGroups:
  - name: mng-1
    instanceType: g5g.xlarge
    desiredCapacity: 1
    
2022-03-18 14:30:51 [✖]  AWS::EKS::Nodegroup/ManagedNodeGroup: CREATE_FAILED – "Resource handler returned message: \"[g5g.xlarge] is not a valid instance type for request
ed amiType AL2_x86_64_GPU (Service: Eks, Status Code: 400, Request ID: 369e97fb-7cb6-4daa-9553-92f48593d666, Extended Request ID: null)\" (RequestToken: cc5e5f39-64b1-373
9-4d94-9a39b1b64d2c, HandlerErrorCode: InvalidRequest)"
```

### 2- AL2 ARM GPU unmanaged

unmanaged instance on G5g (ARM GPU):
```
nodeGroups:
  - name: ng-1
    instanceType: g5g.xlarge
    desiredCapacity: 1
   
2022-03-18 14:38:20 [✖]  AWS::AutoScaling::AutoScalingGroup/NodeGroup: CREATE_FAILED – "You must use a valid fully-formed launch template. The architecture 'arm64' of the specified instance type does not match the architecture 'x86_64' of the specified AMI. Specify an instance type and an AMI that have matching architectures, and try again. You can use 'describe-instance-types' or 'describe-images' to discover the architecture of the instance type or AMI. (Service: AmazonAutoScaling; Status Code: 400; Error Code: ValidationError; Request ID: c361a0dd-0fd6-4414-9eac-f8852f92a7e6; Proxy: null)"
   
```

### 3- BR ARM GPU managed

managed instance on G5g (ARM GPU):
```
managedNodeGroups:
  - name: mng-2
    instanceType: g5g.xlarge
    desiredCapacity: 1
    amiFamily: Bottlerocket
    
Error: couldn't create cluster provider from options: NVIDIA GPU instance types are not supported for managed nodegroups with AMIFamily Bottlerocket
```

### 4- BR x86 GPU managed

managed instance on G5g (ARM GPU):
```
managedNodeGroups:
  - name: mng-3
    instanceType: g4dn.xlarge
    desiredCapacity: 1
    amiFamily: Bottlerocket
    
Error: couldn't create cluster provider from options: NVIDIA GPU instance types are not supported for managed nodegroups with AMIFamily Bottlerocket
```


# After
### 1- AL2 ARM GPU managed
managed instance on G5g (ARM GPU):

```
managedNodeGroups:
  - name: mng-1
    instanceType: g5g.xlarge
    desiredCapacity: 1
    

```

### 2- AL2 ARM GPU unmanaged

unmanaged instance on G5g (ARM GPU):
```
nodeGroups:
  - name: ng-1
    instanceType: g5g.xlarge
    desiredCapacity: 1
   

```

### 3- BR ARM GPU managed

managed instance on G5g (ARM GPU):
```
managedNodeGroups:
  - name: mng-2
    instanceType: g5g.xlarge
    desiredCapacity: 1
    amiFamily: Bottlerocket
    

```

### 4- BR x86 GPU managed

managed instance on G5g (ARM GPU):
```
managedNodeGroups:
  - name: mng-3
    instanceType: g4dn.xlarge
    desiredCapacity: 1
    amiFamily: Bottlerocket
    
```