### PR TITLE
Update aws-node util to 1.11

### DIFF
--- a/pkg/addons/default/assets/aws-node.yaml
+++ b/pkg/addons/default/assets/aws-node.yaml
@@ -1,264 +1,269 @@
 ---
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "aws-node"
-  "namespace": "kube-system"
+# Source: aws-vpc-cni/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-node
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.11.0"
 ---
-"apiVersion": "rbac.authorization.k8s.io/v1"
-"kind": "ClusterRoleBinding"
-"metadata":
-  "name": "aws-node"
-"roleRef":
-  "apiGroup": "rbac.authorization.k8s.io"
-  "kind": "ClusterRole"
-  "name": "aws-node"
-"subjects":
-- "kind": "ServiceAccount"
-  "name": "aws-node"
-  "namespace": "kube-system"
+# Source: aws-vpc-cni/templates/customresourcedefinition.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: eniconfigs.crd.k8s.amazonaws.com
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.11.0"
+spec:
+  scope: Cluster
+  group: crd.k8s.amazonaws.com
+  preserveUnknownFields: false
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+  names:
+    plural: eniconfigs
+    singular: eniconfig
+    kind: ENIConfig
 ---
-"apiVersion": "rbac.authorization.k8s.io/v1"
-"kind": "ClusterRole"
-"metadata":
-  "name": "aws-node"
-"rules":
-- "apiGroups":
-  - "crd.k8s.amazonaws.com"
-  "resources":
-  - "eniconfigs"
-  "verbs":
-  - "get"
-  - "list"
-  - "watch"
-- "apiGroups":
-  - ""
-  "resources":
-  - "namespaces"
-  "verbs":
-  - "list"
-  - "watch"
-  - "get"
-- "apiGroups":
-  - ""
-  "resources":
-  - "pods"
-  "verbs":
-  - "list"
-  - "watch"
-  - "get"
-- "apiGroups":
-  - ""
-  "resources":
-  - "nodes"
-  "verbs":
-  - "list"
-  - "watch"
-  - "get"
-  - "update"
-- "apiGroups":
-  - "extensions"
-  "resources":
-  - "*"
-  "verbs":
-  - "list"
-  - "watch"
+# Source: aws-vpc-cni/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aws-node
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.11.0"
+rules:
+  - apiGroups:
+      - crd.k8s.amazonaws.com
+    resources:
+      - eniconfigs
+    verbs: ["list", "watch", "get"]
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs: ["list", "watch", "get"]
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs: ["list", "watch", "get"]        
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs: ["list", "watch", "get", "update"]
+  - apiGroups: ["extensions"]
+    resources:
+      - '*'
+    verbs: ["list", "watch"]
 ---
-"apiVersion": "apiextensions.k8s.io/v1"
-"kind": "CustomResourceDefinition"
-"metadata":
-  "name": "eniconfigs.crd.k8s.amazonaws.com"
-"spec":
-  "group": "crd.k8s.amazonaws.com"
-  "names":
-    "kind": "ENIConfig"
-    "plural": "eniconfigs"
-    "singular": "eniconfig"
-  "preserveUnknownFields": false
-  "scope": "Cluster"
-  "versions":
-  - "name": "v1alpha1"
-    "schema":
-      "openAPIV3Schema":
-        "type": "object"
-        "x-kubernetes-preserve-unknown-fields": true
-    "served": true
-    "storage": true
+# Source: aws-vpc-cni/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aws-node
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.11.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+  - kind: ServiceAccount
+    name: aws-node
+    namespace: kube-system
 ---
