### PR TITLE
Fix dry run integration test

### DIFF
--- a/integration/tests/dry_run/dry_run_test.go
+++ b/integration/tests/dry_run/dry_run_test.go
@@ -67,7 +67,7 @@ kubernetesNetworkConfig:
   ipFamily: IPv4
 nodeGroups:
 - amiFamily: AmazonLinux2
-  containerRuntime: dockerd
+  containerRuntime: containerd
   disableIMDSv1: false
   disablePodIMDS: false
   instanceSelector: {}


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Since dry run test uses Kubernetes 1.24, `containerd` is now default `containerRuntime`. This PR updates the test accordingly.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

