### PR TITLE
feat(make): remove old update-maxpods instruction from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,11 +157,6 @@ generate-all: generate-always $(conditionally_generated_files) ## Re-generate al
 check-all-generated-files-up-to-date: generate-all ## Run the generate all command and verify there is no new diff
 	git diff --quiet -- $(conditionally_generated_files) || (git --no-pager diff $(conditionally_generated_files); echo "HINT: to fix this, run 'git commit $(conditionally_generated_files) --message \"Update generated files\"'"; exit 1)
 
-### Update maxpods.go from AWS
-.PHONY: update-maxpods
-update-maxpods: ## Re-download the max pods info from AWS and regenerate the maxpods.go file
-	@cd pkg/nodebootstrap && go run maxpods_generate.go
-
 ### Update aws-node addon manifests from AWS
 pkg/addons/default/assets/aws-node.yaml:
 	go generate ./pkg/addons/default/aws_node_generate.go


### PR DESCRIPTION
Signed-off-by: Casale, Robert <Robert.Casale@fmr.com>

### Description
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
This change will remove the no longer relevant `make` instruction `update-maxpods`.

Fixes #5691 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

