### PR TITLE
Do not wait for aws-ebs-csi-driver if there are no nodegroups

### DIFF
--- a/integration/tests/addons/addons_test.go
+++ b/integration/tests/addons/addons_test.go
@@ -101,7 +101,7 @@ var _ = Describe("(Integration) [EKS Addons test]", func() {
 			// setup config file
 			clusterConfig := getInitialClusterConfig()
 			clusterConfig.Addons = append(clusterConfig.Addons, &api.Addon{
-				Name: "aws-ebs-csi-driver",
+				Name: api.AWSEBSCSIDriverAddon,
 			})
 			data, err := json.Marshal(clusterConfig)
 
@@ -119,7 +119,7 @@ var _ = Describe("(Integration) [EKS Addons test]", func() {
 				cmd := params.EksctlGetCmd.
 					WithArgs(
 						"addon",
-						"--name", "aws-ebs-csi-driver",
+						"--name", api.AWSEBSCSIDriverAddon,
 						"--cluster", clusterName,
 						"--verbose", "2",
 					)

--- a/pkg/actions/addon/addon.go
+++ b/pkg/actions/addon/addon.go
@@ -27,10 +27,6 @@ type Manager struct {
 	clientSet     kubeclient.Interface
 }
 
-var (
-	ExportWaitForAddonToBeActive = (*Manager).waitForAddonToBeActive
-)
-
 func New(clusterConfig *api.ClusterConfig, eksAPI awsapi.EKS, stackManager manager.StackManager, withOIDC bool, oidcManager *iamoidc.OpenIDConnectManager, clientSet kubeclient.Interface) (*Manager, error) {
 	return &Manager{
 		clusterConfig: clusterConfig,

--- a/pkg/actions/addon/addon_test.go
+++ b/pkg/actions/addon/addon_test.go
@@ -1,19 +1,51 @@
 package addon_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/weaveworks/eksctl/pkg/actions/addon"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
-	"github.com/weaveworks/eksctl/pkg/eks/mocksv2"
+	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
 )
 
 var _ = Describe("Addon", func() {
-	When("the version is supported", func() {
-		It("does not error", func() {
-			_, err := addon.New(&api.ClusterConfig{Metadata: &api.ClusterMeta{Version: "1.18"}}, &mocksv2.EKS{}, nil, false, nil, nil)
-			Expect(err).NotTo(HaveOccurred())
+	var (
+		clusterConfig *api.ClusterConfig
+		mockProvider  *mockprovider.MockProvider
+		manager       *addon.Manager
+	)
+
+	BeforeEach(func() {
+		var err error
+		clusterConfig = &api.ClusterConfig{Metadata: &api.ClusterMeta{
+			Version: "1.18",
+			Name:    "my-cluster",
+		}}
+		mockProvider = mockprovider.NewMockProvider()
+		manager, err = addon.New(clusterConfig, mockProvider.EKS(), nil, false, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	When("addon is coredns with no nodegroup", func() {
+		It("does not wait for addon to be active", func() {
+			a := &api.Addon{
+				Name: api.CoreDNSAddon,
+			}
+			err := addon.ExportWaitForAddonToBeActive(manager, context.Background(), a, 0)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("addon is aws-ebs-csi-driver with no nodegroup", func() {
+		It("does not wait for addon to be active", func() {
+			a := &api.Addon{
+				Name: api.AWSEBSCSIDriverAddon,
+			}
+			err := addon.ExportWaitForAddonToBeActive(manager, context.Background(), a, 0)
+			Expect(err).To(BeNil())
 		})
 	})
 })

--- a/pkg/actions/addon/addon_test.go
+++ b/pkg/actions/addon/addon_test.go
@@ -1,51 +1,19 @@
 package addon_test
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/weaveworks/eksctl/pkg/actions/addon"
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
-	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
+	"github.com/weaveworks/eksctl/pkg/eks/mocksv2"
 )
 
 var _ = Describe("Addon", func() {
-	var (
-		clusterConfig *api.ClusterConfig
-		mockProvider  *mockprovider.MockProvider
-		manager       *addon.Manager
-	)
-
-	BeforeEach(func() {
-		var err error
-		clusterConfig = &api.ClusterConfig{Metadata: &api.ClusterMeta{
-			Version: "1.18",
-			Name:    "my-cluster",
-		}}
-		mockProvider = mockprovider.NewMockProvider()
-		manager, err = addon.New(clusterConfig, mockProvider.EKS(), nil, false, nil, nil)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	When("addon is coredns with no nodegroup", func() {
-		It("does not wait for addon to be active", func() {
-			a := &api.Addon{
-				Name: api.CoreDNSAddon,
-			}
-			err := addon.ExportWaitForAddonToBeActive(manager, context.Background(), a, 0)
-			Expect(err).To(BeNil())
-		})
-	})
-
-	When("addon is aws-ebs-csi-driver with no nodegroup", func() {
-		It("does not wait for addon to be active", func() {
-			a := &api.Addon{
-				Name: api.AWSEBSCSIDriverAddon,
-			}
-			err := addon.ExportWaitForAddonToBeActive(manager, context.Background(), a, 0)
-			Expect(err).To(BeNil())
+	When("the version is supported", func() {
+		It("does not error", func() {
+			_, err := addon.New(&api.ClusterConfig{Metadata: &api.ClusterMeta{Version: "1.18"}}, &mocksv2.EKS{}, nil, false, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/pkg/actions/addon/create.go
+++ b/pkg/actions/addon/create.go
@@ -23,8 +23,6 @@ import (
 
 const (
 	kubeSystemNamespace = "kube-system"
-	vpcCNIName          = "vpc-cni"
-	ebsCSIDriverName    = "aws-ebs-csi-driver"
 )
 
 func (a *Manager) Create(ctx context.Context, addon *api.Addon, waitTimeout time.Duration) error {
@@ -120,7 +118,7 @@ func (a *Manager) Create(ctx context.Context, addon *api.Addon, waitTimeout time
 		}
 	}
 
-	if addon.CanonicalName() == vpcCNIName {
+	if addon.CanonicalName() == api.VPCCNIAddon {
 		logger.Debug("patching AWS node")
 		err := a.patchAWSNodeSA(ctx)
 		if err != nil {
@@ -246,12 +244,12 @@ func (a *Manager) patchAWSNodeDaemonSet(ctx context.Context) error {
 func (a *Manager) getRecommendedPolicies(addon *api.Addon) (api.InlineDocument, []string, *api.WellKnownPolicies) {
 	// API isn't case-sensitive
 	switch addon.CanonicalName() {
-	case vpcCNIName:
+	case api.VPCCNIAddon:
 		if a.clusterConfig.IPv6Enabled() {
 			return makeIPv6VPCCNIPolicyDocument(api.Partition(a.clusterConfig.Metadata.Region)), nil, nil
 		}
 		return nil, []string{fmt.Sprintf("arn:%s:iam::aws:policy/%s", api.Partition(a.clusterConfig.Metadata.Region), api.IAMPolicyAmazonEKSCNIPolicy)}, nil
-	case ebsCSIDriverName:
+	case api.AWSEBSCSIDriverAddon:
 		return nil, nil, &api.WellKnownPolicies{
 			EBSCSIController: true,
 		}
@@ -263,7 +261,7 @@ func (a *Manager) getRecommendedPolicies(addon *api.Addon) (api.InlineDocument, 
 func (a *Manager) getKnownServiceAccountLocation(addon *api.Addon) (string, string) {
 	// API isn't case sensitive
 	switch addon.CanonicalName() {
-	case vpcCNIName:
+	case api.VPCCNIAddon:
 		logger.Debug("found known service account location %s/%s", api.AWSNodeMeta.Namespace, api.AWSNodeMeta.Name)
 		return api.AWSNodeMeta.Namespace, api.AWSNodeMeta.Name
 	default:

--- a/pkg/actions/addon/create_test.go
+++ b/pkg/actions/addon/create_test.go
@@ -541,7 +541,7 @@ var _ = Describe("Create", func() {
 			When("it's the aws-ebs-csi-driver addon", func() {
 				It("creates a role with the recommended policies and attaches it to the addon", func() {
 					err := manager.Create(context.Background(), &api.Addon{
-						Name:    "aws-ebs-csi-driver",
+						Name:    api.AWSEBSCSIDriverAddon,
 						Version: "v1.0.0-eksbuild.1",
 					}, 0)
 					Expect(err).NotTo(HaveOccurred())
@@ -551,13 +551,13 @@ var _ = Describe("Create", func() {
 					Expect(name).To(Equal("eksctl-my-cluster-addon-aws-ebs-csi-driver"))
 					Expect(resourceSet).NotTo(BeNil())
 					Expect(tags).To(Equal(map[string]string{
-						api.AddonNameTag: "aws-ebs-csi-driver",
+						api.AddonNameTag: api.AWSEBSCSIDriverAddon,
 					}))
 					output, err := resourceSet.RenderJSON()
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(output)).To(ContainSubstring("PolicyEBSCSIController"))
 					Expect(*createAddonInput.ClusterName).To(Equal("my-cluster"))
-					Expect(*createAddonInput.AddonName).To(Equal("aws-ebs-csi-driver"))
+					Expect(*createAddonInput.AddonName).To(Equal(api.AWSEBSCSIDriverAddon))
 					Expect(*createAddonInput.AddonVersion).To(Equal("v1.0.0-eksbuild.1"))
 					Expect(*createAddonInput.ServiceAccountRoleArn).To(Equal("role-arn"))
 				})

--- a/pkg/actions/addon/create_test.go
+++ b/pkg/actions/addon/create_test.go
@@ -357,6 +357,60 @@ var _ = Describe("Create", func() {
 		})
 	})
 
+	type createAddonEntry struct {
+		addonName  string
+		shouldWait bool
+	}
+
+	Context("cluster without nodes", func() {
+		BeforeEach(func() {
+			zeroNodeNG := &api.NodeGroupBase{
+				ScalingConfig: &api.ScalingConfig{
+					DesiredCapacity: aws.Int(0),
+				},
+			}
+			clusterConfig.NodeGroups = []*api.NodeGroup{
+				{
+					NodeGroupBase: zeroNodeNG,
+				},
+			}
+			clusterConfig.ManagedNodeGroups = []*api.ManagedNodeGroup{
+				{
+					NodeGroupBase: zeroNodeNG,
+				},
+			}
+		})
+
+		DescribeTable("addons created with a waitTimeout", func(e createAddonEntry) {
+			expectedDescribeCallsCount := 1
+			if e.shouldWait {
+				expectedDescribeCallsCount++
+				mockProvider.MockEKS().On("DescribeAddon", mock.Anything, mock.MatchedBy(func(input *eks.DescribeAddonInput) bool {
+					return *input.AddonName == e.addonName
+				}), mock.Anything).Return(&eks.DescribeAddonOutput{
+					Addon: &ekstypes.Addon{
+						AddonName: aws.String(e.addonName),
+						Status:    ekstypes.AddonStatusActive,
+					},
+				}, nil).Once()
+			}
+			err := manager.Create(context.Background(), &api.Addon{Name: e.addonName}, time.Nanosecond)
+			Expect(err).NotTo(HaveOccurred())
+			mockProvider.MockEKS().AssertNumberOfCalls(GinkgoT(), "DescribeAddon", expectedDescribeCallsCount)
+		},
+			Entry("should not wait for CoreDNS to become active", createAddonEntry{
+				addonName: api.CoreDNSAddon,
+			}),
+			Entry("should not wait for Amazon EBS CSI driver to become active", createAddonEntry{
+				addonName: api.AWSEBSCSIDriverAddon,
+			}),
+			Entry("should wait for VPC CNI to become active", createAddonEntry{
+				addonName:  api.VPCCNIAddon,
+				shouldWait: true,
+			}),
+		)
+	})
+
 	When("resolveConflicts is configured", func() {
 		DescribeTable("AWS EKS resolve conflicts matches value from cluster config",
 			func(rc ekstypes.ResolveConflicts) {
@@ -483,7 +537,7 @@ var _ = Describe("Create", func() {
 				Context("ipv4", func() {
 					It("creates a role with the recommended policies and attaches it to the addon", func() {
 						err := manager.Create(context.Background(), &api.Addon{
-							Name:    "vpc-cni",
+							Name:    api.VPCCNIAddon,
 							Version: "v1.0.0-eksbuild.1",
 						}, 0)
 						Expect(err).NotTo(HaveOccurred())
@@ -493,14 +547,14 @@ var _ = Describe("Create", func() {
 						Expect(name).To(Equal("eksctl-my-cluster-addon-vpc-cni"))
 						Expect(resourceSet).NotTo(BeNil())
 						Expect(tags).To(Equal(map[string]string{
-							api.AddonNameTag: "vpc-cni",
+							api.AddonNameTag: api.VPCCNIAddon,
 						}))
 						output, err := resourceSet.RenderJSON()
 						Expect(err).NotTo(HaveOccurred())
 						Expect(string(output)).To(ContainSubstring("arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"))
 						Expect(string(output)).To(ContainSubstring(":sub\":\"system:serviceaccount:kube-system:aws-node"))
 						Expect(*createAddonInput.ClusterName).To(Equal("my-cluster"))
-						Expect(*createAddonInput.AddonName).To(Equal("vpc-cni"))
+						Expect(*createAddonInput.AddonName).To(Equal(api.VPCCNIAddon))
 						Expect(*createAddonInput.AddonVersion).To(Equal("v1.0.0-eksbuild.1"))
 						Expect(*createAddonInput.ServiceAccountRoleArn).To(Equal("role-arn"))
 					})
@@ -516,7 +570,7 @@ var _ = Describe("Create", func() {
 
 					It("creates a role with the recommended policies and attaches it to the addon", func() {
 						err := manager.Create(context.Background(), &api.Addon{
-							Name:    "vpc-cni",
+							Name:    api.VPCCNIAddon,
 							Version: "v1.0.0-eksbuild.1",
 						}, 0)
 						Expect(err).NotTo(HaveOccurred())
@@ -525,13 +579,13 @@ var _ = Describe("Create", func() {
 						Expect(name).To(Equal("eksctl-my-cluster-addon-vpc-cni"))
 						Expect(resourceSet).NotTo(BeNil())
 						Expect(tags).To(Equal(map[string]string{
-							api.AddonNameTag: "vpc-cni",
+							api.AddonNameTag: api.VPCCNIAddon,
 						}))
 						output, err := resourceSet.RenderJSON()
 						Expect(err).NotTo(HaveOccurred())
 						Expect(string(output)).To(ContainSubstring("AssignIpv6Addresses"))
 						Expect(*createAddonInput.ClusterName).To(Equal("my-cluster"))
-						Expect(*createAddonInput.AddonName).To(Equal("vpc-cni"))
+						Expect(*createAddonInput.AddonName).To(Equal(api.VPCCNIAddon))
 						Expect(*createAddonInput.AddonVersion).To(Equal("v1.0.0-eksbuild.1"))
 						Expect(*createAddonInput.ServiceAccountRoleArn).To(Equal("role-arn"))
 					})

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -372,6 +372,7 @@ const (
 	VPCCNIAddon                 = "vpc-cni"
 	KubeProxyAddon              = "kube-proxy"
 	CoreDNSAddon                = "coredns"
+	AWSEBSCSIDriverAddon        = "aws-ebs-csi-driver"
 )
 
 // supported version of Karpenter


### PR DESCRIPTION
### Description

similar to #5458; closes #5891, #5585

aws-ebs-csi-driver will stay in degraded state until nodegroups are added.
SInce the addon is now a requirement for k8s 1.23, the cluster creation should not fail.

#### Manual validation

Given cluster config  `cluster.yaml`

```yaml
kind: ClusterConfig
apiVersion: eksctl.io/v1alpha5

metadata:
  name: cluster-1jnq
  region: us-west-2
  version: "1.23"

iam:
  withOIDC: true
  serviceAccounts:
  - metadata:
      name: ebs-csi-controller-sa
      namespace: kube-system
    attachPolicyARNs:
    - "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
    roleOnly: true
    roleName: cluster-1jnq-AmazonEKS_EBS_CSI_DriverRole

addons:
- name: aws-ebs-csi-driver
  version: v1.11.4-eksbuild.1
  serviceAccountRoleARN: arn:aws:iam::ACCOUNT_ID:role/cluster-1jnq-AmazonEKS_EBS_CSI_DriverRole

nodeGroups:
  - name: worker-pool
    instanceType: t3.large
    desiredCapacity: 3

```

Running `eksctl create cluster -f cluster.yaml --without-nodegroup` successfully creates the cluster with no node group.

Additional validated scenarios:
- setting `desiredCapacity: 0` in `cluster.yaml` and running `eksctl create cluster -f cluster.yaml`
- setting `desiredCapacity:0`, `maxSize: 3` in `cluster.yaml` and running `eksctl create cluster -f cluster.yaml`

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] ~Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)~
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:

