### PR TITLE
fix panic when stack has no physical resource id

### DIFF
--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -215,6 +215,9 @@ func (c *StackCollection) GetUnmanagedNodeGroupAutoScalingGroupName(ctx context.
 	if err != nil {
 		return "", err
 	}
+	if res.StackResourceDetail.PhysicalResourceId == nil {
+		return "", fmt.Errorf("%q resource of stack %q has no physical resource id", *input.LogicalResourceId, *res.StackResourceDetail.LogicalResourceId)
+	}
 	return *res.StackResourceDetail.PhysicalResourceId, nil
 }
 

--- a/pkg/cfn/manager/nodegroup_test.go
+++ b/pkg/cfn/manager/nodegroup_test.go
@@ -1,13 +1,19 @@
 package manager
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/stretchr/testify/mock"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
 )
 
 var _ = Describe("StackCollection NodeGroup", func() {
@@ -105,5 +111,56 @@ var _ = Describe("StackCollection NodeGroup", func() {
 				},
 				api.NodeGroupType("")),
 		)
+	})
+
+	Describe("GetUnmanagedNodeGroupAutoScalingGroupName", func() {
+
+		stackName := "stack"
+		logicalResourceID := "NodeGroup"
+		physicalResourceID := "asg"
+
+		It("returns the asg name", func() {
+			p := mockprovider.NewMockProvider()
+			p.MockCloudFormation().On("DescribeStackResource", mock.Anything, &cloudformation.DescribeStackResourceInput{
+				LogicalResourceId: aws.String(logicalResourceID),
+				StackName:         aws.String(stackName),
+			}).Return(&cloudformation.DescribeStackResourceOutput{
+				StackResourceDetail: &types.StackResourceDetail{
+					LogicalResourceId:  aws.String(logicalResourceID),
+					StackName:          aws.String(stackName),
+					PhysicalResourceId: aws.String(physicalResourceID),
+				},
+			}, nil)
+
+			sm := NewStackCollection(p, api.NewClusterConfig())
+			name, err := sm.GetUnmanagedNodeGroupAutoScalingGroupName(context.Background(), &types.Stack{
+				StackName: aws.String(stackName),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(name).To(Equal(physicalResourceID))
+		})
+
+		When("The asg resource has no physical ID", func() {
+			It("returns an error", func() {
+				p := mockprovider.NewMockProvider()
+				p.MockCloudFormation().On("DescribeStackResource", mock.Anything, &cloudformation.DescribeStackResourceInput{
+					LogicalResourceId: aws.String(logicalResourceID),
+					StackName:         aws.String(stackName),
+				}).Return(&cloudformation.DescribeStackResourceOutput{
+					StackResourceDetail: &types.StackResourceDetail{
+						LogicalResourceId:  aws.String(logicalResourceID),
+						StackName:          aws.String(stackName),
+						PhysicalResourceId: nil,
+					},
+				}, fmt.Errorf("no PhysicalResourceId"))
+
+				sm := NewStackCollection(p, api.NewClusterConfig())
+				name, err := sm.GetUnmanagedNodeGroupAutoScalingGroupName(context.Background(), &types.Stack{
+					StackName: aws.String(stackName),
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(name).To(BeEmpty())
+			})
+		})
 	})
 })


### PR DESCRIPTION
### Description

Fix panic in GetUnmanagedNodeGroupAutoScalingGroupName() when a the stack has no physical resource id.
This occurs when the stack creation failed:  the stack is rolled back and the ASG deleted.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

