### PR TITLE
Add user docs for Bottlerocket custom AMI support

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -774,6 +774,11 @@ func ValidateNodeGroup(i int, ng *NodeGroup, cfg *ClusterConfig) error {
 		}
 	}
 
+	if ng.Bottlerocket != nil && ng.AMIFamily != NodeImageFamilyBottlerocket {
+		return fmt.Errorf(`bottlerocket config can only be used with amiFamily "Bottlerocket" but found "%s" (path=%s.bottlerocket)`,
+			ng.AMIFamily, path)
+	}
+
 	if ng.AMI != "" && ng.OverrideBootstrapCommand == nil && ng.AMIFamily != NodeImageFamilyBottlerocket && !IsWindowsImage(ng.AMIFamily) {
 		return errors.Errorf("%[1]s.overrideBootstrapCommand is required when using a custom AMI (%[1]s.ami)", path)
 	}
@@ -790,11 +795,6 @@ func ValidateNodeGroup(i int, ng *NodeGroup, cfg *ClusterConfig) error {
 		if err := validateNodeGroupSSH(ng.SSH); err != nil {
 			return err
 		}
-	}
-
-	if ng.Bottlerocket != nil && ng.AMIFamily != NodeImageFamilyBottlerocket {
-		return fmt.Errorf(`bottlerocket config can only be used with amiFamily "Bottlerocket" but found %s (path=%s.bottlerocket)`,
-			ng.AMIFamily, path)
 	}
 
 	if IsWindowsImage(ng.AMIFamily) || ng.AMIFamily == NodeImageFamilyBottlerocket {

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -1733,6 +1733,17 @@ var _ = Describe("ClusterConfig validation", func() {
 	})
 
 	Describe("Bottlerocket node groups", func() {
+		It("returns an error if bottlerocket settings are used with incorrect amiFamily", func() {
+			ng := &api.NodeGroup{
+				NodeGroupBase: &api.NodeGroupBase{
+					Bottlerocket: &api.NodeGroupBottlerocket{},
+				},
+			}
+			err := api.ValidateNodeGroup(0, ng, api.NewClusterConfig())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring(`bottlerocket config can only be used with amiFamily "Bottlerocket"`)))
+		})
+
 		It("returns an error with unsupported fields", func() {
 			cmd := "/usr/bin/some-command"
 			doc := api.InlineDocument{

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -1740,7 +1740,6 @@ var _ = Describe("ClusterConfig validation", func() {
 				},
 			}
 			err := api.ValidateNodeGroup(0, ng, api.NewClusterConfig())
-			Expect(err).ToNot(HaveOccurred())
 			Expect(err).To(MatchError(ContainSubstring(`bottlerocket config can only be used with amiFamily "Bottlerocket"`)))
 		})
 

--- a/userdocs/src/usage/custom-ami-support.md
+++ b/userdocs/src/usage/custom-ami-support.md
@@ -1,13 +1,4 @@
-# Latest & Custom AMI support
-
-!!! warning
-    In a future as yet undecided release **unmanaged** nodegroups created with **custom AmazonLinux2** or **custom Ubuntu** images
-    will need to have the `overrideBootstrapCommand` configuration option set. This is to ensure that nodes are able
-    to join the cluster. For more information and to track this change please see [this issue](https://github.com/weaveworks/eksctl/issues/3563).
-
-    Users setting the `ami` field on **unmanaged** nodegroups to `ami-XXXX` (i.e. setting a custom AMI) will start to see
-    a warning message that they are being sent down a legacy code path. There is no action to take at this time, but in a future
-    release the users seeing this warning will be affected by the above change.
+# Custom AMI support
 
 ## Setting the node AMI ID
 
@@ -24,8 +15,7 @@ The flag can take the AMI image id for an image to explicitly use. It also can t
 
 !!! note
     When setting `--node-ami` to an ID string, `eksctl` will assume that a custom AMI has been requested.
-    For managed nodes this will mean that `overrideBootstrapCommand` is required. For unmanaged nodes
-    `overrideBootstrapCommand` is recommended for AmazonLinux2 and Ubuntu custom images.
+    For AmazonLinux2 and Ubuntu nodes, both EKS managed and self-managed, this will mean that `overrideBootstrapCommand` is required.
 
 CLI flag examples:
 ```sh
@@ -88,3 +78,20 @@ managedNodeGroups:
 ```
 
 The `--node-ami-family` flag can also be used with `eksctl create nodegroup`.
+
+## Bottlerocket custom AMI support
+
+For Bottlerocket nodes, the `overrideBootstrapCommand` is not supported. Instead, to designate their own bootstrap container, one should use the `bottlerocket` field as part of the configuration file. E.g.
+
+```yaml
+  nodeGroups:
+  - name: bottlerocket-ng
+    ami: ami-custom1234
+    amiFamily: Bottlerocket
+    bottlerocket:
+      enableAdminContainer: true
+      settings:
+        bootstrap-containers
+          bootstrap
+            source: <MY-CONTAINER-URI>
+```


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Closes https://github.com/weaveworks/eksctl/issues/6146

Updates the docs regarding Bottlerocket custom AMI support.

Additionally, makes a small tweak to self-manged nodegroup validation so that we return the appropriate error when user doesn't set `amiFamily: Bottlerocket`. 

```yaml
nodeGroups:
  - name: test-bottlerocket-ng
    instanceType: m5.large
    desiredCapacity: 2
    ami: ami-abc123
    bottlerocket:
      enableAdminContainer: true
      settings:
        motd: "hello world!"
```

```
eksctl % ./eksctl create cluster --config-file config.yaml
Error: bottlerocket config can only be used with amiFamily "Bottlerocket" but found "" (path=nodeGroups[0].bottlerocket)
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

