### PR TITLE
Update migration document to include private nodegroups

### DIFF
--- a/userdocs/src/usage/nodegroup-override-announcement.md
+++ b/userdocs/src/usage/nodegroup-override-announcement.md
@@ -37,6 +37,20 @@ command:
       /etc/eks/bootstrap.sh test-override-11 --container-runtime containerd --kubelet-extra-args "--node-labels=${NODE_LABELS}"
 ```
 
+For nodegroups that have no outbound internet access, you'll need to supply `--apiserver-endpoint` and `--b64-cluster-ca`
+to the bootstrap script as follows:
+
+```yaml
+    overrideBootstrapCommand: |
+      #!/bin/bash
+
+      source /var/lib/cloud/scripts/eksctl/bootstrap.helper.sh
+
+      # Note "--node-labels=${NODE_LABELS}" needs the above helper sourced to work, otherwise will have to be defined manually.
+      /etc/eks/bootstrap.sh test-override-11 --container-runtime containerd --kubelet-extra-args "--node-labels=${NODE_LABELS}" \
+        --apiserver-endpoint ${API_SERVER_URL} --b64-cluster-ca ${B64_CLUSTER_CA}
+```
+
 Note the _`--node-labels`_ setting. If this is not defined, the node will join the cluster, but `eksctl` will ultimately
 time out on the last step when it's waiting for the nodes to be `Ready`. It's doing a Kubernetes lookup for nodes that
 have the label `alpha.eksctl.io/nodegroup-name=<cluster-name>`. This is only true for unmanaged nodegroups. For managed


### PR DESCRIPTION
### Description

Closes https://github.com/weaveworks/eksctl/issues/5085

Update the migration document to include instructions for private nodegroups.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

