### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/cache-dependencies.yaml
+++ b/.github/workflows/cache-dependencies.yaml
@@ -3,8 +3,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   cache-dependencies:
+    permissions:
+      contents: none
     name: Cache dependencies
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push-to-registry:
     name: Build and push container image

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,6 +6,9 @@ on:
 env:
   GOPRIVATE: github.com/weaveworks/aws-sdk-go-private
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -4,8 +4,13 @@ on:
   pull_request:
     types: [labeled, unlabeled, opened, edited, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   enforce-kind:
+    permissions:
+      contents: none
     name: Enforce a valid PR category
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types:
       - published
+permissions:
+  contents: read
+
 jobs:
   publish-docs:
     name: Publish docs to Netlify

--- a/.github/workflows/publish-release-candidate.yaml
+++ b/.github/workflows/publish-release-candidate.yaml
@@ -4,10 +4,17 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+-rc.[0-9]'
 
+permissions:
+  contents: read
+
 jobs:
   test-and-build:
+    permissions:
+      contents: none
     uses: ./.github/workflows/test-and-build.yaml
   publish-release-candidate:
+    permissions:
+      contents: none
     name: Publish GitHub release candidate
     uses: ./.github/workflows/publish-release-type.yaml
     needs: [test-and-build]

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -4,10 +4,17 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
+permissions:
+  contents: read
+
 jobs:
   test-and-build:
+    permissions:
+      contents: none
     uses: ./.github/workflows/test-and-build.yaml
   publish-release:
+    permissions:
+      contents: none
     name: Publish GitHub release
     uses: ./.github/workflows/publish-release-type.yaml
     needs: [test-and-build]

--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -2,6 +2,9 @@ name: PR Rebase
 on:
   issue_comment:
     types: [created]
+permissions:
+  contents: read
+
 jobs:
   rebase:
     name: Rebase

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -6,8 +6,14 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
+    permissions:
+      contents: write  # for release-drafter/release-drafter to create a github release
+      pull-requests: write  # for release-drafter/release-drafter to add label to PR
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,8 +4,14 @@ on:
   schedule:
   - cron: "30 1 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v3

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -10,8 +10,13 @@ on:
     branches:
       - release-[0-9]+.[0-9]+
 
+permissions:
+  contents: read
+
 jobs:
   tag:
+    permissions:
+      contents: write  # for Git to git push
     if: |
       contains(github.event.pull_request.labels.*.name, '/trigger-release') && github.event.pull_request.merge_commit_sha != null
       || contains(github.event.head_commit.message, '/trigger-release')

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -4,6 +4,9 @@ on:
   pull_request: {}
   workflow_call: {}
 
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     name: Unit tests


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
