### PR TITLE
Fix updating kube-proxy to a newer version

### DIFF
--- a/pkg/addons/default/kube_proxy.go
+++ b/pkg/addons/default/kube_proxy.go
@@ -224,7 +224,23 @@ func getLatestImageVersionFromEKS(ctx context.Context, eksAPI awsapi.EKS, contro
 	sort.SliceStable(versions, func(i, j int) bool {
 		return versions[j].LessThan(versions[i])
 	})
-	return versions[0].Original(), nil
+
+	return toMinimalVersion(versions[0]), nil
+}
+
+func toMinimalVersion(v *version.Version) string {
+	preRelease := v.Prerelease()
+	if preRelease == "" {
+		return v.Original()
+	}
+	const versionPrefix = "v"
+	var tagPrefix string
+	if strings.HasPrefix(v.Original(), versionPrefix) {
+		tagPrefix = versionPrefix
+	}
+
+	minimalBuildTag := fmt.Sprintf("%s%s-minimal-%s", tagPrefix, v.Core(), preRelease)
+	return minimalBuildTag
 }
 
 func versionWithOnlyMajorAndMinor(v string) (string, error) {


### PR DESCRIPTION
### Description

The version returned by `DescribeAddonVersions` cannot be used as-is for kube-proxy as it does not always map to the container image version. But for now, it does map to the minimal image tag.

This changelist adds a `minimal` string to the version obtained from `DescribeAddonVersions` to map it to a valid container image.

Fixes #6027


<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

