### PR TITLE
Return StackName field when getting a single managed nodegroup

### DIFF
--- a/pkg/actions/nodegroup/get_test.go
+++ b/pkg/actions/nodegroup/get_test.go
@@ -551,12 +551,12 @@ var _ = Describe("Get", func() {
 			}, nil)
 		})
 
-		It("returns the summary", func() {
+		It("returns the summary and the stack name", func() {
 			summary, err := m.Get(context.Background(), ngName)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(*summary).To(Equal(nodegroup.Summary{
-				StackName:            "",
+				StackName:            stackName,
 				Cluster:              clusterName,
 				Name:                 ngName,
 				Status:               "my-status",


### PR DESCRIPTION
### Description

Fixes #5544

When using `eksctl get nodegroup` for a single managed nodegroup (i.e. using the `--name` flag), the StackName field was always returned empty.
This PR fixes the issue.

Manual test output

```
tiberiu-weave@192-168-0-101 eksctl % ./eksctl get nodegroup --region eu-north-1 --cluster cluster-1 --name ng-49a5a674 -o yaml
- AutoScalingGroupName: eks-ng-49a5a674-52c15ad1-96f0-d295-5ca0-11a47e7abec3
  Cluster: cluster-1
  CreationTime: “2022-08-19T10:25:49.169Z”
  DesiredCapacity: 2
  ImageID: AL2_x86_64
  InstanceType: m5.large
  MaxSize: 2
  MinSize: 2
  Name: ng-49a5a674
  NodeInstanceRoleARN: arn:aws:iam::083751696308:role/eksctl-cluster-1-nodegroup-ng-49a-NodeInstanceRole-1SQGLUI88RTC8
  StackName: eksctl-cluster-1-nodegroup-ng-49a5a674
  Status: ACTIVE
  Type: managed
  Version: “1.23"
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

