### PR TITLE
Improves get nodegroup to return partial results on error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/golangci/golangci-lint v1.50.1
 	github.com/google/uuid v1.3.0
 	github.com/goreleaser/goreleaser v1.6.1
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kris-nova/logger v0.2.1
@@ -289,7 +290,6 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.2.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.3 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect

--- a/pkg/actions/nodegroup/get_test.go
+++ b/pkg/actions/nodegroup/get_test.go
@@ -122,9 +122,9 @@ var _ = Describe("Get", func() {
 						Cluster:              clusterName,
 						Name:                 ngName,
 						Status:               "my-status",
-						MaxSize:              4,
-						MinSize:              0,
-						DesiredCapacity:      2,
+						MaxSize:              aws.Int32(4),
+						MinSize:              aws.Int32(0),
+						DesiredCapacity:      aws.Int32(2),
 						InstanceType:         "-",
 						ImageID:              "ami-type",
 						CreationTime:         t,
@@ -186,9 +186,9 @@ var _ = Describe("Get", func() {
 						Cluster:              clusterName,
 						Name:                 ngName,
 						Status:               "my-status",
-						MaxSize:              4,
-						MinSize:              0,
-						DesiredCapacity:      2,
+						MaxSize:              aws.Int32(4),
+						MinSize:              aws.Int32(0),
+						DesiredCapacity:      aws.Int32(2),
 						InstanceType:         "-",
 						ImageID:              "ami-type",
 						CreationTime:         t,
@@ -265,9 +265,9 @@ var _ = Describe("Get", func() {
 						Cluster:              clusterName,
 						Name:                 ngName,
 						Status:               "my-status",
-						MaxSize:              4,
-						MinSize:              0,
-						DesiredCapacity:      2,
+						MaxSize:              aws.Int32(4),
+						MinSize:              aws.Int32(0),
+						DesiredCapacity:      aws.Int32(2),
 						InstanceType:         "big",
 						ImageID:              "ami-type",
 						CreationTime:         t,
@@ -335,9 +335,9 @@ var _ = Describe("Get", func() {
 						Cluster:              clusterName,
 						Name:                 ngName,
 						Status:               "my-status",
-						MaxSize:              4,
-						MinSize:              0,
-						DesiredCapacity:      2,
+						MaxSize:              aws.Int32(4),
+						MinSize:              aws.Int32(0),
+						DesiredCapacity:      aws.Int32(2),
 						InstanceType:         "m5.xlarge",
 						ImageID:              "ami-custom",
 						CreationTime:         t,
@@ -465,9 +465,9 @@ var _ = Describe("Get", func() {
 					Name:                 unmanagedNodegroupName,
 					Status:               "CREATE_COMPLETE",
 					AutoScalingGroupName: "asg",
-					MaxSize:              100,
-					DesiredCapacity:      50,
-					MinSize:              1,
+					MaxSize:              aws.Int32(100),
+					MinSize:              aws.Int32(1),
+					DesiredCapacity:      aws.Int32(50),
 					Version:              "1.21.1",
 					CreationTime:         creationTime,
 					NodeGroupType:        api.NodeGroupTypeUnmanaged,
@@ -478,9 +478,9 @@ var _ = Describe("Get", func() {
 					Cluster:              clusterName,
 					Name:                 ngName,
 					Status:               "my-status",
-					MaxSize:              4,
-					MinSize:              0,
-					DesiredCapacity:      2,
+					MaxSize:              aws.Int32(4),
+					MinSize:              aws.Int32(0),
+					DesiredCapacity:      aws.Int32(2),
 					InstanceType:         "-",
 					ImageID:              "ami-type",
 					CreationTime:         t,
@@ -489,6 +489,44 @@ var _ = Describe("Get", func() {
 					Version:              "1.18",
 					NodeGroupType:        api.NodeGroupTypeManaged,
 				}))
+			})
+
+			When("a nodegroup is in an invalid state", func() {
+				BeforeEach(func() {
+					fakeStackManager.GetUnmanagedNodeGroupAutoScalingGroupNameReturns("", fmt.Errorf("some error"))
+				})
+				It("returns the nodegroups with partial summmary for the invalid one", func() {
+					summaries, err := m.GetAll(context.Background())
+					Expect(err).NotTo(HaveOccurred())
+					Expect(summaries).To(HaveLen(2))
+
+					unmanagedSummary := *summaries[0]
+					Expect(unmanagedSummary).To(Equal(nodegroup.Summary{
+						StackName:     unmanagedStackName,
+						Cluster:       clusterName,
+						Name:          unmanagedNodegroupName,
+						Status:        "CREATE_COMPLETE",
+						CreationTime:  creationTime,
+						NodeGroupType: api.NodeGroupTypeUnmanaged,
+					}))
+
+					Expect(*summaries[1]).To(Equal(nodegroup.Summary{
+						StackName:            stackName,
+						Cluster:              clusterName,
+						Name:                 ngName,
+						Status:               "my-status",
+						MaxSize:              aws.Int32(4),
+						MinSize:              aws.Int32(0),
+						DesiredCapacity:      aws.Int32(2),
+						InstanceType:         "-",
+						ImageID:              "ami-type",
+						CreationTime:         t,
+						NodeInstanceRoleARN:  "node-role",
+						AutoScalingGroupName: "asg-name",
+						Version:              "1.18",
+						NodeGroupType:        api.NodeGroupTypeManaged,
+					}))
+				})
 			})
 		})
 	})
@@ -560,9 +598,9 @@ var _ = Describe("Get", func() {
 				Cluster:              clusterName,
 				Name:                 ngName,
 				Status:               "my-status",
-				MaxSize:              4,
-				MinSize:              0,
-				DesiredCapacity:      2,
+				MaxSize:              aws.Int32(4),
+				MinSize:              aws.Int32(0),
+				DesiredCapacity:      aws.Int32(2),
 				InstanceType:         "m5.xlarge",
 				ImageID:              "ami-type",
 				CreationTime:         t,
@@ -585,9 +623,9 @@ var _ = Describe("Get", func() {
 					Cluster:              clusterName,
 					Name:                 ngName,
 					Status:               "my-status",
-					MaxSize:              4,
-					MinSize:              0,
-					DesiredCapacity:      2,
+					MaxSize:              aws.Int32(4),
+					MinSize:              aws.Int32(0),
+					DesiredCapacity:      aws.Int32(2),
 					InstanceType:         "m5.xlarge",
 					ImageID:              "ami-type",
 					CreationTime:         t,

--- a/pkg/actions/nodegroup/nodegroup_suite_test.go
+++ b/pkg/actions/nodegroup/nodegroup_suite_test.go
@@ -1,7 +1,7 @@
 package nodegroup_test
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -35,7 +35,7 @@ var _ = BeforeSuite(func() {
 })
 
 func mustReadFile(path string) string {
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	Expect(err).NotTo(HaveOccurred())
 	return strings.Trim(string(bytes), "\n")
 }

--- a/pkg/cfn/manager/nodegroup.go
+++ b/pkg/cfn/manager/nodegroup.go
@@ -232,7 +232,7 @@ func (c *StackCollection) GetUnmanagedNodeGroupAutoScalingGroupName(ctx context.
 		return "", err
 	}
 	if res.StackResourceDetail.PhysicalResourceId == nil {
-		return "", fmt.Errorf("%q resource of stack %q has no physical resource id", *input.LogicalResourceId, *res.StackResourceDetail.LogicalResourceId)
+		return "", fmt.Errorf("%q resource of stack %q has no physical resource id", *input.LogicalResourceId, *input.StackName)
 	}
 	return *res.StackResourceDetail.PhysicalResourceId, nil
 }

--- a/pkg/ctl/get/nodegroup.go
+++ b/pkg/ctl/get/nodegroup.go
@@ -78,7 +78,7 @@ func doGetNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *getCmdParams) 
 	if ng.Name == "" {
 		summaries, err = manager.GetAll(ctx)
 		if err != nil {
-			return err
+			logger.Warning("getting all nodegroups: %v", err)
 		}
 	} else {
 		summary, err := manager.Get(ctx, ng.Name)
@@ -123,13 +123,13 @@ func addSummaryTableColumns(printer *printers.TablePrinter) {
 		return s.CreationTime.Format(time.RFC3339)
 	})
 	printer.AddColumn("MIN SIZE", func(s *nodegroup.Summary) string {
-		return strconv.Itoa(s.MinSize)
+		return formatInt32Ptr(s.MinSize)
 	})
 	printer.AddColumn("MAX SIZE", func(s *nodegroup.Summary) string {
-		return strconv.Itoa(s.MaxSize)
+		return formatInt32Ptr(s.MaxSize)
 	})
 	printer.AddColumn("DESIRED CAPACITY", func(s *nodegroup.Summary) string {
-		return strconv.Itoa(s.DesiredCapacity)
+		return formatInt32Ptr(s.DesiredCapacity)
 	})
 	printer.AddColumn("INSTANCE TYPE", func(s *nodegroup.Summary) string {
 		return s.InstanceType
@@ -143,4 +143,11 @@ func addSummaryTableColumns(printer *printers.TablePrinter) {
 	printer.AddColumn("TYPE", func(s *nodegroup.Summary) api.NodeGroupType {
 		return s.NodeGroupType
 	})
+}
+
+func formatInt32Ptr(i *int32) string {
+	if i == nil {
+		return ""
+	}
+	return strconv.FormatInt(int64(*i), 10)
 }


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Improve get nodegroups so that it never fails on error. It will log errors as warning and display incomplete nodegroups summary instead of the first error encountered.

This allow to get all nodegroups even if a nodegroup / stack is in an unexpected state.


### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

### Manual tests
Before:
```
$ eksctl version
0.119.0
$ eksctl get nodegroup --cluster cluster-1
2022-11-18 18:43:19 [!]  error collecting Cloudformation outputs for stack eksctl-my-cluster-nodegroup-default-2: no output "InstanceRoleARN" in stack "eksctl-my-cluster-nodegroup-default-2"
Error: getting autoscalinggroupname: "NodeGroup" resource of stack "NodeGroup" has no physical resource id
```

After:
```
$ eksctl version
0.121.0-dev+6e394aa1c.2022-11-18T17:17:14Z
$ eksctl get nodegroup --cluster cluster-1
2022-11-18 18:44:17 [!]  error collecting Cloudformation outputs for stack eksctl-my-cluster-nodegroup-default-2: no output "InstanceRoleARN" in stack "eksctl-my-cluster-nodegroup-default-2"
2022-11-18 18:44:17 [!]  error getting summary for stack eksctl-my-cluster-nodegroup-default-2: getting autoscalinggroupname: "NodeGroup" resource of stack "eksctl-my-cluster-nodegroup-default-2" has no physical resource id
CLUSTER       NODEGROUP    STATUS               CREATED                 MIN SIZE    MAX SIZE    DESIRED CAPACITY    INSTANCE TYPE    IMAGE ID                 ASG NAME                                                         TYPE
my-cluster    default-1    CREATE_COMPLETE      2022-11-15T02:58:54Z    0           1           0                   m5.xlarge        ami-0f513d07d2f4c8f52    eksctl-my-cluster-nodegroup-default-1-NodeGroup-13YZN3SRU2EP9    unmanaged
my-cluster    default-2    ROLLBACK_COMPLETE    2022-11-18T17:31:05Z                                                t3.small         ami-04d371f1608ff01db                                                                     unmanaged
```