### PR TITLE
Improve log message when calling DescribeCluster during registration fails

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -70,7 +70,7 @@ func (c *EKSConnector) RegisterCluster(ctx context.Context, cluster ExternalClus
 	if err != nil {
 		var notFoundError *ekstypes.ResourceNotFoundException
 		if !errors.As(err, &notFoundError) {
-			return nil, errors.New("unexpected error calling DescribeCluster")
+			return nil, errors.Wrap(err, "unexpected error calling DescribeCluster")
 		}
 	} else {
 		return nil, errors.Errorf("cluster already exists; deregister the cluster first using `eksctl deregister cluster --name %s --region %s` and try again", cluster.Name, c.Provider.Region())


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Print actual error why `DescribeCluster` may fail while registering non-EKS cluster.
Hopefully this will assist in debugging https://github.com/weaveworks/eksctl/issues/5971

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

