### PR TITLE
Fix cluster name in nodegroup-override-announcement

### DIFF
--- a/userdocs/src/announcements/nodegroup-override-announcement.md
+++ b/userdocs/src/announcements/nodegroup-override-announcement.md
@@ -34,7 +34,7 @@ command:
       source /var/lib/cloud/scripts/eksctl/bootstrap.helper.sh
 
       # Note "--node-labels=${NODE_LABELS}" needs the above helper sourced to work, otherwise will have to be defined manually.
-      /etc/eks/bootstrap.sh test-override-11 --container-runtime containerd --kubelet-extra-args "--node-labels=${NODE_LABELS}"
+      /etc/eks/bootstrap.sh ${CLUSTER_NAME} --container-runtime containerd --kubelet-extra-args "--node-labels=${NODE_LABELS}"
 ```
 
 For nodegroups that have no outbound internet access, you'll need to supply `--apiserver-endpoint` and `--b64-cluster-ca`
@@ -47,7 +47,7 @@ to the bootstrap script as follows:
       source /var/lib/cloud/scripts/eksctl/bootstrap.helper.sh
 
       # Note "--node-labels=${NODE_LABELS}" needs the above helper sourced to work, otherwise will have to be defined manually.
-      /etc/eks/bootstrap.sh test-override-11 --container-runtime containerd --kubelet-extra-args "--node-labels=${NODE_LABELS}" \
+      /etc/eks/bootstrap.sh ${CLUSTER_NAME} --container-runtime containerd --kubelet-extra-args "--node-labels=${NODE_LABELS}" \
         --apiserver-endpoint ${API_SERVER_URL} --b64-cluster-ca ${B64_CLUSTER_CA}
 ```
 


### PR DESCRIPTION
Previously the cluster name was "test-override-11", which created errors. Should use the variable CLUSTER_NAME.

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

