### PR TITLE
Added wait option for unowned cluster tests

### DIFF
--- a/integration/tests/unowned_cluster/unowned_cluster_test.go
+++ b/integration/tests/unowned_cluster/unowned_cluster_test.go
@@ -250,6 +250,7 @@ var _ = Describe("(Integration) [non-eksctl cluster & nodegroup support]", func(
 				"--cluster", params.ClusterName,
 				"--name", "fp-test",
 				"--namespace", "default",
+				"--wait",
 			)
 		Expect(cmd).To(RunSuccessfullyWithOutputStringLines(
 			ContainElement(SatisfyAll(ContainSubstring("created"), ContainSubstring("fp-test"))),
@@ -261,6 +262,7 @@ var _ = Describe("(Integration) [non-eksctl cluster & nodegroup support]", func(
 				"fargateprofile",
 				"--cluster", params.ClusterName,
 				"--verbose", "2",
+				"--wait",
 			)
 		Expect(cmd).To(RunSuccessfullyWithOutputStringLines(
 			ContainElement(ContainSubstring("fp-test")),


### PR DESCRIPTION
### Description
Added wait option for unowned cluster tests, as suggested here https://github.com/weaveworks/eksctl-ci/issues/51#issuecomment-1222094068

Part of https://github.com/weaveworks/eksctl-ci/issues/51 

Integration test run - 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

