### PR TITLE
Update Karpenter CFN template to support Spot Interruption Queue

### DIFF
--- a/pkg/cfn/builder/karpenter.go
+++ b/pkg/cfn/builder/karpenter.go
@@ -171,7 +171,7 @@ func (k *KarpenterResourceSet) addResourcesForKarpenter() error {
 		},
 		{
 			"Effect":   effectAllow,
-			"Resource": gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("ARN")),
+			"Resource": gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("Arn")),
 			"Action": []string{
 				sqsDeleteMessage,
 				sqsGetQueueAttributes,
@@ -200,7 +200,7 @@ func (k *KarpenterResourceSet) addResourcesForKarpenter() error {
 				sqsService,
 			},
 		},
-		"Resource": gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("ARN")),
+		"Resource": gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("Arn")),
 		"Action": []string{
 			sqsSendMessage,
 		},
@@ -219,7 +219,7 @@ func (k *KarpenterResourceSet) addResourcesForKarpenter() error {
 		Targets: []gfnevents.Rule_Target{
 			{
 				Id:  gfnt.NewString(KarpenterInterruptionQueueTarget),
-				Arn: gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("ARN")),
+				Arn: gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("Arn")),
 			},
 		},
 	}
@@ -233,7 +233,7 @@ func (k *KarpenterResourceSet) addResourcesForKarpenter() error {
 		Targets: []gfnevents.Rule_Target{
 			{
 				Id:  gfnt.NewString(KarpenterInterruptionQueueTarget),
-				Arn: gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("ARN")),
+				Arn: gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("Arn")),
 			},
 		},
 	}
@@ -247,7 +247,7 @@ func (k *KarpenterResourceSet) addResourcesForKarpenter() error {
 		Targets: []gfnevents.Rule_Target{
 			{
 				Id:  gfnt.NewString(KarpenterInterruptionQueueTarget),
-				Arn: gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("ARN")),
+				Arn: gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("Arn")),
 			},
 		},
 	}
@@ -261,7 +261,7 @@ func (k *KarpenterResourceSet) addResourcesForKarpenter() error {
 		Targets: []gfnevents.Rule_Target{
 			{
 				Id:  gfnt.NewString(KarpenterInterruptionQueueTarget),
-				Arn: gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("ARN")),
+				Arn: gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("Arn")),
 			},
 		},
 	}

--- a/pkg/cfn/builder/karpenter.go
+++ b/pkg/cfn/builder/karpenter.go
@@ -57,7 +57,7 @@ const (
 	// SQS
 	sqsDeleteMessage      = "sqs:DeleteMessage"
 	sqsGetQueueAttributes = "sqs:GetQueueAttributes"
-	sqsGetQueueUrl        = "sqs:GetQueueUrl"
+	sqsGetQueueURL        = "sqs:GetQueueUrl"
 	sqsReceiveMessage     = "sqs:ReceiveMessage"
 	sqsSendMessage        = "sqs:SendMessage"
 )
@@ -175,7 +175,7 @@ func (k *KarpenterResourceSet) addResourcesForKarpenter() error {
 			"Action": []string{
 				sqsDeleteMessage,
 				sqsGetQueueAttributes,
-				sqsGetQueueUrl,
+				sqsGetQueueURL,
 				sqsReceiveMessage,
 			},
 		},

--- a/pkg/cfn/builder/karpenter.go
+++ b/pkg/cfn/builder/karpenter.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	gfn "github.com/weaveworks/goformation/v4/cloudformation"
+	gfnevents "github.com/weaveworks/goformation/v4/cloudformation/events"
 	gfniam "github.com/weaveworks/goformation/v4/cloudformation/iam"
+	gfnsqs "github.com/weaveworks/goformation/v4/cloudformation/sqs"
 	gfnt "github.com/weaveworks/goformation/v4/cloudformation/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -20,6 +22,12 @@ const (
 	KarpenterManagedPolicy = "KarpenterControllerPolicy"
 	// KarpenterNodeInstanceProfile is the name of node instance profile.
 	KarpenterNodeInstanceProfile = "KarpenterNodeInstanceProfile"
