### PR TITLE
Update docs to mention what happens when you create an addon with no policy sources

### DIFF
--- a/userdocs/src/usage/addons.md
+++ b/userdocs/src/usage/addons.md
@@ -47,7 +47,7 @@ addons:
 
 You can specify at most one of `attachPolicy`, `attachPolicyARNs` and `serviceAccountRoleARN`.
 
-If none of these are specified, the addon will be created with a role with the recommended policies.
+If none of these are specified, the addon will be created with a role that has all recommended policies attached.
 
 !!!note
     In order to attach policies to addons your cluster must have `OIDC` enabled. If it's not enabled we ignore any policies

--- a/userdocs/src/usage/addons.md
+++ b/userdocs/src/usage/addons.md
@@ -47,6 +47,8 @@ addons:
 
 You can specify at most one of `attachPolicy`, `attachPolicyARNs` and `serviceAccountRoleARN`.
 
+If none of these are specified, the addon will be created with a role with the recommended policies.
+
 !!!note
     In order to attach policies to addons your cluster must have `OIDC` enabled. If it's not enabled we ignore any policies
     attached.


### PR DESCRIPTION
### Description

This is a documentation-only change.

Update https://eksctl.io/usage/addons/ to describe what happens if you create an addon without specifying any of the optional `attachPolicy`, `attachPolicyARNs` or `serviceAccountRoleARN`. From what happened when I tried it, this is what you want to do a lot of the time.

### Checklist
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

