### PR TITLE
Fix identity provider integration test

### DIFF
--- a/integration/tests/identity_provider/identity_provider_test.go
+++ b/integration/tests/identity_provider/identity_provider_test.go
@@ -135,9 +135,8 @@ var _ = Describe("(Integration) [Identity Provider]", func() {
 			return len(list.Items), nil
 		}, "10m", "20s").Should(Equal(1))
 
-		secrets, err := clientset.CoreV1().Secrets(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+		_, err = clientset.CoreV1().Secrets(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(secrets.Items).NotTo(BeEmpty())
 
 		By("ensuring the client does not have write access")
 		_, err = clientset.CoreV1().ConfigMaps(metav1.NamespaceDefault).Create(context.TODO(), &corev1.ConfigMap{


### PR DESCRIPTION
### Description

Kubernetes 1.24 does not automatically create Secret API objects containing service account tokens for `ServiceAccount`s. This changelist removes the assertion for a non-empty `Secret` list as it's redundant.

Closes #6114 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