+	// KarpenterInterruptionQueue is the name of the interruption queue
+	KarpenterInterruptionQueue = "KarpenterInterruptionQueue"
+	// KarpenterInterruptionQueuePolicy interruption queue policy name
+	KarpenterInterruptionQueuePolicy = "KarpenterInterruptionQueuePolicy"
+	// KarpenterInterruptionQueueTarget interruption queue target ID
+	KarpenterInterruptionQueueTarget = "KarpenterInterruptionQueueTarget"
 )
 
 const (
@@ -46,6 +54,27 @@ const (
 	ssmGetParameter            = "ssm:GetParameter"
 	// Pricing
 	pricingGetProducts = "pricing:GetProducts"
+	// SQS
+	sqsDeleteMessage      = "sqs:DeleteMessage"
+	sqsGetQueueAttributes = "sqs:GetQueueAttributes"
+	sqsGetQueueUrl        = "sqs:GetQueueUrl"
+	sqsReceiveMessage     = "sqs:ReceiveMessage"
+	sqsSendMessage        = "sqs:SendMessage"
+)
+
+const (
+	ScheduledChangeRule     = "ScheduledChangeRule"
+	SpotInterruptionRule    = "SpotInterruptionRule"
+	RebalanceRule           = "RebalanceRule"
+	InstanceStateChangeRule = "InstanceStateChangeRule"
+
+	eventsService = "events.amazonaws.com"
+	sqsService    = "sqs.amazonaws.com"
+
+	awsHealth = "aws.health"
+	awsEC2    = "aws.ec2"
+
+	defaultMessageRetentionPeriod = 300
 )
 
 // KarpenterResourceSet stores the resource information of the Karpenter stack
@@ -114,36 +143,130 @@ func (k *KarpenterResourceSet) addResourcesForKarpenter() error {
 	k.newResource(KarpenterNodeInstanceProfile, &instanceProfile)
 
 	managedPolicyName := gfnt.NewString(fmt.Sprintf("eksctl-%s-%s", KarpenterManagedPolicy, k.clusterSpec.Metadata.Name))
-	statements := cft.MapOfInterfaces{
-		"Effect":   effectAllow,
-		"Resource": resourceAll,
-		"Action": []string{
-			ec2CreateFleet,
-			ec2CreateLaunchTemplate,
-			ec2CreateTags,
-			ec2DescribeAvailabilityZones,
-			ec2DescribeInstanceTypeOfferings,
-			ec2DescribeInstanceTypes,
-			ec2DescribeInstances,
-			ec2DescribeLaunchTemplates,
-			ec2DescribeSecurityGroups,
-			ec2DescribeSubnets,
-			ec2DeleteLaunchTemplate,
-			ec2RunInstances,
-			ec2TerminateInstances,
-			ec2DescribeImages,
-			ec2DescribeSpotPriceHistory,
-			iamPassRole,
-			iamCreateServiceLinkedRole,
-			ssmGetParameter,
-			pricingGetProducts,
+	rolePolicyStatements := []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				ec2CreateFleet,
+				ec2CreateLaunchTemplate,
+				ec2CreateTags,
+				ec2DescribeAvailabilityZones,
+				ec2DescribeInstanceTypeOfferings,
+				ec2DescribeInstanceTypes,
+				ec2DescribeInstances,
+				ec2DescribeLaunchTemplates,
+				ec2DescribeSecurityGroups,
+				ec2DescribeSubnets,
+				ec2DeleteLaunchTemplate,
+				ec2RunInstances,
+				ec2TerminateInstances,
+				ec2DescribeImages,
+				ec2DescribeSpotPriceHistory,
+				iamPassRole,
+				iamCreateServiceLinkedRole,
+				ssmGetParameter,
+				pricingGetProducts,
+			},
+		},
+		{
+			"Effect":   effectAllow,
+			"Resource": gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("ARN")),
+			"Action": []string{
+				sqsDeleteMessage,
+				sqsGetQueueAttributes,
+				sqsGetQueueUrl,
+				sqsReceiveMessage,
+			},
 		},
 	}
 	managedPolicy := gfniam.ManagedPolicy{
 		ManagedPolicyName: managedPolicyName,
-		PolicyDocument:    cft.MakePolicyDocument(statements),
+		PolicyDocument:    cft.MakePolicyDocument(rolePolicyStatements...),
 	}
 	k.newResource(KarpenterManagedPolicy, &managedPolicy)
