### PR TITLE
Fix 404 karpenter provisioner link in documentation

### DIFF
--- a/userdocs/src/usage/eksctl-karpenter.md
+++ b/userdocs/src/usage/eksctl-karpenter.md
@@ -47,7 +47,7 @@ karpenter:
 
 OIDC must be defined in order to install Karpenter.
 
-Once Karpenter is successfully installed, add a [Provisioner](https://karpenter.sh/docs/provisioner/) so Karpenter
+Once Karpenter is successfully installed, add a [Provisioner](https://karpenter.sh/docs/concepts/provisioners/) so Karpenter
 can start adding the right nodes to the cluster.
 
 The provisioner's `instanceProfile` section must match the created `NodeInstanceProfile` role's name. For example:


### PR DESCRIPTION
### Description
Replaced https://karpenter.sh/docs/provisioner/ with https://karpenter.sh/docs/concepts/provisioners/

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

