### PR TITLE
Add override integration test

### DIFF
--- a/integration/tests/override_bootstrap/override_bootstrap_test.go
+++ b/integration/tests/override_bootstrap/override_bootstrap_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+//revive:disable Not changing package name
+package override_bootstrap
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsssm "github.com/aws/aws-sdk-go/service/ssm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+
+	. "github.com/weaveworks/eksctl/integration/matchers"
+	. "github.com/weaveworks/eksctl/integration/runner"
+	"github.com/weaveworks/eksctl/integration/tests"
+	"github.com/weaveworks/eksctl/pkg/testutils"
+)
+
+var params *tests.Params
+
+func init() {
+	// Call testing.Init() prior to tests.NewParams(), as otherwise -test.* will not be recognised. See also: https://golang.org/doc/go1.13#testing
+	testing.Init()
+	params = tests.NewParams("override")
+}
+
+func TestOverrideBootstrap(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}
+
+var _ = Describe("(Integration) [Test OverrideBootstrapCommand]", func() {
+	var (
+		customAMI string
+	)
+
+	BeforeSuite(func() {
+		awsSession := NewSession(params.Region)
+		ssm := awsssm.New(awsSession)
+		input := &awsssm.GetParameterInput{
+			Name: aws.String("/aws/service/eks/optimized-ami/1.21/amazon-linux-2/recommended/image_id"),
+		}
+		output, err := ssm.GetParameter(input)
+		Expect(err).NotTo(HaveOccurred())
+		customAMI = *output.Parameter.Value
+		cmd := params.EksctlCreateCmd.WithArgs(
+			"cluster",
+			"--verbose", "4",
+			"--name", params.ClusterName,
+			"--tags", "alpha.eksctl.io/description=eksctl integration test",
+			"--version", params.Version,
+			"--kubeconfig", params.KubeconfigPath,
+		)
+		Expect(cmd).To(RunSuccessfully())
+	})
+
+	AfterSuite(func() {
+		params.DeleteClusters()
+		gexec.KillAndWait()
+		if params.KubeconfigTemp {
+			Expect(os.Remove(params.KubeconfigPath)).To(Succeed())
+		}
+		Expect(os.RemoveAll(params.TestDirectory)).To(Succeed())
+	})
+
+	Context("override bootstrap command for managed and un-managed nodegroups", func() {
+
+		It("can create a working nodegroups which can join the cluster", func() {
+			By(fmt.Sprintf("using the following EKS optimised AMI: %s", customAMI))
+			content, err := os.ReadFile(filepath.Join("testdata/override-bootstrap.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			content = bytes.ReplaceAll(content, []byte("<generated>"), []byte(params.ClusterName))
+			content = bytes.ReplaceAll(content, []byte("<generated-region>"), []byte(params.Region))
+			content = bytes.ReplaceAll(content, []byte("<generated-ami>"), []byte(customAMI))
+			cmd := params.EksctlCreateCmd.
+				WithArgs(
+					"nodegroup",
+					"--config-file", "-",
+					"--verbose", "4",
+				).
+				WithoutArg("--region", params.Region).
+				WithStdin(bytes.NewReader(content))
+			Expect(cmd).To(RunSuccessfully())
+		})
+
+	})
+})

--- a/integration/tests/override_bootstrap/testdata/override-bootstrap.yaml
+++ b/integration/tests/override_bootstrap/testdata/override-bootstrap.yaml
@@ -1,0 +1,28 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+# name is generated
+metadata:
+  name: <generated>
+  region: <generated-region>
+
+nodeGroups:
+  - name: unm-1
+    ami: <generated-ami>
+    desiredCapacity: 1
+    maxSize: 2
+    minSize: 1
+    overrideBootstrapCommand: |
+      #!/bin/bash
+      source /var/lib/cloud/scripts/eksctl/bootstrap.helper.sh
+      /etc/eks/bootstrap.sh <generated> --kubelet-extra-args "--node-labels=${NODE_LABELS}"    
+
+managedNodeGroups:
+  - name: mng-1
+    ami: <generated-ami>
+    desiredCapacity: 1
+    maxSize: 2
+    minSize: 1
+    overrideBootstrapCommand: |
+      #!/bin/bash
+      /etc/eks/bootstrap.sh <generated>    


### PR DESCRIPTION
### Description

Closes https://github.com/weaveworks/eksctl/issues/4972

Added a simple integration test to test functionality of overriding using two nodegroups and a configuration file. Nodegroup 1 is unmanaged and nodegroup 2 is managed, testing both at the same time.

Local run:

```
Ran 1 of 1 Specs in 1704.933 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestOverrideBootstrap (1704.93s)
PASS

Ginkgo ran 1 suite in 28m47.554883904s
Test Suite Passed
```

This is a basic test suite which can be extended upon later with various scenarios.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

