### PR TITLE
Remove support for heptio-authenticator-aws

### DIFF
--- a/pkg/eks/client_test.go
+++ b/pkg/eks/client_test.go
@@ -85,15 +85,13 @@ var _ = Describe("eks auth helpers", func() {
 					// TODO: This test depends on which authenticator(s) is(are) installed and
 					// the code deciding which one should be picked up. Ideally we'd like to
 					// test all combinations, probably best done with a unit test.
-					Expect(k.AuthInfos[ctx].Exec.Command).To(MatchRegexp("(heptio-authenticator-aws|aws-iam-authenticator|aws)"))
+					Expect(k.AuthInfos[ctx].Exec.Command).To(BeElementOf("aws-iam-authenticator", "aws"))
 
 					var expectedArgs, roleARNArg string
 					switch k.AuthInfos[ctx].Exec.Command {
 					case "aws":
 						expectedArgs = "eks get-token --cluster-name auth-test-cluster --region eu-west-3"
 						roleARNArg = "--role-arn"
-					case "heptio-authenticator-aws":
-						fallthrough
 					case "aws-iam-authenticator":
 						expectedArgs = "token -i auth-test-cluster"
 						roleARNArg = "-r"

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -24,8 +24,6 @@ import (
 const (
 	// AWSIAMAuthenticator defines the name of the AWS IAM authenticator
 	AWSIAMAuthenticator = "aws-iam-authenticator"
-	// HeptioAuthenticatorAWS defines the old name of AWS IAM authenticator
-	HeptioAuthenticatorAWS = "heptio-authenticator-aws"
 	// AWSEKSAuthenticator defines the recently added `aws eks get-token` command
 	AWSEKSAuthenticator = "aws"
 	// AWSIAMAuthenticatorMinimumBetaVersion this is the minimum version at which aws-iam-authenticator uses v1beta1 as APIVersion
@@ -51,11 +49,10 @@ func DefaultPath() string {
 	return clientcmd.RecommendedHomeFile
 }
 
-// AuthenticatorCommands returns all of authenticator commands
+// AuthenticatorCommands returns all authenticator commands.
 func AuthenticatorCommands() []string {
 	return []string{
 		AWSIAMAuthenticator,
-		HeptioAuthenticatorAWS,
 		AWSEKSAuthenticator,
 	}
 }
@@ -189,15 +186,7 @@ func AppendAuthenticator(config *clientcmdapi.Config, cluster ClusterInfo, authe
 				Value: meta.Region,
 			})
 		}
-	case HeptioAuthenticatorAWS:
-		args = []string{"token", "-i", cluster.ID()}
-		roleARNFlag = "-r"
-		if meta.Region != "" {
-			execConfig.Env = append(execConfig.Env, clientcmdapi.ExecEnvVar{
-				Name:  "AWS_DEFAULT_REGION",
-				Value: meta.Region,
-			})
-		}
+
 	case AWSEKSAuthenticator:
 		// if [aws-cli v1/aws-cli v2] is above or equal to [v1.23.9/v2.6.3] respectively, we change the APIVersion to v1beta1.
 		if awsCLIIsBetaVersion, err := awsCliIsAboveVersion(); err != nil {


### PR DESCRIPTION
### Description

eksctl gives preference to `heptio-authenticator-aws` over the AWS CLI when writing the kubeconfig file.  This behaviour is no longer desirable as `heptio-authenticator-aws` was renamed to `aws-iam-authenticator` quite a while back. 

Closes #5859 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

