### PR TITLE
Removing the usage of aws-go-sdk v1 in integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.20.3
 	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.15.5
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.4
+	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.15.4
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/eks v1.20.6
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.14.3
@@ -47,7 +48,6 @@ require (
 	github.com/kubicorn/kubicorn v0.0.0-20180829191017-06f6bce92acc
 	github.com/lithammer/dedent v1.1.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1
-	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.19.0
 	github.com/orcaman/concurrent-map v1.0.0
@@ -346,8 +346,8 @@ require (
 	github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354 // indirect
 	github.com/nishanths/exhaustive v0.7.11 // indirect
 	github.com/nishanths/predeclared v0.2.1 // indirect
-	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
@@ -456,7 +456,6 @@ require (
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/mail.v2 v2.3.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	honnef.co/go/tools v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -415,6 +415,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.15.5 h1:Xhev2SU4X5LDEYcP3E+Qw
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.15.5/go.mod h1:8DHmtyLloIycLx5Mo40eokftqod5j0Np2Zx+VedyP9Q=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.4 h1:mBqjBKtZzvAc9j7gU+FEHbhTKSr02iqMOdQIL/7GZ78=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.4/go.mod h1:R49Py2lGoKH7bCpwhjN9l7MfR/PU6zHXn1tCRR8cwOs=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.15.4 h1:sMzxamrhhkUrL/Ok7OyeJbJR46u4dbXOci0ucsOQu1c=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.15.4/go.mod h1:aer8ZSLSiO1d24Xv5MouJ4TdYop2u2tyxRPUYpvueGU=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.36.1 h1:FS8Ja6LuLDVHcX+rmoNpOXqYb52N2A5DwQy7Dgduq4Q=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.36.1/go.mod h1:KOy1O7Fc2+GRgsbn/Kjr15vYDVXMEQALBaPRia3twSY=
 github.com/aws/aws-sdk-go-v2/service/eks v1.20.6 h1:8PoDU6PcQd1w2dC7Pod7ypRAAF0F9XD4US763MHF7Zg=

--- a/integration/matchers/cloudformation.go
+++ b/integration/matchers/cloudformation.go
@@ -1,12 +1,12 @@
 package matchers
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 )
 
 const (
@@ -14,13 +14,13 @@ const (
 )
 
 // stackExists checks to see if a CloudFormation stack exists
-func stackExists(stackName string, session *session.Session) (bool, error) {
-	cfn := cloudformation.New(session)
+func stackExists(stackName string, cfg aws.Config) (bool, error) {
+	cfn := cloudformation.NewFromConfig(cfg)
 
 	input := &cloudformation.ListStackResourcesInput{
 		StackName: aws.String(stackName),
 	}
-	_, err := cfn.ListStackResources(input)
+	_, err := cfn.ListStackResources(context.Background(), input)
 
 	if err != nil {
 		// Check if its a not found error

--- a/integration/matchers/matchers.go
+++ b/integration/matchers/matchers.go
@@ -1,17 +1,17 @@
 package matchers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseks "github.com/aws/aws-sdk-go/service/eks"
 	"github.com/onsi/gomega/types"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-
-	awseks "github.com/aws/aws-sdk-go/service/eks"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
 )
 
 // HaveExistingStack returns a GoMega matcher that will check for the existence of an cloudformation stack
@@ -33,7 +33,7 @@ func (m *existingStack) Match(actual interface{}) (success bool, err error) {
 		return false, errors.New("not a AWS session")
 	}
 
-	found, err := stackExists(m.expectedStackName, actual.(*session.Session))
+	found, err := stackExists(m.expectedStackName, actual.(aws.Config))
 	if err != nil {
 		return false, err
 	}
@@ -73,16 +73,16 @@ func (m *existingCluster) Match(actual interface{}) (success bool, err error) {
 		return false, errors.New("input is nil")
 	}
 
-	if reflect.TypeOf(actual).String() != "*session.Session" {
+	if reflect.TypeOf(actual).String() != "*aws.Config" {
 		return false, errors.New("not a AWS session")
 	}
 
-	eks := awseks.New(actual.(*session.Session))
+	client := eks.NewFromConfig(actual.(aws.Config))
 
-	input := &awseks.DescribeClusterInput{
+	input := &eks.DescribeClusterInput{
 		Name: aws.String(m.expectedName),
 	}
-	output, err := eks.DescribeCluster(input)
+	output, err := client.DescribeCluster(context.Background(), input)
 
 	if err != nil {
 		// Check if its a not found error: ResourceNotFoundException
@@ -94,7 +94,7 @@ func (m *existingCluster) Match(actual interface{}) (success bool, err error) {
 		return false, nil
 	}
 
-	m.actualStatus = *output.Cluster.Status
+	m.actualStatus = string(output.Cluster.Status)
 	if m.actualStatus != m.expectedStatus {
 		m.statusMismatch = true
 		return false, nil

--- a/integration/matchers/session.go
+++ b/integration/matchers/session.go
@@ -1,16 +1,17 @@
 package matchers
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 )
 
-// NewSession creates a new session
-func NewSession(region string) *session.Session {
-	config := aws.NewConfig()
-	config = config.WithRegion(region)
-	opts := session.Options{
-		Config: *config,
+// NewConfig creates a new session
+func NewConfig(region string) aws.Config {
+	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(region))
+	if err != nil {
+		panic(err)
 	}
-	return session.Must(session.NewSessionWithOptions(opts))
+	return cfg
 }

--- a/integration/tests/assertions.go
+++ b/integration/tests/assertions.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	awsec2 "github.com/aws/aws-sdk-go/service/ec2"
+	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,10 +59,10 @@ func AssertNodeVolumes(kubeConfig, region, nodeGroupName, volumeName string) {
 		)
 		instanceIDs = append(instanceIDs, id)
 	}
-	awsSession := matchers.NewSession(region)
-	ec2 := awsec2.New(awsSession)
-	instances, err := ec2.DescribeInstances(&awsec2.DescribeInstancesInput{
-		InstanceIds: aws.StringSlice(instanceIDs),
+	cfg := matchers.NewConfig(region)
+	ec2 := awsec2.NewFromConfig(cfg)
+	instances, err := ec2.DescribeInstances(context.Background(), &awsec2.DescribeInstancesInput{
+		InstanceIds: instanceIDs,
 	})
 	Expect(err).NotTo(HaveOccurred())
 	for _, res := range instances.Reservations {

--- a/integration/tests/before_active/createdeletebeforeactive_test.go
+++ b/integration/tests/before_active/createdeletebeforeactive_test.go
@@ -47,8 +47,8 @@ var _ = BeforeSuite(func() {
 		"--version", params.Version,
 	)
 	cmd.Start()
-	awsSession := NewSession(params.Region)
-	Eventually(awsSession, timeOutSeconds, pollInterval).Should(
+	cfg := NewConfig(params.Region)
+	Eventually(cfg, timeOutSeconds, pollInterval).Should(
 		HaveExistingCluster(params.ClusterName, awseks.ClusterStatusCreating, params.Version))
 })
 
@@ -67,12 +67,12 @@ var _ = Describe("(Integration) Create & Delete before Active", func() {
 
 	Context("after the delete of the cluster in progress has been initiated", func() {
 		It("should eventually delete the EKS cluster and both CloudFormation stacks", func() {
-			awsSession := NewSession(params.Region)
-			Eventually(awsSession, timeOutSeconds, pollInterval).ShouldNot(
+			cfg := NewConfig(params.Region)
+			Eventually(cfg, timeOutSeconds, pollInterval).ShouldNot(
 				HaveExistingCluster(params.ClusterName, awseks.ClusterStatusActive, params.Version))
-			Eventually(awsSession, timeOutSeconds, pollInterval).ShouldNot(
+			Eventually(cfg, timeOutSeconds, pollInterval).ShouldNot(
 				HaveExistingStack(fmt.Sprintf("eksctl-%s-cluster", params.ClusterName)))
-			Eventually(awsSession, timeOutSeconds, pollInterval).ShouldNot(
+			Eventually(cfg, timeOutSeconds, pollInterval).ShouldNot(
 				HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", params.ClusterName, initNG)))
 		})
 	})

--- a/integration/tests/cloudwatch_logging/cloudwatch_logging_test.go
+++ b/integration/tests/cloudwatch_logging/cloudwatch_logging_test.go
@@ -5,27 +5,21 @@
 package cloudwatch_logging
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
-
-	. "github.com/weaveworks/eksctl/integration/matchers"
-
-	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
-
-	"github.com/pkg/errors"
-
-	"github.com/weaveworks/eksctl/pkg/testutils"
-
-	. "github.com/weaveworks/eksctl/integration/runner"
-
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	. "github.com/weaveworks/eksctl/integration/matchers"
+	. "github.com/weaveworks/eksctl/integration/runner"
 	"github.com/weaveworks/eksctl/integration/tests"
 	clusterutils "github.com/weaveworks/eksctl/integration/utilities/cluster"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/testutils"
 )
 
 var params *tests.Params
@@ -34,7 +28,7 @@ func init() {
 	// Call testing.Init() prior to tests.NewParams(), as otherwise -test.* will not be recognised. See also: https://golang.org/doc/go1.13#testing
 	testing.Init()
 	if err := api.Register(); err != nil {
-		panic(errors.Wrap(err, "unexpected error registering API scheme"))
+		panic(fmt.Errorf("unexpected error registering API scheme: %w", err))
 	}
 	params = tests.NewParams("cloudwatch")
 }
@@ -57,8 +51,8 @@ var _ = Describe("(Integration) [CloudWatch Logging test]", func() {
 
 			Expect(cmd).To(RunSuccessfullyWithOutputString(ContainSubstring("set log retention to 545 days for CloudWatch logging")))
 
-			cloudWatchLogs := cloudwatchlogs.New(NewSession(params.Region))
-			logGroups, err := cloudWatchLogs.DescribeLogGroups(&cloudwatchlogs.DescribeLogGroupsInput{
+			cloudWatchLogs := cloudwatchlogs.NewFromConfig(NewConfig(params.Region))
+			logGroups, err := cloudWatchLogs.DescribeLogGroups(context.Background(), &cloudwatchlogs.DescribeLogGroupsInput{
 				LogGroupNamePrefix: aws.String(fmt.Sprintf("/aws/eks/%s/cluster", params.ClusterName)),
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/integration/tests/cluster_api/cluster_api_endpoints_test.go
+++ b/integration/tests/cluster_api/cluster_api_endpoints_test.go
@@ -108,8 +108,8 @@ var _ = Describe("(Integration) Create and Update Cluster with Endpoint Configs"
 					return
 				}
 				Expect(cmd).Should(RunSuccessfully())
-				awsSession := NewSession(params.Region)
-				Eventually(awsSession, timeOutSeconds, pollInterval).Should(
+				config := NewConfig(params.Region)
+				Eventually(config, timeOutSeconds, pollInterval).Should(
 					HaveExistingCluster(clName, awseks.ClusterStatusActive, params.Version))
 			} else if e.Type == updateCluster {
 				utilsCmd := params.EksctlUtilsCmd.
@@ -152,8 +152,8 @@ var _ = Describe("(Integration) Create and Update Cluster with Endpoint Configs"
 					"--name", clName,
 				)
 				Expect(deleteCmd).Should(RunSuccessfully())
-				awsSession := NewSession(params.Region)
-				Eventually(awsSession, timeOutSeconds, pollInterval).
+				config := NewConfig(params.Region)
+				Eventually(config, timeOutSeconds, pollInterval).
 					ShouldNot(HaveExistingCluster(clName, awseks.ClusterStatusActive, params.Version))
 			}
 		},

--- a/integration/tests/cluster_dns/cluster_dns_test.go
+++ b/integration/tests/cluster_dns/cluster_dns_test.go
@@ -9,8 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-
+	"github.com/aws/aws-sdk-go-v2/aws"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 

--- a/integration/tests/crud/creategetdelete_test.go
+++ b/integration/tests/crud/creategetdelete_test.go
@@ -12,20 +12,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
-
-	"k8s.io/client-go/kubernetes"
-
-	"github.com/aws/aws-sdk-go/aws"
-	awsec2 "github.com/aws/aws-sdk-go/service/ec2"
-	awseks "github.com/aws/aws-sdk-go/service/eks"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cfntypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	harness "github.com/dlespiau/kube-test-harness"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/yaml"
 
@@ -120,12 +119,12 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 
 	Describe("cluster with 1 node", func() {
 		It("should have created an EKS cluster and two CloudFormation stacks", func() {
-			awsSession := NewSession(params.Region)
+			config := NewConfig(params.Region)
 
-			Expect(awsSession).To(HaveExistingCluster(params.ClusterName, awseks.ClusterStatusActive, params.Version))
+			Expect(config).To(HaveExistingCluster(params.ClusterName, string(ekstypes.ClusterStatusActive), params.Version))
 
-			Expect(awsSession).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-cluster", params.ClusterName)))
-			Expect(awsSession).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", params.ClusterName, mngNG1)))
+			Expect(config).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-cluster", params.ClusterName)))
+			Expect(config).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", params.ClusterName, mngNG1)))
 		})
 
 		It("should have created a valid kubectl config file", func() {
@@ -156,15 +155,15 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				cmd := params.EksctlUtilsCmd.WithArgs("describe-stacks", "--cluster", params.ClusterName, "-o", "yaml")
 				session := cmd.Run()
 				Expect(session.ExitCode()).To(BeZero())
-				var stacks []*cloudformation.Stack
+				var stacks []*cfntypes.Stack
 				Expect(yaml.Unmarshal(session.Out.Contents(), &stacks)).To(Succeed())
 				Expect(stacks).To(HaveLen(2))
 				nodegroupStack := stacks[0]
 				clusterStack := stacks[1]
-				Expect(aws.StringValue(clusterStack.StackName)).To(ContainSubstring(params.ClusterName))
-				Expect(aws.StringValue(nodegroupStack.StackName)).To(ContainSubstring(params.ClusterName))
-				Expect(aws.StringValue(clusterStack.Description)).To(Equal("EKS cluster (dedicated VPC: true, dedicated IAM: true) [created and managed by eksctl]"))
-				Expect(aws.StringValue(nodegroupStack.Description)).To(Equal("EKS Managed Nodes (SSH access: false) [created by eksctl]"))
+				Expect(aws.ToString(clusterStack.StackName)).To(ContainSubstring(params.ClusterName))
+				Expect(aws.ToString(nodegroupStack.StackName)).To(ContainSubstring(params.ClusterName))
+				Expect(aws.ToString(clusterStack.Description)).To(Equal("EKS cluster (dedicated VPC: true, dedicated IAM: true) [created and managed by eksctl]"))
+				Expect(aws.ToString(nodegroupStack.Description)).To(Equal("EKS Managed Nodes (SSH access: false) [created by eksctl]"))
 			})
 		})
 
@@ -279,7 +278,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 
 		Context("can add a nodegroup into a new subnet", func() {
 			var (
-				subnet        *awsec2.Subnet
+				subnet        *types.Subnet
 				nodegroupName string
 			)
 			BeforeEach(func() {
@@ -294,12 +293,12 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					nodegroupName,
 				)
 				Expect(cmd).To(RunSuccessfully())
-				awsSession := NewSession(params.Region)
-				ec2 := awsec2.New(awsSession)
-				output, err := ec2.DeleteSubnet(&awsec2.DeleteSubnetInput{
+				config := NewConfig(params.Region)
+				ec2 := awsec2.NewFromConfig(config)
+				output, err := ec2.DeleteSubnet(context.Background(), &awsec2.DeleteSubnetInput{
 					SubnetId: subnet.SubnetId,
 				})
-				Expect(err).NotTo(HaveOccurred(), output.GoString())
+				Expect(err).NotTo(HaveOccurred(), output.ResultMetadata)
 
 			})
 			It("creates a new nodegroup", func() {
@@ -313,10 +312,10 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				Expect(err).NotTo(HaveOccurred())
 				cl, err := ctl.GetCluster(context.Background(), params.ClusterName)
 				Expect(err).NotTo(HaveOccurred())
-				awsSession := NewSession(params.Region)
-				ec2 := awsec2.New(awsSession)
-				existingSubnets, err := ec2.DescribeSubnets(&awsec2.DescribeSubnetsInput{
-					SubnetIds: cl.ResourcesVpcConfig.SubnetIds,
+				config := NewConfig(params.Region)
+				ec2 := awsec2.NewFromConfig(config)
+				existingSubnets, err := ec2.DescribeSubnets(context.Background(), &awsec2.DescribeSubnetsInput{
+					SubnetIds: aws.ToStringSlice(cl.ResourcesVpcConfig.SubnetIds),
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(existingSubnets.Subnets) > 0).To(BeTrue())
@@ -329,7 +328,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				fmt.Sscanf(cidr, "%d.%d.%d.%d/%d", &i1, &i2, &i3, &i4, &ic)
 				cidr = fmt.Sprintf("%d.%d.%s.%d/%d", i1, i2, "255", i4, ic)
 
-				var tags []*awsec2.Tag
+				var tags []types.Tag
 
 				// filter aws: tags
 				for _, t := range s.Tags {
@@ -337,38 +336,38 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 						tags = append(tags, t)
 					}
 				}
-				output, err := ec2.CreateSubnet(&awsec2.CreateSubnetInput{
+				output, err := ec2.CreateSubnet(context.Background(), &awsec2.CreateSubnetInput{
 					AvailabilityZone: aws.String("us-west-2a"),
 					CidrBlock:        aws.String(cidr),
-					TagSpecifications: []*awsec2.TagSpecification{
+					TagSpecifications: []types.TagSpecification{
 						{
-							ResourceType: aws.String(awsec2.ResourceTypeSubnet),
+							ResourceType: types.ResourceTypeSubnet,
 							Tags:         tags,
 						},
 					},
 					VpcId: s.VpcId,
 				})
 				Expect(err).NotTo(HaveOccurred())
-				moutput, err := ec2.ModifySubnetAttribute(&awsec2.ModifySubnetAttributeInput{
-					MapPublicIpOnLaunch: &awsec2.AttributeBooleanValue{
+				moutput, err := ec2.ModifySubnetAttribute(context.Background(), &awsec2.ModifySubnetAttributeInput{
+					MapPublicIpOnLaunch: &types.AttributeBooleanValue{
 						Value: aws.Bool(true),
 					},
 					SubnetId: output.Subnet.SubnetId,
 				})
-				Expect(err).NotTo(HaveOccurred(), moutput.GoString())
+				Expect(err).NotTo(HaveOccurred(), moutput.ResultMetadata)
 				subnet = output.Subnet
 
-				routeTables, err := ec2.DescribeRouteTables(&awsec2.DescribeRouteTablesInput{
-					Filters: []*awsec2.Filter{
+				routeTables, err := ec2.DescribeRouteTables(context.Background(), &awsec2.DescribeRouteTablesInput{
+					Filters: []types.Filter{
 						{
 							Name:   aws.String("association.subnet-id"),
-							Values: aws.StringSlice([]string{*s.SubnetId}),
+							Values: []string{*s.SubnetId},
 						},
 					},
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(routeTables.RouteTables) > 0).To(BeTrue(), fmt.Sprintf("route table ended up being empty: %+v", routeTables))
-				routput, err := ec2.AssociateRouteTable(&awsec2.AssociateRouteTableInput{
+				routput, err := ec2.AssociateRouteTable(context.Background(), &awsec2.AssociateRouteTableInput{
 					RouteTableId: routeTables.RouteTables[0].RouteTableId,
 					SubnetId:     subnet.SubnetId,
 				})
@@ -749,7 +748,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 
 					Expect(cmds).To(RunSuccessfully())
 
-					awsSession := NewSession(params.Region)
+					awsSession := NewConfig(params.Region)
 
 					stackNamePrefix := fmt.Sprintf("eksctl-%s-addon-iamserviceaccount-", params.ClusterName)
 
@@ -822,7 +821,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					}
 					Expect(cmds).To(RunSuccessfully())
 
-					awsSession := NewSession(params.Region)
+					awsSession := NewConfig(params.Region)
 
 					stackNamePrefix := fmt.Sprintf("eksctl-%s-addon-iamserviceaccount-", params.ClusterName)
 

--- a/integration/tests/dry_run/dry_run_test.go
+++ b/integration/tests/dry_run/dry_run_test.go
@@ -10,9 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	. "github.com/onsi/ginkgo/v2"
-
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 

--- a/integration/tests/eks_connector/eks_connector_test.go
+++ b/integration/tests/eks_connector/eks_connector_test.go
@@ -1,6 +1,7 @@
 //go:build integration
 // +build integration
 
+//TODO: Migrate this.
 //revive:disable Not changing package name
 package eks_connector_test
 

--- a/integration/tests/existing_vpc/existing_vpc_test.go
+++ b/integration/tests/existing_vpc/existing_vpc_test.go
@@ -13,20 +13,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/weaveworks/eksctl/pkg/eks"
-
+	"github.com/aws/aws-sdk-go-v2/aws"
 	cfn "github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
-	"github.com/aws/aws-sdk-go/aws"
-
-	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	. "github.com/weaveworks/eksctl/integration/runner"
 	"github.com/weaveworks/eksctl/integration/tests"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/testutils"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var params *tests.Params

--- a/integration/tests/kms/kms_test.go
+++ b/integration/tests/kms/kms_test.go
@@ -11,9 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
 
+	. "github.com/weaveworks/eksctl/integration/matchers"
 	. "github.com/weaveworks/eksctl/integration/runner"
 	"github.com/weaveworks/eksctl/integration/tests"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
@@ -64,8 +65,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	ctl = clusterProvider.Provider
 
-	kmsClient := kms.New(ctl.ConfigProvider())
-	output, err := kmsClient.CreateKey(&kms.CreateKeyInput{
+	cfg := NewConfig(params.Region)
+	kmsClient := kms.NewFromConfig(cfg)
+	output, err := kmsClient.CreateKey(context.Background(), &kms.CreateKeyInput{
 		Description: aws.String(fmt.Sprintf("Key to test KMS encryption on EKS cluster %s", params.ClusterName)),
 	})
 	Expect(err).NotTo(HaveOccurred())
@@ -110,10 +112,11 @@ var _ = AfterSuite(func() {
 	)
 	Expect(cmd).To(RunSuccessfully())
 
-	kmsClient := kms.New(ctl.ConfigProvider())
-	_, err := kmsClient.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
+	cfg := NewConfig(params.Region)
+	kmsClient := kms.NewFromConfig(cfg)
+	_, err := kmsClient.ScheduleKeyDeletion(context.Background(), &kms.ScheduleKeyDeletionInput{
 		KeyId:               kmsKeyARN,
-		PendingWindowInDays: aws.Int64(7),
+		PendingWindowInDays: aws.Int32(7),
 	})
 	Expect(err).NotTo(HaveOccurred())
 })

--- a/integration/tests/managed/managed_nodegroup_test.go
+++ b/integration/tests/managed/managed_nodegroup_test.go
@@ -10,7 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	awseks "github.com/aws/aws-sdk-go/service/eks"
 	harness "github.com/dlespiau/kube-test-harness"
 
@@ -227,14 +228,14 @@ var _ = Describe("(Integration) Create Managed Nodegroups", func() {
 		})
 
 		It("should have created an EKS cluster and 4 CloudFormation stacks", func() {
-			awsSession := NewSession(params.Region)
+			config := NewConfig(params.Region)
 
-			Expect(awsSession).To(HaveExistingCluster(params.ClusterName, awseks.ClusterStatusActive, params.Version))
+			Expect(config).To(HaveExistingCluster(params.ClusterName, string(ekstypes.ClusterStatusActive), params.Version))
 
-			Expect(awsSession).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-cluster", params.ClusterName)))
-			Expect(awsSession).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", params.ClusterName, initialAl2Nodegroup)))
-			Expect(awsSession).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", params.ClusterName, bottlerocketNodegroup)))
-			Expect(awsSession).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", params.ClusterName, ubuntuNodegroup)))
+			Expect(config).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-cluster", params.ClusterName)))
+			Expect(config).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", params.ClusterName, initialAl2Nodegroup)))
+			Expect(config).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", params.ClusterName, bottlerocketNodegroup)))
+			Expect(config).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", params.ClusterName, ubuntuNodegroup)))
 		})
 
 		It("should have created a valid kubectl config file", func() {
@@ -531,6 +532,7 @@ var _ = Describe("(Integration) Create Managed Nodegroups", func() {
 				clusterProvider, err := eks.New(context.TODO(), &api.ProviderConfig{Region: params.Region}, clusterConfig)
 				Expect(err).NotTo(HaveOccurred())
 				ctl := clusterProvider.Provider
+				// TODO: Fix this
 				out, err := ctl.EKS().DescribeNodegroup(&awseks.DescribeNodegroupInput{
 					ClusterName:   &params.ClusterName,
 					NodegroupName: aws.String("update-config-ng"),

--- a/integration/tests/override_bootstrap/override_bootstrap_test.go
+++ b/integration/tests/override_bootstrap/override_bootstrap_test.go
@@ -5,13 +5,14 @@ package override_bootstrap
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	awsssm "github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsssm "github.com/aws/aws-sdk-go-v2/service/ssm"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -39,12 +40,12 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	awsSession := NewSession(params.Region)
-	ssm := awsssm.New(awsSession)
+	cfg := NewConfig(params.Region)
+	ssm := awsssm.NewFromConfig(cfg)
 	input := &awsssm.GetParameterInput{
 		Name: aws.String("/aws/service/eks/optimized-ami/1.21/amazon-linux-2/recommended/image_id"),
 	}
-	output, err := ssm.GetParameter(input)
+	output, err := ssm.GetParameter(context.Background(), input)
 	Expect(err).NotTo(HaveOccurred())
 	customAMI = *output.Parameter.Value
 	cmd := params.EksctlCreateCmd.WithArgs(

--- a/integration/tests/unowned_cluster/unowned_cluster_test.go
+++ b/integration/tests/unowned_cluster/unowned_cluster_test.go
@@ -13,12 +13,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+
 	. "github.com/weaveworks/eksctl/integration/matchers"
 
 	cfn "github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
-	"github.com/aws/aws-sdk-go/aws"
-	awseks "github.com/aws/aws-sdk-go/service/eks"
+	awseks "github.com/aws/aws-sdk-go/service/eks" // TODO: Remove this
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"

--- a/integration/tests/update/update_cluster_test.go
+++ b/integration/tests/update/update_cluster_test.go
@@ -10,22 +10,20 @@ import (
 	"strings"
 	"testing"
 
-	awseks "github.com/aws/aws-sdk-go/service/eks"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
-
-	"github.com/weaveworks/eksctl/pkg/eks"
-
+	"github.com/aws/aws-sdk-go-v2/service/eks/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 
 	. "github.com/weaveworks/eksctl/integration/matchers"
 	. "github.com/weaveworks/eksctl/integration/runner"
 	"github.com/weaveworks/eksctl/integration/tests"
 	"github.com/weaveworks/eksctl/pkg/addons"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/eks"
 	kubewrapper "github.com/weaveworks/eksctl/pkg/kubernetes"
 	"github.com/weaveworks/eksctl/pkg/testutils"
 	"github.com/weaveworks/eksctl/pkg/utils/file"
@@ -114,11 +112,11 @@ var _ = Describe("(Integration) Update addons", func() {
 
 	Context(fmt.Sprintf("cluster with version %s", eksVersion), func() {
 		It("should have created an EKS cluster and two CloudFormation stacks", func() {
-			awsSession := NewSession(params.Region)
+			config := NewConfig(params.Region)
 
-			Expect(awsSession).To(HaveExistingCluster(params.ClusterName, awseks.ClusterStatusActive, eksVersion))
-			Expect(awsSession).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-cluster", params.ClusterName)))
-			Expect(awsSession).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", params.ClusterName, initNG)))
+			Expect(config).To(HaveExistingCluster(params.ClusterName, string(types.ClusterStatusActive), eksVersion))
+			Expect(config).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-cluster", params.ClusterName)))
+			Expect(config).To(HaveExistingStack(fmt.Sprintf("eksctl-%s-nodegroup-%s", params.ClusterName, initNG)))
 		})
 
 		It(fmt.Sprintf("should upgrade the control plane to version %s", nextEKSVersion), func() {

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -668,6 +668,8 @@ type ClusterProvider interface {
 	Region() string
 	Profile() string
 	WaitTimeout() time.Duration
+
+	// TODO: Remove this, the implementation is no longer used effectively anywhere.
 	ConfigProvider() client.ConfigProvider
 	Session() *session.Session
 


### PR DESCRIPTION
### Description

Closes https://github.com/weaveworks/eksctl/issues/5099
Blocked by https://github.com/weaveworks/eksctl/issues/4884

Once EKS is migrated, I will do the rest and run integration tests.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

