### PR TITLE
Allow node instance role to set cloudwatch retention

### DIFF
--- a/pkg/cfn/builder/iam_helper.go
+++ b/pkg/cfn/builder/iam_helper.go
@@ -146,6 +146,10 @@ func createRole(cfnTemplate cfnTemplate, clusterIAMConfig *api.ClusterIAM, iamCo
 		cfnTemplate.attachAllowPolicy("PolicyXRay", refIR, xRayStatements())
 	}
 
+	if api.IsEnabled(iamConfig.WithAddonPolicies.CloudWatch) {
+		cfnTemplate.attachAllowPolicy("PolicyCloudWatch", refIR, cloudwatchStatements())
+	}
+
 	return nil
 }
 

--- a/pkg/cfn/builder/nodegroup_test.go
+++ b/pkg/cfn/builder/nodegroup_test.go
@@ -525,6 +525,20 @@ var _ = Describe("Unmanaged NodeGroup Template Builder", func() {
 					Expect(isRefTo(ngTemplate.Resources["PolicyXRay"].Properties.Roles[0], "NodeInstanceRole")).To(BeTrue())
 				})
 			})
+
+			Context("ng.WithAddonPolicies.CloudWatch is set", func() {
+				BeforeEach(func() {
+					ng.IAM.WithAddonPolicies.CloudWatch = aws.Bool(true)
+				})
+
+				It("adds PolicyCloudWatch to the role", func() {
+					Expect(ngTemplate.Resources).To(HaveKey("PolicyCloudWatch"))
+
+					Expect(ngTemplate.Resources["PolicyCloudWatch"].Properties.Roles).To(HaveLen(1))
+					Expect(isRefTo(ngTemplate.Resources["PolicyCloudWatch"].Properties.Roles[0], "NodeInstanceRole")).To(BeTrue())
+				})
+			})
+
 			// TODO end
 		})
 

--- a/pkg/cfn/builder/statement.go
+++ b/pkg/cfn/builder/statement.go
@@ -270,6 +270,18 @@ func autoScalerStatements() []cft.MapOfInterfaces {
 	}
 }
 
+func cloudwatchStatements() []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"logs:PutRetentionPolicy",
+			},
+		},
+	}
+}
+
 func appMeshStatements(appendAction string) []cft.MapOfInterfaces {
 	return []cft.MapOfInterfaces{
 		{


### PR DESCRIPTION
### Description

Fixes https://github.com/weaveworks/eksctl/issues/6035 by adding `PutRetentionPolicy` to node role when iam.withAddonPolicies.cloudWatch is true

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

