### PR TITLE
Fix eksctl utils write-config breaks in kubectl 1.24

### DIFF
--- a/pkg/utils/kubeconfig/kubeconfig_test.go
+++ b/pkg/utils/kubeconfig/kubeconfig_test.go
@@ -430,5 +430,33 @@ var _ = Describe("Kubeconfig", func() {
 			kubeconfig.AppendAuthenticator(config, clusterMeta, kubeconfig.AWSIAMAuthenticator, "", "")
 			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1alpha1"))
 		})
+		It("defaults to beta1 if we detect aws-cli v1 is at or above 1.23.9", func() {
+			kubeconfig.SetExecCommand(func(name string, arg ...string) *exec.Cmd {
+				return exec.Command(filepath.Join("testdata", "fake-version"), `aws-cli/1.23.9 Python/3.8.8 Linux/5.4.181-109.354.amzn2int.x86_64 exe/x86_64.amzn.2 prompt/off`)
+			})
+			kubeconfig.AppendAuthenticator(config, clusterMeta, kubeconfig.AWSEKSAuthenticator, "", "")
+			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1beta1"))
+		})
+		It("doesn't default to beta1 if we detect aws-cli v1 is below 1.23.9", func() {
+			kubeconfig.SetExecCommand(func(name string, arg ...string) *exec.Cmd {
+				return exec.Command(filepath.Join("testdata", "fake-version"), `aws-cli/1.21.9 Python/3.8.8 Linux/5.4.181-109.354.amzn2int.x86_64 exe/x86_64.amzn.2 prompt/off`)
+			})
+			kubeconfig.AppendAuthenticator(config, clusterMeta, kubeconfig.AWSEKSAuthenticator, "", "")
+			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1alpha1"))
+		})
+		It("defaults to beta1 if we detect aws-cli v2 is at or above 2.6.3", func() {
+			kubeconfig.SetExecCommand(func(name string, arg ...string) *exec.Cmd {
+				return exec.Command(filepath.Join("testdata", "fake-version"), `aws-cli/2.6.3 Python/3.8.8 Linux/5.4.181-109.354.amzn2int.x86_64 exe/x86_64.amzn.2 prompt/off`)
+			})
+			kubeconfig.AppendAuthenticator(config, clusterMeta, kubeconfig.AWSEKSAuthenticator, "", "")
+			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1beta1"))
+		})
+		It("doesn't default to beta1 if we detect aws-cli v2 below 2.6.3", func() {
+			kubeconfig.SetExecCommand(func(name string, arg ...string) *exec.Cmd {
+				return exec.Command(filepath.Join("testdata", "fake-version"), `aws-cli/2.4.3 Python/3.8.8 Linux/5.4.181-109.354.amzn2int.x86_64 exe/x86_64.amzn.2 prompt/off`)
+			})
+			kubeconfig.AppendAuthenticator(config, clusterMeta, kubeconfig.AWSEKSAuthenticator, "", "")
+			Expect(config.AuthInfos["test"].Exec.APIVersion).To(Equal("client.authentication.k8s.io/v1alpha1"))
+		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: Eddie Torres <torredil@amazon.com>

### Description
- Fixes #5257
- Extended `authenticatorIsBetaVersion` check as seen here: https://github.com/weaveworks/eksctl/blob/637d454ef59305b4af6633ff939674eff1f408c2/pkg/utils/kubeconfig/kubeconfig.go#L161-L166 to `case AWSEKSAuthenticator`: 
https://github.com/weaveworks/eksctl/blob/637d454ef59305b4af6633ff939674eff1f408c2/pkg/utils/kubeconfig/kubeconfig.go#L185
- For context: https://github.com/weaveworks/eksctl/blob/637d454ef59305b4af6633ff939674eff1f408c2/pkg/utils/kubeconfig/kubeconfig.go#L32-L36

### Checklist
- [X] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

