### PR TITLE
Update availabilityZones example under managed node group

### DIFF
--- a/userdocs/src/usage/eks-managed-nodes.md
+++ b/userdocs/src/usage/eks-managed-nodes.md
@@ -142,6 +142,38 @@ managedNodeGroups:
       /etc/eks/bootstrap.sh managed-cluster --kubelet-extra-args '--node-labels=eks.amazonaws.com/nodegroup=custom-ng,eks.amazonaws.com/nodegroup-image=ami-0e124de4755b2734d'
 ```
 
+If you are requesting an instance type that is only available in one zone (and the eksctl config requires
+specification of two) make sure to add the availability zone to your node group request:
+
+
+```yaml
+# cluster.yaml
+# A cluster with a managed nodegroup with "availabilityZones"
+---
+
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: flux-cluster
+  region: us-east-2
+  version: "1.23"
+ 
+availabilityZones: ["us-east-2b", "us-east-2c"]
+managedNodeGroups:
+  - name: workers
+    instanceType: hpc6a.48xlarge
+    minSize: 64
+    maxSize: 64
+    labels: { "fluxoperator": "true" }
+    availabilityZones: ["us-east-2b"]   
+    efaEnabled: true
+    placement:
+      groupName: eks-efa-testing
+```
+
+This can be true for instance types like [the Hpc6 family](https://aws.amazon.com/ec2/instance-types/hpc6/) that are only available
+in one zone.
 
 ### Existing clusters
 


### PR DESCRIPTION
It is not currently clear to the user that a specific availability zone can be requested under a managed node group. Having spent time / resources and ultimately guessing about this param (and previously having looked on the page and not seeing it) adding this to the documentation would be hugely useful! I made it as a diff in terms of syntax highlighting so it sticks out, but we could also do yaml and then have the user see it. If there is a better place to show this, please let me know!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

