### PR TITLE
Add RBAC Permissions for PVC for emr-containers

### DIFF
--- a/pkg/authconfigmap/assets/emr-containers-rbac.yaml
+++ b/pkg/authconfigmap/assets/emr-containers-rbac.yaml
@@ -24,6 +24,9 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "rolebindings"]
     verbs: ["get", "list", "watch", "describe", "create", "edit", "delete", "deletecollection", "annotate", "patch", "label"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["create", "list", "delete"]   
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
### Description

PR to solve the [k8s RBAC permission for PVC](https://github.com/weaveworks/eksctl/issues/5397). Starting from  Spark3.2, it cleans up PersistentClaims and Services at the end of each app, which requires the extra RBAC permissions in k8s.

Here is the published [official document on EMR on EKS](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/permissions-for-pvc.html) which has been tested by customers.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

