### PR TITLE
Make AMI Bottlerocket value case insensitive

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -167,6 +167,7 @@ func setNodeGroupBaseDefaults(ng *NodeGroupBase, meta *ClusterMeta) {
 	if ng.InstanceSelector == nil {
 		ng.InstanceSelector = &InstanceSelector{}
 	}
+	normalizeAMIFamily(ng)
 	if ng.AMIFamily == NodeImageFamilyBottlerocket {
 		setBottlerocketNodeGroupDefaults(ng)
 	}

--- a/pkg/apis/eksctl.io/v1alpha5/defaults_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults_test.go
@@ -236,6 +236,18 @@ var _ = Describe("ClusterConfig validation", func() {
 			Expect(testNodeGroup.Bottlerocket).NotTo(BeNil())
 			Expect(testNodeGroup.Bottlerocket.EnableAdminContainer).To(BeNil())
 		})
+
+		It("tolerates non standard casing of AMI Family", func() {
+			testNodeGroup := NodeGroup{
+				NodeGroupBase: &NodeGroupBase{
+					AMIFamily: "BoTTleRocKet",
+				},
+			}
+
+			SetNodeGroupDefaults(&testNodeGroup, &ClusterMeta{}, false)
+
+			Expect(testNodeGroup.NodeGroupBase.AMIFamily).To(Equal(NodeImageFamilyBottlerocket))
+		})
 	})
 
 	Context("Cluster NAT settings", func() {


### PR DESCRIPTION
### Description
resolves https://github.com/weaveworks/eksctl/issues/5697
This PR replaces https://github.com/weaveworks/eksctl/pull/5721 due to issues caused by the previous PR using main branch in the fork as the base. 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Output from locally built binary (does not panic due to bad casing):
```
./eksctl create nodegroup --cluster multitenant --managed --node-ami-family BOTTLERoCkeT
2022-09-26 17:57:55 [ℹ]  will use version 1.22 for new nodegroup(s) based on control plane version
2022-09-26 17:57:57 [ℹ]  nodegroup "ng-e4cc9867" will use "" [Bottlerocket/1.22]
2022-09-26 17:58:04 [ℹ]  3 existing nodegroup(s) (ng-85cbae68,ng-945c938a,private) will be excluded
2022-09-26 17:58:04 [ℹ]  1 nodegroup (ng-e4cc9867) was included (based on the include/exclude rules)
2022-09-26 17:58:04 [ℹ]  will create a CloudFormation stack for each of 1 managed nodegroups in cluster "multitenant"
2022-09-26 17:58:04 [ℹ]
2 sequential tasks: { fix cluster compatibility, 1 task: { 1 task: { create managed nodegroup "ng-e4cc9867" } }
}
2022-09-26 17:58:04 [ℹ]  checking cluster stack for missing resources
2022-09-26 17:58:07 [ℹ]  cluster stack has all required resources
2022-09-26 17:58:11 [ℹ]  building managed nodegroup stack "eksctl-multitenant-nodegroup-ng-e4cc9867"
2022-09-26 17:58:12 [ℹ]  deploying stack "eksctl-multitenant-nodegroup-ng-e4cc9867"
2022-09-26 17:58:12 [ℹ]  waiting for CloudFormation stack "eksctl-multitenant-nodegroup-ng-e4cc9867"
```
### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

