### PR TITLE
Fix release version in notifications

### DIFF
--- a/.github/workflows/publish-release-type.yaml
+++ b/.github/workflows/publish-release-type.yaml
@@ -50,13 +50,13 @@ jobs:
           ./build/scripts/do-release-candidate.sh
       - name: get version
         id: get_version
-        run: echo name=VERSION::$(echo ${GITHUB_REF#refs/*/}) >> $GITHUB_OUTPUT
+        run: echo "version=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: slack on success - team-pitch-black
         if: ${{ success() }}
         uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
         with:
           slack_token: ${{ secrets.slackToken }}
-          message: ":cool-doge: ${{ inputs.name }} successful for tag <https://github.com/weaveworks/eksctl/releases/tag/${{ steps.get_version.outputs.VERSION }}|${{ steps.get_version.outputs.VERSION }}>"
+          message: ":cool-doge: ${{ inputs.name }} successful for tag <https://github.com/weaveworks/eksctl/releases/tag/${{ steps.get_version.outputs.version }}|${{ steps.get_version.outputs.version }}>"
           channel: team-pitch-black
           color: green
           verbose: false
@@ -65,7 +65,7 @@ jobs:
         uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
         with:
           slack_token: ${{ secrets.slackToken }}
-          message: ":ahhhhhhhhh: ${{ inputs.name }} has failed for tag <https://github.com/weaveworks/eksctl/releases/tag/${{ steps.get_version.outputs.VERSION }}|${{ steps.get_version.outputs.VERSION }}>"
+          message: ":ahhhhhhhhh: ${{ inputs.name }} has failed for tag <https://github.com/weaveworks/eksctl/releases/tag/${{ steps.get_version.outputs.version }}|${{ steps.get_version.outputs.version }}>"
           channel: team-pitch-black
           color: red
           verbose: true
@@ -74,7 +74,7 @@ jobs:
         uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
         with:
           slack_token: ${{ secrets.slackToken }}
-          message: ":tada: <https://github.com/weaveworks/eksctl/releases/tag/${{ steps.get_version.outputs.VERSION }}|${{ steps.get_version.outputs.VERSION }}> released!"
+          message: ":tada: <https://github.com/weaveworks/eksctl/releases/tag/${{ steps.get_version.outputs.version }}|${{ steps.get_version.outputs.version }}> released!"
           channel: aws-dev
           color: green
           verbose: false

--- a/.github/workflows/update-generated.yaml
+++ b/.github/workflows/update-generated.yaml
@@ -40,10 +40,10 @@ jobs:
           git config user.email "weaveworksbot@users.noreply.github.com"
           git add -u
           if ! EDITOR=true git commit -m "Update aws-node"; then
-            echo "name=changes::false" >> $GITHUB_OUTPUT
+            echo "changes=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-          echo "name=changes::true" >> $GITHUB_OUTPUT
+          echo "changes=true" >> $GITHUB_OUTPUT
           ! git diff --exit-code $DEFAULT_BRANCH HEAD
           git push --force-with-lease origin HEAD
       - uses: actions/github-script@v6.3.3


### PR DESCRIPTION
### Description

When our GitHub Actions workflows were migrated away from the deprecated `set-output` command, the syntax used was incorrect: https://github.com/weaveworks/eksctl/pull/5927.

This changelist fixes the syntax used for environment files.

Fixes #5974 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

