### PR TITLE
Suspicious unused wait in upgradeUsingStack()

### DIFF
--- a/pkg/actions/nodegroup/upgrade.go
+++ b/pkg/actions/nodegroup/upgrade.go
@@ -196,7 +196,7 @@ func (m *Manager) upgradeUsingStack(ctx context.Context, options UpgradeOptions,
 			return err
 		}
 
-		if err := m.stackManager.UpdateNodeGroupStack(ctx, options.NodegroupName, string(bytes), true); err != nil {
+		if err := m.stackManager.UpdateNodeGroupStack(ctx, options.NodegroupName, string(bytes), wait); err != nil {
 			return errors.Wrap(err, "error updating nodegroup stack")
 		}
 		return nil


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

The `updateStack` function defined in `upgradeUsingStack` takes a `wait` (bool) argument but doesn't use it.
Instead It always call `m.stackManager.UpdateNodeGroupStack` with `wait=true`.
Then one of the calls to `updateStack` use `option.Wait` which is ignored: https://github.com/weaveworks/eksctl/blob/main/pkg/actions/nodegroup/upgrade.go#L279

This MR modifies `updateStack` to use the wait argument to call `UpdateNodeGroupStack`.

I'm not sure if we should respect the `options.Wait` or just always call `UpdateNodeGroupStack` with `wait=true` (and remove the wait parameter of `updateStack`)?

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

