### PR TITLE
Fix incorrect version info for command "eksctl info"

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
-	"strings"
-	"unicode"
 
 	"github.com/weaveworks/eksctl/pkg/version"
 )
@@ -18,6 +16,16 @@ type Info struct {
 	EksctlVersion  string
 	KubectlVersion string
 	OS             string
+}
+
+// clientVersion holds git version info of kubectl client
+type clientVersion struct {
+	GitVersion string
+}
+
+// kubectlInfo holds version inof of kubectl client
+type kubectlInfo struct {
+	ClientVersion clientVersion
 }
 
 // GetInfo returns versions info
@@ -36,19 +44,23 @@ func getEksctlVersion() string {
 
 // getKubectlVersion returns the kubectl version
 func getKubectlVersion() string {
-	cmd := exec.Command("kubectl", "version", "--short", "--client")
+	cmd := exec.Command("kubectl", "version", "--client", "--output", "json")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Sprintf("error : %v", err)
 	}
 
-	values := strings.FieldsFunc(string(out), func(c rune) bool {
-		return unicode.IsSpace(c)
-	})
-	if len(values) == 0 {
+	var info kubectlInfo
+
+	if err := json.Unmarshal([]byte(string(out)), &info); err != nil {
+		return fmt.Sprintf("error : %v", err)
+	}
+
+	if len(info.ClientVersion.GitVersion) == 0 {
 		return "unknown version"
 	}
-	return values[len(values)-1]
+
+	return info.ClientVersion.GitVersion
 }
 
 // String return info as JSON


### PR DESCRIPTION
### Description

Command `eksctl info` reported the wrong version info of `kubectl`

    $ eksctl info
    eksctl version: 0.97.0
    kubectl version: v4.5.4 # <---- it's actually the version of Kustomize.
    OS: darwin

    $ kubectl version --client --short
    Flag --short has been deprecated, and will be removed in the future. The --short output will become the default. # <---- stderr.
    Client Version: v1.24.0 # <---- what we really need
    Kustomize Version: v4.5.4

To resolve this issue, change to use `--output json` and retrieve version information from "gitVersion".

    $ kubectl version --client --output json
    {
      "clientVersion": {
        "major": "1",
        "minor": "24",
        "gitVersion": "v1.24.0", # <---- get this version information as output.
        "gitCommit": "4ce5a8954017644c5420bae81d72b09b735c21f0",
        "gitTreeState": "clean",
        "buildDate": "2022-05-03T13:36:49Z",
        "goVersion": "go1.18.1",
        "compiler": "gc",
        "platform": "darwin/amd64"
      },
      "kustomizeVersion": "v4.5.4"
    }

Test result:

    $ go test
    Running Suite: <path>/eksctl/pkg/info/info_suite_test.go - <path>/eksctl/pkg/info
    =================================================================================
    Random Seed: 1652781848

    Will run 2 of 2 specs
    ••

    Ran 2 of 2 Specs in 0.103 seconds
    SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
    PASS
    ok  	github.com/weaveworks/eksctl/pkg/info	0.875s

### Checklist
- [X] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

