### PR TITLE
Add option to preserve addon config during update

### DIFF
--- a/pkg/actions/addon/update.go
+++ b/pkg/actions/addon/update.go
@@ -19,15 +19,16 @@ func (a *Manager) Update(ctx context.Context, addon *api.Addon, waitTimeout time
 	logger.Debug("addon: %v", addon)
 
 	updateAddonInput := &eks.UpdateAddonInput{
-		AddonName:   &addon.Name,
-		ClusterName: &a.clusterConfig.Metadata.Name,
+		AddonName:        &addon.Name,
+		ClusterName:      &a.clusterConfig.Metadata.Name,
+		ResolveConflicts: addon.ResolveConflicts.ToEKSType(),
 	}
 
 	if addon.Force {
 		updateAddonInput.ResolveConflicts = ekstypes.ResolveConflictsOverwrite
-		logger.Debug("setting resolve conflicts to overwrite")
-
 	}
+
+	logger.Debug("resolve conflicts set to %s", updateAddonInput.ResolveConflicts)
 
 	summary, err := a.Get(ctx, addon)
 	if err != nil {

--- a/pkg/actions/addon/update_test.go
+++ b/pkg/actions/addon/update_test.go
@@ -400,6 +400,24 @@ var _ = Describe("Update", func() {
 				})
 			})
 
