### PR TITLE
Changed albIngress to awsLoadBalancerController in usage iam-policies example

### DIFF
--- a/userdocs/src/usage/iam-policies.md
+++ b/userdocs/src/usage/iam-policies.md
@@ -20,7 +20,7 @@ nodeGroups:
         ebs: true
         fsx: true
         efs: true
-        albIngress: true
+        awsLoadBalancerController: true
         xRay: true
         cloudWatch: true
 ```


### PR DESCRIPTION
Changed albIngress to awsLoadBalancerController in usage iam-policies example because it's deprecated
