### PR TITLE
Updates to karpenter cloudformation policies

### DIFF
--- a/pkg/cfn/builder/karpenter.go
+++ b/pkg/cfn/builder/karpenter.go
@@ -38,9 +38,13 @@ const (
 	ec2DeleteLaunchTemplate          = "ec2:DeleteLaunchTemplate"
 	ec2RunInstances                  = "ec2:RunInstances"
 	ec2TerminateInstances            = "ec2:TerminateInstances"
+	ec2DescribeImages                = "ec2:DescribeImages"
+	ec2DescribeSpotPriceHistory      = "ec2:DescribeSpotPriceHistory"
 	// IAM
 	iamPassRole     = "iam:PassRole"
 	ssmGetParameter = "ssm:GetParameter"
+	// Pricing
+	pricingGetProducts = "pricing:GetProducts"
 )
 
 // KarpenterResourceSet stores the resource information of the Karpenter stack
@@ -126,8 +130,11 @@ func (k *KarpenterResourceSet) addResourcesForKarpenter() error {
 			ec2DeleteLaunchTemplate,
 			ec2RunInstances,
 			ec2TerminateInstances,
+			ec2DescribeImages,
+			ec2DescribeSpotPriceHistory,
 			iamPassRole,
 			ssmGetParameter,
+			pricingGetProducts,
 		},
 	}
 	managedPolicy := gfniam.ManagedPolicy{

--- a/pkg/cfn/builder/karpenter_test.go
+++ b/pkg/cfn/builder/karpenter_test.go
@@ -101,8 +101,11 @@ var expectedTemplate = `{
                 "ec2:DeleteLaunchTemplate",
                 "ec2:RunInstances",
                 "ec2:TerminateInstances",
+                "ec2:DescribeImages",
+				"ec2:DescribeSpotPriceHistory",
                 "iam:PassRole",
-                "ssm:GetParameter"
+                "ssm:GetParameter",
+				"pricing:GetProducts"
               ],
               "Effect": "Allow",
               "Resource": "*"
@@ -224,8 +227,11 @@ var expectedTemplateWithPermissionBoundary = `{
                 "ec2:DeleteLaunchTemplate",
                 "ec2:RunInstances",
                 "ec2:TerminateInstances",
+				"ec2:DescribeImages",
+				"ec2:DescribeSpotPriceHistory",
                 "iam:PassRole",
-                "ssm:GetParameter"
+                "ssm:GetParameter",
+				"pricing:GetProducts"
               ],
               "Effect": "Allow",
               "Resource": "*"

--- a/pkg/cfn/builder/karpenter_test.go
+++ b/pkg/cfn/builder/karpenter_test.go
@@ -102,10 +102,10 @@ var expectedTemplate = `{
                 "ec2:RunInstances",
                 "ec2:TerminateInstances",
                 "ec2:DescribeImages",
-				"ec2:DescribeSpotPriceHistory",
+                "ec2:DescribeSpotPriceHistory",
                 "iam:PassRole",
                 "ssm:GetParameter",
-				"pricing:GetProducts"
+                "pricing:GetProducts"
               ],
               "Effect": "Allow",
               "Resource": "*"
@@ -227,11 +227,11 @@ var expectedTemplateWithPermissionBoundary = `{
                 "ec2:DeleteLaunchTemplate",
                 "ec2:RunInstances",
                 "ec2:TerminateInstances",
-				"ec2:DescribeImages",
-				"ec2:DescribeSpotPriceHistory",
+                "ec2:DescribeImages",
+                "ec2:DescribeSpotPriceHistory",
                 "iam:PassRole",
                 "ssm:GetParameter",
-				"pricing:GetProducts"
+                "pricing:GetProducts"
               ],
               "Effect": "Allow",
               "Resource": "*"


### PR DESCRIPTION
### Description
Added the cloudformation polices as mentioned here https://github.com/aws/karpenter/blob/main/website/content/en/v0.15.0/getting-started/getting-started-with-eksctl/cloudformation.yaml#L43

Fixes #5672 

Testing locally 
```
eksctl create cluster -f examples/29-cluster-with-karpenter.yaml                                                                                                          
2022-10-04 11:37:17 [ℹ]  eksctl version 0.115.0-dev+b4d637fc6.2022-10-04T11:33:04Z
2022-10-04 11:37:17 [ℹ]  using region us-west-2
2022-10-04 11:37:17 [ℹ]  setting availability zones to [us-west-2b us-west-2d us-west-2c]
2022-10-04 11:37:17 [ℹ]  subnets for us-west-2b - public:192.168.0.0/19 private:192.168.96.0/19
2022-10-04 11:37:17 [ℹ]  subnets for us-west-2d - public:192.168.32.0/19 private:192.168.128.0/19
2022-10-04 11:37:17 [ℹ]  subnets for us-west-2c - public:192.168.64.0/19 private:192.168.160.0/19
2022-10-04 11:37:17 [ℹ]  nodegroup "managed-ng-1" will use "" [AmazonLinux2/1.21]
2022-10-04 11:37:17 [ℹ]  using Kubernetes version 1.21
2022-10-04 11:37:17 [ℹ]  creating EKS cluster "cluster-with-karpenter-test-gini" in "us-west-2" region with managed nodes
2022-10-04 11:37:17 [ℹ]  1 nodegroup (managed-ng-1) was included (based on the include/exclude rules)
2022-10-04 11:37:17 [ℹ]  will create a CloudFormation stack for cluster itself and 0 nodegroup stack(s)
2022-10-04 11:37:17 [ℹ]  will create a CloudFormation stack for cluster itself and 1 managed nodegroup stack(s)
2022-10-04 11:37:17 [ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=us-west-2 --cluster=cluster-with-karpenter-test-gini'
2022-10-04 11:37:17 [ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "cluster-with-karpenter-test-gini" in "us-west-2"
2022-10-04 11:37:17 [ℹ]  CloudWatch logging will not be enabled for cluster "cluster-with-karpenter-test-gini" in "us-west-2"
...
2022-10-04 11:37:17 [ℹ]  building cluster stack "eksctl-cluster-with-karpenter-test-gini-cluster"
2022-10-04 11:37:19 [ℹ]  deploying stack "eksctl-cluster-with-karpenter-test-gini-cluster"
2022-10-04 11:37:49 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-cluster"
2022-10-04 11:38:19 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-cluster"
2022-10-04 11:39:20 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-cluster"
2022-10-04 11:40:21 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-cluster"
2022-10-04 11:41:21 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-cluster"
2022-10-04 11:42:22 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-cluster"
2022-10-04 11:43:23 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-cluster"
2022-10-04 11:44:23 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-cluster"
2022-10-04 11:45:24 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-cluster"
2022-10-04 11:46:25 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-cluster"
2022-10-04 11:47:25 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-cluster"
2022-10-04 11:48:26 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-cluster"
2022-10-04 11:49:27 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-cluster"
2022-10-04 11:51:33 [ℹ]  building iamserviceaccount stack "eksctl-cluster-with-karpenter-test-gini-addon-iamserviceaccount-kube-system-aws-node"
2022-10-04 11:51:34 [ℹ]  deploying stack "eksctl-cluster-with-karpenter-test-gini-addon-iamserviceaccount-kube-system-aws-node"
2022-10-04 11:51:34 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-addon-iamserviceaccount-kube-system-aws-node"
2022-10-04 11:52:05 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-addon-iamserviceaccount-kube-system-aws-node"
2022-10-04 11:52:05 [ℹ]  serviceaccount "kube-system/aws-node" already exists
2022-10-04 11:52:05 [ℹ]  updated serviceaccount "kube-system/aws-node"
2022-10-04 11:52:06 [ℹ]  daemonset "kube-system/aws-node" restarted
2022-10-04 11:52:06 [ℹ]  building managed nodegroup stack "eksctl-cluster-with-karpenter-test-gini-nodegroup-managed-ng-1"
2022-10-04 11:52:07 [ℹ]  deploying stack "eksctl-cluster-with-karpenter-test-gini-nodegroup-managed-ng-1"
2022-10-04 11:52:07 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-nodegroup-managed-ng-1"
2022-10-04 11:52:38 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-nodegroup-managed-ng-1"
2022-10-04 11:53:19 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-nodegroup-managed-ng-1"
2022-10-04 11:54:41 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-nodegroup-managed-ng-1"
2022-10-04 11:55:37 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-nodegroup-managed-ng-1"
2022-10-04 11:55:37 [ℹ]  waiting for the control plane to become ready
2022-10-04 11:55:37 [✔]  saved kubeconfig as "/Users/himangini/.kube/config"
2022-10-04 11:55:37 [ℹ]  no tasks
2022-10-04 11:55:37 [✔]  all EKS cluster resources for "cluster-with-karpenter-test-gini" have been created
2022-10-04 11:55:38 [ℹ]  nodegroup "managed-ng-1" has 1 node(s)
2022-10-04 11:55:38 [ℹ]  node "ip-192-168-82-102.us-west-2.compute.internal" is ready
2022-10-04 11:55:38 [ℹ]  waiting for at least 1 node(s) to become ready in "managed-ng-1"
2022-10-04 11:55:38 [ℹ]  nodegroup "managed-ng-1" has 1 node(s)
2022-10-04 11:55:38 [ℹ]  node "ip-192-168-82-102.us-west-2.compute.internal" is ready
2022-10-04 11:55:38 [ℹ]  1 task: { create karpenter for stack "cluster-with-karpenter-test-gini" }
2022-10-04 11:55:38 [ℹ]  building nodegroup stack "eksctl-cluster-with-karpenter-test-gini-karpenter"
2022-10-04 11:55:39 [ℹ]  deploying stack "eksctl-cluster-with-karpenter-test-gini-karpenter"
2022-10-04 11:55:39 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-karpenter"
2022-10-04 11:56:10 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-karpenter"
2022-10-04 11:56:43 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-karpenter"
2022-10-04 11:58:26 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-karpenter"
2022-10-04 11:58:26 [ℹ]  1 task: { create IAM role for serviceaccount "karpenter/karpenter" }
2022-10-04 11:58:26 [ℹ]  1 task: { create IAM role for serviceaccount "karpenter/karpenter" }
2022-10-04 11:58:26 [ℹ]  building iamserviceaccount stack "eksctl-cluster-with-karpenter-test-gini-addon-iamserviceaccount-karpenter-karpenter"
2022-10-04 11:58:26 [ℹ]  deploying stack "eksctl-cluster-with-karpenter-test-gini-addon-iamserviceaccount-karpenter-karpenter"
2022-10-04 11:58:26 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-addon-iamserviceaccount-karpenter-karpenter"
2022-10-04 11:58:57 [ℹ]  waiting for CloudFormation stack "eksctl-cluster-with-karpenter-test-gini-addon-iamserviceaccount-karpenter-karpenter"
...
2022-10-04 11:59:44 [✔]  EKS cluster "cluster-with-karpenter-test-gini" in "us-west-2" region is ready

```


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

