### PR TITLE
Correct cluster and nodegroup name validation

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -713,13 +713,13 @@ func (ue *unsupportedFieldError) Error() string {
 
 // IsInvalidNameArg checks whether the name contains invalid characters
 func IsInvalidNameArg(name string) bool {
-	re := regexp.MustCompile(`[^a-zA-Z0-9\-]+`)
-	return re.MatchString(name)
+	re := regexp.MustCompile(`^([A-Za-z0-9][-A-Za-z0-9]*)?[A-Za-z0-9]$`)
+	return !re.MatchString(name)
 }
 
 // errInvalidName error when invalid characters for a name is provided
 func ErrInvalidName(name string) error {
-	return fmt.Errorf("validation for %s failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*", name)
+	return fmt.Errorf("validation for %s failed, name must satisfy regular expression pattern: ([A-Za-z0-9][-A-Za-z0-9]*)?[A-Za-z0-9]", name)
 }
 
 func validateNodeGroupName(name string) error {

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -53,31 +53,30 @@ var _ = Describe("ClusterConfig validation", func() {
 		})
 	})
 
+
 	Describe("nodeGroups[*].name validation", func() {
 		var (
 			cfg *api.ClusterConfig
+			ng *api.NodeGroup
 			err error
 		)
 
 		BeforeEach(func() {
 			cfg = api.NewClusterConfig()
-			ng0 := cfg.NewNodeGroup()
-			ng0.Name = "ng_invalid-name-10"
-			ng1 := cfg.NewNodeGroup()
-			ng1.Name = "ng100_invalid_name"
-			ng2 := cfg.NewNodeGroup()
-			ng2.Name = "ng100@invalid-name"
+			ng = cfg.NewNodeGroup()
 		})
 
-		It("should reject invalid nodegroup names", func() {
-			err = api.ValidateClusterConfig(cfg)
-			Expect(err).NotTo(HaveOccurred())
+		DescribeTable("rejecting invalid names", 
+			func(ngName string) {
+				ng.Name = ngName
 
-			for i, ng := range cfg.NodeGroups {
-				err = api.ValidateNodeGroup(i, ng, cfg)
+				err = api.ValidateNodeGroup(0, ng, cfg)
 				Expect(err).To(HaveOccurred())
-			}
-		})
+			},
+			Entry("starts with [^A-Za-z0-9]", "-ng-invalid-name-10"),
+			Entry("contains [^A-Za-z0-9\\-]", "ng100_invalid-name"),
+			Entry("ends with [^A-Za-z0-9]", "ng-invalid-name-10--"),
+		)
 	})
 
 	Describe("nodeGroups[*].containerRuntime validation", func() {

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -65,7 +65,7 @@ var _ = Describe("ClusterConfig validation", func() {
 			ng = cfg.NewNodeGroup()
 		})
 
-		DescribeTable("rejecting invalid names", 
+		DescribeTable("rejecting invalid names",
 			func(ngName string) {
 				ng.Name = ngName
 

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -53,11 +53,10 @@ var _ = Describe("ClusterConfig validation", func() {
 		})
 	})
 
-
 	Describe("nodeGroups[*].name validation", func() {
 		var (
 			cfg *api.ClusterConfig
-			ng *api.NodeGroup
+			ng  *api.NodeGroup
 			err error
 		)
 
@@ -76,6 +75,18 @@ var _ = Describe("ClusterConfig validation", func() {
 			Entry("starts with [^A-Za-z0-9]", "-ng-invalid-name-10"),
 			Entry("contains [^A-Za-z0-9\\-]", "ng100_invalid-name"),
 			Entry("ends with [^A-Za-z0-9]", "ng-invalid-name-10--"),
+		)
+
+		DescribeTable("accepting valid names",
+			func(ngName string) {
+				ng.Name = ngName
+
+				err = api.ValidateNodeGroup(0, ng, cfg)
+				Expect(err).NotTo(HaveOccurred())
+			},
+			Entry("starts with [0-9]", "123---123"),
+			Entry("starts and ends with [a-z]", "ng-valid-name"),
+			Entry("starts and ends with [A-Z]", "Ng-valid-name-A"),
 		)
 	})
 

--- a/pkg/ctl/create/nodegroup_test.go
+++ b/pkg/ctl/create/nodegroup_test.go
@@ -91,7 +91,7 @@ var _ = Describe("create nodegroup", func() {
 			}),
 			Entry("with nodegroup name as flag with invalid characters", invalidParamsCase{
 				args:  []string{"--cluster", "clusterName", "--name", "eksctl-ng_k8s_nodegroup1"},
-				error: "validation for eksctl-ng_k8s_nodegroup1 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*",
+				error: "validation for eksctl-ng_k8s_nodegroup1 failed, name must satisfy regular expression pattern: ([A-Za-z0-9][-A-Za-z0-9]*)?[A-Za-z0-9]",
 			}),
 		)
 	})
@@ -163,7 +163,7 @@ var _ = Describe("create nodegroup", func() {
 			}),
 			Entry("with nodegroup name as flag with invalid characters", invalidParamsCase{
 				args:  []string{"--name", "eksctl-ng_k8s_nodegroup1"},
-				error: "validation for eksctl-ng_k8s_nodegroup1 failed, name must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*",
+				error: "validation for eksctl-ng_k8s_nodegroup1 failed, name must satisfy regular expression pattern: ([A-Za-z0-9][-A-Za-z0-9]*)?[A-Za-z0-9]",
 			}),
 			Entry("with version flag", invalidParamsCase{
 				args:  []string{"--version", "1.18"},


### PR DESCRIPTION
### Description
Stems from #6303. 

Corrected the name validation regex to prevent names starting or ending with `-`. 
Added some test cases for name validation. 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

