### PR TITLE
Adding containerd runtime support for Windows

### DIFF
--- a/examples/32-windows-nodes-with-containerd.yaml
+++ b/examples/32-windows-nodes-with-containerd.yaml
@@ -1,0 +1,22 @@
+# An example of ClusterConfig containing Windows and Linux node groups to support Windows workloads on containerd runtime.
+# This example should be run with `eksctl create cluster -f 32-windows-nodes-with-containerd.yaml`.
+---
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: windows-cluster
+  region: us-west-2
+
+nodeGroups:
+  - name: windows-ng
+    amiFamily: WindowsServer2019FullContainer
+    minSize: 2
+    maxSize: 3
+    containerRuntime: containerd
+
+managedNodeGroups:
+  - name: linux-ng
+    instanceType: t2.large
+    minSize: 2
+    maxSize: 3

--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -231,6 +231,9 @@ func setDefaultsForAdditionalVolumes(ng *NodeGroupBase) {
 func setContainerRuntimeDefault(ng *NodeGroup) {
 	if ng.ContainerRuntime == nil {
 		ng.ContainerRuntime = &DefaultContainerRuntime
+		if IsWindowsImage(ng.AMIFamily) {
+			ng.ContainerRuntime = &DefaultContainerRuntimeForWindows
+		}
 	}
 }
 

--- a/pkg/apis/eksctl.io/v1alpha5/defaults_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults_test.go
@@ -232,6 +232,17 @@ var _ = Describe("ClusterConfig validation", func() {
 			SetNodeGroupDefaults(&testNodeGroup, &ClusterMeta{})
 			Expect(*testNodeGroup.ContainerRuntime).To(Equal(DefaultContainerRuntime))
 		})
+		When("ami family is windows", func() {
+			It("defaults to docker as a container runtime", func() {
+				testNodeGroup := NodeGroup{
+					NodeGroupBase: &NodeGroupBase{
+						AMIFamily: NodeImageFamilyWindowsServer2019CoreContainer,
+					},
+				}
+				SetNodeGroupDefaults(&testNodeGroup, &ClusterMeta{})
+				Expect(*testNodeGroup.ContainerRuntime).To(Equal(DefaultContainerRuntimeForWindows))
+			})
+		})
 	})
 
 	Describe("Cluster Managed Shared Node Security Group settings", func() {

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -189,8 +189,9 @@ const (
 
 // Container runtime values.
 const (
-	ContainerRuntimeContainerD = "containerd"
-	ContainerRuntimeDockerD    = "dockerd"
+	ContainerRuntimeContainerD       = "containerd"
+	ContainerRuntimeDockerD          = "dockerd"
+	ContainerRuntimeDockerForWindows = "docker"
 )
 
 const (
@@ -366,7 +367,8 @@ var (
 
 var (
 	// DefaultContainerRuntime defines the default container runtime.
-	DefaultContainerRuntime = ContainerRuntimeDockerD
+	DefaultContainerRuntime           = ContainerRuntimeDockerD
+	DefaultContainerRuntimeForWindows = ContainerRuntimeDockerForWindows
 )
 
 // Enabled return pointer to true value

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -698,12 +698,13 @@ func ValidateNodeGroup(i int, ng *NodeGroup) error {
 	}
 
 	if ng.ContainerRuntime != nil {
-		if *ng.ContainerRuntime == ContainerRuntimeContainerD && ng.AMIFamily != NodeImageFamilyAmazonLinux2 {
-			// check if it's dockerd or containerd
-			return fmt.Errorf("%s as runtime is only support for AL2 ami family", ContainerRuntimeContainerD)
+		if *ng.ContainerRuntime == ContainerRuntimeContainerD {
+			if ng.AMIFamily != NodeImageFamilyAmazonLinux2 && !IsWindowsImage(ng.AMIFamily) {
+				return fmt.Errorf("%s as runtime is only supported for AL2 or Windows ami family", ContainerRuntimeContainerD)
+			}
 		}
-		if *ng.ContainerRuntime != ContainerRuntimeDockerD && *ng.ContainerRuntime != ContainerRuntimeContainerD {
-			return fmt.Errorf("only %s and %s are supported for container runtime", ContainerRuntimeContainerD, ContainerRuntimeDockerD)
+		if *ng.ContainerRuntime != ContainerRuntimeDockerD && *ng.ContainerRuntime != ContainerRuntimeContainerD && *ng.ContainerRuntime != ContainerRuntimeDockerForWindows {
+			return fmt.Errorf("only %s, %s and %s are supported for container runtime", ContainerRuntimeContainerD, ContainerRuntimeDockerD, ContainerRuntimeDockerForWindows)
 		}
 	}
 

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -82,6 +82,25 @@ var _ = Describe("ClusterConfig validation", func() {
 	})
 
 	Describe("nodeGroups[*].containerRuntime validation", func() {
+
+		It("allows accepted values", func() {
+			cfg := api.NewClusterConfig()
+			ng0 := cfg.NewNodeGroup()
+			ng0.Name = "node-group"
+			ng0.ContainerRuntime = aws.String(api.ContainerRuntimeDockerForWindows)
+			err := api.ValidateNodeGroup(0, ng0)
+			Expect(err).NotTo(HaveOccurred())
+
+			ng0.ContainerRuntime = aws.String(api.ContainerRuntimeDockerD)
+			err = api.ValidateNodeGroup(0, ng0)
+			Expect(err).NotTo(HaveOccurred())
+
+			ng0.ContainerRuntime = aws.String(api.ContainerRuntimeContainerD)
+			ng0.AMIFamily = api.NodeImageFamilyAmazonLinux2
+			err = api.ValidateNodeGroup(0, ng0)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("should reject invalid container runtime", func() {
 			cfg := api.NewClusterConfig()
 			ng0 := cfg.NewNodeGroup()
@@ -92,7 +111,8 @@ var _ = Describe("ClusterConfig validation", func() {
 			err = api.ValidateNodeGroup(0, ng0)
 			Expect(err).To(HaveOccurred())
 		})
-		It("containerd is only allowed for AL2", func() {
+
+		It("containerd is only allowed for AL2 or Windows", func() {
 			cfg := api.NewClusterConfig()
 			ng0 := cfg.NewNodeGroup()
 			ng0.Name = "node-group"
@@ -102,6 +122,11 @@ var _ = Describe("ClusterConfig validation", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = api.ValidateNodeGroup(0, ng0)
 			Expect(err).To(HaveOccurred())
+			ng0.AMIFamily = api.NodeImageFamilyWindowsServer2019CoreContainer
+			err = api.ValidateClusterConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			err = api.ValidateNodeGroup(0, ng0)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 

--- a/pkg/nodebootstrap/windows.go
+++ b/pkg/nodebootstrap/windows.go
@@ -6,7 +6,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/kris-nova/logger"
+
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/nodebootstrap/utils"
 )
@@ -64,6 +66,10 @@ func (b *Windows) makeBootstrapParams() string {
 		{
 			key:   "DNSClusterIP",
 			value: b.ng.ClusterDNS,
+		},
+		{
+			key:   "ContainerRuntime",
+			value: aws.ToString(b.ng.ContainerRuntime),
 		},
 		{
 			key:   "KubeletExtraArgs",

--- a/pkg/nodebootstrap/windows_test.go
+++ b/pkg/nodebootstrap/windows_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/nodebootstrap"
 )
@@ -30,6 +31,7 @@ var _ = Describe("Windows", func() {
 			NodeGroupBase: &api.NodeGroupBase{
 				AMIFamily: api.NodeImageFamilyWindowsServer2019CoreContainer,
 			},
+			ContainerRuntime: &api.DefaultContainerRuntimeForWindows,
 		}
 		if e.updateNodeGroup != nil {
 			e.updateNodeGroup(ng)
@@ -46,7 +48,7 @@ var _ = Describe("Windows", func() {
 			expectedUserData: `
 <powershell>
 [string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
-& $EKSBootstrapScriptFile -EKSClusterName "windohs" -APIServerEndpoint "https://test.com" -Base64ClusterCA "dGVzdA==" -KubeletExtraArgs "--node-labels= --register-with-taints=" 3>&1 4>&1 5>&1 6>&1
+& $EKSBootstrapScriptFile -EKSClusterName "windohs" -APIServerEndpoint "https://test.com" -Base64ClusterCA "dGVzdA==" -ContainerRuntime "docker" -KubeletExtraArgs "--node-labels= --register-with-taints=" 3>&1 4>&1 5>&1 6>&1
 </powershell>
 `,
 		}),
@@ -61,7 +63,7 @@ var _ = Describe("Windows", func() {
 			expectedUserData: `
 <powershell>
 [string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
-& $EKSBootstrapScriptFile -EKSClusterName "windohs" -APIServerEndpoint "https://test.com" -Base64ClusterCA "dGVzdA==" -KubeletExtraArgs "--node-labels=foo=bar --register-with-taints=" 3>&1 4>&1 5>&1 6>&1
+& $EKSBootstrapScriptFile -EKSClusterName "windohs" -APIServerEndpoint "https://test.com" -Base64ClusterCA "dGVzdA==" -ContainerRuntime "docker" -KubeletExtraArgs "--node-labels=foo=bar --register-with-taints=" 3>&1 4>&1 5>&1 6>&1
 </powershell>
 `,
 		}),
@@ -80,7 +82,7 @@ var _ = Describe("Windows", func() {
 			expectedUserData: `
 <powershell>
 [string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
-& $EKSBootstrapScriptFile -EKSClusterName "windohs" -APIServerEndpoint "https://test.com" -Base64ClusterCA "dGVzdA==" -KubeletExtraArgs "--node-labels= --register-with-taints=foo=bar:NoSchedule" 3>&1 4>&1 5>&1 6>&1
+& $EKSBootstrapScriptFile -EKSClusterName "windohs" -APIServerEndpoint "https://test.com" -Base64ClusterCA "dGVzdA==" -ContainerRuntime "docker" -KubeletExtraArgs "--node-labels= --register-with-taints=foo=bar:NoSchedule" 3>&1 4>&1 5>&1 6>&1
 </powershell>
 `,
 		}),
@@ -93,7 +95,7 @@ var _ = Describe("Windows", func() {
 			expectedUserData: `
 <powershell>
 [string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
-& $EKSBootstrapScriptFile -EKSClusterName "windohs" -APIServerEndpoint "https://test.com" -Base64ClusterCA "dGVzdA==" -KubeletExtraArgs "--node-labels= --register-with-taints= --max-pods=100" 3>&1 4>&1 5>&1 6>&1
+& $EKSBootstrapScriptFile -EKSClusterName "windohs" -APIServerEndpoint "https://test.com" -Base64ClusterCA "dGVzdA==" -ContainerRuntime "docker" -KubeletExtraArgs "--node-labels= --register-with-taints= --max-pods=100" 3>&1 4>&1 5>&1 6>&1
 </powershell>
 `,
 		}),
@@ -109,7 +111,7 @@ var _ = Describe("Windows", func() {
 <powershell>
 [string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
 wget -UseBasicParsing -O amazon-cloudwatch-agent.msi https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi
-& $EKSBootstrapScriptFile -EKSClusterName "windohs" -APIServerEndpoint "https://test.com" -Base64ClusterCA "dGVzdA==" -KubeletExtraArgs "--node-labels= --register-with-taints=" 3>&1 4>&1 5>&1 6>&1
+& $EKSBootstrapScriptFile -EKSClusterName "windohs" -APIServerEndpoint "https://test.com" -Base64ClusterCA "dGVzdA==" -ContainerRuntime "docker" -KubeletExtraArgs "--node-labels= --register-with-taints=" 3>&1 4>&1 5>&1 6>&1
 </powershell>
 `,
 		}),
@@ -128,7 +130,21 @@ wget -UseBasicParsing -O amazon-cloudwatch-agent.msi https://s3.amazonaws.com/am
 [string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
 wget -UseBasicParsing -O amazon-cloudwatch-agent.msi https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi
 start /wait msiexec.exe /qb /i "amazon-cloudwatch-agent.msi"
-& $EKSBootstrapScriptFile -EKSClusterName "windohs" -APIServerEndpoint "https://test.com" -Base64ClusterCA "dGVzdA==" -KubeletExtraArgs "--node-labels= --register-with-taints=" 3>&1 4>&1 5>&1 6>&1
+& $EKSBootstrapScriptFile -EKSClusterName "windohs" -APIServerEndpoint "https://test.com" -Base64ClusterCA "dGVzdA==" -ContainerRuntime "docker" -KubeletExtraArgs "--node-labels= --register-with-taints=" 3>&1 4>&1 5>&1 6>&1
+</powershell>
+`,
+		}),
+
+		Entry("with containerd container runtime", windowsEntry{
+			updateNodeGroup: func(ng *api.NodeGroup) {
+				containerd := api.ContainerRuntimeContainerD
+				ng.ContainerRuntime = &containerd
+			},
+
+			expectedUserData: `
+<powershell>
+[string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
+& $EKSBootstrapScriptFile -EKSClusterName "windohs" -APIServerEndpoint "https://test.com" -Base64ClusterCA "dGVzdA==" -ContainerRuntime "containerd" -KubeletExtraArgs "--node-labels= --register-with-taints=" 3>&1 4>&1 5>&1 6>&1
 </powershell>
 `,
 		}),

--- a/userdocs/src/usage/container-runtime.md
+++ b/userdocs/src/usage/container-runtime.md
@@ -1,6 +1,6 @@
 # Define Container Runtime
 
-For AL2 ( AmazonLinux2 ) AMIs it's possible to set container runtime to `containerd`.
+For AL2 ( AmazonLinux2 ) and Windows AMIs, it's possible to set container runtime to `containerd`.
 
 ## Un-managed Nodes
 


### PR DESCRIPTION
Closes https://github.com/weaveworks/eksctl/issues/5082 again. :D

The change here is that we increased the volume on the Windows test, and also the waiting time because pulling can take over 20 minutes for containerd.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

