### PR TITLE
Get method should not set addon version

### DIFF
--- a/pkg/actions/addon/get.go
+++ b/pkg/actions/addon/get.go
@@ -58,11 +58,15 @@ func (a *Manager) Get(ctx context.Context, addon *api.Addon) (Summary, error) {
 		serviceAccountRoleARN = *output.Addon.ServiceAccountRoleArn
 	}
 
-	if addon.Version == "" {
-		addon.Version = *output.Addon.AddonVersion
+	addonWithVersion := &api.Addon{
+		Name:    addon.Name,
+		Version: addon.Version,
+	}
+	if addonWithVersion.Version == "" {
+		addonWithVersion.Version = *output.Addon.AddonVersion
 	}
 
-	newerVersion, err := a.findNewerVersions(ctx, addon)
+	newerVersion, err := a.findNewerVersions(ctx, addonWithVersion)
 	if err != nil {
 		return Summary{}, err
 	}


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

When running `eksctl update addon` command, **_without_** specifying `--version` flag, an info message should be displayed, explaining that the version won't be updated. However, currently, the `get addon` method which is run beforehand, wrongly sets the addon version to the current one. This PR addresses the issue.

Fixes #5565

### Manual testing

```
tiberiu-weave eksctl % ./eksctl update addon --cluster cluster-25 --name kube-proxy --force --wait 
2022-10-19 10:55:23 [ℹ]  no new version provided, preserving existing version: v1.22.6-eksbuild.1
2022-10-19 10:55:23 [ℹ]  updating addon
2022-10-19 10:55:33 [ℹ]  addon "kube-proxy" active


tiberiu-weave eksctl % ./eksctl get addon --cluster cluster-25 --name kube-proxy --output yaml    
- IAMRole: ""
  Issues: null
  Name: kube-proxy
  NewerVersion: v1.22.11-eksbuild.2
  Status: ACTIVE
  Version: v1.22.6-eksbuild.1
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

