### PR TITLE
Support Karpenter version `0.9.0`

### DIFF
--- a/examples/29-cluster-with-karpenter.yaml
+++ b/examples/29-cluster-with-karpenter.yaml
@@ -12,7 +12,7 @@ iam:
   withOIDC: true
 
 karpenter:
-  version: '0.6.2'
+  version: '0.9.0'
   createServiceAccount: true # default is false
 
 managedNodeGroups:

--- a/integration/tests/karpenter/testdata/cluster-config.yaml
+++ b/integration/tests/karpenter/testdata/cluster-config.yaml
@@ -5,7 +5,7 @@ metadata:
   name: <generated>
 
 karpenter:
-  version: '0.6.2'
+  version: '0.9.0'
 
 iam:
   withOIDC: true

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -346,8 +346,8 @@ const (
 
 // supported version of Karpenter
 const (
-	supportedKarpenterVersion      = "0.6"
-	supportedKarpenterVersionMinor = 6
+	supportedKarpenterVersion      = "0.9"
+	supportedKarpenterVersionMinor = 9
 )
 
 var (

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -1788,9 +1788,9 @@ var _ = Describe("ClusterConfig validation", func() {
 			cfg := api.NewClusterConfig()
 			cfg.IAM.WithOIDC = aws.Bool(true)
 			cfg.Karpenter = &api.Karpenter{
-				Version: "0.7.0",
+				Version: "0.10.0",
 			}
-			Expect(api.ValidateClusterConfig(cfg)).To(MatchError(ContainSubstring("failed to validate karpenter config: maximum supported version is 0.6")))
+			Expect(api.ValidateClusterConfig(cfg)).To(MatchError(ContainSubstring("failed to validate karpenter config: maximum supported version is 0.9")))
 		})
 	})
 

--- a/userdocs/src/usage/eksctl-karpenter.md
+++ b/userdocs/src/usage/eksctl-karpenter.md
@@ -2,7 +2,7 @@
 
 `eksctl` provides adding [Karpenter](https://karpenter.sh/) to a newly created cluster. It will create all the necessary
 prerequisites outlined in Karpenter's [Getting Started](https://karpenter.sh/docs/getting-started/) section including installing
-Karpenter itself using Helm. We currently support installing version's up to `0.6.*`
+Karpenter itself using Helm. We currently support installing versions up to `0.9.*`
 
 To that end, a new configuration value has been introduced into `eksctl` cluster config called `karpenter`. The following
 yaml outlines a typical installation configuration:
@@ -16,12 +16,12 @@ metadata:
   region: us-west-2
   version: '1.20'
   tags:
-    karpenter.sh/discovery: cluster-with-karpenter
+    karpenter.sh/discovery: cluster-with-karpenter # here, it is set to the cluster name
 iam:
   withOIDC: true # required
 
 karpenter:
-  version: '0.6.2'
+  version: '0.9.0'
 
 managedNodeGroups:
   - name: managed-ng-1
@@ -35,7 +35,7 @@ to be set:
 
 ```yaml
 karpenter:
-  version: '0.6.2'
+  version: '0.9.0'
   createServiceAccount: true # default is false
   defaultInstanceProfile: 'KarpenterNodeInstanceProfile' # default is to use the IAM instance profile created by eksctl
 ```
@@ -45,7 +45,7 @@ OIDC must be defined in order to install Karpenter.
 Once Karpenter is successfully installed, add a [Provisioner](https://karpenter.sh/docs/provisioner/) so Karpenter
 can start adding the right nodes to the cluster.
 
-The provisioner's `instanceProfile` section must match the created NodeInstaneProfile role's name. For example:
+The provisioner's `instanceProfile` section must match the created `NodeInstanceProfile` role's name. For example:
 
 ```yaml
 apiVersion: karpenter.sh/v1alpha5
@@ -63,11 +63,11 @@ spec:
   provider:
     instanceProfile: eksctl-KarpenterNodeInstanceProfile-${CLUSTER_NAME}
     subnetSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
+      karpenter.sh/discovery: cluster-with-karpenter # must match the tag set in the config file
     securityGroupSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
+      karpenter.sh/discovery: cluster-with-karpenter # must match the tag set in the config file
   ttlSecondsAfterEmpty: 30
 ```
 
-Note that unless `defaultInstanceProfile` is defined the name used for instanceProfile is
+Note that unless `defaultInstanceProfile` is defined, the name used for `instanceProfile` is
 `eksctl-KarpenterNodeInstanceProfile-<cluster-name>`.


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Closes #5023

## 1. Integration tests
Changed the version used in the Karpenter test suite to `0.9.0` and ran the suite locally, which was successful:
```
[0]     "karpenter": {
[0]         "version": "0.9.0",
[0]         "createServiceAccount": false
[0]     }


...


[0] Ran 1 of 1 Specs in 1857.639 seconds
[0] SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[0] --- PASS: TestKarpenter (1857.64s)
[0] PASS
```

## 2. Manual test

1. Created a cluster using the example in `examples/29-cluster-with-karpenter.yaml` - changed the cluster name to add `nm-` prefix + changed the tag to the cluster name.
2. Applied a Provisioner: 
```
apiVersion: karpenter.sh/v1alpha5
kind: Provisioner
metadata:
  name: default
spec:
  requirements:
    - key: karpenter.sh/capacity-type
      operator: In
      values: ["on-demand"]
  limits:
    resources:
      cpu: 1000
  provider:
    instanceProfile: eksctl-KarpenterNodeInstanceProfile-nm-cluster-with-karpenter
    subnetSelector:
      karpenter.sh/discovery: nm-cluster-with-karpenter
    securityGroupSelector:
      karpenter.sh/discovery: nm-cluster-with-karpenter
  ttlSecondsAfterEmpty: 30
```
4. Created a Deployment: 
```
kubectl create deployment inflate --image=public.ecr.aws/eks-distro/kubernetes/pause:3.2
```
5. Scaled up: 
```
kubectl scale deployment inflate --replicas=50
```
7. Checked that the Pods were all in `Running` state. Also checked that a Node was created to accommodate all the new Pods that were created.
8. Scaled down:
```
kubectl scale deployment inflate --replicas=0
```
9. Checked that all the Pods and the Node were all deleted.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

