### PR TITLE
Retry temporary failure in identity provider test

### DIFF
--- a/integration/tests/identity_provider/identity_provider_test.go
+++ b/integration/tests/identity_provider/identity_provider_test.go
@@ -126,9 +126,14 @@ var _ = Describe("(Integration) [Identity Provider]", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("reading Kubernetes resources")
-		list, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(list.Items).To(HaveLen(1))
+		Eventually(func() (int, error) {
+			list, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+			if err != nil {
+				fmt.Fprintf(GinkgoWriter, "error reading Kubernetes nodes: %v\n", err)
+				return 0, err
+			}
+			return len(list.Items), nil
+		}, "10m", "20s").Should(Equal(1))
 
 		secrets, err := clientset.CoreV1().Secrets(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/actions/identityproviders/associate.go
+++ b/pkg/actions/identityproviders/associate.go
@@ -39,7 +39,7 @@ func (m *Manager) Associate(ctx context.Context, options AssociateIdentityProvid
 					logger.Info("started associating identity provider %s", idP.Name)
 					if options.WaitTimeout > 0 {
 						updateWaiter := waiter.NewUpdateWaiter(m.eksAPI, func(options *waiter.UpdateWaiterOptions) {
-							options.RetryAttemptLogMessage = "waiting for update %q in cluster %q to succeed"
+							options.RetryAttemptLogMessage = fmt.Sprintf("waiting for update %q in cluster %q to complete", *update.Id, m.metadata.Name)
 						})
 						if err := updateWaiter.Wait(ctx, &eks.DescribeUpdateInput{
 							Name:     aws.String(m.metadata.Name),


### PR DESCRIPTION
### Description

Logs from the run:

```
[0] STEP: creating an OIDC Clientset 11/04/22 09:03:35.109
[0] STEP: reading Kubernetes resources 11/04/22 09:03:35.552
[0] error reading Kubernetes nodes: Unauthorized
[0] error reading Kubernetes nodes: Unauthorized
[0] error reading Kubernetes nodes: Unauthorized
[0] STEP: ensuring the client does not have write access 11/04/22 09:05:37.304
[0] STEP: disassociating the identity provider 11/04/22 09:05:37.389
```

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

