### PR TITLE
Bump nvidia-device-plugin to 0.12.3

### DIFF
--- a/pkg/addons/assets/nvidia-device-plugin.yaml
+++ b/pkg/addons/assets/nvidia-device-plugin.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -25,18 +24,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      # This annotation is deprecated. Kept here for backward compatibility
-      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         name: nvidia-device-plugin-ds
     spec:
       tolerations:
-      # This toleration is deprecated. Kept here for backward compatibility
-      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-      - key: CriticalAddonsOnly
-        operator: Exists
       - key: nvidia.com/gpu
         operator: Exists
         effect: NoSchedule
@@ -46,9 +37,11 @@ spec:
       # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
       priorityClassName: "system-node-critical"
       containers:
-      - image: nvcr.io/nvidia/k8s-device-plugin:v0.9.0
+      - image: nvcr.io/nvidia/k8s-device-plugin:v0.12.3
         name: nvidia-device-plugin-ctr
-        args: ["--fail-on-init-error=false"]
+        env:
+          - name: FAIL_ON_INIT_ERROR
+            value: "false"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -60,4 +53,3 @@ spec:
         - name: device-plugin
           hostPath:
             path: /var/lib/kubelet/device-plugins
-


### PR DESCRIPTION

### Description
0.9 is a bit over 18 months old at this point. Matching versions of drivers, CUDA and packages 
can be a bit difficult with older versions (see, for 
example https://github.com/pangeo-data/pangeo-docker-images/issues/390).

Tries to match https://github.com/weaveworks/eksctl/pull/3696.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

