### PR TITLE
Fix iamserviceaccount `create` duplicate entry check not being behind the created flag

### DIFF
--- a/pkg/ctl/create/iamidentitymapping.go
+++ b/pkg/ctl/create/iamidentitymapping.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/authconfigmap"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
@@ -137,7 +138,7 @@ func doCreateIAMIdentityMapping(cmd *cmdutils.Cmd, options iamIdentityMappingOpt
 		for _, identity := range identities {
 			arn := identity.ARN()
 
-			if iam.CompareIdentity(id, identity) {
+			if iam.CompareIdentity(id, identity) && options.NoDuplicateArns {
 				logger.Warning("found existing mapping that matches the one being created, quitting.")
 				return nil
 			}


### PR DESCRIPTION
### Description

Fix the crud duplication test failure by only checking duplication if the flag is on.

Introduced in this pr: https://github.com/weaveworks/eksctl/pull/4963/

Closes https://github.com/weaveworks/eksctl/issues/5081

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