-"apiVersion": "apps/v1"
-"kind": "DaemonSet"
-"metadata":
-  "labels":
-    "k8s-app": "aws-node"
-  "name": "aws-node"
-  "namespace": "kube-system"
-"spec":
-  "selector":
-    "matchLabels":
-      "k8s-app": "aws-node"
-  "template":
-    "metadata":
-      "labels":
-        "k8s-app": "aws-node"
-    "spec":
-      "affinity":
-        "nodeAffinity":
-          "requiredDuringSchedulingIgnoredDuringExecution":
-            "nodeSelectorTerms":
-            - "matchExpressions":
-              - "key": "beta.kubernetes.io/os"
-                "operator": "In"
-                "values":
-                - "linux"
-              - "key": "beta.kubernetes.io/arch"
-                "operator": "In"
-                "values":
-                - "amd64"
-                - "arm64"
-              - "key": "eks.amazonaws.com/compute-type"
-                "operator": "NotIn"
-                "values":
-                - "fargate"
-            - "matchExpressions":
-              - "key": "kubernetes.io/os"
-                "operator": "In"
-                "values":
-                - "linux"
-              - "key": "kubernetes.io/arch"
-                "operator": "In"
-                "values":
-                - "amd64"
-                - "arm64"
-              - "key": "eks.amazonaws.com/compute-type"
-                "operator": "NotIn"
-                "values":
-                - "fargate"
-      "containers":
-      - "env":
-        - "name": "ADDITIONAL_ENI_TAGS"
-          "value": "{}"
-        - "name": "AWS_VPC_CNI_NODE_PORT_SUPPORT"
-          "value": "true"
-        - "name": "AWS_VPC_ENI_MTU"
-          "value": "9001"
-        - "name": "AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER"
-          "value": "false"
-        - "name": "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG"
-          "value": "false"
-        - "name": "AWS_VPC_K8S_CNI_EXTERNALSNAT"
-          "value": "false"
-        - "name": "AWS_VPC_K8S_CNI_LOGLEVEL"
-          "value": "DEBUG"
-        - "name": "AWS_VPC_K8S_CNI_LOG_FILE"
-          "value": "/host/var/log/aws-routed-eni/ipamd.log"
-        - "name": "AWS_VPC_K8S_CNI_RANDOMIZESNAT"
-          "value": "prng"
-        - "name": "AWS_VPC_K8S_CNI_VETHPREFIX"
-          "value": "eni"
-        - "name": "AWS_VPC_K8S_PLUGIN_LOG_FILE"
-          "value": "/var/log/aws-routed-eni/plugin.log"
-        - "name": "AWS_VPC_K8S_PLUGIN_LOG_LEVEL"
-          "value": "DEBUG"
-        - "name": "DISABLE_INTROSPECTION"
-          "value": "false"
-        - "name": "DISABLE_METRICS"
-          "value": "false"
-        - "name": "DISABLE_NETWORK_RESOURCE_PROVISIONING"
-          "value": "false"
-        - "name": "ENABLE_POD_ENI"
-          "value": "false"
-        - "name": "ENABLE_PREFIX_DELEGATION"
-          "value": "false"
-        - "name": "MY_NODE_NAME"
-          "valueFrom":
-            "fieldRef":
-              "fieldPath": "spec.nodeName"
-        - "name": "WARM_ENI_TARGET"
-          "value": "1"
-        - "name": "WARM_PREFIX_TARGET"
-          "value": "1"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.3"
-        "livenessProbe":
-          "exec":
-            "command":
-            - "/app/grpc-health-probe"
-            - "-addr=:50051"
-            - "-connect-timeout=2s"
-            - "-rpc-timeout=2s"
-          "initialDelaySeconds": 60
-          "timeoutSeconds": 5
-        "name": "aws-node"
-        "ports":
-        - "containerPort": 61678
-          "name": "metrics"
-        "readinessProbe":
-          "exec":
-            "command":
-            - "/app/grpc-health-probe"
-            - "-addr=:50051"
-            - "-connect-timeout=2s"
-            - "-rpc-timeout=2s"
-          "initialDelaySeconds": 1
-        "resources":
-          "requests":
-            "cpu": "10m"
-        "securityContext":
-          "capabilities":
-            "add":
-            - "NET_ADMIN"
-        "volumeMounts":
-        - "mountPath": "/host/opt/cni/bin"
-          "name": "cni-bin-dir"
-        - "mountPath": "/host/etc/cni/net.d"
-          "name": "cni-net-dir"
-        - "mountPath": "/host/var/log/aws-routed-eni"
-          "name": "log-dir"
-        - "mountPath": "/var/run/aws-node"
-          "name": "run-dir"
-        - "mountPath": "/var/run/dockershim.sock"
-          "name": "dockershim"
-        - "mountPath": "/run/xtables.lock"
-          "name": "xtables-lock"
-      "hostNetwork": true
-      "initContainers":
-      - "env":
-        - "name": "DISABLE_TCP_EARLY_DEMUX"
-          "value": "false"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.3"
-        "name": "aws-vpc-cni-init"
-        "securityContext":
-          "privileged": true
-        "volumeMounts":
-        - "mountPath": "/host/opt/cni/bin"
-          "name": "cni-bin-dir"
-      "priorityClassName": "system-node-critical"
-      "serviceAccountName": "aws-node"
-      "terminationGracePeriodSeconds": 10
-      "tolerations":
-      - "operator": "Exists"
-      "volumes":
-      - "hostPath":
-          "path": "/opt/cni/bin"
-        "name": "cni-bin-dir"
-      - "hostPath":
-          "path": "/etc/cni/net.d"
-        "name": "cni-net-dir"
-      - "hostPath":
-          "path": "/var/run/dockershim.sock"
-        "name": "dockershim"
-      - "hostPath":
-          "path": "/run/xtables.lock"
-        "name": "xtables-lock"
-      - "hostPath":
-          "path": "/var/log/aws-routed-eni"
-          "type": "DirectoryOrCreate"
-        "name": "log-dir"
-      - "hostPath":
-          "path": "/var/run/aws-node"
-          "type": "DirectoryOrCreate"
-        "name": "run-dir"
-  "updateStrategy":
-    "rollingUpdate":
-      "maxUnavailable": "10%"
-    "type": "RollingUpdate"
-...
+# Source: aws-vpc-cni/templates/daemonset.yaml
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: aws-node
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.11.0"
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      k8s-app: aws-node
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-node
+        app.kubernetes.io/instance: aws-vpc-cni
+        k8s-app: aws-node
+    spec:
+      priorityClassName: "system-node-critical"
+      serviceAccountName: aws-node
+      hostNetwork: true
+      initContainers:
+      - name: aws-vpc-cni-init
+        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.0"
+        env:
+          - name: DISABLE_TCP_EARLY_DEMUX
+            value: "false"
+          - name: ENABLE_IPv6
+            value: "false"
+        securityContext:
+            privileged: true
+        volumeMounts:
+          - mountPath: /host/opt/cni/bin
+            name: cni-bin-dir
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - operator: Exists
+      securityContext:
+        {}
+      containers:
+        - name: aws-node
+          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.0"
+          ports:
+            - containerPort: 61678
+              name: metrics
+          livenessProbe:
+            exec:
+              command:
+              - /app/grpc-health-probe
+              - -addr=:50051
+              - -connect-timeout=5s
+              - -rpc-timeout=5s
+            initialDelaySeconds: 60
+            timeoutSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+              - /app/grpc-health-probe
+              - -addr=:50051
+              - -connect-timeout=5s
+              - -rpc-timeout=5s
+            initialDelaySeconds: 1
+            timeoutSeconds: 10
+          env:
+            - name: ADDITIONAL_ENI_TAGS
+              value: "{}"
+            - name: AWS_VPC_CNI_NODE_PORT_SUPPORT
+              value: "true"
+            - name: AWS_VPC_ENI_MTU
+              value: "9001"
+            - name: AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER
+              value: "false"
+            - name: AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG
+              value: "false"
+            - name: AWS_VPC_K8S_CNI_EXTERNALSNAT
+              value: "false"
+            - name: AWS_VPC_K8S_CNI_LOGLEVEL
+              value: "DEBUG"
+            - name: AWS_VPC_K8S_CNI_LOG_FILE
+              value: "/host/var/log/aws-routed-eni/ipamd.log"
+            - name: AWS_VPC_K8S_CNI_RANDOMIZESNAT
+              value: "prng"
+            - name: AWS_VPC_K8S_CNI_VETHPREFIX
+              value: "eni"
+            - name: AWS_VPC_K8S_PLUGIN_LOG_FILE
+              value: "/var/log/aws-routed-eni/plugin.log"
+            - name: AWS_VPC_K8S_PLUGIN_LOG_LEVEL
+              value: "DEBUG"
+            - name: DISABLE_INTROSPECTION
+              value: "false"
+            - name: DISABLE_METRICS
+              value: "false"
+            - name: DISABLE_NETWORK_RESOURCE_PROVISIONING
+              value: "false"
+            - name: ENABLE_IPv4
+              value: "true"
+            - name: ENABLE_IPv6
+              value: "false"
+            - name: ENABLE_POD_ENI
+              value: "false"
+            - name: ENABLE_PREFIX_DELEGATION
+              value: "false"
+            - name: WARM_ENI_TARGET
+              value: "1"
+            - name: WARM_PREFIX_TARGET
+              value: "1"
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            requests:
+              cpu: 10m
+          securityContext:
+            capabilities:
+              add:
+              - NET_ADMIN
+          volumeMounts:
+          - mountPath: /host/opt/cni/bin
+            name: cni-bin-dir
+          - mountPath: /host/etc/cni/net.d
+            name: cni-net-dir
+          - mountPath: /host/var/log/aws-routed-eni
+            name: log-dir
+          - mountPath: /var/run/dockershim.sock
+            name: dockershim
+          - mountPath: /var/run/aws-node
+            name: run-dir
+          - mountPath: /run/xtables.lock
+            name: xtables-lock
+      volumes:
+      - name: cni-bin-dir
+        hostPath:
+          path: /opt/cni/bin
+      - name: cni-net-dir
+        hostPath:
+          path: /etc/cni/net.d
+      - name: dockershim
+        hostPath:
+          path: /var/run/dockershim.sock
+      - name: log-dir
+        hostPath:
+          path: /var/log/aws-routed-eni
+          type: DirectoryOrCreate
+      - name: run-dir
+        hostPath:
+          path: /var/run/aws-node
+          type: DirectoryOrCreate
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate

