### PR TITLE
Ldflags -s -w options for make binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ build: generate-always binary ## Generate, lint and build eksctl binary for curr
 
 .PHONY: binary
 binary: ## Build eksctl binary for current OS and place it at ./eksctl
-	CGO_ENABLED=0 go build -ldflags "-X $(version_pkg).gitCommit=$(git_commit) -X $(version_pkg).buildDate=$(build_date)" ./cmd/eksctl
+	CGO_ENABLED=0 go build -ldflags "-s -w -X $(version_pkg).gitCommit=$(git_commit) -X $(version_pkg).buildDate=$(build_date)" ./cmd/eksctl
 
 
 .PHONY: build-all


### PR DESCRIPTION
### Description
Added ldflags `-s -w` options to  `make binary` to reduce the binary size.
These flags are already added in our publish release code so no changes needed elsewhere.

Locally my binary size reduced from 174.4 MB to 143.2 MB

Closes #5757 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

