### PR TITLE
Do not require overrideBootstrapCommand when ami family is Windows

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -645,7 +645,7 @@ func ValidateNodeGroup(i int, ng *NodeGroup) error {
 		}
 	}
 
-	if ng.AMI != "" && ng.OverrideBootstrapCommand == nil && ng.AMIFamily != NodeImageFamilyBottlerocket {
+	if ng.AMI != "" && ng.OverrideBootstrapCommand == nil && ng.AMIFamily != NodeImageFamilyBottlerocket && !IsWindowsImage(ng.AMIFamily) {
 		return errors.Errorf("%[1]s.overrideBootstrapCommand is required when using a custom AMI (%[1]s.ami)", path)
 	}
 
@@ -679,6 +679,10 @@ func ValidateNodeGroup(i int, ng *NodeGroup) error {
 
 		if ng.KubeletExtraConfig != nil {
 			return fieldNotSupported("kubeletExtraConfig")
+		}
+
+		if IsWindowsImage(ng.AMIFamily) && ng.OverrideBootstrapCommand != nil {
+			return fieldNotSupported("overrideBootstrapCommand")
 		}
 
 		if ng.AMIFamily == NodeImageFamilyBottlerocket {

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -146,6 +146,23 @@ var _ = Describe("ClusterConfig validation", func() {
 			ng0.AMIFamily = api.NodeImageFamilyBottlerocket
 			Expect(api.ValidateNodeGroup(0, ng0)).To(Succeed())
 		})
+		It("should not require overrideBootstrapCommand if ami is set and type is Windows", func() {
+			cfg := api.NewClusterConfig()
+			ng0 := cfg.NewNodeGroup()
+			ng0.Name = "node-group"
+			ng0.AMI = "ami-1234"
+			ng0.AMIFamily = api.NodeImageFamilyWindowsServer2019CoreContainer
+			Expect(api.ValidateNodeGroup(0, ng0)).To(Succeed())
+		})
+		It("should throw an error if overrideBootstrapCommand is set and type is Windows", func() {
+			cfg := api.NewClusterConfig()
+			ng0 := cfg.NewNodeGroup()
+			ng0.Name = "node-group"
+			ng0.AMI = "ami-1234"
+			ng0.AMIFamily = api.NodeImageFamilyWindowsServer2019CoreContainer
+			ng0.OverrideBootstrapCommand = aws.String("echo 'yo'")
+			Expect(api.ValidateNodeGroup(0, ng0)).To(MatchError(ContainSubstring("overrideBootstrapCommand is not supported for WindowsServer2019CoreContainer nodegroups")))
+		})
 		It("should accept ami with a overrideBootstrapCommand set", func() {
 			cfg := api.NewClusterConfig()
 			ng0 := cfg.NewNodeGroup()


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Currently, when you create windows nodes with custom AMI, you have to describe `overrideBootstrapCommand` in the template[ [code 1]](https://github.com/weaveworks/eksctl/blob/3180a16b7a4549e66cad3683ef0a71d719c259f4/pkg/apis/eksctl.io/v1alpha5/validation.go#L648-L650).
However, eksctl ignores the value of `overrideBootstrapCommand` and configures Userdata for windows nodes automatically [[code 2]](https://github.com/weaveworks/eksctl/blob/3180a16b7a4549e66cad3683ef0a71d719c259f4/pkg/nodebootstrap/windows.go#L33-L81).

I think eksctl should indicate overrideBootstrapCommand is not support in windows nodes because you can misunderstand that created windows nodes are configured with your customize Userdata.

[test]
```
$ cat test.yaml
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig
 
metadata:
  name: test-cluster
  region: ap-northeast-1
  version: "1.21"

nodeGroups:
  - name: windows-test-ng
    ami: ami-111111111111
    amiFamily: WindowsServer2019CoreContainer
    overrideBootstrapCommand: |
       <powershell>
       hello world
       </powershell>

$ ./eksctl create nodegroup -f test.yaml
Error: couldn't create cluster provider from options: overrideBootstrapCommand is not supported for WindowsServer2019CoreContainer nodegroups (path=nodeGroups[0].overrideBootstrapCommand)
```

### Checklist
- [X] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [X] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

