### PR TITLE
Remove GPU validation on AMI families (resolves #5256)

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/gpu_validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/gpu_validation_test.go
@@ -102,22 +102,18 @@ var _ = Describe("GPU instance support", func() {
 		Entry("Windows2004", gpuInstanceEntry{
 			amiFamily:            api.NodeImageFamilyWindowsServer2004CoreContainer,
 			gpuInstanceType:      "p2.xlarge",
-			expectUnsupportedErr: true,
 		}),
 		Entry("Windows2019Core", gpuInstanceEntry{
 			amiFamily:            api.NodeImageFamilyWindowsServer2019CoreContainer,
 			gpuInstanceType:      "g3.8xlarge",
-			expectUnsupportedErr: true,
 		}),
 		Entry("Windows2019Full", gpuInstanceEntry{
 			amiFamily:            api.NodeImageFamilyWindowsServer2019FullContainer,
 			gpuInstanceType:      "p3.2xlarge",
-			expectUnsupportedErr: true,
 		}),
 		Entry("Windows20H2Core", gpuInstanceEntry{
 			amiFamily:            api.NodeImageFamilyWindowsServer20H2CoreContainer,
 			gpuInstanceType:      "g4dn.xlarge",
-			expectUnsupportedErr: true,
 		}),
 	)
 	Describe("ARM GPU", func() {

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -515,12 +515,6 @@ func validateNodeGroupBase(np NodePool, path string) error {
 		}
 	}
 
-	// Only AmazonLinux2 and Bottlerocket support NVIDIA GPUs
-	if instanceutils.IsNvidiaInstanceType(SelectInstanceType(np)) &&
-		(ng.AMIFamily != NodeImageFamilyAmazonLinux2 && ng.AMIFamily != NodeImageFamilyBottlerocket && ng.AMIFamily != "") {
-		return errors.Errorf("NVIDIA GPU instance types are not supported for %s", ng.AMIFamily)
-	}
-
 	// Bottlerocket doesn't support Inferentia hosts
 	if instanceutils.IsInferentiaInstanceType(SelectInstanceType(np)) && ng.AMIFamily == NodeImageFamilyBottlerocket {
 		return errors.Errorf("Inferentia instance types are not supported for %s", ng.AMIFamily)


### PR DESCRIPTION
 - Windows is only incompatible with ARM on EKS, including A10G equipped ones
 - ARM and Windows issues are handled elsewhere

### Description

Resolves #5256 by allowing GPUs on Windows again.

