### PR TITLE
Support for new versions of karpenter

### DIFF
--- a/pkg/karpenter/karpenter.go
+++ b/pkg/karpenter/karpenter.go
@@ -28,6 +28,7 @@ const (
 	serviceAccountAnnotation = "annotations"
 	serviceAccountName       = "name"
 	settings                 = "settings"
+	interruptionQueueName    = "interruptionQueueName"
 )
 
 // Options contains values which Karpenter uses to configure the installation.
@@ -68,6 +69,7 @@ func (k *Installer) Install(ctx context.Context, serviceAccountRoleARN string, i
 		},
 		serviceAccountName: DefaultServiceAccountName,
 	}
+
 	values := map[string]interface{}{
 		clusterName:     k.ClusterConfig.Metadata.Name,
 		clusterEndpoint: k.ClusterConfig.Status.Endpoint,
@@ -79,6 +81,7 @@ func (k *Installer) Install(ctx context.Context, serviceAccountRoleARN string, i
 				defaultInstanceProfile: instanceProfileName,
 				clusterName:            k.ClusterConfig.Metadata.Name,
 				clusterEndpoint:        k.ClusterConfig.Status.Endpoint,
+				interruptionQueueName:  k.ClusterConfig.Metadata.Name,
 			},
 		},
 		serviceAccount: serviceAccountMap,

--- a/pkg/karpenter/karpenter.go
+++ b/pkg/karpenter/karpenter.go
@@ -27,6 +27,7 @@ const (
 	serviceAccount           = "serviceAccount"
 	serviceAccountAnnotation = "annotations"
 	serviceAccountName       = "name"
+	settings                 = "settings"
 )
 
 // Options contains values which Karpenter uses to configure the installation.
@@ -72,6 +73,13 @@ func (k *Installer) Install(ctx context.Context, serviceAccountRoleARN string, i
 		clusterEndpoint: k.ClusterConfig.Status.Endpoint,
 		aws: map[string]interface{}{
 			defaultInstanceProfile: instanceProfileName,
+		},
+		settings: map[string]interface{}{
+			aws: map[string]interface{}{
+				defaultInstanceProfile: instanceProfileName,
+				clusterName:            k.ClusterConfig.Metadata.Name,
+				clusterEndpoint:        k.ClusterConfig.Status.Endpoint,
+			},
 		},
 		serviceAccount: serviceAccountMap,
 	}

--- a/pkg/karpenter/karpenter_test.go
+++ b/pkg/karpenter/karpenter_test.go
@@ -61,6 +61,13 @@ var _ = Describe("Install", func() {
 				aws: map[string]interface{}{
 					defaultInstanceProfile: "role/profile",
 				},
+				settings: map[string]interface{}{
+					aws: map[string]interface{}{
+						defaultInstanceProfile: "role/profile",
+						clusterName:            cfg.Metadata.Name,
+						clusterEndpoint:        cfg.Status.Endpoint,
+					},
+				},
 			}
 			Expect(args).To(Equal(providers.InstallChartOpts{
 				ChartName:       "oci://public.ecr.aws/karpenter/karpenter",
@@ -102,6 +109,13 @@ var _ = Describe("Install", func() {
 					},
 					aws: map[string]interface{}{
 						defaultInstanceProfile: "role/profile",
+					},
+					settings: map[string]interface{}{
+						aws: map[string]interface{}{
+							defaultInstanceProfile: "role/profile",
+							clusterName:            cfg.Metadata.Name,
+							clusterEndpoint:        cfg.Status.Endpoint,
+						},
 					},
 				}
 				Expect(opts.Values).To(Equal(values))

--- a/pkg/karpenter/karpenter_test.go
+++ b/pkg/karpenter/karpenter_test.go
@@ -66,6 +66,7 @@ var _ = Describe("Install", func() {
 						defaultInstanceProfile: "role/profile",
 						clusterName:            cfg.Metadata.Name,
 						clusterEndpoint:        cfg.Status.Endpoint,
+						interruptionQueueName:  cfg.Metadata.Name,
 					},
 				},
 			}
@@ -115,6 +116,7 @@ var _ = Describe("Install", func() {
 							defaultInstanceProfile: "role/profile",
 							clusterName:            cfg.Metadata.Name,
 							clusterEndpoint:        cfg.Status.Endpoint,
+							interruptionQueueName:  cfg.Metadata.Name,
 						},
 					},
 				}


### PR DESCRIPTION
### Description
Added support for newer versions (`> 0.19.0`) of Karpenter by supplying extra `settings`
Manually tested installing versions `0.18.0`, `0.19.0` and `0.20.0` successfully 🎉 

Closes #6033 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

