### PR TITLE
Allow all EKS versions to be used for Outposts clusters

### DIFF
--- a/examples/35-outposts.yaml
+++ b/examples/35-outposts.yaml
@@ -10,7 +10,6 @@ kind: ClusterConfig
 metadata:
   name: outpost
   region: us-west-2
-  version: "1.21"
 
 nodeGroups:
   - name: ng

--- a/pkg/apis/eksctl.io/v1alpha5/outposts_validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/outposts_validation_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Outposts validation", func() {
 
 	DescribeTable("unsupported ClusterConfig features", func(oe outpostsEntry) {
 		clusterConfig := api.NewClusterConfig()
-		clusterConfig.Metadata.Version = api.Version1_21
+		clusterConfig.Metadata.Version = api.LatestVersion
 		clusterConfig.Outpost = &api.Outpost{
 			ControlPlaneOutpostARN: "arn:aws:outposts:us-west-2:1234:outpost/op-1234",
 		}
@@ -166,7 +166,7 @@ var _ = Describe("Outposts validation", func() {
 
 	DescribeTable("support for node AMI families", func(amiFamily string, shouldFail bool) {
 		clusterConfig := api.NewClusterConfig()
-		clusterConfig.Metadata.Version = api.Version1_21
+		clusterConfig.Metadata.Version = api.LatestVersion
 		clusterConfig.Outpost = &api.Outpost{
 			ControlPlaneOutpostARN: "arn:aws:outposts:us-west-2:1234:outpost/op-1234",
 		}

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -208,19 +208,7 @@ func ValidateClusterConfig(cfg *ClusterConfig) error {
 
 // ValidateClusterVersion validates the cluster version.
 func ValidateClusterVersion(clusterConfig *ClusterConfig) error {
-	clusterVersion := clusterConfig.Metadata.Version
-	if clusterConfig.IsControlPlaneOnOutposts() {
-		switch clusterVersion {
-		case "":
-			return fmt.Errorf("cluster version must be explicitly set to %[1]s for Outposts clusters as only version %[1]s is currently supported", Version1_21)
-		case Version1_21:
-			return nil
-		default:
-			return fmt.Errorf("only version %s is supported on Outposts", Version1_21)
-		}
-	}
-
-	if clusterVersion != "" && clusterVersion != DefaultVersion && !IsSupportedVersion(clusterVersion) {
+	if clusterVersion := clusterConfig.Metadata.Version; clusterVersion != "" && clusterVersion != DefaultVersion && !IsSupportedVersion(clusterVersion) {
 		if IsDeprecatedVersion(clusterVersion) {
 			return fmt.Errorf("invalid version, %s is no longer supported, supported values: %s\nsee also: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html", clusterVersion, strings.Join(SupportedVersions(), ", "))
 		}

--- a/userdocs/src/usage/outposts.md
+++ b/userdocs/src/usage/outposts.md
@@ -24,7 +24,6 @@ kind: ClusterConfig
 metadata:
   name: outpost
   region: us-west-2
-  version: "1.21"
 
 outpost:
   # Required.
@@ -54,13 +53,9 @@ By default, eksctl attempts to choose the smallest available instance type on Ou
 When the control plane is on Outposts, nodegroups are created on that Outpost. You can optionally specify the Outpost ARN for the nodegroup in `nodeGroup.outpostARN` but it must match the control plane's Outpost ARN.
 
 
-!!!warning
-    Local clusters support EKS 1.21 only. Support for newer versions will be added later.
-
-
 !!!abstract "New"
     [Fully-private cluster support](eks-private-cluster.md)
-    
+
     eksctl now supports creating fully-private clusters on AWS Outposts.
 
 ```yaml
@@ -72,7 +67,6 @@ kind: ClusterConfig
 metadata:
   name: outpost-fully-private
   region: us-west-2
-  version: "1.21"
 
 privateCluster:
   enabled: true
@@ -98,7 +92,6 @@ kind: ClusterConfig
 metadata:
   name: outpost
   region: us-west-2
-  version: "1.21"
 
 outpost:
   # Required.
@@ -160,7 +153,6 @@ kind: ClusterConfig
 metadata:
   name: existing-cluster
   region: us-west-2
-  version: "1.21"
 
 nodeGroups:
   # Nodegroup will be created in an AWS region.
@@ -191,7 +183,6 @@ kind: ClusterConfig
 metadata:
   name: extended-cluster-vpc
   region: us-west-2
-  version: "1.21"
 
 vpc:
   id: vpc-1234


### PR DESCRIPTION
### Description

Allows all EKS versions to be used for Outposts clusters.

Closes #6170 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