+
+	interruptionQueue := gfnsqs.Queue{
+		QueueName:              gfnt.NewString(k.clusterSpec.Metadata.Name),
+		MessageRetentionPeriod: gfnt.NewInteger(defaultMessageRetentionPeriod),
+	}
+	queueRef := k.newResource(KarpenterInterruptionQueue, &interruptionQueue)
+
+	queuePolicyStatements := cft.MapOfInterfaces{
+		"Effect": effectAllow,
+		"Principal": cft.MapOfInterfaces{
+			"Service": cft.SliceOfInterfaces{
+				eventsService,
+				sqsService,
+			},
+		},
+		"Resource": gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("ARN")),
+		"Action": []string{
+			sqsSendMessage,
+		},
+	}
+	interruptionQueuePolicy := gfnsqs.QueuePolicy{
+		Queues:         gfnt.NewSlice(queueRef),
+		PolicyDocument: cft.MakePolicyDocument(queuePolicyStatements),
+	}
+	k.newResource(KarpenterInterruptionQueuePolicy, &interruptionQueuePolicy)
+
+	scheduledChangeRule := gfnevents.Rule{
+		EventPattern: cft.MapOfInterfaces{
+			"source":      gfnt.NewSlice(gfnt.NewString(awsHealth)),
+			"detail-type": gfnt.NewSlice(gfnt.NewString("AWS Health Event")),
+		},
+		Targets: []gfnevents.Rule_Target{
+			{
+				Id:  gfnt.NewString(KarpenterInterruptionQueueTarget),
+				Arn: gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("ARN")),
+			},
+		},
+	}
+	k.newResource(ScheduledChangeRule, &scheduledChangeRule)
+
+	spotInterruptionRule := gfnevents.Rule{
+		EventPattern: cft.MapOfInterfaces{
+			"source":      gfnt.NewSlice(gfnt.NewString(awsEC2)),
+			"detail-type": gfnt.NewSlice(gfnt.NewString("EC2 Spot Instance Interruption Warning")),
+		},
+		Targets: []gfnevents.Rule_Target{
+			{
+				Id:  gfnt.NewString(KarpenterInterruptionQueueTarget),
+				Arn: gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("ARN")),
+			},
+		},
+	}
+	k.newResource(SpotInterruptionRule, &spotInterruptionRule)
+
+	rebalanceRule := gfnevents.Rule{
+		EventPattern: cft.MapOfInterfaces{
+			"source":      gfnt.NewSlice(gfnt.NewString(awsEC2)),
+			"detail-type": gfnt.NewSlice(gfnt.NewString("EC2 Instance Rebalance Recommendation")),
+		},
+		Targets: []gfnevents.Rule_Target{
+			{
+				Id:  gfnt.NewString(KarpenterInterruptionQueueTarget),
+				Arn: gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("ARN")),
+			},
+		},
+	}
+	k.newResource(RebalanceRule, &rebalanceRule)
+
+	instanceStateChangeRule := gfnevents.Rule{
+		EventPattern: cft.MapOfInterfaces{
+			"source":      gfnt.NewSlice(gfnt.NewString(awsEC2)),
+			"detail-type": gfnt.NewSlice(gfnt.NewString("EC2 Instance State-change Notification")),
+		},
+		Targets: []gfnevents.Rule_Target{
+			{
+				Id:  gfnt.NewString(KarpenterInterruptionQueueTarget),
+				Arn: gfnt.MakeFnGetAtt(KarpenterInterruptionQueue, gfnt.NewString("ARN")),
+			},
+		},
+	}
+	k.newResource(InstanceStateChangeRule, &instanceStateChangeRule)
+
 	return nil
 }
 

--- a/pkg/cfn/builder/karpenter_test.go
+++ b/pkg/cfn/builder/karpenter_test.go
@@ -96,7 +96,7 @@ var expectedTemplate = `{
             "Arn": {
               "Fn::GetAtt": [
                 "KarpenterInterruptionQueue",
-                "ARN"
+                "Arn"
               ]
             },
             "Id": "KarpenterInterruptionQueueTarget"
@@ -146,7 +146,7 @@ var expectedTemplate = `{
               "Resource": {
                 "Fn::GetAtt": [
                   "KarpenterInterruptionQueue",
-                  "ARN"
+                  "Arn"
                 ]
               }
             }
