### PR TITLE
Remove runAsNonRoot config for nvidia-device-plugin demonset

### DIFF
--- a/pkg/addons/assets/nvidia-device-plugin.yaml
+++ b/pkg/addons/assets/nvidia-device-plugin.yaml
@@ -50,7 +50,6 @@ spec:
         name: nvidia-device-plugin-ctr
         args: ["--fail-on-init-error=false"]
         securityContext:
-          runAsNonRoot: true
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]


### PR DESCRIPTION
Signed-off-by: Allen Xu <allxu@nvidia.com>

This PR removes the runAsNonRoot config that was introduced in #5970 
To close: #6025

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

