### PR TITLE
 Wait for coredns to be deleted before recreating in Addons integration test

### DIFF
--- a/integration/tests/addons/addons_test.go
+++ b/integration/tests/addons/addons_test.go
@@ -376,6 +376,18 @@ var _ = Describe("(Integration) [EKS Addons test]", func() {
 				)
 			Expect(cmd).To(RunSuccessfully())
 
+			Eventually(func() runner.Cmd {
+				cmd := params.EksctlGetCmd.
+					WithArgs(
+						"addon",
+						"--name", "coredns",
+						"--cluster", clusterName,
+						"--verbose", "2",
+						"--region", params.Region,
+					)
+				return cmd
+			}, "5m", "30s").ShouldNot(RunSuccessfully())
+
 			By("successfully creating an addon with configuration values")
 			clusterConfig := getInitialClusterConfig()
 			clusterConfig.Addons = []*api.Addon{


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Closes https://github.com/weaveworks/eksctl-ci/issues/74

This test spec is occasionally failing because it deletes coredns addon asynchronously and then creates another coredns addon after. Its creation fails with already present as seen above while the status is actually DELETING.
Adding a fix which polls until coredns is actually deleted.

@yuxiang-zhang - thank you for investigating! 🚀 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

