### PR TITLE
Remove incorrect test

### DIFF
--- a/integration/tests/crud/creategetdelete_test.go
+++ b/integration/tests/crud/creategetdelete_test.go
@@ -393,7 +393,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 			})
 		})
 
-		Context("creating a nodegroup with containerd runtime and adding a delay in preBootstrapCommands", func() {
+		Context("creating a nodegroup with containerd runtime", func() {
 			var (
 				nodegroupName string
 			)
@@ -410,10 +410,9 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 				)
 				Expect(cmd).To(RunSuccessfully())
 			})
-			It("should create the nodegroups successfully and have no auth failures", func() {
+			It("should create the nodegroups successfully", func() {
 				clusterConfig := makeClusterConfig()
 				clusterConfig.Metadata.Name = params.ClusterName
-				delayedNGName := "delayed-ng"
 				clusterConfig.NodeGroups = []*api.NodeGroup{
 					{
 						NodeGroupBase: &api.NodeGroupBase{
@@ -428,17 +427,6 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 						},
 						ContainerRuntime: aws.String(api.ContainerRuntimeContainerD),
 					},
-					{
-						NodeGroupBase: &api.NodeGroupBase{
-							Name: delayedNGName,
-							ScalingConfig: &api.ScalingConfig{
-								DesiredCapacity: aws.Int(1),
-							},
-							PreBootstrapCommands: []string{
-								"sleep 720",
-							},
-						},
-					},
 				}
 
 				cmd := params.EksctlCreateCmd.
@@ -452,10 +440,6 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					WithStdin(clusterutils.Reader(clusterConfig))
 				Expect(cmd).To(RunSuccessfully())
 				tests.AssertNodeVolumes(params.KubeconfigPath, params.Region, "test-containerd", "/dev/sdb")
-
-				By("ensuring that the delayed nodegroup is created successfully")
-				nodeList := tests.ListNodes(makeClientset(), delayedNGName)
-				Expect(nodeList).To(HaveLen(1))
 			})
 		})
 
@@ -577,7 +561,7 @@ var _ = Describe("(Integration) Create, Get, Scale & Delete", func() {
 					"--cluster", params.ClusterName,
 				)
 				Expect(cmd).To(RunSuccessfullyWithOutputString(BeNodeGroupsWithNamesWhich(
-					HaveLen(5),
+					HaveLen(4),
 					ContainElement(mngNG1),
 					ContainElement(mngNG2),
 					ContainElement(unmNG1),


### PR DESCRIPTION
### Description

Removes the delayed nodegroup creation test because there seems to be no reliable way of adding a delay to nodegroup creation. What the test was trying to accomplish has been manually tested though. 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

