### PR TITLE
Remove redundant `gh auth status` check in publish-docs workflow

### DIFF
--- a/build/scripts/publish-docs.sh
+++ b/build/scripts/publish-docs.sh
@@ -6,7 +6,6 @@ DIR="${BASH_SOURCE%/*}"
 . "${DIR}/tag-common.sh"
 
 
-check_prereqs
 check_origin
 
 release_branch=$(release_branch)


### PR DESCRIPTION
### Description

`check_prereqs` checks if the `gh` CLI is authenticated with a GitHub host, but this is not required as `gh` is not used in the docs publishing workflow. 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

