### PR TITLE
Add support for me-central-1

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -147,6 +147,9 @@ const (
 	// RegionAPEast1 represents the Asia Pacific Region Hong Kong
 	RegionAPEast1 = "ap-east-1"
 
+	// RegionMECentral1 represents the Middle East Region Dubai
+	RegionMECentral1 = "me-central-1"
+
 	// RegionMESouth1 represents the Middle East Region Bahrain
 	RegionMESouth1 = "me-south-1"
 
@@ -290,6 +293,9 @@ const (
 
 	// eksResourceAccountAPEast1 defines the AWS EKS account ID that provides node resources in ap-east-1 region
 	eksResourceAccountAPEast1 = "800184023465"
+
+	// eksResourceAccountMECentral1 defines the AWS EKS account ID that provides node resources in me-central-1 region
+	eksResourceAccountMECentral1 = "759879836304"
 
 	// eksResourceAccountMESouth1 defines the AWS EKS account ID that provides node resources in me-south-1 region
 	eksResourceAccountMESouth1 = "558608220178"
@@ -449,6 +455,7 @@ func SupportedRegions() []string {
 		RegionAPSouthEast3,
 		RegionAPSouth1,
 		RegionAPEast1,
+		RegionMECentral1,
 		RegionMESouth1,
 		RegionSAEast1,
 		RegionAFSouth1,
@@ -569,6 +576,8 @@ func EKSResourceAccountID(region string) string {
 	switch region {
 	case RegionAPEast1:
 		return eksResourceAccountAPEast1
+	case RegionMECentral1:
+		return eksResourceAccountMECentral1
 	case RegionMESouth1:
 		return eksResourceAccountMESouth1
 	case RegionCNNorthwest1:


### PR DESCRIPTION
### Description
Support for new DXB `me-central-1` region

Closes https://github.com/weaveworks/eksctl-private/issues/541

Tested locally

```
eksctl create cluster --name gini-test-dxb-region --region me-central-1
2022-10-27 18:29:29 [ℹ]  eksctl version 0.117.0-dev+40b07090e.2022-10-27T17:50:12Z
2022-10-27 18:29:29 [ℹ]  using region me-central-1
2022-10-27 18:29:30 [ℹ]  setting availability zones to [me-central-1b me-central-1c me-central-1a]
2022-10-27 18:29:30 [ℹ]  subnets for me-central-1b - public:192.168.0.0/19 private:192.168.96.0/19
2022-10-27 18:29:30 [ℹ]  subnets for me-central-1c - public:192.168.32.0/19 private:192.168.128.0/19
2022-10-27 18:29:30 [ℹ]  subnets for me-central-1a - public:192.168.64.0/19 private:192.168.160.0/19
2022-10-27 18:29:30 [ℹ]  nodegroup "ng-cb7769b2" will use "" [AmazonLinux2/1.23]
2022-10-27 18:29:30 [ℹ]  using Kubernetes version 1.23
2022-10-27 18:29:30 [ℹ]  creating EKS cluster "gini-test-dxb-region" in "me-central-1" region with managed nodes
2022-10-27 18:29:30 [ℹ]  will create 2 separate CloudFormation stacks for cluster itself and the initial managed nodegroup
...
2022-10-27 18:44:26 [✔]  EKS cluster "gini-test-dxb-region" in "me-central-1" region is ready
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

