### PR TITLE
Support for clusters with trn1 instance types

### DIFF
--- a/integration/tests/trainium/trainium_test.go
+++ b/integration/tests/trainium/trainium_test.go
@@ -6,10 +6,15 @@ package trainium
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -19,6 +24,7 @@ import (
 	. "github.com/weaveworks/eksctl/integration/runner"
 	"github.com/weaveworks/eksctl/integration/tests"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/awsapi"
 	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/testutils"
 )
@@ -29,6 +35,8 @@ var (
 	params                  *tests.Params
 	clusterWithNeuronPlugin string
 	clusterWithoutPlugin    string
+	nodeZones               string
+	clusterZones            string
 )
 
 func init() {
@@ -58,16 +66,23 @@ var _ = BeforeSuite(func() {
 	clusterWithNeuronPlugin = defaultCluster
 
 	if !params.SkipCreate {
+		cfg := NewConfig(params.Region)
+		ctx := context.Background()
+		ec2API := ec2.NewFromConfig(cfg)
+		nodeZones, clusterZones = getAvailabilityZones(ctx, ec2API)
+
 		cmd := params.EksctlCreateCmd.WithArgs(
 			"cluster",
 			"--verbose", "4",
 			"--name", clusterWithoutPlugin,
+			"--zones", clusterZones,
 			"--tags", "alpha.eksctl.io/description=eksctl integration test",
 			"--install-neuron-plugin=false",
 			"--nodegroup-name", initNG,
 			"--node-labels", "ng-name="+initNG,
 			"--nodes", "1",
 			"--node-type", "trn1.2xlarge",
+			"--node-zones", nodeZones,
 			"--version", params.Version,
 			"--kubeconfig", params.KubeconfigPath,
 		)
@@ -77,11 +92,13 @@ var _ = BeforeSuite(func() {
 			"cluster",
 			"--verbose", "4",
 			"--name", clusterWithNeuronPlugin,
+			"--zones", clusterZones,
 			"--tags", "alpha.eksctl.io/description=eksctl integration test",
 			"--nodegroup-name", initNG,
 			"--node-labels", "ng-name="+initNG,
 			"--nodes", "1",
-			"--node-type", "trn1.xlarge",
+			"--node-type", "trn1.2xlarge",
+			"--node-zones", nodeZones,
 			"--version", params.Version,
 			"--kubeconfig", params.KubeconfigPath,
 		)
@@ -147,6 +164,7 @@ var _ = Describe("(Integration) Trainium nodes", func() {
 						"--node-labels", "ng-name="+newNG,
 						"--nodes", "1",
 						"--node-type", "trn1.2xlarge",
+						"--node-zones", nodeZones,
 						"--version", params.Version,
 					)
 					Expect(cmd).To(RunSuccessfully())
@@ -162,7 +180,7 @@ var _ = Describe("(Integration) Trainium nodes", func() {
 
 var _ = AfterSuite(func() {
 	params.DeleteClusters()
-	gexec.KillAndWait()
+	gexec.KillAndWait(30 * time.Minute)
 	if params.KubeconfigTemp {
 		os.Remove(params.KubeconfigPath)
 	}
@@ -186,4 +204,58 @@ func newClientSet(name string) *kubernetes.Clientset {
 	clientSet, err := ctl.NewStdClientSet(cfg)
 	Expect(err).ShouldNot(HaveOccurred())
 	return clientSet
+}
+
+func getAvailabilityZones(ctx context.Context, ec2API awsapi.EC2) (string, string) {
+	zoneMap := map[string]bool{}
+	clusterZones := []string{}
+	nodeZones := []string{}
+
+	// Trn1 instance types are only available in one AZ per region at this time
+	// TODO: dynamically discover zones as part of the core codebase
+	trnInstanceZones := map[string]string{
+		"us-west-2": "usw2-az4",
+		"us-east-1": "use1-az5",
+	}
+
+	input := &ec2.DescribeAvailabilityZonesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   aws.String("region-name"),
+				Values: []string{params.Region},
+			}, {
+				Name:   aws.String("state"),
+				Values: []string{string(ec2types.AvailabilityZoneStateAvailable)},
+			}, {
+				Name:   aws.String("zone-type"),
+				Values: []string{string(ec2types.LocationTypeAvailabilityZone)},
+			},
+		},
+	}
+
+	// Get all zones for the region
+	output, err := ec2API.DescribeAvailabilityZones(ctx, input)
+	Expect(err).NotTo(HaveOccurred())
+	zones := output.AvailabilityZones
+
+	// Add the zones to the zoneMap where the instance type is supported
+	for _, zone := range zones {
+		if *zone.ZoneId == trnInstanceZones[params.Region] {
+			nodeZones = append(nodeZones, *zone.ZoneName)
+			zoneMap[*zone.ZoneName] = true
+		}
+	}
+
+	// If we have fewer than the minimum required number of availabilty zones
+	// then backfill clusterZones to get to MinRequiredAvailabilityZones
+	for i := 0; i < len(zones) && len(zoneMap) < api.MinRequiredAvailabilityZones; i++ {
+		zoneMap[*zones[i].ZoneName] = true
+	}
+
+	// convert this back to a slice of strings
+	for zone := range zoneMap {
+		clusterZones = append(clusterZones, zone)
+	}
+
+	return strings.Join(nodeZones, ","), strings.Join(clusterZones, ",")
 }

--- a/integration/tests/trainium/trainium_test.go
+++ b/integration/tests/trainium/trainium_test.go
@@ -1,0 +1,189 @@
+//go:build integration
+// +build integration
+
+package trainium
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/weaveworks/eksctl/integration/matchers"
+	. "github.com/weaveworks/eksctl/integration/runner"
+	"github.com/weaveworks/eksctl/integration/tests"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/eks"
+	"github.com/weaveworks/eksctl/pkg/testutils"
+)
+
+var (
+	defaultCluster          string
+	noInstallCluster        string
+	params                  *tests.Params
+	clusterWithNeuronPlugin string
+	clusterWithoutPlugin    string
+)
+
+func init() {
+	// Call testing.Init() prior to tests.NewParams(), as otherwise -test.* will not be recognised. See also: https://golang.org/doc/go1.13#testing
+	testing.Init()
+	params = tests.NewParams("trn1")
+	defaultCluster = params.ClusterName
+	noInstallCluster = params.NewClusterName("trn1-no-plugin")
+}
+
+func TestTrainium(t *testing.T) {
+	testutils.RegisterAndRun(t)
+}
+
+const initNG = "trn1-ng-0"
+
+var _ = BeforeSuite(func() {
+	params.KubeconfigTemp = false
+	if params.KubeconfigPath == "" {
+		wd, _ := os.Getwd()
+		f, _ := os.CreateTemp(wd, "kubeconfig-")
+		params.KubeconfigPath = f.Name()
+		params.KubeconfigTemp = true
+	}
+
+	clusterWithoutPlugin = noInstallCluster
+	clusterWithNeuronPlugin = defaultCluster
+
+	if !params.SkipCreate {
+		cmd := params.EksctlCreateCmd.WithArgs(
+			"cluster",
+			"--verbose", "4",
+			"--name", clusterWithoutPlugin,
+			"--tags", "alpha.eksctl.io/description=eksctl integration test",
+			"--install-neuron-plugin=false",
+			"--nodegroup-name", initNG,
+			"--node-labels", "ng-name="+initNG,
+			"--nodes", "1",
+			"--node-type", "trn1.2xlarge",
+			"--version", params.Version,
+			"--kubeconfig", params.KubeconfigPath,
+		)
+		Expect(cmd).To(RunSuccessfully())
+
+		cmd = params.EksctlCreateCmd.WithArgs(
+			"cluster",
+			"--verbose", "4",
+			"--name", clusterWithNeuronPlugin,
+			"--tags", "alpha.eksctl.io/description=eksctl integration test",
+			"--nodegroup-name", initNG,
+			"--node-labels", "ng-name="+initNG,
+			"--nodes", "1",
+			"--node-type", "trn1.xlarge",
+			"--version", params.Version,
+			"--kubeconfig", params.KubeconfigPath,
+		)
+		Expect(cmd).To(RunSuccessfully())
+	}
+})
+
+var _ = Describe("(Integration) Trainium nodes", func() {
+	const (
+		newNG = "trn1-ng-1"
+	)
+
+	Context("cluster with trn1 nodes", func() {
+		Context("by default", func() {
+			BeforeEach(func() {
+				cmd := params.EksctlUtilsCmd.WithArgs(
+					"write-kubeconfig",
+					"--verbose", "4",
+					"--cluster", clusterWithoutPlugin,
+					"--kubeconfig", params.KubeconfigPath,
+				)
+				Expect(cmd).To(RunSuccessfully())
+			})
+
+			It("should have installed the neuron device plugin", func() {
+				clientSet := newClientSet(clusterWithNeuronPlugin)
+				_, err := clientSet.AppsV1().DaemonSets("kube-system").Get(context.TODO(), "neuron-device-plugin-daemonset", metav1.GetOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			It("should not have installed the nvidia device plugin", func() {
+				_, err := newClientSet(clusterWithNeuronPlugin).AppsV1().DaemonSets("kube-system").Get(context.TODO(), "nvidia-device-plugin-daemonset", metav1.GetOptions{})
+				Expect(err).Should(BeNotFoundError())
+			})
+		})
+
+		Context("with --install-neuron-plugin=false", func() {
+			BeforeEach(func() {
+				cmd := params.EksctlUtilsCmd.WithArgs(
+					"write-kubeconfig",
+					"--verbose", "4",
+					"--cluster", clusterWithoutPlugin,
+					"--kubeconfig", params.KubeconfigPath,
+				)
+				Expect(cmd).To(RunSuccessfully())
+			})
+
+			It("should not have installed the neuron device plugin", func() {
+				_, err := newClientSet(clusterWithoutPlugin).AppsV1().DaemonSets("kube-system").Get(context.TODO(), "neuron-device-plugin-daemonset", metav1.GetOptions{})
+				Expect(err).Should(BeNotFoundError())
+			})
+
+			When("adding an unmanaged nodegroup by default", func() {
+				It("should install without error", func() {
+					cmd := params.EksctlCreateCmd.WithArgs(
+						"nodegroup",
+						"--cluster", clusterWithoutPlugin,
+						"--managed=false",
+						"--nodes", "1",
+						"--verbose", "4",
+						"--name", newNG,
+						"--tags", "alpha.eksctl.io/description=eksctl integration test",
+						"--node-labels", "ng-name="+newNG,
+						"--nodes", "1",
+						"--node-type", "trn1.2xlarge",
+						"--version", params.Version,
+					)
+					Expect(cmd).To(RunSuccessfully())
+				})
+				It("should install the neuron device plugin", func() {
+					_, err := newClientSet(clusterWithoutPlugin).AppsV1().DaemonSets("kube-system").Get(context.TODO(), "neuron-device-plugin-daemonset", metav1.GetOptions{})
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+			})
+		})
+	})
+})
+
+var _ = AfterSuite(func() {
+	params.DeleteClusters()
+	gexec.KillAndWait()
+	if params.KubeconfigTemp {
+		os.Remove(params.KubeconfigPath)
+	}
+	os.RemoveAll(params.TestDirectory)
+})
+
+func newClientSet(name string) *kubernetes.Clientset {
+	cfg := &api.ClusterConfig{
+		Metadata: &api.ClusterMeta{
+			Name:   name,
+			Region: params.Region,
+		},
+	}
+	ctx := context.Background()
+	ctl, err := eks.New(ctx, &api.ProviderConfig{Region: params.Region}, cfg)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = ctl.RefreshClusterStatus(ctx, cfg)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	clientSet, err := ctl.NewStdClientSet(cfg)
+	Expect(err).ShouldNot(HaveOccurred())
+	return clientSet
+}

--- a/pkg/addons/assets/neuron-device-plugin.yaml
+++ b/pkg/addons/assets/neuron-device-plugin.yaml
@@ -113,7 +113,7 @@ spec:
                       - trn1.2xlarge
                       - trn1.32xlarge
       containers:
-        - image: "public.ecr.aws/neuron/neuron-device-plugin:1.5.3.0"
+        - image: "public.ecr.aws/neuron/neuron-device-plugin:2.1.2.0"
           imagePullPolicy: Always
           name: k8s-neuron-device-plugin-ctr
           env:

--- a/pkg/apis/eksctl.io/v1alpha5/gpu_validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/gpu_validation_test.go
@@ -12,8 +12,9 @@ import (
 var _ = Describe("GPU instance support", func() {
 
 	type gpuInstanceEntry struct {
-		gpuInstanceType string
-		amiFamily       string
+		gpuInstanceType  string
+		amiFamily        string
+		instanceTypeName string
 
 		expectUnsupportedErr bool
 	}
@@ -21,7 +22,7 @@ var _ = Describe("GPU instance support", func() {
 	assertValidationError := func(e gpuInstanceEntry, err error) {
 		if e.expectUnsupportedErr {
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("Inferentia instance types are not supported for %s", e.amiFamily))))
+			Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("%s instance types are not supported for %s", e.instanceTypeName, e.amiFamily))))
 			return
 		}
 		Expect(err).NotTo(HaveOccurred())
@@ -50,6 +51,13 @@ var _ = Describe("GPU instance support", func() {
 			amiFamily:            api.NodeImageFamilyBottlerocket,
 			gpuInstanceType:      "inf1.xlarge",
 			expectUnsupportedErr: true,
+			instanceTypeName:     "Inferentia",
+		}),
+		Entry("Bottlerocket", gpuInstanceEntry{
+			amiFamily:            api.NodeImageFamilyBottlerocket,
+			gpuInstanceType:      "trn1.2xlarge",
+			expectUnsupportedErr: true,
+			instanceTypeName:     "Trainium",
 		}),
 	)
 
@@ -72,6 +80,10 @@ var _ = Describe("GPU instance support", func() {
 			gpuInstanceType: "inf1.xlarge",
 			amiFamily:       api.NodeImageFamilyAmazonLinux2,
 		}),
+		Entry("AL2", gpuInstanceEntry{
+			gpuInstanceType: "trn1.2xlarge",
+			amiFamily:       api.NodeImageFamilyAmazonLinux2,
+		}),
 		Entry("AMI unset", gpuInstanceEntry{
 			gpuInstanceType: "g4dn.xlarge",
 		}),
@@ -82,6 +94,11 @@ var _ = Describe("GPU instance support", func() {
 		Entry("Bottlerocket infra", gpuInstanceEntry{
 			amiFamily:            api.NodeImageFamilyBottlerocket,
 			gpuInstanceType:      "inf1.xlarge",
+			expectUnsupportedErr: true,
+		}),
+		Entry("Bottlerocket infra", gpuInstanceEntry{
+			amiFamily:            api.NodeImageFamilyBottlerocket,
+			gpuInstanceType:      "trn1.2xlarge",
 			expectUnsupportedErr: true,
 		}),
 		Entry("Bottlerocket nvidia", gpuInstanceEntry{

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -619,13 +619,19 @@ func validateNodeGroupBase(np NodePool, path string, controlPlaneOnOutposts bool
 		logger.Warning("%s does not ship with NVIDIA GPU drivers installed, hence won't support running GPU-accelerated workloads out of the box", ng.AMIFamily)
 	}
 
-	// Bottlerocket doesn't support Inferentia hosts
-	if instanceutils.IsInferentiaInstanceType(SelectInstanceType(np)) && ng.AMIFamily != NodeImageFamilyAmazonLinux2 && ng.AMIFamily != "" {
-		return errors.Errorf("Inferentia instance types are not supported for %s", ng.AMIFamily)
-	}
-	// Bottlerocket doesn't support Trainium hosts
-	if instanceutils.IsTrainiumInstanceType(SelectInstanceType(np)) && ng.AMIFamily != NodeImageFamilyAmazonLinux2 && ng.AMIFamily != "" {
-		return errors.Errorf("Trainium instance types are not supported for %s", ng.AMIFamily)
+	if ng.AMIFamily != NodeImageFamilyAmazonLinux2 && ng.AMIFamily != "" {
+		instanceType := SelectInstanceType(np)
+		unsupportedErr := func(instanceTypeName string) error {
+			return fmt.Errorf("%s instance types are not supported for %s", instanceTypeName, ng.AMIFamily)
+		}
+		// Only AL2 supports Inferentia hosts.
+		if instanceutils.IsInferentiaInstanceType(instanceType) {
+			return unsupportedErr("Inferentia")
+		}
+		// Only AL2 supports Trainium hosts.
+		if instanceutils.IsTrainiumInstanceType(instanceType) {
+			return unsupportedErr("Trainium")
+		}
 	}
 
 	if ng.CapacityReservation != nil {

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -620,8 +620,12 @@ func validateNodeGroupBase(np NodePool, path string, controlPlaneOnOutposts bool
 	}
 
 	// Bottlerocket doesn't support Inferentia hosts
-	if instanceutils.IsInferentiaInstanceType(SelectInstanceType(np)) && ng.AMIFamily == NodeImageFamilyBottlerocket {
+	if instanceutils.IsInferentiaInstanceType(SelectInstanceType(np)) && ng.AMIFamily != NodeImageFamilyAmazonLinux2 && ng.AMIFamily != "" {
 		return errors.Errorf("Inferentia instance types are not supported for %s", ng.AMIFamily)
+	}
+	// Bottlerocket doesn't support Trainium hosts
+	if instanceutils.IsTrainiumInstanceType(SelectInstanceType(np)) && ng.AMIFamily != NodeImageFamilyAmazonLinux2 && ng.AMIFamily != "" {
+		return errors.Errorf("Trainium instance types are not supported for %s", ng.AMIFamily)
 	}
 
 	if ng.CapacityReservation != nil {

--- a/pkg/ctl/cmdutils/nodegroup_flags.go
+++ b/pkg/ctl/cmdutils/nodegroup_flags.go
@@ -62,7 +62,7 @@ func AddCommonCreateNodeGroupFlags(fs *pflag.FlagSet, cmd *Cmd, ng *api.NodeGrou
 // AddCommonCreateNodeGroupIAMAddonsFlags adds flags to set ng.IAM.WithAddonPolicies
 func AddCommonCreateNodeGroupAddonsFlags(fs *pflag.FlagSet, ng *api.NodeGroup, options *CreateNGOptions) {
 	addCommonCreateNodeGroupIAMAddonsFlags(fs, ng)
-	fs.BoolVarP(&options.InstallNeuronDevicePlugin, "install-neuron-plugin", "", true, "install Neuron plugin for Inferentia nodes")
+	fs.BoolVarP(&options.InstallNeuronDevicePlugin, "install-neuron-plugin", "", true, "install Neuron plugin for Inferentia and Trainium nodes")
 	fs.BoolVarP(&options.InstallNvidiaDevicePlugin, "install-nvidia-plugin", "", true, "install Nvidia plugin for GPU nodes")
 }
 

--- a/pkg/eks/tasks.go
+++ b/pkg/eks/tasks.go
@@ -372,7 +372,7 @@ func (c *ClusterProvider) ClusterTasksForNodeGroups(cfg *api.ClusterConfig, inst
 	var clusterRequiresNeuronDevicePlugin, clusterRequiresNvidiaDevicePlugin, efaEnabled bool
 	for _, ng := range cfg.NodeGroups {
 		clusterRequiresNeuronDevicePlugin = clusterRequiresNeuronDevicePlugin ||
-			api.HasInstanceType(ng, instanceutils.IsInferentiaInstanceType)
+			api.HasInstanceType(ng, instanceutils.IsNeuronInstanceType)
 		// Only AL2 requires the NVIDIA device plugin
 		clusterRequiresNvidiaDevicePlugin = clusterRequiresNvidiaDevicePlugin ||
 			(api.HasInstanceType(ng, instanceutils.IsNvidiaInstanceType) &&
@@ -381,7 +381,7 @@ func (c *ClusterProvider) ClusterTasksForNodeGroups(cfg *api.ClusterConfig, inst
 	}
 	for _, ng := range cfg.ManagedNodeGroups {
 		clusterRequiresNeuronDevicePlugin = clusterRequiresNeuronDevicePlugin ||
-			api.HasInstanceTypeManaged(ng, instanceutils.IsInferentiaInstanceType)
+			api.HasInstanceTypeManaged(ng, instanceutils.IsNeuronInstanceType)
 		// Only AL2 requires the NVIDIA device plugin
 		clusterRequiresNvidiaDevicePlugin = clusterRequiresNvidiaDevicePlugin ||
 			(api.HasInstanceTypeManaged(ng, instanceutils.IsNvidiaInstanceType) &&

--- a/pkg/utils/instance/instance.go
+++ b/pkg/utils/instance/instance.go
@@ -24,7 +24,14 @@ func IsARMInstanceType(instanceType string) bool {
 // IsGPUInstanceType returns true if the instance type is GPU optimised
 func IsGPUInstanceType(instanceType string) bool {
 	return IsNvidiaInstanceType(instanceType) ||
-		IsInferentiaInstanceType(instanceType)
+		IsInferentiaInstanceType(instanceType) ||
+		IsTrainiumInstanceType(instanceType)
+}
+
+// IsNeuronInstanceType returns true if the instance type requires AWS Neuron
+func IsNeuronInstanceType(instanceType string) bool {
+	return IsInferentiaInstanceType(instanceType) ||
+		IsTrainiumInstanceType(instanceType)
 }
 
 // IsARMGPUInstanceType returns true if the instance type is ARM-GPU architecture
@@ -45,6 +52,11 @@ func IsNvidiaInstanceType(instanceType string) bool {
 // IsInferentiaInstanceType returns true if the instance type requires AWS Neuron
 func IsInferentiaInstanceType(instanceType string) bool {
 	return strings.HasPrefix(instanceType, "inf1")
+}
+
+// IsTrainiumnstanceType returns true if the instance type requires AWS Neuron
+func IsTrainiumInstanceType(instanceType string) bool {
+	return strings.HasPrefix(instanceType, "trn1")
 }
 
 // GetSmallestInstanceType returns the smallest instance type in instanceTypes.


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Per #5896, TRN1 instance types are now available in us-west-2 and us-east-1.  This PR ensures Trn1 instance types will be launched with the EKS Accelerated AMI by default and also will install the Neuron Device Plugin by default.  This also upgrades the Neuron Device Plugin to version ~~1.9.3.0~~ 2.1.2.0 which is required for Trn1 support.

Example:
```
./eksctl create cluster \
    --name trainium \
    --region us-west \
    --zones us-west-2b,us-west-2d \
    --nodegroup-name trainium-2 \
    --node-type trn1.2xlarge \
    --node-zones us-west-2d \
    --nodes 1 \
    --nodes-min 1 \
    --nodes-max 4 \
    --ssh-access \
    --with-oidc
```

```
% k get pods -A
NAMESPACE     NAME                                   READY   STATUS    RESTARTS   AGE
kube-system   aws-node-zwjbd                         1/1     Running   0          12m
kube-system   coredns-57ff979f67-bc6tl               1/1     Running   0          22m
kube-system   coredns-57ff979f67-xg28h               1/1     Running   0          22m
kube-system   kube-proxy-vdj4w                       1/1     Running   0          12m
kube-system   neuron-device-plugin-daemonset-p872b   1/1     Running   0          10m
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

