### PR TITLE
allow cloudwatch to set retention

### DIFF
--- a/pkg/cfn/builder/iam_helper.go
+++ b/pkg/cfn/builder/iam_helper.go
@@ -146,6 +146,10 @@ func createRole(cfnTemplate cfnTemplate, clusterIAMConfig *api.ClusterIAM, iamCo
 		cfnTemplate.attachAllowPolicy("PolicyXRay", refIR, xRayStatements())
 	}
 
+	if api.IsEnabled(iamConfig.WithAddonPolicies.CloudWatch) {
+		cfnTemplate.attachAllowPolicy("PolicyCloudwatch", refIR, cloudwatchStatements())
+	}
+
 	return nil
 }
 

--- a/pkg/cfn/builder/statement.go
+++ b/pkg/cfn/builder/statement.go
@@ -270,6 +270,18 @@ func autoScalerStatements() []cft.MapOfInterfaces {
 	}
 }
 
+func cloudwatchStatements() []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"logs:PutRetentionPolicy",
+			},
+		},
+	}
+}
+
 func appMeshStatements(appendAction string) []cft.MapOfInterfaces {
 	return []cft.MapOfInterfaces{
 		{


### PR DESCRIPTION
### Description

This fixes
```
AccessDeniedException: User: arn:aws:sts::254324309357:assumed-role/eksctl-test-7-nodegroup-test-2-4-NodeInstanceRole-2P9BUNW69CSJ/i-06280fb260c5b01d4 is not authorized to perform: logs:PutRetentionPolicy
```
when installing aws for fluentbit helm chart, fixes #5605 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