+			When("resolveConflict is configured", func() {
+				DescribeTable("AWS EKS resolve conflicts matches value from cluster config",
+					func(rc api.ResolveConflicts) {
+						err := addonManager.Update(context.Background(), &api.Addon{
+							Name:             "my-addon",
+							Version:          "v1.0.0-eksbuild.2",
+							ResolveConflicts: rc,
+						}, 0)
+
+						Expect(err).NotTo(HaveOccurred())
+						Expect(updateAddonInput.ResolveConflicts).To(Equal(rc.ToEKSType()))
+					},
+					Entry("none", api.None),
+					Entry("overwrite", api.Overwrite),
+					Entry("preserve", api.Preserve),
+				)
+			})
+
 			When("wellKnownPolicies are configured", func() {
 				When("its an update to an existing cloudformation", func() {
 					It("updates the stack", func() {

--- a/pkg/apis/eksctl.io/v1alpha5/addon.go
+++ b/pkg/apis/eksctl.io/v1alpha5/addon.go
@@ -28,6 +28,9 @@ type Addon struct {
 	// Each tag consists of a key and an optional value, both of which you define.
 	// +optional
 	Tags map[string]string `json:"tags,omitempty"`
+	// ResolveConflicts determines how to resolve field value conflicts for an EKS add-on
+	// if a value was changed from default
+	ResolveConflicts ResolveConflicts `json:"resolveConflicts,omitempty"`
 	// Force overwrites an existing self-managed add-on with an EKS managed add-on.
 	// Force is intended to be used when migrating an existing self-managed add-on to an EKS managed add-on.
 	Force bool `json:"-"`

--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -59,6 +59,11 @@
           "description": "ARN of the permissions' boundary to associate",
           "x-intellij-html-description": "ARN of the permissions' boundary to associate"
         },
+        "resolveConflicts": {
+          "$ref": "#/definitions/ResolveConflicts",
+          "description": "determines how to resolve field value conflicts for an EKS add-on if a value was changed from default",
+          "x-intellij-html-description": "determines how to resolve field value conflicts for an EKS add-on if a value was changed from default"
+        },
         "serviceAccountRoleARN": {
           "type": "string"
         },
@@ -88,7 +93,8 @@
         "attachPolicy",
         "permissionsBoundary",
         "wellKnownPolicies",
-        "tags"
+        "tags",
+        "resolveConflicts"
       ],
       "additionalProperties": false,
       "description": "holds the EKS addon configuration",
@@ -2135,6 +2141,11 @@
       "additionalProperties": false,
       "description": "defines the configuration for a fully-private cluster",
       "x-intellij-html-description": "defines the configuration for a fully-private cluster"
+    },
+    "ResolveConflicts": {
+      "type": "integer",
+      "description": "ResolveConflictsType determines how to resolve field value conflicts for an EKS add-on if a value was changed from default",
+      "x-intellij-html-description": "ResolveConflictsType determines how to resolve field value conflicts for an EKS add-on if a value was changed from default"
     },
     "SecretsEncryption": {
       "required": [


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Closes [weaveworks/eksctl-private#321](https://github.com/weaveworks/eksctl-private/issues/321)

As a user I want to be able to retain my config changes during add-on upgrades so that I do not need to redo steps that I have previously done. This will be done via the resolve conflicts option, allowing us to **_overwrite_** or **_preserve_** the config changes during upgrade. For further context, see [AWS API](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html#AmazonEKS-UpdateAddon-request-resolveConflicts).

The `resolveConficts` setting will be accepted **!!exclusively!!** via config file, since we are going towards a more declarative approach for eksctl commands. E.G.

```
addons:
- name: vpc-cni 
  attachPolicyARNs:
    - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
  resolveConflicts: preserve
```

### Manual testing steps

**Prerequisites**

- Created EKS managed `coredns` addon via

```
tiberiu-weave eksctl % create addon --name coredns --cluster my-cluster --version v1.8.7-eksbuild.1 --force
```

- Edited `coredns` configMap `cache` value from `30` to `20` via

```
tiberiu-weave eksctl % kubectl edit configmap coredns -n kube-system
configmap/coredns edited 
```

**Tests**

1. **resolveConflicts: preserve**
```
tiberiu-weave eksctl % ./eksctl update addon --config-file examples/addons.yaml 
2022-10-24 15:48:32 [▶]  resolve conflicts set to PRESERVE
2022-10-24 15:48:33 [ℹ]  updating addon
2022-10-24 15:48:45 [ℹ]  addon "coredns" active

tiberiu-weave eksctl % ./eksctl get addon --cluster my-cluster --name coredns --output yaml
- IAMRole: ""
  Issues: null
  Name: coredns
  NewerVersion: ""
  Status: ACTIVE
  Version: v1.8.7-eksbuild.1
```
Check that `cache` is still `20`
```
tiberiu-weave eksctl % kubectl get configmap coredns -n kube-system --output yaml
data:
  Corefile: |
    .:53 {
        ...
        cache 20
        ...
    }
```
2. **resolveConflicts: none**
```
tiberiu-weave eksctl % ./eksctl update addon --config-file examples/addons.yaml 
2022-10-24 15:49:00 [▶]  resolve conflicts set to NONE
2022-10-24 15:49:01 [ℹ]  updating addon

tiberiu-weave eksctl % ./eksctl get addon --cluster my-cluster --name coredns --output yaml
- IAMRole: ""
  Issues:
  - Code: ConfigurationConflict
    Message: |-
      Conflicts found when trying to apply. Will not continue due to resolve conflicts mode. Conflicts:
      ConfigMap coredns - .data.Corefile
    ResourceIDs: null
  Name: coredns
  NewerVersion: ""
  Status: UPDATE_FAILED
  Version: v1.8.7-eksbuild.1
```


3. **resolveConflicts: overwrite**
```
tiberiu-weave eksctl % ./eksctl update addon --config-file examples/addons.yaml
2022-10-24 15:49:33 [▶]  resolve conflicts set to OVERWRITE
2022-10-24 15:59:34 [ℹ]  updating addon
2022-10-24 15:59:45 [ℹ]  addon "coredns" active

tiberiu-weave eksctl % ./eksctl get addon --cluster my-cluster --name coredns --output yaml
- IAMRole: ""
  Issues: null
  Name: coredns
  NewerVersion: ""
  Status: ACTIVE
  Version: v1.8.7-eksbuild.1
  ```
Check `cache` is back to `30`
```
tiberiu-weave eksctl % kubectl get configmap coredns -n kube-system --output yaml
data:
  Corefile: |
    .:53 {
        ...
        cache 30
        ...
    }
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

