### PR TITLE
Fixed failing crud test

### DIFF
--- a/integration/tests/crud/creategetdelete_test.go
+++ b/integration/tests/crud/creategetdelete_test.go
@@ -481,12 +481,14 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					"-o", "yaml",
 				)
 
-				Expect(getMngNgCmd).To(RunSuccessfullyWithOutputStringLines(
-					ContainElement(ContainSubstring("MaxSize: 5"))),
-					ContainElement(ContainSubstring("MinSize: 5")),
-					ContainElement(ContainSubstring("DesiredCapacity: 5")),
-					ContainElement(ContainSubstring("Type: managed")),
-				)
+				Expect(getMngNgCmd).To(SatisfyAll(
+					RunSuccessfullyWithOutputStringLines(
+						ContainElement(ContainSubstring("MaxSize: 5")),
+						ContainElement(ContainSubstring("MinSize: 5")),
+						ContainElement(ContainSubstring("DesiredCapacity: 5")),
+						ContainElement(ContainSubstring("Type: managed")),
+					),
+				))
 
 				getUnmNgCmd := params.EksctlGetCmd.WithArgs(
 					"nodegroup",
@@ -495,12 +497,14 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					"-o", "yaml",
 				)
 
-				Expect(getUnmNgCmd).To(RunSuccessfullyWithOutputStringLines(
-					ContainElement(ContainSubstring("MaxSize: 5"))),
-					ContainElement(ContainSubstring("MinSize: 5")),
-					ContainElement(ContainSubstring("DesiredCapacity: 5")),
-					ContainElement(ContainSubstring("Type: unmanaged")),
-				)
+				Expect(getUnmNgCmd).To(SatisfyAll(
+					RunSuccessfullyWithOutputStringLines(
+						ContainElement(ContainSubstring("MaxSize: 5")),
+						ContainElement(ContainSubstring("MinSize: 5")),
+						ContainElement(ContainSubstring("DesiredCapacity: 5")),
+						ContainElement(ContainSubstring("Type: unmanaged")),
+					),
+				))
 			})
 		})
 


### PR DESCRIPTION
### Description
Fixed the failing tests panic by adding parenthesis correctly and added `StatisfyAll`option for all the matchers.

Closes https://github.com/weaveworks/eksctl-ci/issues/61

Ran the suite locally 

```
ginkgo -tags integration -v --timeout 2h  --progress integration/tests/crud/... -- -test.v -ginkgo.v 
...
Ran 43 of 43 Specs in 5150.177 seconds
SUCCESS! -- 43 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestCRUD (5150.18s)
PASS

Ginkgo ran 1 suite in 1h26m10.879953245s
Test Suite Passed
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

