### PR TITLE
Fix selecting subnet IDs from subnet names

### DIFF
--- a/pkg/vpc/vpc.go
+++ b/pkg/vpc/vpc.go
@@ -604,7 +604,7 @@ func SelectNodeGroupSubnets(ctx context.Context, np api.NodePool, clusterConfig 
 		} else {
 			subnetMapping = clusterConfig.VPC.LocalZoneSubnets.Public
 		}
-	} else if len(ng.AvailabilityZones) > 0 {
+	} else {
 		zones = ng.AvailabilityZones
 		if ng.PrivateNetworking {
 			subnetMapping = clusterConfig.VPC.Subnets.Private


### PR DESCRIPTION
### Description

Fixes selecting subnet IDs from subnet names specified in the VPC config. 

Fixes https://github.com/weaveworks/eksctl/issues/5260

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