@@ -189,7 +189,7 @@ var expectedTemplate = `{
               "Resource": {
                 "Fn::GetAtt": [
                   "KarpenterInterruptionQueue",
-                  "ARN"
+                  "Arn"
                 ]
               }
             }
@@ -284,7 +284,7 @@ var expectedTemplate = `{
             "Arn": {
               "Fn::GetAtt": [
                 "KarpenterInterruptionQueue",
-                "ARN"
+                "Arn"
               ]
             },
             "Id": "KarpenterInterruptionQueueTarget"
@@ -308,7 +308,7 @@ var expectedTemplate = `{
             "Arn": {
               "Fn::GetAtt": [
                 "KarpenterInterruptionQueue",
-                "ARN"
+                "Arn"
               ]
             },
             "Id": "KarpenterInterruptionQueueTarget"
@@ -332,7 +332,7 @@ var expectedTemplate = `{
             "Arn": {
               "Fn::GetAtt": [
                 "KarpenterInterruptionQueue",
-                "ARN"
+                "Arn"
               ]
             },
             "Id": "KarpenterInterruptionQueueTarget"
@@ -382,7 +382,7 @@ var expectedTemplateWithPermissionBoundary = `{
             "Arn": {
               "Fn::GetAtt": [
                 "KarpenterInterruptionQueue",
-                "ARN"
+                "Arn"
               ]
             },
             "Id": "KarpenterInterruptionQueueTarget"
@@ -432,7 +432,7 @@ var expectedTemplateWithPermissionBoundary = `{
               "Resource": {
                 "Fn::GetAtt": [
                   "KarpenterInterruptionQueue",
-                  "ARN"
+                  "Arn"
                 ]
               }
             }
@@ -475,7 +475,7 @@ var expectedTemplateWithPermissionBoundary = `{
               "Resource": {
                 "Fn::GetAtt": [
                   "KarpenterInterruptionQueue",
-                  "ARN"
+                  "Arn"
                 ]
               }
             }
@@ -571,7 +571,7 @@ var expectedTemplateWithPermissionBoundary = `{
             "Arn": {
               "Fn::GetAtt": [
                 "KarpenterInterruptionQueue",
-                "ARN"
+                "Arn"
               ]
             },
             "Id": "KarpenterInterruptionQueueTarget"
@@ -595,7 +595,7 @@ var expectedTemplateWithPermissionBoundary = `{
             "Arn": {
               "Fn::GetAtt": [
                 "KarpenterInterruptionQueue",
-                "ARN"
+                "Arn"
               ]
             },
             "Id": "KarpenterInterruptionQueueTarget"
@@ -619,7 +619,7 @@ var expectedTemplateWithPermissionBoundary = `{
             "Arn": {
               "Fn::GetAtt": [
                 "KarpenterInterruptionQueue",
-                "ARN"
+                "Arn"
               ]
             },
             "Id": "KarpenterInterruptionQueueTarget"

--- a/pkg/cfn/builder/karpenter_test.go
+++ b/pkg/cfn/builder/karpenter_test.go
@@ -80,6 +80,30 @@ var expectedTemplate = `{
     }
   },
   "Resources": {
+    "InstanceStateChangeRule": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "EventPattern": {
+          "detail-type": [
+            "EC2 Instance State-change Notification"
+          ],
+          "source": [
+            "aws.ec2"
+          ]
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "KarpenterInterruptionQueue",
+                "ARN"
+              ]
+            },
+            "Id": "KarpenterInterruptionQueueTarget"
+          }
+        ]
+      }
+    },
     "KarpenterControllerPolicy": {
       "Type": "AWS::IAM::ManagedPolicy",
       "Properties": {
@@ -110,10 +134,73 @@ var expectedTemplate = `{
               ],
               "Effect": "Allow",
               "Resource": "*"
+            },
+            {
+              "Action": [
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+                "sqs:ReceiveMessage"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "KarpenterInterruptionQueue",
+                  "ARN"
+                ]
+              }
             }
           ],
           "Version": "2012-10-17"
         }
