### PR TITLE
Use correct image path in coredns manifest

### DIFF
--- a/pkg/addons/default/assets/coredns-1.25.json
+++ b/pkg/addons/default/assets/coredns-1.25.json
@@ -170,7 +170,7 @@
                   "-conf",
                   "/etc/coredns/Corefile"
                 ],
-                "image": "602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/eks/coredns:v1.9.3-eksbuild.2",
+                "image": "%s.dkr.ecr.%s.%s/eks/coredns:v1.9.3-eksbuild.2",
                 "imagePullPolicy": "IfNotPresent",
                 "livenessProbe": {
                   "failureThreshold": 5,

--- a/pkg/addons/default/testdata/sample-1.25.json
+++ b/pkg/addons/default/testdata/sample-1.25.json
@@ -356,7 +356,7 @@
                   "-conf",
                   "/etc/coredns/Corefile"
                 ],
-                "image": "602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/eks/coredns:v1.9.3-eksbuild.2",
+                "image": "%s.dkr.ecr.%s.%s/eks/coredns:v1.9.3-eksbuild.2",
                 "imagePullPolicy": "IfNotPresent",
                 "livenessProbe": {
                   "failureThreshold": 5,


### PR DESCRIPTION
### Description
Closes #6390 
Fixed the image path for the coredns manifest generated for 1.25

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

