### PR TITLE
Fix ARN partition issue to support IPv6 in China regions

### DIFF
--- a/pkg/actions/addon/create.go
+++ b/pkg/actions/addon/create.go
@@ -230,7 +230,7 @@ func (a *Manager) getRecommendedPolicies(addon *api.Addon) (api.InlineDocument, 
 	switch addon.CanonicalName() {
 	case vpcCNIName:
 		if a.clusterConfig.IPv6Enabled() {
-			return makeIPv6VPCCNIPolicyDocument(), nil, nil
+			return makeIPv6VPCCNIPolicyDocument(api.Partition(a.clusterConfig.Metadata.Region)), nil, nil
 		}
 		return nil, []string{fmt.Sprintf("arn:%s:iam::aws:policy/%s", api.Partition(a.clusterConfig.Metadata.Region), api.IAMPolicyAmazonEKSCNIPolicy)}, nil
 	case ebsCSIDriverName:
@@ -301,7 +301,7 @@ func (a *Manager) createStack(ctx context.Context, resourceSet builder.ResourceS
 	return <-errChan
 }
 
-func makeIPv6VPCCNIPolicyDocument() map[string]interface{} {
+func makeIPv6VPCCNIPolicyDocument(partition string) map[string]interface{} {
 	return map[string]interface{}{
 		"Version": "2012-10-17",
 		"Statement": []map[string]interface{}{
@@ -321,7 +321,7 @@ func makeIPv6VPCCNIPolicyDocument() map[string]interface{} {
 				"Action": []string{
 					"ec2:CreateTags",
 				},
-				"Resource": "arn:aws:ec2:*:*:network-interface/*",
+				"Resource": fmt.Sprintf("arn:%s:ec2:*:*:network-interface/*", partition),
 			},
 		},
 	}


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Fix the issue to provision IPv6 cluster in China regions (#5645), the [IPv6 VPC CNI Policy](https://github.com/weaveworks/eksctl/blob/4f71db6d61f4fdc73b89cc3edb4eca3bd932a792/pkg/actions/addon/create.go#L304) was created and the ARN for ENI is `arn:aws:ec2:*:*:network-interface/*`, the expected ARN for China regions should be `arn:aws-cn:ec2:*:*:network-interface/*`

I have tested this fix, here is config file:
```
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: ipv6-test
  region: cn-northwest-1
  version: "1.21"

kubernetesNetworkConfig:
  ipFamily: IPv6

addons:
  - name: vpc-cni
    version: latest
  - name: coredns
    version: latest
  - name: kube-proxy
    version: latest

iam:
  withOIDC: true

managedNodeGroups:
  - name: mng-1
```
and the output: 
```
[ec2-user@ip-172-31-30-56 temp]$ ./eksctl create cluster -f ./ipv6-test.yaml
2022-08-24 19:32:59 [ℹ]  eksctl version 0.110.0-dev+4f71db6d.2022-08-22T17:58:56Z
2022-08-24 19:32:59 [ℹ]  using region cn-northwest-1
2022-08-24 19:33:00 [ℹ]  setting availability zones to [cn-northwest-1b cn-northwest-1a cn-northwest-1c]
2022-08-24 19:33:00 [ℹ]  subnets for cn-northwest-1b - public:192.168.0.0/19 private:192.168.96.0/19
2022-08-24 19:33:00 [ℹ]  subnets for cn-northwest-1a - public:192.168.32.0/19 private:192.168.128.0/19
2022-08-24 19:33:00 [ℹ]  subnets for cn-northwest-1c - public:192.168.64.0/19 private:192.168.160.0/19
2022-08-24 19:33:00 [ℹ]  nodegroup "mng-1" will use "" [AmazonLinux2/1.21]
2022-08-24 19:33:00 [ℹ]  using Kubernetes version 1.21
2022-08-24 19:33:00 [ℹ]  creating EKS cluster "ipv6-test" in "cn-northwest-1" region with managed nodes
2022-08-24 19:33:00 [ℹ]  1 nodegroup (mng-1) was included (based on the include/exclude rules)
2022-08-24 19:33:00 [ℹ]  will create a CloudFormation stack for cluster itself and 0 nodegroup stack(s)
2022-08-24 19:33:00 [ℹ]  will create a CloudFormation stack for cluster itself and 1 managed nodegroup stack(s)
2022-08-24 19:33:00 [ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=cn-northwest-1 --cluster=ipv6-test'
2022-08-24 19:33:00 [ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "ipv6-test" in "cn-northwest-1"
2022-08-24 19:33:00 [ℹ]  CloudWatch logging will not be enabled for cluster "ipv6-test" in "cn-northwest-1"
2022-08-24 19:33:00 [ℹ]  you can enable it with 'eksctl utils update-cluster-logging --enable-types={SPECIFY-YOUR-LOG-TYPES-HERE (e.g. all)} --region=cn-northwest-1 --cluster=ipv6-test'
2022-08-24 19:33:00 [ℹ]
2 sequential tasks: { create cluster control plane "ipv6-test",
    2 sequential sub-tasks: {
        5 sequential sub-tasks: {
            wait for control plane to become ready,
            associate IAM OIDC provider,
            no tasks,
            restart daemonset "kube-system/aws-node",
            1 task: { create addons },
        },
        create managed nodegroup "mng-1",
    }
}
2022-08-24 19:33:00 [ℹ]  building cluster stack "eksctl-ipv6-test-cluster"
2022-08-24 19:33:00 [ℹ]  deploying stack "eksctl-ipv6-test-cluster"
2022-08-24 19:33:30 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-cluster"
2022-08-24 19:34:00 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-cluster"
2022-08-24 19:35:00 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-cluster"
2022-08-24 19:36:00 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-cluster"
2022-08-24 19:37:00 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-cluster"
2022-08-24 19:38:00 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-cluster"
2022-08-24 19:39:00 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-cluster"
2022-08-24 19:40:00 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-cluster"
2022-08-24 19:41:00 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-cluster"
2022-08-24 19:42:00 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-cluster"
2022-08-24 19:43:00 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-cluster"
2022-08-24 19:45:01 [ℹ]  daemonset "kube-system/aws-node" restarted
2022-08-24 19:45:01 [ℹ]  creating role using recommended policies
2022-08-24 19:45:02 [ℹ]  deploying stack "eksctl-ipv6-test-addon-vpc-cni"
2022-08-24 19:45:02 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-addon-vpc-cni"
2022-08-24 19:45:32 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-addon-vpc-cni"
2022-08-24 19:45:32 [ℹ]  creating addon
2022-08-24 19:45:42 [ℹ]  addon "vpc-cni" active
2022-08-24 19:45:42 [ℹ]  building managed nodegroup stack "eksctl-ipv6-test-nodegroup-mng-1"
2022-08-24 19:45:43 [ℹ]  deploying stack "eksctl-ipv6-test-nodegroup-mng-1"
2022-08-24 19:45:43 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-nodegroup-mng-1"
2022-08-24 19:46:13 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-nodegroup-mng-1"
2022-08-24 19:47:08 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-nodegroup-mng-1"
2022-08-24 19:47:58 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-nodegroup-mng-1"
2022-08-24 19:49:11 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-nodegroup-mng-1"
2022-08-24 19:50:29 [ℹ]  waiting for CloudFormation stack "eksctl-ipv6-test-nodegroup-mng-1"
2022-08-24 19:50:29 [ℹ]  waiting for the control plane availability...
2022-08-24 19:50:29 [✔]  saved kubeconfig as "/home/ec2-user/.kube/config"
2022-08-24 19:50:29 [ℹ]  no tasks
2022-08-24 19:50:29 [✔]  all EKS cluster resources for "ipv6-test" have been created
2022-08-24 19:50:29 [ℹ]  nodegroup "mng-1" has 2 node(s)
2022-08-24 19:50:29 [ℹ]  node "ip-192-168-55-233.cn-northwest-1.compute.internal" is ready
2022-08-24 19:50:29 [ℹ]  node "ip-192-168-86-58.cn-northwest-1.compute.internal" is ready
2022-08-24 19:50:29 [ℹ]  waiting for at least 2 node(s) to become ready in "mng-1"
2022-08-24 19:50:29 [ℹ]  nodegroup "mng-1" has 2 node(s)
2022-08-24 19:50:29 [ℹ]  node "ip-192-168-55-233.cn-northwest-1.compute.internal" is ready
2022-08-24 19:50:29 [ℹ]  node "ip-192-168-86-58.cn-northwest-1.compute.internal" is ready
2022-08-24 19:50:29 [ℹ]  no recommended policies found, proceeding without any IAM
2022-08-24 19:50:29 [ℹ]  creating addon
2022-08-24 19:50:40 [ℹ]  addon "coredns" active
2022-08-24 19:50:40 [ℹ]  no recommended policies found, proceeding without any IAM
2022-08-24 19:50:40 [ℹ]  creating addon
2022-08-24 19:51:32 [ℹ]  addon "kube-proxy" active
2022-08-24 19:51:32 [ℹ]  kubectl command should work with "/home/ec2-user/.kube/config", try 'kubectl get nodes'
2022-08-24 19:51:32 [✔]  EKS cluster "ipv6-test" in "cn-northwest-1" region is ready
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

