### PR TITLE
Added Propagation of ManagedNodeGroup Tags to their corresponding AutoScalingGroups

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -1113,7 +1113,7 @@
             "type": "string"
           },
           "type": "object",
-          "description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged). Applied to the Autoscaling Group, the EKS Nodegroup resource and to the EC2 instances (managed)",
+          "description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged), Applied to the Autoscaling Group, the EKS Nodegroup resource and to the EC2 instances (managed)",
           "x-intellij-html-description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged), Applied to the Autoscaling Group, the EKS Nodegroup resource and to the EC2 instances (managed)",
           "default": "{}"
         },
@@ -1325,6 +1325,12 @@
         "desiredCapacity": {
           "type": "integer"
         },
+        "disableASGTagPropagation": {
+          "type": "boolean",
+          "description": "disables the tag propagation to ASG in case desired capacity is 0.",
+          "x-intellij-html-description": "disables the tag propagation to ASG in case desired capacity is 0.",
+          "default": false
+        },
         "disableIMDSv1": {
           "type": "boolean",
           "description": "requires requests to the metadata service to use IMDSv2 tokens",
@@ -1451,8 +1457,8 @@
             "type": "string"
           },
           "type": "object",
-          "description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged). Applied to the ASG, the EKS Nodegroup resource and to the EC2 instances (managed)",
-          "x-intellij-html-description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged). Applied to the ASG, the EKS Nodegroup resource and to the EC2 instances (managed)",
+          "description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged), Applied to the Autoscaling Group, the EKS Nodegroup resource and to the EC2 instances (managed)",
+          "x-intellij-html-description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged), Applied to the Autoscaling Group, the EKS Nodegroup resource and to the EC2 instances (managed)",
           "default": "{}"
         },
         "taints": {
@@ -1557,6 +1563,7 @@
         "clusterDNS",
         "kubeletExtraConfig",
         "containerRuntime",
+        "disableASGTagPropagation",
         "maxInstanceLifetime"
       ],
       "additionalProperties": false,

--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -976,12 +976,6 @@
         "desiredCapacity": {
           "type": "integer"
         },
-        "disableASGTagPropagation": {
-          "type": "boolean",
-          "description": "disables the tag propagation to ASG.",
-          "x-intellij-html-description": "disables the tag propagation to ASG.",
-          "default": false
-        },
         "disableIMDSv1": {
           "type": "boolean",
           "description": "requires requests to the metadata service to use IMDSv2 tokens",
@@ -1082,6 +1076,11 @@
           "x-intellij-html-description": "Enable <a href=\"/usage/vpc-networking/#use-private-subnets-for-initial-nodegroup\">private networking</a> for nodegroup",
           "default": "false"
         },
+        "propagateASGTags": {
+          "type": "boolean",
+          "description": "Propagate all taints and labels to the ASG automatically.",
+          "x-intellij-html-description": "Propagate all taints and labels to the ASG automatically."
+        },
         "releaseVersion": {
           "type": "string",
           "description": "the AMI version of the EKS optimized AMI to use",
@@ -1114,7 +1113,7 @@
             "type": "string"
           },
           "type": "object",
-          "description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged), Applied to the Autoscaling Group, the EKS Nodegroup resource and to the EC2 instances (managed)",
+          "description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged). Applied to the Autoscaling Group, the EKS Nodegroup resource and to the EC2 instances (managed)",
           "x-intellij-html-description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged), Applied to the Autoscaling Group, the EKS Nodegroup resource and to the EC2 instances (managed)",
           "default": "{}"
         },
@@ -1197,7 +1196,7 @@
         "additionalVolumes",
         "preBootstrapCommands",
         "overrideBootstrapCommand",
-        "disableASGTagPropagation",
+        "propagateASGTags",
         "disableIMDSv1",
         "disablePodIMDS",
         "placement",
@@ -1326,12 +1325,6 @@
         "desiredCapacity": {
           "type": "integer"
         },
-        "disableASGTagPropagation": {
-          "type": "boolean",
-          "description": "disables the tag propagation to ASG in case desired capacity is 0.",
-          "x-intellij-html-description": "disables the tag propagation to ASG in case desired capacity is 0.",
-          "default": false
-        },
         "disableIMDSv1": {
           "type": "boolean",
           "description": "requires requests to the metadata service to use IMDSv2 tokens",
@@ -1458,8 +1451,8 @@
             "type": "string"
           },
           "type": "object",
-          "description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged), Applied to the Autoscaling Group, the EKS Nodegroup resource and to the EC2 instances (managed)",
-          "x-intellij-html-description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged), Applied to the Autoscaling Group, the EKS Nodegroup resource and to the EC2 instances (managed)",
+          "description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged). Applied to the ASG, the EKS Nodegroup resource and to the EC2 instances (managed)",
+          "x-intellij-html-description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged). Applied to the ASG, the EKS Nodegroup resource and to the EC2 instances (managed)",
           "default": "{}"
         },
         "taints": {
@@ -1546,7 +1539,7 @@
         "additionalVolumes",
         "preBootstrapCommands",
         "overrideBootstrapCommand",
-        "disableASGTagPropagation",
+        "propagateASGTags",
         "disableIMDSv1",
         "disablePodIMDS",
         "placement",
@@ -1564,7 +1557,6 @@
         "clusterDNS",
         "kubeletExtraConfig",
         "containerRuntime",
-        "propagateASGTags",
         "maxInstanceLifetime"
       ],
       "additionalProperties": false,

--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -976,6 +976,12 @@
         "desiredCapacity": {
           "type": "integer"
         },
+        "disableASGTagPropagation": {
+          "type": "boolean",
+          "description": "disables the tag propagation to ASG.",
+          "x-intellij-html-description": "disables the tag propagation to ASG.",
+          "default": false
+        },
         "disableIMDSv1": {
           "type": "boolean",
           "description": "requires requests to the metadata service to use IMDSv2 tokens",
@@ -1191,6 +1197,7 @@
         "additionalVolumes",
         "preBootstrapCommands",
         "overrideBootstrapCommand",
+        "disableASGTagPropagation",
         "disableIMDSv1",
         "disablePodIMDS",
         "placement",
@@ -1321,8 +1328,9 @@
         },
         "disableASGTagPropagation": {
           "type": "boolean",
-          "description": "disable the tag propagation in case desired capacity is 0.",
-          "x-intellij-html-description": "disable the tag propagation in case desired capacity is 0."
+          "description": "disables the tag propagation to ASG in case desired capacity is 0.",
+          "x-intellij-html-description": "disables the tag propagation to ASG in case desired capacity is 0.",
+          "default": false
         },
         "disableIMDSv1": {
           "type": "boolean",
@@ -1538,6 +1546,7 @@
         "additionalVolumes",
         "preBootstrapCommands",
         "overrideBootstrapCommand",
+        "disableASGTagPropagation",
         "disableIMDSv1",
         "disablePodIMDS",
         "placement",
@@ -1556,7 +1565,6 @@
         "kubeletExtraConfig",
         "containerRuntime",
         "propagateASGTags",
-        "disableASGTagPropagation",
         "maxInstanceLifetime"
       ],
       "additionalProperties": false,

