### PR TITLE
Docs update for supported command for non-eksctl created cluster

### DIFF
--- a/userdocs/src/usage/unowned-clusters.md
+++ b/userdocs/src/usage/unowned-clusters.md
@@ -20,6 +20,7 @@ If we have missed some functionality, please [let us know](https://github.com/we
     - [x] `eksctl create iamidentitymapping`
 - [x] Get:
     - [x] `eksctl get clusters/cluster`
+    - [x] `eksctl get fargateprofile`
     - [x] `eksctl get nodegroup`
     - [x] `eksctl get labels`
 - [x] Delete:


### PR DESCRIPTION
I have tested this functionality and can confirm that following command works on non eksctl created cluster

```
eksctl get fargateprofile -c <cluster>
```