### PR TITLE
Document invalid usage of `--dry-run` with `--profile`

### DIFF
--- a/pkg/ctl/cmdutils/configfile.go
+++ b/pkg/ctl/cmdutils/configfile.go
@@ -383,7 +383,11 @@ func validateZonesAndNodeZones(cmd *cobra.Command) error {
 
 func validateDryRunOptions(cmd *cobra.Command, incompatibleFlags []string) error {
 	if flagName, found := findChangedFlag(cmd, incompatibleFlags); found {
-		return errors.Errorf("cannot use --%s with --dry-run as this option cannot be represented in ClusterConfig", flagName)
+		msg := fmt.Sprintf("cannot use --%s with --dry-run as this option cannot be represented in ClusterConfig", flagName)
+		if flagName == "profile" {
+			msg = fmt.Sprintf("%s: set the AWS_PROFILE environment variable instead", msg)
+		}
+		return errors.New(msg)
 	}
 	return nil
 }

--- a/userdocs/src/usage/dry-run.md
+++ b/userdocs/src/usage/dry-run.md
@@ -86,5 +86,4 @@ $ eksctl create cluster -f generated-cluster.yaml
 When a ClusterConfig file is passed with `--dry-run`, eksctl will output a ClusterConfig file containing the values set in the file.
 
 !!!note
-    There are certain one-off options that cannot be represented in the ClusterConfig file, e.g., `--install-vpc-controllers`. It is expected that `eksctl create cluster --<options...> --dry-run` > config.yaml followed by `eksctl create cluster -f config.yaml` would be equivalent to running the first command without `--dry-run`. eksctl therefore disallows passing options that cannot be represented in the config file when `--dry-run` is passed.
-
+    There are certain one-off options that cannot be represented in the ClusterConfig file, e.g., `--install-vpc-controllers`. It is expected that `eksctl create cluster --<options...> --dry-run` > config.yaml followed by `eksctl create cluster -f config.yaml` would be equivalent to running the first command without `--dry-run`. eksctl therefore disallows passing options that cannot be represented in the config file when `--dry-run` is passed. If you need to pass an AWS profile, set the `AWS_PROFILE` environment variable, instead of passing the `--profile` CLI option.


### PR DESCRIPTION
### Description

Documents invalid usage of `--dry-run` with `--profile`. 

Closes https://github.com/weaveworks/eksctl/issues/6167


### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