--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -1114,8 +1114,8 @@
             "type": "string"
           },
           "type": "object",
-          "description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged), Applied to the EKS Nodegroup resource and to the EC2 instances (managed)",
-          "x-intellij-html-description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged), Applied to the EKS Nodegroup resource and to the EC2 instances (managed)",
+          "description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged), Applied to the Autoscaling Group, the EKS Nodegroup resource and to the EC2 instances (managed)",
+          "x-intellij-html-description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged), Applied to the Autoscaling Group, the EKS Nodegroup resource and to the EC2 instances (managed)",
           "default": "{}"
         },
         "taints": {
@@ -1458,8 +1458,8 @@
             "type": "string"
           },
           "type": "object",
-          "description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged), Applied to the EKS Nodegroup resource and to the EC2 instances (managed)",
-          "x-intellij-html-description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged), Applied to the EKS Nodegroup resource and to the EC2 instances (managed)",
+          "description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged), Applied to the Autoscaling Group, the EKS Nodegroup resource and to the EC2 instances (managed)",
+          "x-intellij-html-description": "Applied to the Autoscaling Group and to the EC2 instances (unmanaged), Applied to the Autoscaling Group, the EKS Nodegroup resource and to the EC2 instances (managed)",
           "default": "{}"
         },
         "taints": {

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -1307,7 +1307,7 @@ type NodeGroupBase struct {
 	// +optional
 	PrivateNetworking bool `json:"privateNetworking"`
 	// Applied to the Autoscaling Group and to the EC2 instances (unmanaged),
-	// Applied to the EKS Nodegroup resource and to the EC2 instances (managed)
+	// Applied to the Autoscaling Group, the EKS Nodegroup resource and to the EC2 instances (managed)
 	// +optional
 	Tags map[string]string `json:"tags,omitempty"`
 	// +optional

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -997,10 +997,6 @@ type NodeGroup struct {
 	// +optional
 	ContainerRuntime *string `json:"containerRuntime,omitempty"`
 
-	// Propagate all taints and labels to the ASG automatically.
-	// +optional
-	PropagateASGTags *bool `json:"propagateASGTags,omitempty"`
-
 	// MaxInstanceLifetime defines the maximum amount of time in seconds an instance stays alive.
 	// +optional
 	MaxInstanceLifetime *int `json:"maxInstanceLifetime,omitempty"`
@@ -1364,10 +1360,9 @@ type NodeGroupBase struct {
 	// +optional
 	OverrideBootstrapCommand *string `json:"overrideBootstrapCommand,omitempty"`
 
-	// DisableASGTagPropagation disables the tag propagation to ASG in case desired capacity is 0.
-	// Defaults to `false`
+	// Propagate all taints and labels to the ASG automatically.
 	// +optional
-	DisableASGTagPropagation *bool `json:"disableASGTagPropagation,omitempty"`
+	PropagateASGTags *bool `json:"propagateASGTags,omitempty"`
 
 	// DisableIMDSv1 requires requests to the metadata service to use IMDSv2 tokens
 	// Defaults to `false`

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -1001,10 +1001,6 @@ type NodeGroup struct {
 	// +optional
 	PropagateASGTags *bool `json:"propagateASGTags,omitempty"`
 
-	// DisableASGTagPropagation disable the tag propagation in case desired capacity is 0.
-	// +optional
-	DisableASGTagPropagation *bool `json:"disableASGTagPropagation,omitempty"`
-
 	// MaxInstanceLifetime defines the maximum amount of time in seconds an instance stays alive.
 	// +optional
 	MaxInstanceLifetime *int `json:"maxInstanceLifetime,omitempty"`
@@ -1367,6 +1363,11 @@ type NodeGroupBase struct {
 	// Override `eksctl`'s bootstrapping script
 	// +optional
 	OverrideBootstrapCommand *string `json:"overrideBootstrapCommand,omitempty"`
+
+	// DisableASGTagPropagation disables the tag propagation to ASG in case desired capacity is 0.
+	// Defaults to `false`
+	// +optional
+	DisableASGTagPropagation *bool `json:"disableASGTagPropagation,omitempty"`
 
 	// DisableIMDSv1 requires requests to the metadata service to use IMDSv2 tokens
 	// Defaults to `false`

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -997,6 +997,11 @@ type NodeGroup struct {
 	// +optional
 	ContainerRuntime *string `json:"containerRuntime,omitempty"`
 
+	// DisableASGTagPropagation disables the tag propagation to ASG in case desired capacity is 0.
+	// Defaults to `false`
+	// +optional
+	DisableASGTagPropagation *bool `json:"disableASGTagPropagation,omitempty"`
+
 	// MaxInstanceLifetime defines the maximum amount of time in seconds an instance stays alive.
 	// +optional
 	MaxInstanceLifetime *int `json:"maxInstanceLifetime,omitempty"`

--- a/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
@@ -1015,19 +1015,11 @@ func (in *NodeGroup) DeepCopyInto(out *NodeGroup) {
 		*out = new(string)
 		**out = **in
 	}
-<<<<<<< HEAD
-	if in.PropagateASGTags != nil {
-		in, out := &in.PropagateASGTags, &out.PropagateASGTags
-		*out = new(bool)
-		**out = **in
-	}
 	if in.DisableASGTagPropagation != nil {
 		in, out := &in.DisableASGTagPropagation, &out.DisableASGTagPropagation
 		*out = new(bool)
 		**out = **in
 	}
-=======
->>>>>>> a155a0d8 (Update generated files)
 	if in.MaxInstanceLifetime != nil {
 		in, out := &in.MaxInstanceLifetime, &out.MaxInstanceLifetime
 		*out = new(int)
@@ -1159,8 +1151,8 @@ func (in *NodeGroupBase) DeepCopyInto(out *NodeGroupBase) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.DisableASGTagPropagation != nil {
-		in, out := &in.DisableASGTagPropagation, &out.DisableASGTagPropagation
+	if in.PropagateASGTags != nil {
+		in, out := &in.PropagateASGTags, &out.PropagateASGTags
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
@@ -1015,6 +1015,7 @@ func (in *NodeGroup) DeepCopyInto(out *NodeGroup) {
 		*out = new(string)
 		**out = **in
 	}
+<<<<<<< HEAD
 	if in.PropagateASGTags != nil {
 		in, out := &in.PropagateASGTags, &out.PropagateASGTags
 		*out = new(bool)
@@ -1025,6 +1026,8 @@ func (in *NodeGroup) DeepCopyInto(out *NodeGroup) {
 		*out = new(bool)
 		**out = **in
 	}
+=======
+>>>>>>> a155a0d8 (Update generated files)
 	if in.MaxInstanceLifetime != nil {
 		in, out := &in.MaxInstanceLifetime, &out.MaxInstanceLifetime
 		*out = new(int)
@@ -1154,6 +1157,11 @@ func (in *NodeGroupBase) DeepCopyInto(out *NodeGroupBase) {
 	if in.OverrideBootstrapCommand != nil {
 		in, out := &in.OverrideBootstrapCommand, &out.OverrideBootstrapCommand
 		*out = new(string)
+		**out = **in
+	}
+	if in.DisableASGTagPropagation != nil {
+		in, out := &in.DisableASGTagPropagation, &out.DisableASGTagPropagation
+		*out = new(bool)
 		**out = **in
 	}
 	if in.DisableIMDSv1 != nil {

--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -23,6 +23,7 @@ import (
 
 // MaximumTagNumber for ASGs as described here https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-tagging.html
 const MaximumTagNumber = 50
+const MaximumCreatedTagNumberPerCall = 25
 
 // NodeGroupResourceSet stores the resource information of the nodegroup
 type NodeGroupResourceSet struct {

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -16,7 +16,6 @@ import (
 
 	cttypes "github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
@@ -316,7 +315,7 @@ func (c *StackCollection) checkASGTagsNumber(ngName, asgName string, propagatedT
 	for ngTagKey := range propagatedTags {
 		for _, asgTag := range asgTags {
 			// decrease the unique tag key count if there is a match
-			if asgTag.Key != nil && *asgTag.Key == ngTagKey {
+			if aws.StringValue(asgTag.Key) == ngTagKey {
 				uniqueTagKeyCount--
 				break
 			}

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -29,11 +29,12 @@ import (
 )
 
 const (
-	resourcesRootPath = "Resources"
-	outputsRootPath   = "Outputs"
-	mappingsRootPath  = "Mappings"
-	ourStackRegexFmt  = "^(eksctl|EKS)-%s-((cluster|nodegroup-.+|addon-.+|fargate|karpenter)|(VPC|ServiceRole|ControlPlane|DefaultNodeGroup))$"
-	clusterStackRegex = "eksctl-.*-cluster"
+	resourcesRootPath            = "Resources"
+	resourceTypeAutoScalingGroup = "auto-scaling-group"
+	outputsRootPath              = "Outputs"
+	mappingsRootPath             = "Mappings"
+	ourStackRegexFmt             = "^(eksctl|EKS)-%s-((cluster|nodegroup-.+|addon-.+|fargate|karpenter)|(VPC|ServiceRole|ControlPlane|DefaultNodeGroup))$"
+	clusterStackRegex            = "eksctl-.*-cluster"
 )
 
 var (
@@ -262,7 +263,7 @@ func (c *StackCollection) PropagateManagedNodeGroupTagsToASG(ngName string, ngTa
 			for ngTagKey, ngTagValue := range ngTags {
 				asgTag := asTypes.Tag{
 					ResourceId:        aws.String(asgName),
-					ResourceType:      aws.String("auto-scaling-group"),
+					ResourceType:      aws.String(resourceTypeAutoScalingGroup),
 					Key:               aws.String(ngTagKey),
 					Value:             aws.String(ngTagValue),
 					PropagateAtLaunch: aws.Bool(false),
@@ -299,7 +300,7 @@ func (c *StackCollection) checkASGTagsNumber(ngName, asgName string, propagatedT
 	tagsFilter := &autoscaling.DescribeTagsInput{
 		Filters: []asTypes.Filter{
 			{
-				Name:   aws.String("auto-scaling-group"),
+				Name:   aws.String(resourceTypeAutoScalingGroup),
 				Values: []string{asgName},
 			},
 		},

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
-	astypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	asTypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/aws/aws-sdk-go-v2/service/cloudtrail"
@@ -245,7 +245,7 @@ func (c *StackCollection) PropagateManagedNodeGroupTagsToASG(ngName string, ngTa
 	go func() {
 		defer close(errCh)
 		// build the input tags for all ASGs attached to the managed nodegroup
-		asgTags := []astypes.Tag{}
+		asgTags := []asTypes.Tag{}
 
 		for _, asgName := range asgNames {
 			// skip directly if not tags are required to be created
@@ -260,7 +260,7 @@ func (c *StackCollection) PropagateManagedNodeGroupTagsToASG(ngName string, ngTa
 			}
 			// build the list of tags to attach to the ASG
 			for ngTagKey, ngTagValue := range ngTags {
-				asgTag := astypes.Tag{
+				asgTag := asTypes.Tag{
 					ResourceId:        aws.String(asgName),
 					ResourceType:      aws.String("auto-scaling-group"),
 					Key:               aws.String(ngTagKey),
@@ -272,7 +272,7 @@ func (c *StackCollection) PropagateManagedNodeGroupTagsToASG(ngName string, ngTa
 		}
 
 		// consider the maximum number of tags we can create at once...
-		var chunkedASGTags [][]astypes.Tag
+		var chunkedASGTags [][]asTypes.Tag
 		chunkSize := builder.MaximumCreatedTagNumberPerCall
 		for start := 0; start < len(asgTags); start += chunkSize {
 			end := start + chunkSize
@@ -297,7 +297,7 @@ func (c *StackCollection) PropagateManagedNodeGroupTagsToASG(ngName string, ngTa
 // checkASGTagsNumber limit considering the new propagated tags
 func (c *StackCollection) checkASGTagsNumber(ngName, asgName string, propagatedTags map[string]string) error {
 	tagsFilter := &autoscaling.DescribeTagsInput{
-		Filters: []astypes.Filter{
+		Filters: []asTypes.Filter{
 			{
 				Name:   aws.String("auto-scaling-group"),
 				Values: []string{asgName},

--- a/pkg/cfn/manager/api.go
+++ b/pkg/cfn/manager/api.go
@@ -14,6 +14,8 @@ import (
 
 	cttypes "github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 	"github.com/kris-nova/logger"
 	"github.com/pkg/errors"
@@ -236,6 +238,92 @@ func (c *StackCollection) createStackRequest(ctx context.Context, stackName stri
 
 	logger.Info("deploying stack %q", stackName)
 	return stack, nil
+}
+
+func (c *StackCollection) PropagateManagedNodeGroupTagsToASG(ngName string, ngTags map[string]string, asgNames []string, errCh chan error) error {
+	go func() {
+		defer close(errCh)
+		// build the input tags for all ASGs attached to the managed nodegroup
+		asgTags := []*autoscaling.Tag{}
+
+		for _, asgName := range asgNames {
+			// skip directly if not tags are required to be created
+			if len(ngTags) == 0 {
+				continue
+			}
+
+			// check if the number of tags on the ASG would go over the defined limit
+			if err := c.checkASGTagsNumber(ngName, asgName, ngTags); err != nil {
+				errCh <- err
+				return
+			}
+			// build the list of tags to attach to the ASG
+			for ngTagKey, ngTagValue := range ngTags {
+				asgTag := &autoscaling.Tag{
+					ResourceId:        aws.String(asgName),
+					ResourceType:      aws.String("auto-scaling-group"),
+					Key:               aws.String(ngTagKey),
+					Value:             aws.String(ngTagValue),
+					PropagateAtLaunch: aws.Bool(false),
+				}
+				asgTags = append(asgTags, asgTag)
+			}
+		}
+
+		// consider the maximum number of tags we can create at once...
+		var chunkedASGTags [][]*autoscaling.Tag
+		chunkSize := builder.MaximumCreatedTagNumberPerCall
+		for start := 0; start < len(asgTags); start += chunkSize {
+			end := start + chunkSize
+			if end > len(asgTags) {
+				end = len(asgTags)
+			}
+			chunkedASGTags = append(chunkedASGTags, asgTags[start:end])
+		}
+		// ...then create all of them in a loop
+		for _, asgTags := range chunkedASGTags {
+			input := &autoscaling.CreateOrUpdateTagsInput{Tags: asgTags}
+			if _, err := c.asgAPI.CreateOrUpdateTags(input); err != nil {
+				errCh <- errors.Wrapf(err, "creating or updating asg tags for managed nodegroup %q", ngName)
+				return
+			}
+		}
+		errCh <- nil
+	}()
+	return nil
+}
+
+// checkASGTagsNumber limit considering the new propagated tags
+func (c *StackCollection) checkASGTagsNumber(ngName, asgName string, propagatedTags map[string]string) error {
+	tagsFilter := &autoscaling.DescribeTagsInput{
+		Filters: []*autoscaling.Filter{
+			{
+				Name:   aws.String("auto-scaling-group"),
+				Values: []*string{aws.String(asgName)},
+			},
+		},
+	}
+	output, err := c.asgAPI.DescribeTags(tagsFilter)
+	if err != nil {
+		return errors.Wrapf(err, "describing asg %q tags for managed nodegroup %q", asgName, ngName)
+	}
+	asgTags := output.Tags
+	// intersection of key tags to consider the number of tags going
+	// to be attached to the ASG
+	uniqueTagKeyCount := len(asgTags) + len(propagatedTags)
+	for ngTagKey := range propagatedTags {
+		for _, asgTag := range asgTags {
+			// decrease the unique tag key count if there is a match
+			if asgTag.Key != nil && *asgTag.Key == ngTagKey {
+				uniqueTagKeyCount--
+				break
+			}
+		}
+	}
+	if uniqueTagKeyCount > builder.MaximumTagNumber {
+		return fmt.Errorf("number of tags is exceeding the maximum amount for asg %d, was: %d", builder.MaximumTagNumber, uniqueTagKeyCount)
+	}
+	return nil
 }
 
 // UpdateStack will update a CloudFormation stack by creating and executing a ChangeSet

--- a/pkg/cfn/manager/api_test.go
+++ b/pkg/cfn/manager/api_test.go
@@ -6,13 +6,12 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
-	astypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	asTypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	cfn "github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/awstesting"
-	cfn "github.com/aws/aws-sdk-go/service/cloudformation"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -26,29 +25,35 @@ import (
 
 var _ = Describe("StackCollection", func() {
 	Context("PropagateManagedNodeGroupTagsToASG", func() {
-		It("can create propagate tag", func() {
-			// define most mock parameters
-			asgName := "asg-test-name"
-			ngName := "ng-test-name"
-			ngTags := map[string]string{
+		var (
+			asgName string
+			ngName  string
+			ngTags  map[string]string
+			errCh   chan error
+			p       *mockprovider.MockProvider
+		)
+		BeforeEach(func() {
+			asgName = "asg-test-name"
+			ngName = "ng-test-name"
+			ngTags = map[string]string{
 				"tag_key_1": "tag_value_1",
 			}
-			errCh := make(chan error)
+			errCh = make(chan error)
+			p = mockprovider.NewMockProvider()
+		})
 
-			p := mockprovider.NewMockProvider()
-
+		It("can create propagate tag", func() {
 			// DescribeTags classic mock
 			describeTagsInput := &autoscaling.DescribeTagsInput{
-				Filters: []astypes.Filter{{Name: aws.String("auto-scaling-group"), Values: []string{asgName}}},
+				Filters: []asTypes.Filter{{Name: aws.String("auto-scaling-group"), Values: []string{asgName}}},
 			}
-			describeOutput := &autoscaling.DescribeTagsOutput{}
-			p.MockASG().On("DescribeTags", mock.Anything, describeTagsInput).Return(describeOutput, nil)
+			p.MockASG().On("DescribeTags", mock.Anything, describeTagsInput).Return(&autoscaling.DescribeTagsOutput{}, nil)
 
 			// CreateOrUpdateTags classic mock
 			createOrUpdateTagsInput := &autoscaling.CreateOrUpdateTagsInput{
-				Tags: []astypes.Tag{
+				Tags: []asTypes.Tag{
 					{
-						ResourceId:        aws.String("asg-test-name"),
+						ResourceId:        aws.String(asgName),
 						ResourceType:      aws.String("auto-scaling-group"),
 						Key:               aws.String("tag_key_1"),
 						Value:             aws.String("tag_value_1"),
@@ -56,8 +61,7 @@ var _ = Describe("StackCollection", func() {
 					},
 				},
 			}
-			createOrUpdateTagsOutput := &autoscaling.CreateOrUpdateTagsOutput{}
-			p.MockASG().On("CreateOrUpdateTags", mock.Anything, createOrUpdateTagsInput).Return(createOrUpdateTagsOutput, nil)
+			p.MockASG().On("CreateOrUpdateTags", mock.Anything, createOrUpdateTagsInput).Return(&autoscaling.CreateOrUpdateTagsOutput{}, nil)
 
 			sm := NewStackCollection(p, api.NewClusterConfig())
 			err := sm.PropagateManagedNodeGroupTagsToASG(ngName, ngTags, []string{asgName}, errCh)
@@ -66,16 +70,12 @@ var _ = Describe("StackCollection", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 		It("cannot propagate tags in chunks of 25", func() {
-			// define most mock parameters
-			ngName := "ng-test-name"
-			asgName := "asg-test-name"
-			ngTags := make(map[string]string)
 			// populate the createOrUpdateTagsSliceInput for easier generation of chunks
-			createOrUpdateTagsSliceInput := []astypes.Tag{}
+			createOrUpdateTagsSliceInput := []asTypes.Tag{}
 			for i := 0; i < 30; i++ {
 				tagKey, tagValue := fmt.Sprintf("tag_key_%d", i), fmt.Sprintf("tag_value_%d", i)
 				ngTags[tagKey] = tagValue
-				createOrUpdateTagsSliceInput = append(createOrUpdateTagsSliceInput, astypes.Tag{
+				createOrUpdateTagsSliceInput = append(createOrUpdateTagsSliceInput, asTypes.Tag{
 					ResourceId:        aws.String(asgName),
 					ResourceType:      aws.String("auto-scaling-group"),
 					Key:               aws.String(tagKey),
@@ -83,16 +83,12 @@ var _ = Describe("StackCollection", func() {
 					PropagateAtLaunch: aws.Bool(false),
 				})
 			}
-			errCh := make(chan error)
-
-			p := mockprovider.NewMockProvider()
 
 			// DescribeTags classic mock
 			describeTagsInput := &autoscaling.DescribeTagsInput{
-				Filters: []astypes.Filter{{Name: aws.String("auto-scaling-group"), Values: []string{asgName}}},
+				Filters: []asTypes.Filter{{Name: aws.String("auto-scaling-group"), Values: []string{asgName}}},
 			}
-			describeOutput := &autoscaling.DescribeTagsOutput{}
-			p.MockASG().On("DescribeTags", mock.Anything, describeTagsInput).Return(describeOutput, nil)
+			p.MockASG().On("DescribeTags", mock.Anything, describeTagsInput).Return(&autoscaling.DescribeTagsOutput{}, nil)
 
 			// CreateOrUpdateTags chunked mock
 			// generate the expected chunk of tags
@@ -115,24 +111,17 @@ var _ = Describe("StackCollection", func() {
 			err = <-errCh
 			Expect(err).NotTo(HaveOccurred())
 		})
-		It("cannot propagate if to many tags", func() {
-			// define parameters
-			ngName := "ng-test-name"
-			asgName := "asg-test-name"
-			ngTags := make(map[string]string)
+		It("cannot propagate if too many tags", func() {
+			// fill parameters
 			for i := 0; i < builder.MaximumTagNumber+1; i++ {
 				ngTags[fmt.Sprintf("tag_key_%d", i)] = fmt.Sprintf("tag_value_%d", i)
 			}
-			errCh := make(chan error)
-
-			p := mockprovider.NewMockProvider()
 
 			// DescribeTags classic mock
 			describeTagsInput := &autoscaling.DescribeTagsInput{
-				Filters: []astypes.Filter{{Name: aws.String("auto-scaling-group"), Values: []string{asgName}}},
+				Filters: []asTypes.Filter{{Name: aws.String("auto-scaling-group"), Values: []string{asgName}}},
 			}
-			describeOutput := &autoscaling.DescribeTagsOutput{}
-			p.MockASG().On("DescribeTags", mock.Anything, describeTagsInput).Return(describeOutput, nil)
+			p.MockASG().On("DescribeTags", mock.Anything, describeTagsInput).Return(&autoscaling.DescribeTagsOutput{}, nil)
 
 			sm := NewStackCollection(p, api.NewClusterConfig())
 			err := sm.PropagateManagedNodeGroupTagsToASG(ngName, ngTags, []string{asgName}, errCh)

--- a/pkg/cfn/manager/api_test.go
+++ b/pkg/cfn/manager/api_test.go
@@ -45,7 +45,7 @@ var _ = Describe("StackCollection", func() {
 		It("can create propagate tag", func() {
 			// DescribeTags classic mock
 			describeTagsInput := &autoscaling.DescribeTagsInput{
-				Filters: []asTypes.Filter{{Name: aws.String("auto-scaling-group"), Values: []string{asgName}}},
+				Filters: []asTypes.Filter{{Name: aws.String(resourceTypeAutoScalingGroup), Values: []string{asgName}}},
 			}
 			p.MockASG().On("DescribeTags", mock.Anything, describeTagsInput).Return(&autoscaling.DescribeTagsOutput{}, nil)
 
@@ -54,7 +54,7 @@ var _ = Describe("StackCollection", func() {
 				Tags: []asTypes.Tag{
 					{
 						ResourceId:        aws.String(asgName),
-						ResourceType:      aws.String("auto-scaling-group"),
+						ResourceType:      aws.String(resourceTypeAutoScalingGroup),
 						Key:               aws.String("tag_key_1"),
 						Value:             aws.String("tag_value_1"),
 						PropagateAtLaunch: aws.Bool(false),
@@ -77,7 +77,7 @@ var _ = Describe("StackCollection", func() {
 				ngTags[tagKey] = tagValue
 				createOrUpdateTagsSliceInput = append(createOrUpdateTagsSliceInput, asTypes.Tag{
 					ResourceId:        aws.String(asgName),
-					ResourceType:      aws.String("auto-scaling-group"),
+					ResourceType:      aws.String(resourceTypeAutoScalingGroup),
 					Key:               aws.String(tagKey),
 					Value:             aws.String(tagValue),
 					PropagateAtLaunch: aws.Bool(false),
@@ -86,7 +86,7 @@ var _ = Describe("StackCollection", func() {
 
 			// DescribeTags classic mock
 			describeTagsInput := &autoscaling.DescribeTagsInput{
-				Filters: []asTypes.Filter{{Name: aws.String("auto-scaling-group"), Values: []string{asgName}}},
+				Filters: []asTypes.Filter{{Name: aws.String(resourceTypeAutoScalingGroup), Values: []string{asgName}}},
 			}
 			p.MockASG().On("DescribeTags", mock.Anything, describeTagsInput).Return(&autoscaling.DescribeTagsOutput{}, nil)
 
@@ -119,7 +119,7 @@ var _ = Describe("StackCollection", func() {
 
 			// DescribeTags classic mock
 			describeTagsInput := &autoscaling.DescribeTagsInput{
-				Filters: []asTypes.Filter{{Name: aws.String("auto-scaling-group"), Values: []string{asgName}}},
+				Filters: []asTypes.Filter{{Name: aws.String(resourceTypeAutoScalingGroup), Values: []string{asgName}}},
 			}
 			p.MockASG().On("DescribeTags", mock.Anything, describeTagsInput).Return(&autoscaling.DescribeTagsOutput{}, nil)
 

--- a/pkg/cfn/manager/create_tasks.go
+++ b/pkg/cfn/manager/create_tasks.go
@@ -106,6 +106,14 @@ func (c *StackCollection) NewManagedNodeGroupTask(ctx context.Context, nodeGroup
 			info:              fmt.Sprintf("create managed nodegroup %q", ng.Name),
 			ctx:               ctx,
 		})
+		if ng.DisableASGTagPropagation != nil && *ng.DisableASGTagPropagation {
+			continue
+		}
+		taskTree.Append(&managedNodeGroupTagsToASGPropagationTask{
+			stackCollection: c,
+			nodeGroup:       ng,
+			info:            fmt.Sprintf("propagate tags to ASG for managed nodegroup %q", ng.Name),
+		})
 	}
 	return taskTree
 }

--- a/pkg/cfn/manager/create_tasks.go
+++ b/pkg/cfn/manager/create_tasks.go
@@ -106,14 +106,13 @@ func (c *StackCollection) NewManagedNodeGroupTask(ctx context.Context, nodeGroup
 			info:              fmt.Sprintf("create managed nodegroup %q", ng.Name),
 			ctx:               ctx,
 		})
-		if ng.DisableASGTagPropagation != nil && *ng.DisableASGTagPropagation {
-			continue
+		if api.IsEnabled(ng.PropagateASGTags) {
+			taskTree.Append(&managedNodeGroupTagsToASGPropagationTask{
+				stackCollection: c,
+				nodeGroup:       ng,
+				info:            fmt.Sprintf("propagate tags to ASG for managed nodegroup %q", ng.Name),
+			})
 		}
-		taskTree.Append(&managedNodeGroupTagsToASGPropagationTask{
-			stackCollection: c,
-			nodeGroup:       ng,
-			info:            fmt.Sprintf("propagate tags to ASG for managed nodegroup %q", ng.Name),
-		})
 	}
 	return taskTree
 }

--- a/pkg/cfn/manager/create_tasks.go
+++ b/pkg/cfn/manager/create_tasks.go
@@ -107,6 +107,9 @@ func (c *StackCollection) NewManagedNodeGroupTask(ctx context.Context, nodeGroup
 			ctx:               ctx,
 		})
 		if api.IsEnabled(ng.PropagateASGTags) {
+			// disable parallelisation if any tags propagation is done
+			// since nodegroup must be created to propagate tags to its ASGs
+			taskTree.Parallel = false
 			taskTree.Append(&managedNodeGroupTagsToASGPropagationTask{
 				stackCollection: c,
 				nodeGroup:       ng,

--- a/pkg/cfn/manager/fakes/fake_stack_manager.go
+++ b/pkg/cfn/manager/fakes/fake_stack_manager.go
@@ -725,6 +725,20 @@ type FakeStackManager struct {
 	newUnmanagedNodeGroupTaskReturnsOnCall map[int]struct {
 		result1 *tasks.TaskTree
 	}
+	PropagateManagedNodeGroupTagsToASGStub        func(string, map[string]string, []string, chan error) error
+	propagateManagedNodeGroupTagsToASGMutex       sync.RWMutex
+	propagateManagedNodeGroupTagsToASGArgsForCall []struct {
+		arg1 string
+		arg2 map[string]string
+		arg3 []string
+		arg4 chan error
+	}
+	propagateManagedNodeGroupTagsToASGReturns struct {
+		result1 error
+	}
+	propagateManagedNodeGroupTagsToASGReturnsOnCall map[int]struct {
+		result1 error
+	}
 	RefreshFargatePodExecutionRoleARNStub        func(context.Context) error
 	refreshFargatePodExecutionRoleARNMutex       sync.RWMutex
 	refreshFargatePodExecutionRoleARNArgsForCall []struct {
@@ -4166,6 +4180,75 @@ func (fake *FakeStackManager) NewUnmanagedNodeGroupTaskReturnsOnCall(i int, resu
 	}{result1}
 }
 
+func (fake *FakeStackManager) PropagateManagedNodeGroupTagsToASG(arg1 string, arg2 map[string]string, arg3 []string, arg4 chan error) error {
+	var arg3Copy []string
+	if arg3 != nil {
+		arg3Copy = make([]string, len(arg3))
+		copy(arg3Copy, arg3)
+	}
+	fake.propagateManagedNodeGroupTagsToASGMutex.Lock()
+	ret, specificReturn := fake.propagateManagedNodeGroupTagsToASGReturnsOnCall[len(fake.propagateManagedNodeGroupTagsToASGArgsForCall)]
+	fake.propagateManagedNodeGroupTagsToASGArgsForCall = append(fake.propagateManagedNodeGroupTagsToASGArgsForCall, struct {
+		arg1 string
+		arg2 map[string]string
+		arg3 []string
+		arg4 chan error
+	}{arg1, arg2, arg3Copy, arg4})
+	stub := fake.PropagateManagedNodeGroupTagsToASGStub
+	fakeReturns := fake.propagateManagedNodeGroupTagsToASGReturns
+	fake.recordInvocation("PropagateManagedNodeGroupTagsToASG", []interface{}{arg1, arg2, arg3Copy, arg4})
+	fake.propagateManagedNodeGroupTagsToASGMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStackManager) PropagateManagedNodeGroupTagsToASGCallCount() int {
+	fake.propagateManagedNodeGroupTagsToASGMutex.RLock()
+	defer fake.propagateManagedNodeGroupTagsToASGMutex.RUnlock()
+	return len(fake.propagateManagedNodeGroupTagsToASGArgsForCall)
+}
+
+func (fake *FakeStackManager) PropagateManagedNodeGroupTagsToASGCalls(stub func(string, map[string]string, []string, chan error) error) {
+	fake.propagateManagedNodeGroupTagsToASGMutex.Lock()
+	defer fake.propagateManagedNodeGroupTagsToASGMutex.Unlock()
+	fake.PropagateManagedNodeGroupTagsToASGStub = stub
+}
+
+func (fake *FakeStackManager) PropagateManagedNodeGroupTagsToASGArgsForCall(i int) (string, map[string]string, []string, chan error) {
+	fake.propagateManagedNodeGroupTagsToASGMutex.RLock()
+	defer fake.propagateManagedNodeGroupTagsToASGMutex.RUnlock()
+	argsForCall := fake.propagateManagedNodeGroupTagsToASGArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeStackManager) PropagateManagedNodeGroupTagsToASGReturns(result1 error) {
+	fake.propagateManagedNodeGroupTagsToASGMutex.Lock()
+	defer fake.propagateManagedNodeGroupTagsToASGMutex.Unlock()
+	fake.PropagateManagedNodeGroupTagsToASGStub = nil
+	fake.propagateManagedNodeGroupTagsToASGReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStackManager) PropagateManagedNodeGroupTagsToASGReturnsOnCall(i int, result1 error) {
+	fake.propagateManagedNodeGroupTagsToASGMutex.Lock()
+	defer fake.propagateManagedNodeGroupTagsToASGMutex.Unlock()
+	fake.PropagateManagedNodeGroupTagsToASGStub = nil
+	if fake.propagateManagedNodeGroupTagsToASGReturnsOnCall == nil {
+		fake.propagateManagedNodeGroupTagsToASGReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.propagateManagedNodeGroupTagsToASGReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeStackManager) RefreshFargatePodExecutionRoleARN(arg1 context.Context) error {
 	fake.refreshFargatePodExecutionRoleARNMutex.Lock()
 	ret, specificReturn := fake.refreshFargatePodExecutionRoleARNReturnsOnCall[len(fake.refreshFargatePodExecutionRoleARNArgsForCall)]
@@ -4582,6 +4665,8 @@ func (fake *FakeStackManager) Invocations() map[string][][]interface{} {
 	defer fake.newTasksToDeleteOIDCProviderWithIAMServiceAccountsMutex.RUnlock()
 	fake.newUnmanagedNodeGroupTaskMutex.RLock()
 	defer fake.newUnmanagedNodeGroupTaskMutex.RUnlock()
+	fake.propagateManagedNodeGroupTagsToASGMutex.RLock()
+	defer fake.propagateManagedNodeGroupTagsToASGMutex.RUnlock()
 	fake.refreshFargatePodExecutionRoleARNMutex.RLock()
 	defer fake.refreshFargatePodExecutionRoleARNMutex.RUnlock()
 	fake.stackStatusIsNotReadyMutex.RLock()

--- a/pkg/cfn/manager/interface.go
+++ b/pkg/cfn/manager/interface.go
@@ -91,6 +91,7 @@ type StackManager interface {
 	NewTasksToDeleteNodeGroups(stacks []NodeGroupStack, shouldDelete func(_ string) bool, wait bool, cleanup func(chan error, string) error) (*tasks.TaskTree, error)
 	NewTasksToDeleteOIDCProviderWithIAMServiceAccounts(ctx context.Context, oidc *iamoidc.OpenIDConnectManager, clientSetGetter kubernetes.ClientSetGetter) (*tasks.TaskTree, error)
 	NewUnmanagedNodeGroupTask(ctx context.Context, nodeGroups []*v1alpha5.NodeGroup, forceAddCNIPolicy bool, importer vpc.Importer) *tasks.TaskTree
+	PropagateManagedNodeGroupTagsToASG(ngName string, ngTags map[string]string, asgNames []string, errCh chan error) error
 	RefreshFargatePodExecutionRoleARN(ctx context.Context) error
 	StackStatusIsNotReady(s *Stack) bool
 	StackStatusIsNotTransitional(s *Stack) bool

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -89,16 +89,17 @@ func (c *StackCollection) propagateManagedNodeGroupTagsToASGTask(errorCh chan er
 		return errors.Wrapf(err, "couldn't get managed nodegroup details for nodegroup %q", ng.Name)
 	}
 
-	if res.Nodegroup.Resources != nil {
-		asgNames := []string{}
-		for _, asg := range res.Nodegroup.Resources.AutoScalingGroups {
-			if asg.Name != nil && *asg.Name != "" {
-				asgNames = append(asgNames, *asg.Name)
-			}
-		}
-		return c.PropagateManagedNodeGroupTagsToASG(ng.Name, ng.Tags, asgNames, errorCh)
+	if res.Nodegroup.Resources == nil {
+		return nil
 	}
-	return nil
+
+	asgNames := []string{}
+	for _, asg := range res.Nodegroup.Resources.AutoScalingGroups {
+		if asg.Name != nil && *asg.Name != "" {
+			asgNames = append(asgNames, *asg.Name)
+		}
+	}
+	return c.PropagateManagedNodeGroupTagsToASG(ng.Name, ng.Tags, asgNames, errorCh)
 }
 
 // DescribeNodeGroupStacks calls DescribeStacks and filters out nodegroups

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -79,10 +79,6 @@ func (c *StackCollection) createManagedNodeGroupTask(ctx context.Context, errorC
 }
 
 func (c *StackCollection) propagateManagedNodeGroupTagsToASGTask(errorCh chan error, ng *api.ManagedNodeGroup) error {
-	if ng.DisableASGTagPropagation != nil && *ng.DisableASGTagPropagation {
-		return nil
-	}
-
 	// describe node group to retrieve ASG names
 	input := &eks.DescribeNodegroupInput{
 		ClusterName:   aws.String(c.spec.Metadata.Name),

--- a/pkg/cfn/manager/tasks.go
+++ b/pkg/cfn/manager/tasks.go
@@ -61,6 +61,18 @@ func (t *managedNodeGroupTask) Do(errorCh chan error) error {
 	return t.stackCollection.createManagedNodeGroupTask(t.ctx, errorCh, t.nodeGroup, t.forceAddCNIPolicy, t.vpcImporter)
 }
 
+type managedNodeGroupTagsToASGPropagationTask struct {
+	info            string
+	nodeGroup       *api.ManagedNodeGroup
+	stackCollection *StackCollection
+}
+
+func (t *managedNodeGroupTagsToASGPropagationTask) Describe() string { return t.info }
+
+func (t *managedNodeGroupTagsToASGPropagationTask) Do(errorCh chan error) error {
+	return t.stackCollection.propagateManagedNodeGroupTagsToASGTask(errorCh, t.nodeGroup)
+}
+
 type clusterCompatTask struct {
 	info            string
 	stackCollection *StackCollection

--- a/pkg/cfn/manager/tasks_test.go
+++ b/pkg/cfn/manager/tasks_test.go
@@ -132,10 +132,9 @@ var _ = Describe("StackCollection Tasks", func() {
 				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(context.Background(), makeNodeGroups("foo"), makeManagedNodeGroups("m1"))
 				Expect(tasks.Describe()).To(Equal(`
 2 sequential tasks: { create cluster control plane "test-cluster", 
-    3 parallel sub-tasks: { 
+    2 parallel sub-tasks: { 
         create nodegroup "foo",
         create managed nodegroup "m1",
-        propagate tags to ASG for managed nodegroup "m1",
     } 
 }
 `))
@@ -223,6 +222,18 @@ func makeManagedNodeGroups(names ...string) []*api.ManagedNodeGroup {
 	for _, name := range names {
 		ng := api.NewManagedNodeGroup()
 		ng.Name = name
+		managedNodeGroups = append(managedNodeGroups, ng)
+	}
+	return managedNodeGroups
+}
+
+func makeManagedNodeGroupsWithPropagatedTags(names ...string) []*api.ManagedNodeGroup {
+	propagate := true
+	var managedNodeGroups []*api.ManagedNodeGroup
+	for _, name := range names {
+		ng := api.NewManagedNodeGroup()
+		ng.Name = name
+		ng.PropagateASGTags = &propagate
 		managedNodeGroups = append(managedNodeGroups, ng)
 	}
 	return managedNodeGroups

--- a/pkg/cfn/manager/tasks_test.go
+++ b/pkg/cfn/manager/tasks_test.go
@@ -117,6 +117,19 @@ var _ = Describe("StackCollection Tasks", func() {
 				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(context.Background(), makeNodeGroups("bar", "foo"), makeManagedNodeGroups("m1", "m2"))
 				Expect(tasks.Describe()).To(Equal(`
 2 sequential tasks: { create cluster control plane "test-cluster", 
+    4 parallel sub-tasks: { 
+        create nodegroup "bar",
+        create nodegroup "foo",
+        create managed nodegroup "m1",
+        create managed nodegroup "m2",
+    } 
+}
+`))
+			}
+			{
+				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(context.Background(), makeNodeGroups("bar", "foo"), makeManagedNodeGroupsWithPropagatedTags("m1", "m2"))
+				Expect(tasks.Describe()).To(Equal(`
+2 sequential tasks: { create cluster control plane "test-cluster", 
     6 parallel sub-tasks: { 
         create nodegroup "bar",
         create nodegroup "foo",

--- a/pkg/cfn/manager/tasks_test.go
+++ b/pkg/cfn/manager/tasks_test.go
@@ -117,11 +117,13 @@ var _ = Describe("StackCollection Tasks", func() {
 				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(context.Background(), makeNodeGroups("bar", "foo"), makeManagedNodeGroups("m1", "m2"))
 				Expect(tasks.Describe()).To(Equal(`
 2 sequential tasks: { create cluster control plane "test-cluster", 
-    4 parallel sub-tasks: { 
+    6 parallel sub-tasks: { 
         create nodegroup "bar",
         create nodegroup "foo",
         create managed nodegroup "m1",
+        propagate tags to ASG for managed nodegroup "m1",
         create managed nodegroup "m2",
+        propagate tags to ASG for managed nodegroup "m2",
     } 
 }
 `))
@@ -130,9 +132,10 @@ var _ = Describe("StackCollection Tasks", func() {
 				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(context.Background(), makeNodeGroups("foo"), makeManagedNodeGroups("m1"))
 				Expect(tasks.Describe()).To(Equal(`
 2 sequential tasks: { create cluster control plane "test-cluster", 
-    2 parallel sub-tasks: { 
+    3 parallel sub-tasks: { 
         create nodegroup "foo",
         create managed nodegroup "m1",
+        propagate tags to ASG for managed nodegroup "m1",
     } 
 }
 `))

--- a/pkg/eks/eks_test.go
+++ b/pkg/eks/eks_test.go
@@ -218,13 +218,6 @@ var _ = Describe("EKS API wrapper", func() {
 		})
 	})
 
-	type managedNodesSupportCase struct {
-		platformVersion string
-
-		expectError bool
-		supports    bool
-	}
-
 	type platformVersionCase struct {
 		platformVersion string
 		expectedVersion int

--- a/userdocs/src/usage/autoscaling.md
+++ b/userdocs/src/usage/autoscaling.md
@@ -44,7 +44,7 @@ nodeGroups:
       k8s.io/cluster-autoscaler/node-template/taint/feaster: "true:NoSchedule"
 ```
 
-For unmanaged and managed noderoups, this is done by `eksctl` automatically if `propagateASGTags` is set to `true` like this:
+For unmanaged and managed nodegroups, this is done by `eksctl` automatically if `propagateASGTags` is set to `true` like this:
 
 ```yaml
 nodeGroups:

--- a/userdocs/src/usage/autoscaling.md
+++ b/userdocs/src/usage/autoscaling.md
@@ -44,7 +44,7 @@ nodeGroups:
       k8s.io/cluster-autoscaler/node-template/taint/feaster: "true:NoSchedule"
 ```
 
-For unmanaged noderoups, this is done by `eksctl` automatically if `propagateASGTags` is set to `true` like this:
+For unmanaged and managed noderoups, this is done by `eksctl` automatically if `propagateASGTags` is set to `true` like this:
 
 ```yaml
 nodeGroups:

--- a/userdocs/src/usage/eks-managed-nodes.md
+++ b/userdocs/src/usage/eks-managed-nodes.md
@@ -246,8 +246,6 @@ eksctl scale nodegroup --name=managed-ng-1 --cluster=managed-cluster --nodes=4 -
 EKS Managed Nodegroups are managed by AWS EKS and do not offer the same level of configuration as unmanaged nodegroups.
 The unsupported options are noted below.
 
-- Tags (managedNodeGroups[*].tags) in managed nodegroups apply to the EKS Nodegroup resource and to the EC2 instances launched as part of the nodegroup.
-They do not propagate to the provisioned Autoscaling Group like in unmanaged nodegroups.
 - `iam.instanceProfileARN` is not supported for managed nodegroups.
 - The `amiFamily` field supports only `AmazonLinux2`
 - `instancesDistribution` field is not supported


### PR DESCRIPTION
### Description

#### Resume

I have added Propagation of ManagedNodeGroup (MNG) Tags to their AutoScalingGroups (ASG). This should resolve the issue #1571 

- The changes ensure that AutoScalingGroups Tags are the same as their corresponding ManagedNodeGroup after it has been automatically created by AWS.
- All tags are copied from the ManagedNodeGroup to the AutoScalingGroup. If the tags already exists, it is overridden.
- The propagation is enabled by default (as it is for Unmanaged NodeGroup) and it can be disabled using the DisableASGTagPropagation boolean in the configuration.

#### How it has been done

I tried to find a good place to do it, and added it as an additional task on managed group creation. I switched the Parallel task boolean to false since it requires to be Sequential: we can't propagate the MNG tags to the ASGs without having the MNG created (since the ASGs are created automatically after the MNG creation).

ℹ️ This is my first contribution, thanks for your understanding if I've missed something =)

### Checklist
- [x] Added tests that cover your change (if possible)
    ~~- ⚠️ As it is my first contribution, I would prefer a first review before of course, implementing them~~
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
