### PR TITLE
Make 1.25 the default Kubernetes version

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -578,9 +578,9 @@
         },
         "version": {
           "type": "string",
-          "description": "Valid variants are: `\"1.22\"`, `\"1.23\"`, `\"1.24\"` (default), `\"1.25\"`.",
-          "x-intellij-html-description": "Valid variants are: <code>&quot;1.22&quot;</code>, <code>&quot;1.23&quot;</code>, <code>&quot;1.24&quot;</code> (default), <code>&quot;1.25&quot;</code>.",
-          "default": "1.24",
+          "description": "Valid variants are: `\"1.22\"`, `\"1.23\"`, `\"1.24\"`, `\"1.25\"` (default).",
+          "x-intellij-html-description": "Valid variants are: <code>&quot;1.22&quot;</code>, <code>&quot;1.23&quot;</code>, <code>&quot;1.24&quot;</code>, <code>&quot;1.25&quot;</code> (default).",
+          "default": "1.25",
           "enum": [
             "1.22",
             "1.23",

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -40,7 +40,7 @@ const (
 	Version1_25 = "1.25"
 
 	// DefaultVersion (default)
-	DefaultVersion = Version1_24
+	DefaultVersion = Version1_25
 
 	LatestVersion = Version1_25
 

--- a/pkg/ctl/cmdutils/filter/nodegroup_filter_test.go
+++ b/pkg/ctl/cmdutils/filter/nodegroup_filter_test.go
@@ -346,7 +346,7 @@ const expected = `
 		"metadata": {
 		  "name": "test-3x3-ngs",
 		  "region": "eu-central-1",
-		  "version": "1.24"
+		  "version": "1.25"
 		},
 		"kubernetesNetworkConfig": {
         	"ipFamily": "IPv4"

--- a/userdocs/src/introduction.md
+++ b/userdocs/src/introduction.md
@@ -10,7 +10,7 @@ eksctl create cluster --name=cluster-1 --nodes=4
 
 ```
 
-EKS supports versions `1.22`, `1.23`, `1.24` (default) and `1.25`.
+EKS supports versions `1.22`, `1.23`, `1.24` and `1.25` (default).
 With `eksctl` you can deploy any of the supported versions by passing `--version`.
 
 ```

--- a/userdocs/src/usage/kms-encryption.md
+++ b/userdocs/src/usage/kms-encryption.md
@@ -1,7 +1,10 @@
 # KMS Envelope Encryption for EKS clusters
 
-EKS supports using [AWS KMS](https://aws.amazon.com/about-aws/whats-new/2020/03/amazon-eks-adds-envelope-encryption-for-secrets-with-aws-kms/) keys to provide envelope encryption of Kubernetes secrets stored in EKS. Implementing envelope encryption is considered a security best practice for applications that store sensitive data and is part of a [_defense in depth_ security strategy](https://www.us-cert.gov/bsi/articles/knowledge/principles/defense-in-depth).
+EKS supports using [AWS KMS](https://aws.amazon.com/about-aws/whats-new/2021/03/amazon-eks-supports-adding-kms-envelope-encryption-to-existing-clusters/) keys to provide envelope encryption of Kubernetes secrets stored in EKS. Envelope encryption adds an addition, customer-managed layer of encryption for application secrets or user data that is stored within a Kubernetes cluster.
 
+Previously, Amazon EKS supported [enabling envelope encryption](https://aws.amazon.com/about-aws/whats-new/2020/03/amazon-eks-adds-envelope-encryption-for-secrets-with-aws-kms/) using KMS keys only during cluster creation. Now, you can enable envelope encryption for Amazon EKS clusters at any time.
+
+Read more about Using EKS encryption provider support for defense-in-depth post on the [AWS containers blog](https://aws.amazon.com/blogs/containers/using-eks-encryption-provider-support-for-defense-in-depth/).
 
 ## Creating a cluster with KMS encryption enabled
 


### PR DESCRIPTION
### Description
Closes #6371 
Added changes to make 1.25 default K8s version.

Testing
```
$ eksctl create cluster --name default-gini-1-25 --region us-west-2                                                          1 ↵
2023-03-01 15:15:12 [ℹ]  eksctl version 0.133.0-dev+ebbda10fa.2023-03-01T15:13:06Z
2023-03-01 15:15:12 [ℹ]  using region us-west-2
2023-03-01 15:15:13 [ℹ]  setting availability zones to [us-west-2d us-west-2c us-west-2a]
2023-03-01 15:15:13 [ℹ]  subnets for us-west-2d - public:192.168.0.0/19 private:192.168.96.0/19
2023-03-01 15:15:13 [ℹ]  subnets for us-west-2c - public:192.168.32.0/19 private:192.168.128.0/19
2023-03-01 15:15:13 [ℹ]  subnets for us-west-2a - public:192.168.64.0/19 private:192.168.160.0/19
2023-03-01 15:15:13 [ℹ]  nodegroup "ng-4b0e9d29" will use "" [AmazonLinux2/1.25]
2023-03-01 15:15:13 [ℹ]  using Kubernetes version 1.25
...
2023-03-01 15:31:25 [✔]  EKS cluster "default-gini-1-25" in "us-west-2" region is ready
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