--- a/pkg/addons/default/assets_test.go
+++ b/pkg/addons/default/assets_test.go
@@ -13,7 +13,7 @@ func init() {
 	awsNodeParts := strings.Split(awsNode, "---\n")
 	nonCRDs := []string{}
 	for _, part := range awsNodeParts {
-		if strings.Contains(part, ": \"CustomResourceDefinition\"") {
+		if strings.Contains(part, ": CustomResourceDefinition") {
 			continue
 		}
 		nonCRDs = append(nonCRDs, part)

--- a/pkg/addons/default/aws_node_generate.go
+++ b/pkg/addons/default/aws_node_generate.go
@@ -1,4 +1,4 @@
 package defaultaddons
 
 // Please refer to https://docs.aws.amazon.com/eks/latest/userguide/cni-upgrades.html
-//go:generate curl --silent --location https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.9/config/v1.9/aws-k8s-cni.yaml?raw=1 --output assets/aws-node.yaml
+//go:generate curl --silent --location https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.11.0/config/master/aws-k8s-cni.yaml?raw=1 --output assets/aws-node.yaml

--- a/pkg/addons/default/aws_node_test.go
+++ b/pkg/addons/default/aws_node_test.go
@@ -80,11 +80,11 @@ var _ = Describe("AWS Node", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(awsNode.Spec.Template.Spec.Containers).To(HaveLen(1))
 				Expect(awsNode.Spec.Template.Spec.Containers[0].Image).To(
-					Equal("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:v1.9.3"),
+					Equal("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:v1.11.0"),
 				)
 				Expect(awsNode.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 				Expect(awsNode.Spec.Template.Spec.InitContainers[0].Image).To(
-					Equal("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni-init:v1.9.3"),
+					Equal("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni-init:v1.11.0"),
 				)
 			})
 		})
@@ -100,11 +100,11 @@ var _ = Describe("AWS Node", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(awsNode.Spec.Template.Spec.Containers).To(HaveLen(1))
 				Expect(awsNode.Spec.Template.Spec.Containers[0].Image).To(
-					Equal("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.9.3"),
+					Equal("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.11.0"),
 				)
 				Expect(awsNode.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 				Expect(awsNode.Spec.Template.Spec.InitContainers[0].Image).To(
-					Equal("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.9.3"),
+					Equal("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.11.0"),
 				)
 			})
 		})


### PR DESCRIPTION
Signed-off-by: steveizzle <stefan.riembauer@gmail.com>

### Description

Closes #5336 

Update of the aws-node to the last recommended version from aws with the default manifest. 

### Checklist
- [X] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

