### PR TITLE
Fix empty get addons table output

### DIFF
--- a/pkg/ctl/get/addon.go
+++ b/pkg/ctl/get/addon.go
@@ -90,9 +90,7 @@ func getAddon(cmd *cmdutils.Cmd, params *getCmdParams) error {
 		}
 	}
 
-	if len(summaries) == 0 {
-		logger.Info("no addons found")
-	} else {
+	if len(summaries) > 0 {
 		logger.Info("to see issues for an addon run `eksctl get addon --name <addon-name> --cluster <cluster-name>`")
 	}
 
@@ -105,7 +103,7 @@ func getAddon(cmd *cmdutils.Cmd, params *getCmdParams) error {
 		addAddonSummaryTableColumns(printer.(*printers.TablePrinter))
 	}
 
-	if err := printer.PrintObjWithKind("addonsummary", summaries, os.Stdout); err != nil {
+	if err := printer.PrintObjWithKind("addons", summaries, os.Stdout); err != nil {
 		return err
 	}
 

--- a/pkg/printers/json.go
+++ b/pkg/printers/json.go
@@ -28,14 +28,14 @@ func NewJSONPrinter() OutputPrinter {
 // PrintObj will print the passed object formatted as JSON to
 // the supplied writer.
 func (j *JSONPrinter) PrintObj(obj interface{}, writer io.Writer) error {
-	objVal := reflect.ValueOf(obj)
+	itemsValue := reflect.ValueOf(obj)
 	switch reflect.TypeOf(obj).Kind() {
 	case reflect.Array, reflect.Slice:
-		if objVal.Len() == 0 {
+		if itemsValue.Len() == 0 {
 			obj = make([]string, 0)
 		}
 	case reflect.Map:
-		if objVal.Len() == 0 {
+		if itemsValue.Len() == 0 {
 			obj = make(map[string]int)
 		}
 	}

--- a/pkg/printers/yaml.go
+++ b/pkg/printers/yaml.go
@@ -27,14 +27,14 @@ func NewYAMLPrinter() OutputPrinter {
 // PrintObj will print the passed object formatted as YAML to
 // the supplied writer.
 func (y *YAMLPrinter) PrintObj(obj interface{}, writer io.Writer) error {
-	objVal := reflect.ValueOf(obj)
+	itemsValue := reflect.ValueOf(obj)
 	switch reflect.TypeOf(obj).Kind() {
 	case reflect.Array, reflect.Slice:
-		if objVal.Len() == 0 {
+		if itemsValue.Len() == 0 {
 			obj = make([]string, 0)
 		}
 	case reflect.Map:
-		if objVal.Len() == 0 {
+		if itemsValue.Len() == 0 {
 			obj = make(map[string]int)
 		}
 	}


### PR DESCRIPTION
### Description

#4922 introduced a regression on empty addons output on table format.

Before #4922, the result was empty, with a `no addons found` log:
```
2022-04-05 15:27:29 [ℹ]  eksctl version 0.88.0
2022-04-05 15:27:29 [ℹ]  using region eu-west-3
2022-04-05 15:27:30 [ℹ]  Kubernetes version "1.21" in use by cluster "mycluster"
2022-04-05 15:27:30 [ℹ]  getting all addons
2022-04-05 15:27:30 [ℹ]  no addons found
``` 

#4922 added a `No addonsummary found` output, which is quite dirty:
```
2022-04-05 15:42:17 [ℹ]  eksctl version 0.89.0
2022-04-05 15:42:17 [ℹ]  using region eu-west-3
2022-04-05 15:42:19 [ℹ]  Kubernetes version "1.21" in use by cluster "mycluster"
2022-04-05 15:42:19 [ℹ]  getting all addons
2022-04-05 15:42:19 [ℹ]  no addons found
No addonsummary found
```

I first restored the pre #4922 behavior by silencing the output, but I had errors on `table_test.go`, because a `No clusters found` output is expected.

So, I changed the fix by renaming `addonsummary` into `addons` and removing the additional `no addons found` log to be consistent with `get clusters` and the table printer test:
```
2022-04-05 16:02:28 [ℹ]  eksctl version 0.92.0-dev+e1de47968.2022-04-05T15:57:56Z
2022-04-05 16:02:28 [ℹ]  using region eu-west-3
2022-04-05 16:02:29 [ℹ]  Kubernetes version "1.21" in use by cluster "mycluster"
2022-04-05 16:02:29 [ℹ]  getting all addons
No addons found
```

I also renamed the `objVal` variables I've added in #4922, to be consistent with the same `itemsValue` variable that was already in the table printer.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [X] Refactored something and made the world a better place :star2:

