### PR TITLE
Extend available length of EKS Cluster name by trimming IAM Role policy name

### DIFF
--- a/pkg/cfn/builder/iam_test.go
+++ b/pkg/cfn/builder/iam_test.go
@@ -105,7 +105,7 @@ var _ = Describe("template builder for IAM", func() {
 			Expect(t).NotTo(HaveResourceWithProperties(outputs.IAMServiceAccountRoleName, "ManagedPolicyArns"))
 
 			Expect(t).To(HaveResourceWithPropertyValue(outputs.IAMServiceAccountRoleName, "AssumeRolePolicyDocument", expectedServiceAccountAssumeRolePolicyDocument))
-			Expect(t).To(HaveResourceWithPropertyValue("Policy1", "PolicyName", `{ "Fn::Sub": "${AWS::StackName}-Policy1" }`))
+			Expect(t).To(HaveResourceWithPropertyValue("Policy1", "PolicyName", `"Policy1"`))
 			Expect(t).To(HaveResourceWithPropertyValue("Policy1", "PolicyDocument", `{
             "Version": "2012-10-17",
             "Statement": [
@@ -200,7 +200,7 @@ var _ = Describe("template builder for IAM", func() {
 		]`))
 
 			Expect(t).To(HaveResourceWithPropertyValue(outputs.IAMServiceAccountRoleName, "AssumeRolePolicyDocument", expectedServiceAccountAssumeRolePolicyDocument))
-			Expect(t).To(HaveResourceWithPropertyValue("Policy1", "PolicyName", `{ "Fn::Sub": "${AWS::StackName}-Policy1" }`))
+			Expect(t).To(HaveResourceWithPropertyValue("Policy1", "PolicyName", `"Policy1"`))
 			Expect(t).To(HaveResourceWithPropertyValue("Policy1", "PolicyDocument", `{
             "Version": "2012-10-17",
             "Statement": [
@@ -399,7 +399,7 @@ var _ = Describe("template builder for IAM", func() {
 			Expect(t).NotTo(HaveResourceWithProperties(outputs.IAMServiceAccountRoleName, "ManagedPolicyArns"))
 
 			Expect(t).To(HaveResourceWithPropertyValue(outputs.IAMServiceAccountRoleName, "AssumeRolePolicyDocument", expectedAssumeRolePolicyDocument))
-			Expect(t).To(HaveResourceWithPropertyValue("Policy1", "PolicyName", `{ "Fn::Sub": "${AWS::StackName}-Policy1" }`))
+			Expect(t).To(HaveResourceWithPropertyValue("Policy1", "PolicyName", `"Policy1"`))
 			Expect(t).To(HaveResourceWithPropertyValue("Policy1", "PolicyDocument", `{
 		   "Version": "2012-10-17",
 		   "Statement": [

--- a/pkg/cfn/template/iam_helpers.go
+++ b/pkg/cfn/template/iam_helpers.go
@@ -5,7 +5,7 @@ import gfn "github.com/weaveworks/goformation/v4/cloudformation/types"
 // AttachPolicy attaches the specified policy document
 func (t *Template) AttachPolicy(name string, refRole *Value, policyDoc MapOfInterfaces) {
 	t.NewResource(name, &IAMPolicy{
-		PolicyName:     MakeName(name),
+		PolicyName:     NewString(name),
 		Roles:          MakeSlice(refRole),
 		PolicyDocument: policyDoc,
 	})


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Close #5614

Remove stack name prefix from IAM Role inline policy name **_created by well-known policy_** to extend a length of EKS Cluster name.

For example, when using `awsLoadBalancerController: true`, cluster name max length is limited to 24 as the overall policy name would exceed 128 characters. With this change, the limit is extended to 56 for this particular case.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

### Manual test

Test with cluster name `test-012345678901234567890123456789012345678901234567890`, 56 characters

```sh
$ ./eksctl create cluster --name test-012345678901234567890123456789012345678901234567890 --without-nodegroup --with-oidc --region ap-northeast-1 --version 1.23 
2022-08-15 10:59:05 [ℹ]  eksctl version 0.110.0-dev+e12dc7374.2022-08-14T17:30:29Z
2022-08-15 10:59:05 [ℹ]  using region ap-northeast-1
2022-08-15 10:59:10 [ℹ]  setting availability zones to [ap-northeast-1c ap-northeast-1d ap-northeast-1a]
2022-08-15 10:59:10 [ℹ]  subnets for ap-northeast-1c - public:192.168.0.0/19 private:192.168.96.0/19
2022-08-15 10:59:10 [ℹ]  subnets for ap-northeast-1d - public:192.168.32.0/19 private:192.168.128.0/19
2022-08-15 10:59:10 [ℹ]  subnets for ap-northeast-1a - public:192.168.64.0/19 private:192.168.160.0/19
2022-08-15 10:59:10 [ℹ]  using Kubernetes version 1.23
2022-08-15 10:59:10 [ℹ]  creating EKS cluster "test-012345678901234567890123456789012345678901234567890" in "ap-northeast-1" region with 
2022-08-15 10:59:10 [ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=ap-northeast-1 --cluster=test-012345678901234567890123456789012345678901234567890'
2022-08-15 10:59:10 [ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "test-012345678901234567890123456789012345678901234567890" in "ap-northeast-1"
2022-08-15 10:59:10 [ℹ]  CloudWatch logging will not be enabled for cluster "test-012345678901234567890123456789012345678901234567890" in "ap-northeast-1"
2022-08-15 10:59:10 [ℹ]  you can enable it with 'eksctl utils update-cluster-logging --enable-types={SPECIFY-YOUR-LOG-TYPES-HERE (e.g. all)} --region=ap-northeast-1 --cluster=test-012345678901234567890123456789012345678901234567890'
2022-08-15 10:59:10 [ℹ]  
2 sequential tasks: { create cluster control plane "test-012345678901234567890123456789012345678901234567890", 
    4 sequential sub-tasks: { 
        wait for control plane to become ready,
        associate IAM OIDC provider,
        2 sequential sub-tasks: { 
            create IAM role for serviceaccount "kube-system/aws-node",
            create serviceaccount "kube-system/aws-node",
        },
        restart daemonset "kube-system/aws-node",
    } 
}
2022-08-15 10:59:10 [ℹ]  building cluster stack "eksctl-test-012345678901234567890123456789012345678901234567890-cluster"
2022-08-15 10:59:16 [ℹ]  deploying stack "eksctl-test-012345678901234567890123456789012345678901234567890-cluster"
2022-08-15 10:59:46 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-cluster"
2022-08-15 11:00:21 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-cluster"
2022-08-15 11:01:26 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-cluster"
2022-08-15 11:02:31 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-cluster"
2022-08-15 11:03:36 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-cluster"
2022-08-15 11:04:41 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-cluster"
2022-08-15 11:05:46 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-cluster"
2022-08-15 11:06:51 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-cluster"
2022-08-15 11:07:57 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-cluster"
2022-08-15 11:09:02 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-cluster"
2022-08-15 11:10:07 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-cluster"
2022-08-15 11:12:40 [ℹ]  building iamserviceaccount stack "eksctl-test-012345678901234567890123456789012345678901234567890-addon-iamserviceaccount-kube-system-aws-node"
2022-08-15 11:12:46 [ℹ]  deploying stack "eksctl-test-012345678901234567890123456789012345678901234567890-addon-iamserviceaccount-kube-system-aws-node"
2022-08-15 11:12:46 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-addon-iamserviceaccount-kube-system-aws-node"
2022-08-15 11:13:21 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-addon-iamserviceaccount-kube-system-aws-node"
2022-08-15 11:13:21 [ℹ]  serviceaccount "kube-system/aws-node" already exists
2022-08-15 11:13:21 [ℹ]  updated serviceaccount "kube-system/aws-node"
2022-08-15 11:13:21 [ℹ]  daemonset "kube-system/aws-node" restarted
2022-08-15 11:13:21 [ℹ]  waiting for the control plane availability...
2022-08-15 11:13:21 [✔]  saved kubeconfig as "/Users/jlandowner/.kube/config"
2022-08-15 11:13:21 [ℹ]  no tasks
2022-08-15 11:13:21 [✔]  all EKS cluster resources for "test-012345678901234567890123456789012345678901234567890" have been created
2022-08-15 11:13:25 [ℹ]  kubectl command should work with "/Users/jlandowner/.kube/config", try 'kubectl get nodes'
2022-08-15 11:13:25 [✔]  EKS cluster "test-012345678901234567890123456789012345678901234567890" in "ap-northeast-1" region is ready


$ cat <<EOF > irsa.yaml 
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: test-012345678901234567890123456789012345678901234567890
  region: ap-northeast-1

iam:
  withOIDC: true
  serviceAccounts:
  # This IRSA will be sucessfully created
  - metadata:
      name: aws-load-balancer-controller
      namespace: kube-system
    wellKnownPolicies:
      awsLoadBalancerController: true

  # This IRSA will be sucessfully created even using the same well-known policy
  - metadata:
      name: another-sa-well-known
      namespace: kube-system
    wellKnownPolicies:
      awsLoadBalancerController: true
      efsCSIController: true

  # This IRSA will fail due to over 128 length of CloudFormation stack name
  - metadata:
      name: aws-load-balancer-controller
      namespace: kube-system2
    wellKnownPolicies:
      awsLoadBalancerController: true
      efsCSIController: true
EOF

$ k create ns kube-system2
namespace/kube-system2 created

$ ./eksctl create iamserviceaccount -f irsa.yaml --approve                                           
2022-08-15 11:34:42 [ℹ]  1 existing iamserviceaccount(s) (kube-system/aws-node) will be excluded
2022-08-15 11:34:42 [ℹ]  3 iamserviceaccounts (kube-system/another-sa-well-known, kube-system/aws-load-balancer-controller, kube-system2/aws-load-balancer-controller) were included (based on the include/exclude rules)
2022-08-15 11:34:42 [!]  serviceaccounts that exist in Kubernetes will be excluded, use --override-existing-serviceaccounts to override
2022-08-15 11:34:42 [ℹ]  
3 parallel tasks: { 
    2 sequential sub-tasks: { 
        create IAM role for serviceaccount "kube-system/aws-load-balancer-controller",
        create serviceaccount "kube-system/aws-load-balancer-controller",
    }, 
    2 sequential sub-tasks: { 
        create IAM role for serviceaccount "kube-system/another-sa-well-known",
        create serviceaccount "kube-system/another-sa-well-known",
    }, 
    2 sequential sub-tasks: { 
        create IAM role for serviceaccount "kube-system2/aws-load-balancer-controller",
        create serviceaccount "kube-system2/aws-load-balancer-controller",
    } 
}
2022-08-15 11:34:42 [ℹ]  building iamserviceaccount stack "eksctl-test-012345678901234567890123456789012345678901234567890-addon-iamserviceaccount-kube-system2-aws-load-balancer-controller"
2022-08-15 11:34:42 [ℹ]  building iamserviceaccount stack "eksctl-test-012345678901234567890123456789012345678901234567890-addon-iamserviceaccount-kube-system-another-sa-well-known"
2022-08-15 11:34:42 [ℹ]  building iamserviceaccount stack "eksctl-test-012345678901234567890123456789012345678901234567890-addon-iamserviceaccount-kube-system-aws-load-balancer-controller"
2022-08-15 11:34:42 [ℹ]  an error occurred creating the stack, to cleanup resources, run 'eksctl delete iamserviceaccount --region=ap-northeast-1 --name=aws-load-balancer-controller --namespace=kube-system2'
2022-08-15 11:34:47 [ℹ]  deploying stack "eksctl-test-012345678901234567890123456789012345678901234567890-addon-iamserviceaccount-kube-system-aws-load-balancer-controller"
2022-08-15 11:34:47 [ℹ]  deploying stack "eksctl-test-012345678901234567890123456789012345678901234567890-addon-iamserviceaccount-kube-system-another-sa-well-known"
2022-08-15 11:34:47 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-addon-iamserviceaccount-kube-system-another-sa-well-known"
2022-08-15 11:34:47 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-addon-iamserviceaccount-kube-system-aws-load-balancer-controller"
2022-08-15 11:35:23 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-addon-iamserviceaccount-kube-system-another-sa-well-known"
2022-08-15 11:35:23 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-addon-iamserviceaccount-kube-system-aws-load-balancer-controller"
2022-08-15 11:36:02 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-addon-iamserviceaccount-kube-system-another-sa-well-known"
2022-08-15 11:36:02 [ℹ]  created serviceaccount "kube-system/another-sa-well-known"
2022-08-15 11:36:13 [ℹ]  waiting for CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-addon-iamserviceaccount-kube-system-aws-load-balancer-controller"
2022-08-15 11:36:13 [ℹ]  created serviceaccount "kube-system/aws-load-balancer-controller"
2022-08-15 11:36:13 [ℹ]  1 error(s) occurred and IAM Role stacks haven't been updated properly, you may wish to check CloudFormation console
2022-08-15 11:36:13 [✖]  creating CloudFormation stack "eksctl-test-012345678901234567890123456789012345678901234567890-addon-iamserviceaccount-kube-system2-aws-load-balancer-controller": operation error CloudFormation: CreateStack, https response error StatusCode: 400, RequestID: XXXXXX, api error ValidationError: Stack name cannot exceed 128 characters
Error: failed to create iamserviceaccount(s)

$ ./eksctl get iamserviceaccounts --cluster  test-012345678901234567890123456789012345678901234567890
NAMESPACE	NAME				ROLE ARN
kube-system	another-sa-well-known		arn:aws:iam::ACCOUNTID:role/eksctl-test-01234567890123456789012345678901-Role1-GN92LN9KV5DY
kube-system	aws-load-balancer-controller	arn:aws:iam::ACCOUNTID:role:role/eksctl-test-01234567890123456789012345678901-Role1-1DH9A6OAHET1
kube-system	aws-node			arn:aws:iam::ACCOUNTID:role:role/eksctl-test-01234567890123456789012345678901-Role1-SU4FDNEG8QUM

$ aws iam list-role-policies --role-name eksctl-test-01234567890123456789012345678901-Role1-1DH9A6OAHET1 
{
    "PolicyNames": [
        "PolicyAWSLoadBalancerController"
    ]
}

$ aws iam list-role-policies --role-name eksctl-test-01234567890123456789012345678901-Role1-GN92LN9KV5DY                               
{
    "PolicyNames": [
        "PolicyAWSLoadBalancerController",
        "PolicyEFSCSIController"
    ]
}

```
