### PR TITLE
Fix cluster argument in addons integration tests

### DIFF
--- a/integration/tests/addons/addons_test.go
+++ b/integration/tests/addons/addons_test.go
@@ -628,7 +628,7 @@ var _ = Describe("(Integration) [EKS Addons test]", func() {
 
 		AfterEach(func() {
 			cmd := params.EksctlDeleteClusterCmd.
-				WithArgs("--cluster", clusterConfig.Metadata.Name).
+				WithArgs("--name", clusterConfig.Metadata.Name).
 				WithArgs("--verbose", "2")
 			Expect(cmd).To(RunSuccessfully())
 		})


### PR DESCRIPTION
### Description

This changelist fixes the `delete cluster` command in the new addons integration test to use `--name`, instead of `--cluster` as the argument. 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

