### PR TITLE
Add coredns-1.23 asset

### DIFF
--- a/build/updates/dump-coredns-manifests.sh
+++ b/build/updates/dump-coredns-manifests.sh
@@ -29,6 +29,7 @@ kubectl \
               del(.items[].metadata.creationTimestamp) |
               del(.items[].metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"]) |
               del(.items[].metadata.annotations["deployment.kubernetes.io/revision"]) |
+              del(.items[].spec.clusterIPs) |
               del(.items[].spec.clusterIP) |
               del(.items[].secrets) |
               del(.items[].status)

--- a/pkg/addons/default/assets/coredns-1.23.json
+++ b/pkg/addons/default/assets/coredns-1.23.json
@@ -19,6 +19,11 @@
         "namespace": "kube-system"
       },
       "spec": {
+        "internalTrafficPolicy": "Cluster",
+        "ipFamilies": [
+          "IPv4"
+        ],
+        "ipFamilyPolicy": "SingleStack",
         "ports": [
           {
             "name": "dns",
@@ -164,7 +169,7 @@
                   "-conf",
                   "/etc/coredns/Corefile"
                 ],
-                "image": "%s.dkr.ecr.%s.%s/eks/coredns:v1.8.0-eksbuild.1",
+                "image": "%s.dkr.ecr.%s.%s/eks/coredns:v1.8.7-eksbuild.2",
                 "imagePullPolicy": "IfNotPresent",
                 "livenessProbe": {
                   "failureThreshold": 5,
@@ -321,6 +326,18 @@
           ],
           "verbs": [
             "get"
+          ]
+        },
+        {
+          "apiGroups": [
+            "discovery.k8s.io"
+          ],
+          "resources": [
+            "endpointslices"
+          ],
+          "verbs": [
+            "list",
+            "watch"
           ]
         }
       ]


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Changes
- deletes the coredns asset for 1.19
- adds a coredns asset for 1.23 to use `1.8.7-eksbuild.2` as recommend by the AWS [docs](https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html)

### Process
- followed the guide in the Handbook on how to update the coredns asset: https://github.com/weaveworks/eksctl-handbook/blob/main/new-kubernetes-version.md#updating-eksctl-and-testing
- ran the script `build/updates/dump-coredns-manifests.sh` (thanks @Himangini), which does mostly the same as what's written in the Handbook - I modified one line to also delete `clusterIPs`
- tested that `eksctl utils update-coredns --cluster=<clusterName>` works with 1.23 :) 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

