### PR TITLE
Allow creating Windows and Ubuntu nodegroups with NVIDIA GPU instances

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/gpu_validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/gpu_validation_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
-	instanceutils "github.com/weaveworks/eksctl/pkg/utils/instance"
 )
 
 var _ = Describe("GPU instance support", func() {
@@ -22,11 +21,7 @@ var _ = Describe("GPU instance support", func() {
 	assertValidationError := func(e gpuInstanceEntry, err error) {
 		if e.expectUnsupportedErr {
 			Expect(err).To(HaveOccurred())
-			if instanceutils.IsNvidiaInstanceType(e.gpuInstanceType) {
-				Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("GPU instance types are not supported for %s", e.amiFamily))))
-			} else {
-				Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("Inferentia instance types are not supported for %s", e.amiFamily))))
-			}
+			Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("Inferentia instance types are not supported for %s", e.amiFamily))))
 			return
 		}
 		Expect(err).NotTo(HaveOccurred())
@@ -48,9 +43,8 @@ var _ = Describe("GPU instance support", func() {
 			amiFamily:       api.NodeImageFamilyAmazonLinux2,
 		}),
 		Entry("Ubuntu2004", gpuInstanceEntry{
-			amiFamily:            api.NodeImageFamilyUbuntu2004,
-			gpuInstanceType:      "g4dn.xlarge",
-			expectUnsupportedErr: true,
+			amiFamily:       api.NodeImageFamilyUbuntu2004,
+			gpuInstanceType: "g4dn.xlarge",
 		}),
 		Entry("Bottlerocket", gpuInstanceEntry{
 			amiFamily:            api.NodeImageFamilyBottlerocket,
@@ -95,19 +89,16 @@ var _ = Describe("GPU instance support", func() {
 			gpuInstanceType: "g4dn.xlarge",
 		}),
 		Entry("Ubuntu2004", gpuInstanceEntry{
-			amiFamily:            api.NodeImageFamilyUbuntu2004,
-			gpuInstanceType:      "g4dn.xlarge",
-			expectUnsupportedErr: true,
+			amiFamily:       api.NodeImageFamilyUbuntu2004,
+			gpuInstanceType: "g4dn.xlarge",
 		}),
 		Entry("Windows2019Core", gpuInstanceEntry{
-			amiFamily:            api.NodeImageFamilyWindowsServer2019CoreContainer,
-			gpuInstanceType:      "g3.8xlarge",
-			expectUnsupportedErr: true,
+			amiFamily:       api.NodeImageFamilyWindowsServer2019CoreContainer,
+			gpuInstanceType: "g3.8xlarge",
 		}),
 		Entry("Windows2019Full", gpuInstanceEntry{
-			amiFamily:            api.NodeImageFamilyWindowsServer2019FullContainer,
-			gpuInstanceType:      "p3.2xlarge",
-			expectUnsupportedErr: true,
+			amiFamily:       api.NodeImageFamilyWindowsServer2019FullContainer,
+			gpuInstanceType: "p3.2xlarge",
 		}),
 	)
 	Describe("ARM GPU", func() {

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -518,10 +518,9 @@ func validateNodeGroupBase(np NodePool, path string) error {
 		}
 	}
 
-	// Only AmazonLinux2 and Bottlerocket support NVIDIA GPUs
 	if instanceutils.IsNvidiaInstanceType(SelectInstanceType(np)) &&
 		(ng.AMIFamily != NodeImageFamilyAmazonLinux2 && ng.AMIFamily != NodeImageFamilyBottlerocket && ng.AMIFamily != "") {
-		return errors.Errorf("NVIDIA GPU instance types are not supported for %s", ng.AMIFamily)
+		logger.Warning("%s does not ship with NVIDIA GPU drivers installed, hence won't support running GPU-accelerated workloads out of the box", ng.AMIFamily)
 	}
 
 	// Bottlerocket doesn't support Inferentia hosts

--- a/userdocs/src/usage/gpu-support.md
+++ b/userdocs/src/usage/gpu-support.md
@@ -16,6 +16,9 @@ GPU instance type and they will select the correct EKS optimized accelerated AMI
 Eksctl will detect that an AMI with a GPU-enabled instance type has been selected and
 will install the [NVIDIA Kubernetes device plugin](https://github.com/NVIDIA/k8s-device-plugin) automatically.
 
+!!! note
+    Windows and Ubuntu AMIs do not ship with GPU drivers installed, hence running GPU-accelerated workloads will not work out of the box.
+
 To disable the automatic plugin installation, and manually install a specific version,
 use `--install-nvidia-plugin=false` with the create command. For example:
 


### PR DESCRIPTION
Signed-off-by: Tibi <110664232+TiberiuGC@users.noreply.github.com>

### Description

We should be able to create Windows and Ubuntu nodegroups with NVIDIA GPU instances, which is why we 
are removing the previously configured error for this scenario. However, we will log a warning as these AMIs don't ship with GPU drivers installed and we don't want give the illusion that running GPU-accelerated workloads will work out of the box.

Fixes #5256 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

