### PR TITLE
Fix ASG tag propagation

### DIFF
--- a/pkg/cfn/manager/create_tasks.go
+++ b/pkg/cfn/manager/create_tasks.go
@@ -38,26 +38,32 @@ func (c *StackCollection) NewTasksToCreateClusterWithNodeGroups(ctx context.Cont
 
 	appendNodeGroupTasksTo := func(taskTree *tasks.TaskTree) {
 		vpcImporter := vpc.NewStackConfigImporter(c.MakeClusterStackName())
-		nodeGroupTasks := c.NewUnmanagedNodeGroupTask(ctx, nodeGroups, false, vpcImporter)
-		managedNodeGroupTasks := c.NewManagedNodeGroupTask(ctx, managedNodeGroups, false, vpcImporter)
-		if managedNodeGroupTasks.Len() > 0 {
-			nodeGroupTasks.Append(managedNodeGroupTasks.Tasks...)
+		nodeGroupTasks := &tasks.TaskTree{
+			Parallel:  true,
+			IsSubTask: true,
+		}
+		if unmanagedNodeGroupTasks := c.NewUnmanagedNodeGroupTask(ctx, nodeGroups, false, vpcImporter); unmanagedNodeGroupTasks.Len() > 0 {
+			unmanagedNodeGroupTasks.IsSubTask = true
+			nodeGroupTasks.Append(unmanagedNodeGroupTasks)
+		}
+		if managedNodeGroupTasks := c.NewManagedNodeGroupTask(ctx, managedNodeGroups, false, vpcImporter); managedNodeGroupTasks.Len() > 0 {
+			managedNodeGroupTasks.IsSubTask = true
+			nodeGroupTasks.Append(managedNodeGroupTasks)
 		}
 
 		if nodeGroupTasks.Len() > 0 {
-			nodeGroupTasks.IsSubTask = true
 			taskTree.Append(nodeGroupTasks)
 		}
 	}
 
 	if len(postClusterCreationTasks) > 0 {
-		postClusterCreationTaskTree := tasks.TaskTree{
+		postClusterCreationTaskTree := &tasks.TaskTree{
 			Parallel:  false,
 			IsSubTask: true,
 		}
 		postClusterCreationTaskTree.Append(postClusterCreationTasks...)
-		appendNodeGroupTasksTo(&postClusterCreationTaskTree)
-		taskTree.Append(&postClusterCreationTaskTree)
+		appendNodeGroupTasksTo(postClusterCreationTaskTree)
+		taskTree.Append(postClusterCreationTaskTree)
 	} else {
 		appendNodeGroupTasksTo(&taskTree)
 	}
@@ -88,7 +94,13 @@ func (c *StackCollection) NewUnmanagedNodeGroupTask(ctx context.Context, nodeGro
 func (c *StackCollection) NewManagedNodeGroupTask(ctx context.Context, nodeGroups []*api.ManagedNodeGroup, forceAddCNIPolicy bool, vpcImporter vpc.Importer) *tasks.TaskTree {
 	taskTree := &tasks.TaskTree{Parallel: true}
 	for _, ng := range nodeGroups {
-		taskTree.Append(&managedNodeGroupTask{
+		// Disable parallelisation if any tags propagation is done
+		// since nodegroup must be created to propagate tags to its ASGs.
+		subTask := &tasks.TaskTree{
+			Parallel:  false,
+			IsSubTask: true,
+		}
+		subTask.Append(&managedNodeGroupTask{
 			stackCollection:   c,
 			nodeGroup:         ng,
 			forceAddCNIPolicy: forceAddCNIPolicy,
@@ -97,16 +109,14 @@ func (c *StackCollection) NewManagedNodeGroupTask(ctx context.Context, nodeGroup
 			ctx:               ctx,
 		})
 		if api.IsEnabled(ng.PropagateASGTags) {
-			// disable parallelisation if any tags propagation is done
-			// since nodegroup must be created to propagate tags to its ASGs
-			taskTree.Parallel = false
-			taskTree.Append(&managedNodeGroupTagsToASGPropagationTask{
+			subTask.Append(&managedNodeGroupTagsToASGPropagationTask{
 				stackCollection: c,
 				nodeGroup:       ng,
 				info:            fmt.Sprintf("propagate tags to ASG for managed nodegroup %q", ng.Name),
 				ctx:             ctx,
 			})
 		}
+		taskTree.Append(subTask)
 	}
 	return taskTree
 }

--- a/pkg/cfn/manager/tasks_test.go
+++ b/pkg/cfn/manager/tasks_test.go
@@ -119,11 +119,15 @@ var _ = Describe("StackCollection Tasks", func() {
 				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(context.Background(), makeNodeGroups("bar", "foo"), makeManagedNodeGroups("m1", "m2"))
 				Expect(tasks.Describe()).To(Equal(`
 2 sequential tasks: { create cluster control plane "test-cluster", 
-    4 parallel sub-tasks: { 
-        create nodegroup "bar",
-        create nodegroup "foo",
-        create managed nodegroup "m1",
-        create managed nodegroup "m2",
+    2 parallel sub-tasks: { 
+        2 parallel sub-tasks: { 
+            create nodegroup "bar",
+            create nodegroup "foo",
+        },
+        2 parallel sub-tasks: { 
+            create managed nodegroup "m1",
+            create managed nodegroup "m2",
+        },
     } 
 }
 `))
@@ -132,13 +136,21 @@ var _ = Describe("StackCollection Tasks", func() {
 				tasks := stackManager.NewTasksToCreateClusterWithNodeGroups(context.Background(), makeNodeGroups("bar", "foo"), makeManagedNodeGroupsWithPropagatedTags("m1", "m2"))
 				Expect(tasks.Describe()).To(Equal(`
 2 sequential tasks: { create cluster control plane "test-cluster", 
-    6 parallel sub-tasks: { 
-        create nodegroup "bar",
-        create nodegroup "foo",
-        create managed nodegroup "m1",
-        propagate tags to ASG for managed nodegroup "m1",
-        create managed nodegroup "m2",
-        propagate tags to ASG for managed nodegroup "m2",
+    2 parallel sub-tasks: { 
+        2 parallel sub-tasks: { 
+            create nodegroup "bar",
+            create nodegroup "foo",
+        },
+        2 parallel sub-tasks: { 
+            2 sequential sub-tasks: { 
+                create managed nodegroup "m1",
+                propagate tags to ASG for managed nodegroup "m1",
+            },
+            2 sequential sub-tasks: { 
+                create managed nodegroup "m2",
+                propagate tags to ASG for managed nodegroup "m2",
+            },
+        },
     } 
 }
 `))


### PR DESCRIPTION
### Description

The ASG tag propagation task was running in parallel with the managed nodegroup creation task and was failing because it wasn't waiting for the nodegroup creation to complete. 

Fixes https://github.com/weaveworks/eksctl/issues/5285

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

