### PR TITLE
Fix typo in ELB cleanup process

### DIFF
--- a/pkg/eks/services_v2.go
+++ b/pkg/eks/services_v2.go
@@ -76,7 +76,7 @@ func (s *ServicesV2) ELB() awsapi.ELB {
 // ELBV2 implements the ELBV2 service.
 func (s *ServicesV2) ELBV2() awsapi.ELBV2 {
 	s.mu.Lock()
-	defer s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.elasticloadbalancingV2 == nil {
 		s.elasticloadbalancingV2 = elasticloadbalancingv2.NewFromConfig(s.config)
 	}


### PR DESCRIPTION
### Description

This was blocking the ELB cleanup process because the lock was not being released. The typo was likely introduced when fixing merge conflicts because integration tests had passed earlier on the ELB branch. 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

