### PR TITLE
Fix docs for `--force` in addons

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/addon.go
+++ b/pkg/apis/eksctl.io/v1alpha5/addon.go
@@ -28,7 +28,8 @@ type Addon struct {
 	// Each tag consists of a key and an optional value, both of which you define.
 	// +optional
 	Tags map[string]string `json:"tags,omitempty"`
-	// Force applies the add-on to overwrite an existing add-on
+	// Force overwrites an existing self-managed add-on with an EKS managed add-on.
+	// Force is intended to be used when migrating an existing self-managed add-on to an EKS managed add-on.
 	Force bool `json:"-"`
 }
 

--- a/pkg/ctl/create/addon.go
+++ b/pkg/ctl/create/addon.go
@@ -29,7 +29,7 @@ func createAddonCmd(cmd *cmdutils.Cmd) {
 		fs.StringVar(&cmd.ClusterConfig.Addons[0].Name, "name", "", "Add-on name")
 		fs.StringVar(&cmd.ClusterConfig.Addons[0].Version, "version", "", "Add-on version. Use `eksctl utils describe-addon-versions` to discover a version or set to \"latest\"")
 		fs.StringVar(&cmd.ClusterConfig.Addons[0].ServiceAccountRoleARN, "service-account-role-arn", "", "Add-on serviceAccountRoleARN")
-		fs.BoolVar(&force, "force", false, "Force applies the add-on to overwrite an existing add-on")
+		fs.BoolVar(&force, "force", false, "Force migrates an existing self-managed add-on to an EKS managed add-on")
 		fs.BoolVar(&wait, "wait", false, "Wait for the addon creation to complete")
 
 		fs.StringSliceVar(&cmd.ClusterConfig.Addons[0].AttachPolicyARNs, "attach-policy-arn", []string{}, "ARN of the policies to attach")

--- a/pkg/ctl/update/addon.go
+++ b/pkg/ctl/update/addon.go
@@ -29,7 +29,7 @@ func updateAddonCmd(cmd *cmdutils.Cmd) {
 		fs.StringVar(&cmd.ClusterConfig.Addons[0].Name, "name", "", "Addon name")
 		fs.StringVar(&cmd.ClusterConfig.Addons[0].Version, "version", "", "Add-on version. Use `eksctl utils describe-addon-versions` to discover a version or set to \"latest\"")
 		fs.StringVar(&cmd.ClusterConfig.Addons[0].ServiceAccountRoleARN, "service-account-role-arn", "", "Addon serviceAccountRoleARN")
-		fs.BoolVar(&force, "force", false, "Force applies the add-on to overwrite an existing add-on")
+		fs.BoolVar(&force, "force", false, "Force migrates an existing self-managed add-on to an EKS managed add-on")
 		fs.BoolVar(&wait, "wait", false, "Wait for the addon update to complete")
 	})
 


### PR DESCRIPTION
### Description

Fixes docs for the `--force` flag in `create|update addons`. 

Closes https://github.com/weaveworks/eksctl/issues/5444

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