+      }
+    },
+    "KarpenterInterruptionQueue": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {
+        "MessageRetentionPeriod": 300,
+        "QueueName": "test-karpenter",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}/KarpenterInterruptionQueue"
+            }
+          }
+        ]
+      }
+    },
+    "KarpenterInterruptionQueuePolicy": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:SendMessage"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com",
+                  "sqs.amazonaws.com"
+                ]
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "KarpenterInterruptionQueue",
+                  "ARN"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Queues": [
+          {
+            "Ref": "KarpenterInterruptionQueue"
+          }
+        ]
       }
     },
     "KarpenterNodeInstanceProfile": {
@@ -180,6 +267,78 @@ var expectedTemplate = `{
           }
         ]
       }
+    },
+    "RebalanceRule": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "EventPattern": {
+          "detail-type": [
+            "EC2 Instance Rebalance Recommendation"
+          ],
+          "source": [
+            "aws.ec2"
+          ]
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "KarpenterInterruptionQueue",
+                "ARN"
+              ]
+            },
+            "Id": "KarpenterInterruptionQueueTarget"
+          }
+        ]
+      }
+    },
+    "ScheduledChangeRule": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "EventPattern": {
+          "detail-type": [
+            "AWS Health Event"
+          ],
+          "source": [
+            "aws.health"
+          ]
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "KarpenterInterruptionQueue",
+                "ARN"
+              ]
+            },
+            "Id": "KarpenterInterruptionQueueTarget"
+          }
+        ]
+      }
+    },
+    "SpotInterruptionRule": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "EventPattern": {
+          "detail-type": [
+            "EC2 Spot Instance Interruption Warning"
+          ],
+          "source": [
+            "aws.ec2"
+          ]
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "KarpenterInterruptionQueue",
+                "ARN"
+              ]
+            },
+            "Id": "KarpenterInterruptionQueueTarget"
+          }
+        ]
+      }
     }
   }
 }`
@@ -207,6 +366,30 @@ var expectedTemplateWithPermissionBoundary = `{
     }
   },
   "Resources": {
+    "InstanceStateChangeRule": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "EventPattern": {
+          "detail-type": [
+            "EC2 Instance State-change Notification"
+          ],
+          "source": [
+            "aws.ec2"
+          ]
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "KarpenterInterruptionQueue",
+                "ARN"
+              ]
+            },
+            "Id": "KarpenterInterruptionQueueTarget"
+          }
+        ]
+      }
+    },
     "KarpenterControllerPolicy": {
       "Type": "AWS::IAM::ManagedPolicy",
       "Properties": {
@@ -237,10 +420,73 @@ var expectedTemplateWithPermissionBoundary = `{
               ],
               "Effect": "Allow",
               "Resource": "*"
+            },
+            {
+              "Action": [
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+                "sqs:ReceiveMessage"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "KarpenterInterruptionQueue",
+                  "ARN"
+                ]
+              }
             }
           ],
           "Version": "2012-10-17"
         }
+      }
+    },
+    "KarpenterInterruptionQueue": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {
+        "MessageRetentionPeriod": 300,
+        "QueueName": "test-karpenter",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Sub": "${AWS::StackName}/KarpenterInterruptionQueue"
+            }
+          }
+        ]
+      }
+    },
+    "KarpenterInterruptionQueuePolicy": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:SendMessage"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com",
+                  "sqs.amazonaws.com"
+                ]
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "KarpenterInterruptionQueue",
+                  "ARN"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Queues": [
+          {
+            "Ref": "KarpenterInterruptionQueue"
+          }
+        ]
       }
     },
     "KarpenterNodeInstanceProfile": {
@@ -305,6 +551,78 @@ var expectedTemplateWithPermissionBoundary = `{
             "Value": {
               "Fn::Sub": "${AWS::StackName}/KarpenterNodeRole"
             }
+          }
+        ]
+      }
+    },
+    "RebalanceRule": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "EventPattern": {
+          "detail-type": [
+            "EC2 Instance Rebalance Recommendation"
+          ],
+          "source": [
+            "aws.ec2"
+          ]
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "KarpenterInterruptionQueue",
+                "ARN"
+              ]
+            },
+            "Id": "KarpenterInterruptionQueueTarget"
+          }
+        ]
+      }
+    },
+    "ScheduledChangeRule": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "EventPattern": {
+          "detail-type": [
+            "AWS Health Event"
+          ],
+          "source": [
+            "aws.health"
+          ]
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "KarpenterInterruptionQueue",
+                "ARN"
+              ]
+            },
+            "Id": "KarpenterInterruptionQueueTarget"
+          }
+        ]
+      }
+    },
+    "SpotInterruptionRule": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "EventPattern": {
+          "detail-type": [
+            "EC2 Spot Instance Interruption Warning"
+          ],
+          "source": [
+            "aws.ec2"
+          ]
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "KarpenterInterruptionQueue",
+                "ARN"
+              ]
+            },
+            "Id": "KarpenterInterruptionQueueTarget"
           }
         ]
       }


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Closes https://github.com/weaveworks/eksctl/issues/6373

### Manual Test
`eksctl create cluster --config-file` [config-with-karpenter.yaml](https://github.com/weaveworks/eksctl/blob/main/examples/29-cluster-with-karpenter.yaml)
```
...
2023-03-22 09:10:56 [✔]  EKS cluster "cluster-with-karpenter" in "us-west-2" region is ready
```

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/110664232/226833118-4510882a-3a0a-41b5-bb85-4c50fe15da76.png">


### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

