### PR TITLE
Append autoscaling tags with PropagateASGTags

### DIFF
--- a/pkg/cfn/builder/nodegroup.go
+++ b/pkg/cfn/builder/nodegroup.go
@@ -260,7 +260,7 @@ func (n *NodeGroupResourceSet) addResourcesForNodeGroup(ctx context.Context) err
 			"PropagateAtLaunch": "true",
 		},
 	}
-	if api.IsEnabled(n.spec.IAM.WithAddonPolicies.AutoScaler) {
+	if api.IsEnabled(n.spec.IAM.WithAddonPolicies.AutoScaler) || api.IsEnabled(n.spec.PropagateASGTags) {
 		tags = append(tags,
 			map[string]string{
 				"Key":               "k8s.io/cluster-autoscaler/enabled",


### PR DESCRIPTION
The current behaviour is to only add the tags

 k8s.io/cluster-autoscaler/enabled = 'true'
 k8s.io/cluster-autoscaler/CLUSTER_NAME = 'owned'

to an ASG when WithAddonPolicies.IAM is enabled. However, the IAM policy is only required for nodes that host the autoscaling controller. Additionally, clusters that don't rely on IAM instance profiles but use OIDC authentication for the autoscaling controller don't need the IAM policy addon at all.
Since we can assume that all nodegroups that have PropagateASGTags enabled are supposed to be auto-scaled it makes sense to also add the autoscaling tags to those ASGs.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

