### PR TITLE
Standardize cluster / nodegroup version before doing validations and …

### DIFF
--- a/pkg/actions/nodegroup/create_test.go
+++ b/pkg/actions/nodegroup/create_test.go
@@ -3,7 +3,6 @@ package nodegroup_test
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
@@ -120,11 +119,6 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 		t.expectedCalls(k, &ngFilter)
 	}
 },
-	Entry("fails when cluster version is not supported", ngEntry{
-		version:     "1.14",
-		expectedErr: fmt.Errorf("invalid version, %s is no longer supported, supported values: auto, default, latest, %s\nsee also: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html", "1.14", strings.Join(api.SupportedVersions(), ", ")),
-	}),
-
 	Entry("when cluster is unowned, fails to load VPC from config if config is not supplied", ngEntry{
 		mockCalls: func(k *fakes.FakeKubeProvider, f *utilFakes.FakeNodegroupFilter, p *mockprovider.MockProvider, _ *fake.Clientset) {
 			k.NewRawClientReturns(&kubernetes.RawClient{}, nil)

--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -232,23 +232,21 @@ func getDefaultVolumeType(nodeGroupOnOutposts bool) string {
 }
 
 func setContainerRuntimeDefault(ng *NodeGroup, clusterVersion string) {
-	var runtime string
 	if ng.ContainerRuntime != nil {
 		return
 	}
 
+	// since clusterVersion is standardised beforehand, we can safely ignore the error
 	isDockershimDeprecated, _ := utils.IsMinVersion(DockershimDeprecationVersion, clusterVersion)
 
 	if isDockershimDeprecated {
-		runtime = ContainerRuntimeContainerD
+		ng.ContainerRuntime = aws.String(ContainerRuntimeContainerD)
 	} else {
-		runtime = ContainerRuntimeDockerD
+		ng.ContainerRuntime = aws.String(ContainerRuntimeDockerD)
 		if IsWindowsImage(ng.AMIFamily) {
-			runtime = ContainerRuntimeDockerForWindows
+			ng.ContainerRuntime = aws.String(ContainerRuntimeDockerForWindows)
 		}
 	}
-
-	ng.ContainerRuntime = &runtime
 }
 
 func setIAMDefaults(iamConfig *NodeGroupIAM) {

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
 
@@ -16,6 +17,7 @@ import (
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils/filter"
+	"github.com/weaveworks/eksctl/pkg/eks"
 	"github.com/weaveworks/eksctl/pkg/utils/names"
 )
 
@@ -51,7 +53,7 @@ func createNodeGroupCmd(cmd *cmdutils.Cmd) {
 		}
 
 		ctx := context.Background()
-		ctl, err := cmd.NewProviderForExistingCluster(ctx)
+		ctl, err := cmd.NewProviderForExistingClusterHelper(ctx, checkNodeGroupVersion)
 		if err != nil {
 			return fmt.Errorf("could not create cluster provider from options: %w", err)
 		}
@@ -122,4 +124,38 @@ func createNodeGroupCmdWithRunFunc(cmd *cmdutils.Cmd, runFunc runFn) {
 	cmdutils.AddInstanceSelectorOptions(cmd.FlagSetGroup, ng)
 
 	cmdutils.AddCommonFlagsForAWS(cmd, &cmd.ProviderConfig, true)
+}
+
+func checkNodeGroupVersion(ctl *eks.ClusterProvider, meta *api.ClusterMeta) error {
+	switch meta.Version {
+	case "auto":
+		break
+	case "":
+		meta.Version = "auto"
+	case "default":
+		meta.Version = api.DefaultVersion
+		logger.Info("will use default version (%s) for new nodegroup(s)", meta.Version)
+	case "latest":
+		meta.Version = api.LatestVersion
+		logger.Info("will use latest version (%s) for new nodegroup(s)", meta.Version)
+	default:
+		if !api.IsSupportedVersion(meta.Version) {
+			if api.IsDeprecatedVersion(meta.Version) {
+				return fmt.Errorf("invalid version, %s is no longer supported, supported values: auto, default, latest, %s\nsee also: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html", meta.Version, strings.Join(api.SupportedVersions(), ", "))
+			}
+			return fmt.Errorf("invalid version %s, supported values: auto, default, latest, %s", meta.Version, strings.Join(api.SupportedVersions(), ", "))
+		}
+	}
+
+	if v := ctl.ControlPlaneVersion(); v == "" {
+		return fmt.Errorf("unable to get control plane version")
+	} else if meta.Version == "auto" {
+		meta.Version = v
+		logger.Info("will use version %s for new nodegroup(s) based on control plane version", meta.Version)
+	} else if meta.Version != v {
+		hint := "--version=auto"
+		logger.Warning("will use version %s for new nodegroup(s), while control plane version is %s; to automatically inherit the version use %q", meta.Version, v, hint)
+	}
+
+	return nil
 }

--- a/pkg/ctl/create/nodegroup_test.go
+++ b/pkg/ctl/create/nodegroup_test.go
@@ -1,11 +1,17 @@
 package create
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go/aws"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/ctl/cmdutils"
+	"github.com/weaveworks/eksctl/pkg/eks"
 )
 
 var _ = Describe("create nodegroup", func() {
@@ -179,6 +185,74 @@ var _ = Describe("create nodegroup", func() {
 				error: unsupportedWindowsError,
 			}),
 		)
-
 	})
+
+	type checkNodeGroupVersionInput struct {
+		ctl             *eks.ClusterProvider
+		meta            *api.ClusterMeta
+		expectedVersion string
+		expectedErr     string
+	}
+
+	providerVersion1_23 := &eks.ClusterProvider{
+		Status: &eks.ProviderStatus{
+			ClusterInfo: &eks.ClusterInfo{
+				Cluster: &types.Cluster{
+					Version: aws.String(api.Version1_23),
+				},
+			},
+		},
+	}
+
+	DescribeTable("checkNodeGroupVersion",
+		func(input checkNodeGroupVersionInput) {
+			err := checkNodeGroupVersion(input.ctl, input.meta)
+			if input.expectedErr != "" {
+				Expect(err).To(MatchError(ContainSubstring(input.expectedErr)))
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+			Expect(input.meta.Version).To(Equal(input.expectedVersion))
+		},
+		Entry("version is left empty", checkNodeGroupVersionInput{
+			ctl:             providerVersion1_23,
+			meta:            &api.ClusterMeta{},
+			expectedVersion: api.Version1_23,
+		}),
+		Entry("version is set to auto", checkNodeGroupVersionInput{
+			ctl: providerVersion1_23,
+			meta: &api.ClusterMeta{
+				Version: "auto",
+			},
+			expectedVersion: api.Version1_23,
+		}),
+		Entry("version is set to latest", checkNodeGroupVersionInput{
+			ctl: providerVersion1_23,
+			meta: &api.ClusterMeta{
+				Version: "latest",
+			},
+			expectedVersion: api.LatestVersion,
+		}),
+		Entry("version is set to deprecated version", checkNodeGroupVersionInput{
+			meta: &api.ClusterMeta{
+				Version: api.Version1_15,
+			},
+			expectedErr: fmt.Sprintf("invalid version, %s is no longer supported", api.Version1_15),
+		}),
+		Entry("version is set to unsupported version", checkNodeGroupVersionInput{
+			meta: &api.ClusterMeta{
+				Version: "100",
+			},
+			expectedErr: fmt.Sprintf("invalid version 100, supported values: auto, default, latest, %s", strings.Join(api.SupportedVersions(), ", ")),
+		}),
+		Entry("fails to retrieve control plane version", checkNodeGroupVersionInput{
+			ctl: &eks.ClusterProvider{
+				Status: &eks.ProviderStatus{},
+			},
+			meta: &api.ClusterMeta{
+				Version: "auto",
+			},
+			expectedErr: "unable to get control plane version",
+		}),
+	)
 })

--- a/pkg/nodebootstrap/windows_test.go
+++ b/pkg/nodebootstrap/windows_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	. "github.com/onsi/ginkgo/v2"
 
 	. "github.com/onsi/gomega"
@@ -27,12 +28,11 @@ var _ = Describe("Windows", func() {
 			Endpoint:                 "https://test.com",
 			CertificateAuthorityData: []byte("test"),
 		}
-		runtime := api.ContainerRuntimeDockerForWindows
 		ng := &api.NodeGroup{
 			NodeGroupBase: &api.NodeGroupBase{
 				AMIFamily: api.NodeImageFamilyWindowsServer2019CoreContainer,
 			},
-			ContainerRuntime: &runtime,
+			ContainerRuntime: aws.String(api.ContainerRuntimeDockerForWindows),
 		}
 		if e.updateNodeGroup != nil {
 			e.updateNodeGroup(ng)


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Closes https://github.com/weaveworks/eksctl-private/issues/471

When setting default `containerRuntime` and doing similar validation, we are currently comparing the `clusterVersion` with `DockershimDeprecationVersion` (i.e. `1.24`). However this comparison turns out to be troublesome, as `clusterVersion` at that point doesn't always have a numeric format (e.g. `1.22`), it can also be `""`, `auto` or `latest`. This PR standardises the version before doing the comparison.

### Manual tests

#### 1. Try to create a cluster on `1.24` with a `nodeGroup` with `containerRuntime: dockerd`
```
% ./eksctl create cluster --config-file cluster.yaml
Error: only containerd is supported for container runtime, starting with EKS version 1.24
```

#### 2. Try to create a cluster on `1.24` with a `nodeGroup` without specifying `containerRuntime` explicitly
```
% ./eksctl create cluster --config-file cluster.yaml
EKS cluster "cluster-test" in "eu-north-1" region is ready
```
And now check the nodegroup `containerRuntime` was set to `containerd`
```
% kubectl get nodes --all-namespaces
Container Runtime Version:  containerd://1.6.6
```

#### 3. Try to add a second `nodeGroup` to the cluster, with `containerRuntime: dockerd`, without setting cluster version.
This `create nodegroup` command shall fetch version number as `1.24` from control plane and realise the nodegroup can't be created.
```
 % ./eksctl create nodegroup --config-file cluster.yaml
will use latest version (1.24) for new nodegroup(s)
Error: could not create cluster provider from options: only containerd is supported for container runtime, starting with EKS version 1.24
```


### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

