### PR TITLE
Add support for managed bottlerocket nodes

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/gpu_validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/gpu_validation_test.go
@@ -16,7 +16,6 @@ var _ = Describe("GPU instance support", func() {
 	type gpuInstanceEntry struct {
 		gpuInstanceType string
 		amiFamily       string
-		customErr       string
 
 		expectUnsupportedErr bool
 	}
@@ -24,9 +23,7 @@ var _ = Describe("GPU instance support", func() {
 	assertValidationError := func(e gpuInstanceEntry, err error) {
 		if e.expectUnsupportedErr {
 			Expect(err).To(HaveOccurred())
-			if e.customErr != "" {
-				Expect(err).To(MatchError(e.customErr))
-			} else if instanceutils.IsNvidiaInstanceType(e.gpuInstanceType) {
+			if instanceutils.IsNvidiaInstanceType(e.gpuInstanceType) {
 				Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("GPU instance types are not supported for %s", e.amiFamily))))
 			} else {
 				Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("Inferentia instance types are not supported for %s", e.amiFamily))))
@@ -50,12 +47,6 @@ var _ = Describe("GPU instance support", func() {
 		Entry("AL2", gpuInstanceEntry{
 			gpuInstanceType: "g5.12xlarge",
 			amiFamily:       api.NodeImageFamilyAmazonLinux2,
-		}),
-		Entry("Bottlerocket", gpuInstanceEntry{
-			amiFamily:            api.NodeImageFamilyBottlerocket,
-			gpuInstanceType:      "g4dn.xlarge",
-			expectUnsupportedErr: true,
-			customErr:            fmt.Sprintf("NVIDIA GPU instance types are not supported for managed nodegroups with AMIFamily %s", api.NodeImageFamilyBottlerocket),
 		}),
 		Entry("Ubuntu2004", gpuInstanceEntry{
 			amiFamily:            api.NodeImageFamilyUbuntu2004,
@@ -95,10 +86,18 @@ var _ = Describe("GPU instance support", func() {
 			amiFamily:       api.NodeImageFamilyBottlerocket,
 			gpuInstanceType: "g4dn.xlarge",
 		}),
-		Entry("Bottlerocket", gpuInstanceEntry{
+		Entry("Bottlerocket infra", gpuInstanceEntry{
 			amiFamily:            api.NodeImageFamilyBottlerocket,
 			gpuInstanceType:      "inf1.xlarge",
 			expectUnsupportedErr: true,
+		}),
+		Entry("Bottlerocket nvidia", gpuInstanceEntry{
+			amiFamily:       api.NodeImageFamilyBottlerocket,
+			gpuInstanceType: "g4dn.xlarge",
+		}),
+		Entry("Bottlerocket nvidia arm", gpuInstanceEntry{
+			amiFamily:       api.NodeImageFamilyBottlerocket,
+			gpuInstanceType: "g5g.xlarge",
 		}),
 		Entry("Ubuntu2004", gpuInstanceEntry{
 			amiFamily:            api.NodeImageFamilyUbuntu2004,

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -863,11 +863,6 @@ func ValidateManagedNodeGroup(index int, ng *ManagedNodeGroup) error {
 		return err
 	}
 
-	if instanceutils.IsNvidiaInstanceType(SelectInstanceType(ng)) && ng.AMIFamily == NodeImageFamilyBottlerocket {
-		logger.Info("Bottlerocket GPU support is for unmanaged nodegroups only. If you're using CLI flags pass --managed=false")
-		return errors.Errorf("NVIDIA GPU instance types are not supported for managed nodegroups with AMIFamily %s", ng.AMIFamily)
-	}
-
 	if ng.IAM != nil {
 		if err := validateNodeGroupIAM(ng.IAM, ng.IAM.InstanceRoleARN, "instanceRoleARN", path); err != nil {
 			return err

--- a/pkg/cfn/builder/managed_nodegroup.go
+++ b/pkg/cfn/builder/managed_nodegroup.go
@@ -262,18 +262,22 @@ func validateLaunchTemplate(launchTemplateData *ec2.ResponseLaunchTemplateData, 
 
 func getAMIType(ng *api.ManagedNodeGroup, instanceType string) string {
 	amiTypeMapping := map[string]struct {
-		X86x64 string
-		GPU    string
+		X86    string
+		X86GPU string
 		ARM    string
+		ARMGPU string
 	}{
 		api.NodeImageFamilyAmazonLinux2: {
-			X86x64: eks.AMITypesAl2X8664,
-			GPU:    eks.AMITypesAl2X8664Gpu,
+			X86:    eks.AMITypesAl2X8664,
+			X86GPU: eks.AMITypesAl2X8664Gpu,
 			ARM:    eks.AMITypesAl2Arm64,
 		},
 		api.NodeImageFamilyBottlerocket: {
-			X86x64: eks.AMITypesBottlerocketX8664,
+			X86: eks.AMITypesBottlerocketX8664,
+			//TODO reference aws-sdk-go variable when published
+			X86GPU: "BOTTLEROCKET_x86_64_NVIDIA",
 			ARM:    eks.AMITypesBottlerocketArm64,
+			ARMGPU: "BOTTLEROCKET_ARM_64_NVIDIA",
 		},
 	}
 
@@ -283,12 +287,15 @@ func getAMIType(ng *api.ManagedNodeGroup, instanceType string) string {
 	}
 
 	switch {
+
+	case instanceutils.IsGPUInstanceType(instanceType) && instanceutils.IsARMInstanceType(instanceType):
+		return amiType.ARMGPU
 	case instanceutils.IsGPUInstanceType(instanceType):
-		return amiType.GPU
+		return amiType.X86GPU
 	case instanceutils.IsARMInstanceType(instanceType):
 		return amiType.ARM
 	default:
-		return amiType.X86x64
+		return amiType.X86
 	}
 }
 

--- a/pkg/cfn/builder/managed_nodegroup_ami_type_test.go
+++ b/pkg/cfn/builder/managed_nodegroup_ami_type_test.go
@@ -131,6 +131,27 @@ var _ = DescribeTable("Managed Nodegroup AMI type", func(e amiTypeEntry) {
 		},
 		expectedAMIType: "BOTTLEROCKET_ARM_64",
 	}),
+	Entry("Bottlerocket ARM GPU instance type", amiTypeEntry{
+		nodeGroup: &api.ManagedNodeGroup{
+			NodeGroupBase: &api.NodeGroupBase{
+				Name:         "test",
+				AMIFamily:    api.NodeImageFamilyBottlerocket,
+				InstanceType: "g5g.xlarge",
+			},
+		},
+		expectedAMIType: "BOTTLEROCKET_ARM_64_NVIDIA",
+	}),
+
+	Entry("Bottlerocket x86 Nvidia GPU instance type", amiTypeEntry{
+		nodeGroup: &api.ManagedNodeGroup{
+			NodeGroupBase: &api.NodeGroupBase{
+				Name:         "test",
+				AMIFamily:    api.NodeImageFamilyBottlerocket,
+				InstanceType: "g4dn.xlarge",
+			},
+		},
+		expectedAMIType: "BOTTLEROCKET_x86_64_NVIDIA",
+	}),
 
 	Entry("non-native Ubuntu", amiTypeEntry{
 		nodeGroup: &api.ManagedNodeGroup{


### PR DESCRIPTION
### Description
Closes https://github.com/weaveworks/eksctl/issues/4916

TODO:
- Run `eksctl create nodegroup` with the below nodegroups once the AMI types are published to verify the PR works
```yaml
managedNodeGroups:
  - name: arm-gpu
    instanceType: g5g.xlarge # arm gpu instance
    desiredCapacity: 1
    amiFamily: Bottlerocket
  - name: x86-gpu
    instanceType: g4dn.xlarge # x86 gpu instance
    desiredCapacity: 1
    amiFamily: Bottlerocket
```