### PR TITLE
Fix flux version validation

### DIFF
--- a/pkg/awsapi/autoscaling.go
+++ b/pkg/awsapi/autoscaling.go
@@ -10,84 +10,67 @@ import (
 
 // ASG provides an interface to the AWS ASG service.
 type ASG interface {
-	// Attaches one or more EC2 instances to the specified Auto Scaling group. When you
-	// attach instances, Amazon EC2 Auto Scaling increases the desired capacity of the
-	// group by the number of instances being attached. If the number of instances
+	// Attaches one or more EC2 instances to the specified Auto Scaling group. When
+	// you attach instances, Amazon EC2 Auto Scaling increases the desired capacity of
+	// the group by the number of instances being attached. If the number of instances
 	// being attached plus the desired capacity of the group exceeds the maximum size
 	// of the group, the operation fails. If there is a Classic Load Balancer attached
 	// to your Auto Scaling group, the instances are also registered with the load
 	// balancer. If there are target groups attached to your Auto Scaling group, the
 	// instances are also registered with the target groups. For more information, see
-	// Attach EC2 instances to your Auto Scaling group
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/attach-instance-asg.html)
+	// Attach EC2 instances to your Auto Scaling group (https://docs.aws.amazon.com/autoscaling/ec2/userguide/attach-instance-asg.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	AttachInstances(ctx context.Context, params *AttachInstancesInput, optFns ...func(*Options)) (*AttachInstancesOutput, error)
-	// This API call has been replaced with a new "traffic sources" API call
-	// (AttachTrafficSources) that can attach multiple traffic sources types. While we
-	// continue to support AttachLoadBalancerTargetGroups, and you can use both the
-	// original AttachLoadBalancerTargetGroups API call and the new
-	// AttachTrafficSources API call on the same Auto Scaling group, we recommend using
-	// the new "traffic sources" API call to simplify how you manage traffic sources.
-	// Attaches one or more target groups to the specified Auto Scaling group. This
-	// operation is used with the following load balancer types:
+	// This API operation is superseded by AttachTrafficSources , which can attach
+	// multiple traffic sources types. We recommend using AttachTrafficSources to
+	// simplify how you manage traffic sources. However, we continue to support
+	// AttachLoadBalancerTargetGroups . You can use both the original
+	// AttachLoadBalancerTargetGroups API operation and AttachTrafficSources on the
+	// same Auto Scaling group. Attaches one or more target groups to the specified
+	// Auto Scaling group. This operation is used with the following load balancer
+	// types:
+	//   - Application Load Balancer - Operates at the application layer (layer 7) and
+	//     supports HTTP and HTTPS.
+	//   - Network Load Balancer - Operates at the transport layer (layer 4) and
+	//     supports TCP, TLS, and UDP.
+	//   - Gateway Load Balancer - Operates at the network layer (layer 3).
 	//
-	// * Application Load
-	// Balancer - Operates at the application layer (layer 7) and supports HTTP and
-	// HTTPS.
-	//
-	// * Network Load Balancer - Operates at the transport layer (layer 4) and
-	// supports TCP, TLS, and UDP.
-	//
-	// * Gateway Load Balancer - Operates at the network
-	// layer (layer 3).
-	//
-	// To describe the target groups for an Auto Scaling group, call
-	// the DescribeLoadBalancerTargetGroups API. To detach the target group from the
-	// Auto Scaling group, call the DetachLoadBalancerTargetGroups API. This operation
-	// is additive and does not detach existing target groups or Classic Load Balancers
+	// To describe the target groups for an Auto Scaling group, call the
+	// DescribeLoadBalancerTargetGroups API. To detach the target group from the Auto
+	// Scaling group, call the DetachLoadBalancerTargetGroups API. This operation is
+	// additive and does not detach existing target groups or Classic Load Balancers
 	// from the Auto Scaling group. For more information, see Use Elastic Load
-	// Balancing to distribute traffic across the instances in your Auto Scaling group
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-load-balancer.html)
+	// Balancing to distribute traffic across the instances in your Auto Scaling group (https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-load-balancer.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	AttachLoadBalancerTargetGroups(ctx context.Context, params *AttachLoadBalancerTargetGroupsInput, optFns ...func(*Options)) (*AttachLoadBalancerTargetGroupsOutput, error)
-	// This API call has been replaced with a new "traffic sources" API call
-	// (AttachTrafficSources) that can attach multiple traffic sources types. While we
-	// continue to support AttachLoadBalancers, and you can use both the original
-	// AttachLoadBalancers API call and the new AttachTrafficSources API call on the
-	// same Auto Scaling group, we recommend using the new "traffic sources" API call
-	// to simplify how you manage traffic sources. Attaches one or more Classic Load
-	// Balancers to the specified Auto Scaling group. Amazon EC2 Auto Scaling registers
-	// the running instances with these Classic Load Balancers. To describe the load
-	// balancers for an Auto Scaling group, call the DescribeLoadBalancers API. To
-	// detach a load balancer from the Auto Scaling group, call the DetachLoadBalancers
-	// API. This operation is additive and does not detach existing Classic Load
-	// Balancers or target groups from the Auto Scaling group. For more information,
-	// see Use Elastic Load Balancing to distribute traffic across the instances in
-	// your Auto Scaling group
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-load-balancer.html)
+	// This API operation is superseded by AttachTrafficSources , which can attach
+	// multiple traffic sources types. We recommend using AttachTrafficSources to
+	// simplify how you manage traffic sources. However, we continue to support
+	// AttachLoadBalancers . You can use both the original AttachLoadBalancers API
+	// operation and AttachTrafficSources on the same Auto Scaling group. Attaches one
+	// or more Classic Load Balancers to the specified Auto Scaling group. Amazon EC2
+	// Auto Scaling registers the running instances with these Classic Load Balancers.
+	// To describe the load balancers for an Auto Scaling group, call the
+	// DescribeLoadBalancers API. To detach a load balancer from the Auto Scaling
+	// group, call the DetachLoadBalancers API. This operation is additive and does
+	// not detach existing Classic Load Balancers or target groups from the Auto
+	// Scaling group. For more information, see Use Elastic Load Balancing to
+	// distribute traffic across the instances in your Auto Scaling group (https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-load-balancer.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	AttachLoadBalancers(ctx context.Context, params *AttachLoadBalancersInput, optFns ...func(*Options)) (*AttachLoadBalancersOutput, error)
 	// Attaches one or more traffic sources to the specified Auto Scaling group. You
 	// can use any of the following as traffic sources for an Auto Scaling group:
+	//   - Application Load Balancer
+	//   - Classic Load Balancer
+	//   - Gateway Load Balancer
+	//   - Network Load Balancer
+	//   - VPC Lattice
 	//
-	// *
-	// Application Load Balancer
-	//
-	// * Classic Load Balancer
-	//
-	// * Network Load Balancer
-	//
-	// *
-	// Gateway Load Balancer
-	//
-	// * VPC Lattice
-	//
-	// This operation is additive and does not
-	// detach existing traffic sources from the Auto Scaling group. After the operation
-	// completes, use the DescribeTrafficSources API to return details about the state
-	// of the attachments between traffic sources and your Auto Scaling group. To
-	// detach a traffic source from the Auto Scaling group, call the
-	// DetachTrafficSources API.
+	// This operation is additive and does not detach existing traffic sources from
+	// the Auto Scaling group. After the operation completes, use the
+	// DescribeTrafficSources API to return details about the state of the attachments
+	// between traffic sources and your Auto Scaling group. To detach a traffic source
+	// from the Auto Scaling group, call the DetachTrafficSources API.
 	AttachTrafficSources(ctx context.Context, params *AttachTrafficSourcesInput, optFns ...func(*Options)) (*AttachTrafficSourcesOutput, error)
 	// Deletes one or more scheduled actions for the specified Auto Scaling group.
 	BatchDeleteScheduledAction(ctx context.Context, params *BatchDeleteScheduledActionInput, optFns ...func(*Options)) (*BatchDeleteScheduledActionOutput, error)
@@ -96,8 +79,7 @@ type ASG interface {
 	BatchPutScheduledUpdateGroupAction(ctx context.Context, params *BatchPutScheduledUpdateGroupActionInput, optFns ...func(*Options)) (*BatchPutScheduledUpdateGroupActionOutput, error)
 	// Cancels an instance refresh or rollback that is in progress. If an instance
 	// refresh or rollback is not in progress, an ActiveInstanceRefreshNotFound error
-	// occurs. This operation is part of the instance refresh feature
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
+	// occurs. This operation is part of the instance refresh feature (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
 	// in Amazon EC2 Auto Scaling, which helps you update instances in your Auto
 	// Scaling group after you make configuration changes. When you cancel an instance
 	// refresh, this does not roll back any changes that it made. Use the
@@ -106,78 +88,60 @@ type ASG interface {
 	// Completes the lifecycle action for the specified token or instance with the
 	// specified result. This step is a part of the procedure for adding a lifecycle
 	// hook to an Auto Scaling group:
+	//   - (Optional) Create a launch template or launch configuration with a user
+	//     data script that runs while an instance is in a wait state due to a lifecycle
+	//     hook.
+	//   - (Optional) Create a Lambda function and a rule that allows Amazon
+	//     EventBridge to invoke your Lambda function when an instance is put into a wait
+	//     state due to a lifecycle hook.
+	//   - (Optional) Create a notification target and an IAM role. The target can be
+	//     either an Amazon SQS queue or an Amazon SNS topic. The role allows Amazon EC2
+	//     Auto Scaling to publish lifecycle notifications to the target.
+	//   - Create the lifecycle hook. Specify whether the hook is used when the
+	//     instances launch or terminate.
+	//   - If you need more time, record the lifecycle action heartbeat to keep the
+	//     instance in a wait state.
+	//   - If you finish before the timeout period ends, send a callback by using the
+	//     CompleteLifecycleAction API call.
 	//
-	// * (Optional) Create a launch template or launch
-	// configuration with a user data script that runs while an instance is in a wait
-	// state due to a lifecycle hook.
-	//
-	// * (Optional) Create a Lambda function and a rule
-	// that allows Amazon EventBridge to invoke your Lambda function when an instance
-	// is put into a wait state due to a lifecycle hook.
-	//
-	// * (Optional) Create a
-	// notification target and an IAM role. The target can be either an Amazon SQS
-	// queue or an Amazon SNS topic. The role allows Amazon EC2 Auto Scaling to publish
-	// lifecycle notifications to the target.
-	//
-	// * Create the lifecycle hook. Specify
-	// whether the hook is used when the instances launch or terminate.
-	//
-	// * If you need
-	// more time, record the lifecycle action heartbeat to keep the instance in a wait
-	// state.
-	//
-	// * If you finish before the timeout period ends, send a callback by using
-	// the CompleteLifecycleAction API call.
-	//
-	// For more information, see Amazon EC2 Auto
-	// Scaling lifecycle hooks
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/lifecycle-hooks.html) in
-	// the Amazon EC2 Auto Scaling User Guide.
+	// For more information, see Amazon EC2 Auto Scaling lifecycle hooks (https://docs.aws.amazon.com/autoscaling/ec2/userguide/lifecycle-hooks.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	CompleteLifecycleAction(ctx context.Context, params *CompleteLifecycleActionInput, optFns ...func(*Options)) (*CompleteLifecycleActionOutput, error)
 	// We strongly recommend using a launch template when calling this operation to
 	// ensure full functionality for Amazon EC2 Auto Scaling and Amazon EC2. Creates an
 	// Auto Scaling group with the specified name and attributes. If you exceed your
 	// maximum limit of Auto Scaling groups, the call fails. To query this limit, call
 	// the DescribeAccountLimits API. For information about updating this limit, see
-	// Quotas for Amazon EC2 Auto Scaling
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-quotas.html)
+	// Quotas for Amazon EC2 Auto Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-quotas.html)
 	// in the Amazon EC2 Auto Scaling User Guide. For introductory exercises for
-	// creating an Auto Scaling group, see Getting started with Amazon EC2 Auto Scaling
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/GettingStartedTutorial.html)
-	// and Tutorial: Set up a scaled and load-balanced application
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-register-lbs-with-asg.html)
+	// creating an Auto Scaling group, see Getting started with Amazon EC2 Auto Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/GettingStartedTutorial.html)
+	// and Tutorial: Set up a scaled and load-balanced application (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-register-lbs-with-asg.html)
 	// in the Amazon EC2 Auto Scaling User Guide. For more information, see Auto
-	// Scaling groups
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/AutoScalingGroup.html) in
-	// the Amazon EC2 Auto Scaling User Guide. Every Auto Scaling group has three size
-	// properties (DesiredCapacity, MaxSize, and MinSize). Usually, you set these sizes
-	// based on a specific number of instances. However, if you configure a mixed
-	// instances policy that defines weights for the instance types, you must specify
-	// these sizes with the same units that you use for weighting instances.
+	// Scaling groups (https://docs.aws.amazon.com/autoscaling/ec2/userguide/AutoScalingGroup.html)
+	// in the Amazon EC2 Auto Scaling User Guide. Every Auto Scaling group has three
+	// size properties ( DesiredCapacity , MaxSize , and MinSize ). Usually, you set
+	// these sizes based on a specific number of instances. However, if you configure a
+	// mixed instances policy that defines weights for the instance types, you must
+	// specify these sizes with the same units that you use for weighting instances.
 	CreateAutoScalingGroup(ctx context.Context, params *CreateAutoScalingGroupInput, optFns ...func(*Options)) (*CreateAutoScalingGroupOutput, error)
 	// Creates a launch configuration. If you exceed your maximum limit of launch
 	// configurations, the call fails. To query this limit, call the
-	// DescribeAccountLimits API. For information about updating this limit, see Quotas
-	// for Amazon EC2 Auto Scaling
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-quotas.html)
+	// DescribeAccountLimits API. For information about updating this limit, see
+	// Quotas for Amazon EC2 Auto Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-quotas.html)
 	// in the Amazon EC2 Auto Scaling User Guide. For more information, see Launch
-	// configurations
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchConfiguration.html)
+	// configurations (https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchConfiguration.html)
 	// in the Amazon EC2 Auto Scaling User Guide. Amazon EC2 Auto Scaling configures
 	// instances launched as part of an Auto Scaling group using either a launch
 	// template or a launch configuration. We strongly recommend that you do not use
 	// launch configurations. They do not provide full functionality for Amazon EC2
 	// Auto Scaling or Amazon EC2. For information about using launch templates, see
-	// Launch templates
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-templates.html) in
-	// the Amazon EC2 Auto Scaling User Guide.
+	// Launch templates (https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-templates.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	CreateLaunchConfiguration(ctx context.Context, params *CreateLaunchConfigurationInput, optFns ...func(*Options)) (*CreateLaunchConfigurationOutput, error)
-	// Creates or updates tags for the specified Auto Scaling group. When you specify a
-	// tag with a key that already exists, the operation overwrites the previous tag
+	// Creates or updates tags for the specified Auto Scaling group. When you specify
+	// a tag with a key that already exists, the operation overwrites the previous tag
 	// definition, and you do not get an error message. For more information, see Tag
-	// Auto Scaling groups and instances
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-tagging.html)
+	// Auto Scaling groups and instances (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-tagging.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	CreateOrUpdateTags(ctx context.Context, params *CreateOrUpdateTagsInput, optFns ...func(*Options)) (*CreateOrUpdateTagsOutput, error)
 	// Deletes the specified Auto Scaling group. If the group has instances or scaling
@@ -188,29 +152,27 @@ type ASG interface {
 	// it, call the DetachInstances API with the list of instances and the option to
 	// decrement the desired capacity. This ensures that Amazon EC2 Auto Scaling does
 	// not launch replacement instances. To terminate all instances before deleting the
-	// Auto Scaling group, call the UpdateAutoScalingGroup API and set the minimum size
-	// and desired capacity of the Auto Scaling group to zero. If the group has scaling
-	// policies, deleting the group deletes the policies, the underlying alarm actions,
-	// and any alarm that no longer has an associated action. For more information, see
-	// Delete your Auto Scaling infrastructure
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-process-shutdown.html)
+	// Auto Scaling group, call the UpdateAutoScalingGroup API and set the minimum
+	// size and desired capacity of the Auto Scaling group to zero. If the group has
+	// scaling policies, deleting the group deletes the policies, the underlying alarm
+	// actions, and any alarm that no longer has an associated action. For more
+	// information, see Delete your Auto Scaling infrastructure (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-process-shutdown.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	DeleteAutoScalingGroup(ctx context.Context, params *DeleteAutoScalingGroupInput, optFns ...func(*Options)) (*DeleteAutoScalingGroupOutput, error)
-	// Deletes the specified launch configuration. The launch configuration must not be
-	// attached to an Auto Scaling group. When this call completes, the launch
+	// Deletes the specified launch configuration. The launch configuration must not
+	// be attached to an Auto Scaling group. When this call completes, the launch
 	// configuration is no longer available for use.
 	DeleteLaunchConfiguration(ctx context.Context, params *DeleteLaunchConfigurationInput, optFns ...func(*Options)) (*DeleteLaunchConfigurationOutput, error)
 	// Deletes the specified lifecycle hook. If there are any outstanding lifecycle
-	// actions, they are completed first (ABANDON for launching instances, CONTINUE for
-	// terminating instances).
+	// actions, they are completed first ( ABANDON for launching instances, CONTINUE
+	// for terminating instances).
 	DeleteLifecycleHook(ctx context.Context, params *DeleteLifecycleHookInput, optFns ...func(*Options)) (*DeleteLifecycleHookOutput, error)
 	// Deletes the specified notification.
 	DeleteNotificationConfiguration(ctx context.Context, params *DeleteNotificationConfigurationInput, optFns ...func(*Options)) (*DeleteNotificationConfigurationOutput, error)
-	// Deletes the specified scaling policy. Deleting either a step scaling policy or a
-	// simple scaling policy deletes the underlying alarm action, but does not delete
+	// Deletes the specified scaling policy. Deleting either a step scaling policy or
+	// a simple scaling policy deletes the underlying alarm action, but does not delete
 	// the alarm, even if it no longer has an associated action. For more information,
-	// see Deleting a scaling policy
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/deleting-scaling-policy.html)
+	// see Deleting a scaling policy (https://docs.aws.amazon.com/autoscaling/ec2/userguide/deleting-scaling-policy.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	DeletePolicy(ctx context.Context, params *DeletePolicyInput, optFns ...func(*Options)) (*DeletePolicyOutput, error)
 	// Deletes the specified scheduled action.
@@ -218,31 +180,25 @@ type ASG interface {
 	// Deletes the specified tags.
 	DeleteTags(ctx context.Context, params *DeleteTagsInput, optFns ...func(*Options)) (*DeleteTagsOutput, error)
 	// Deletes the warm pool for the specified Auto Scaling group. For more
-	// information, see Warm pools for Amazon EC2 Auto Scaling
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-warm-pools.html)
+	// information, see Warm pools for Amazon EC2 Auto Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-warm-pools.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	DeleteWarmPool(ctx context.Context, params *DeleteWarmPoolInput, optFns ...func(*Options)) (*DeleteWarmPoolOutput, error)
 	// Describes the current Amazon EC2 Auto Scaling resource quotas for your account.
 	// When you establish an Amazon Web Services account, the account has initial
 	// quotas on the maximum number of Auto Scaling groups and launch configurations
 	// that you can create in a given Region. For more information, see Quotas for
-	// Amazon EC2 Auto Scaling
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-quotas.html)
+	// Amazon EC2 Auto Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-quotas.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	DescribeAccountLimits(ctx context.Context, params *DescribeAccountLimitsInput, optFns ...func(*Options)) (*DescribeAccountLimitsOutput, error)
 	// Describes the available adjustment types for step scaling and simple scaling
 	// policies. The following adjustment types are supported:
-	//
-	// * ChangeInCapacity
-	//
-	// *
-	// ExactCapacity
-	//
-	// * PercentChangeInCapacity
+	//   - ChangeInCapacity
+	//   - ExactCapacity
+	//   - PercentChangeInCapacity
 	DescribeAdjustmentTypes(ctx context.Context, params *DescribeAdjustmentTypesInput, optFns ...func(*Options)) (*DescribeAdjustmentTypesOutput, error)
-	// Gets information about the Auto Scaling groups in the account and Region. If you
-	// specify Auto Scaling group names, the output includes information for only the
-	// specified Auto Scaling groups. If you specify filters, the output includes
+	// Gets information about the Auto Scaling groups in the account and Region. If
+	// you specify Auto Scaling group names, the output includes information for only
+	// the specified Auto Scaling groups. If you specify filters, the output includes
 	// information for only those Auto Scaling groups that meet the filter criteria. If
 	// you do not specify group names or filters, the output includes information for
 	// all Auto Scaling groups. This operation also returns information about instances
@@ -254,8 +210,7 @@ type ASG interface {
 	// Describes the notification types that are supported by Amazon EC2 Auto Scaling.
 	DescribeAutoScalingNotificationTypes(ctx context.Context, params *DescribeAutoScalingNotificationTypesInput, optFns ...func(*Options)) (*DescribeAutoScalingNotificationTypesOutput, error)
 	// Gets information about the instance refreshes for the specified Auto Scaling
-	// group. This operation is part of the instance refresh feature
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
+	// group. This operation is part of the instance refresh feature (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
 	// in Amazon EC2 Auto Scaling, which helps you update instances in your Auto
 	// Scaling group after you make configuration changes. To help you determine the
 	// status of an instance refresh, Amazon EC2 Auto Scaling returns information about
@@ -270,75 +225,67 @@ type ASG interface {
 	DescribeLaunchConfigurations(ctx context.Context, params *DescribeLaunchConfigurationsInput, optFns ...func(*Options)) (*DescribeLaunchConfigurationsOutput, error)
 	// Describes the available types of lifecycle hooks. The following hook types are
 	// supported:
-	//
-	// * autoscaling:EC2_INSTANCE_LAUNCHING
-	//
-	// *
-	// autoscaling:EC2_INSTANCE_TERMINATING
+	//   - autoscaling:EC2_INSTANCE_LAUNCHING
+	//   - autoscaling:EC2_INSTANCE_TERMINATING
 	DescribeLifecycleHookTypes(ctx context.Context, params *DescribeLifecycleHookTypesInput, optFns ...func(*Options)) (*DescribeLifecycleHookTypesOutput, error)
 	// Gets information about the lifecycle hooks for the specified Auto Scaling group.
 	DescribeLifecycleHooks(ctx context.Context, params *DescribeLifecycleHooksInput, optFns ...func(*Options)) (*DescribeLifecycleHooksOutput, error)
-	// This API call has been replaced with a new "traffic sources" API call
-	// (DescribeTrafficSources) that can describe multiple traffic sources types. While
-	// we continue to support DescribeLoadBalancerTargetGroups, and you can use both
-	// the original DescribeLoadBalancerTargetGroups API call and the new
-	// DescribeTrafficSources API call on the same Auto Scaling group, we recommend
-	// using the new "traffic sources" API call to simplify how you manage traffic
-	// sources. Gets information about the Elastic Load Balancing target groups for the
-	// specified Auto Scaling group. To determine the attachment status of the target
-	// group, use the State element in the response. When you attach a target group to
-	// an Auto Scaling group, the initial State value is Adding. The state transitions
-	// to Added after all Auto Scaling instances are registered with the target group.
-	// If Elastic Load Balancing health checks are enabled for the Auto Scaling group,
-	// the state transitions to InService after at least one Auto Scaling instance
-	// passes the health check. When the target group is in the InService state, Amazon
-	// EC2 Auto Scaling can terminate and replace any instances that are reported as
-	// unhealthy. If no registered instances pass the health checks, the target group
-	// doesn't enter the InService state. Target groups also have an InService state if
-	// you attach them in the CreateAutoScalingGroup API call. If your target group
-	// state is InService, but it is not working properly, check the scaling activities
-	// by calling DescribeScalingActivities and take any corrective actions necessary.
-	// For help with failed health checks, see Troubleshooting Amazon EC2 Auto Scaling:
-	// Health checks
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ts-as-healthchecks.html)
-	// in the Amazon EC2 Auto Scaling User Guide. For more information, see Use Elastic
-	// Load Balancing to distribute traffic across the instances in your Auto Scaling
-	// group
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-load-balancer.html)
+	// This API operation is superseded by DescribeTrafficSources , which can describe
+	// multiple traffic sources types. We recommend using DetachTrafficSources to
+	// simplify how you manage traffic sources. However, we continue to support
+	// DescribeLoadBalancerTargetGroups . You can use both the original
+	// DescribeLoadBalancerTargetGroups API operation and DescribeTrafficSources on
+	// the same Auto Scaling group. Gets information about the Elastic Load Balancing
+	// target groups for the specified Auto Scaling group. To determine the attachment
+	// status of the target group, use the State element in the response. When you
+	// attach a target group to an Auto Scaling group, the initial State value is
+	// Adding . The state transitions to Added after all Auto Scaling instances are
+	// registered with the target group. If Elastic Load Balancing health checks are
+	// enabled for the Auto Scaling group, the state transitions to InService after at
+	// least one Auto Scaling instance passes the health check. When the target group
+	// is in the InService state, Amazon EC2 Auto Scaling can terminate and replace
+	// any instances that are reported as unhealthy. If no registered instances pass
+	// the health checks, the target group doesn't enter the InService state. Target
+	// groups also have an InService state if you attach them in the
+	// CreateAutoScalingGroup API call. If your target group state is InService , but
+	// it is not working properly, check the scaling activities by calling
+	// DescribeScalingActivities and take any corrective actions necessary. For help
+	// with failed health checks, see Troubleshooting Amazon EC2 Auto Scaling: Health
+	// checks (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ts-as-healthchecks.html)
+	// in the Amazon EC2 Auto Scaling User Guide. For more information, see Use
+	// Elastic Load Balancing to distribute traffic across the instances in your Auto
+	// Scaling group (https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-load-balancer.html)
 	// in the Amazon EC2 Auto Scaling User Guide. You can use this operation to
 	// describe target groups that were attached by using
-	// AttachLoadBalancerTargetGroups, but not for target groups that were attached by
-	// using AttachTrafficSources.
+	// AttachLoadBalancerTargetGroups , but not for target groups that were attached by
+	// using AttachTrafficSources .
 	DescribeLoadBalancerTargetGroups(ctx context.Context, params *DescribeLoadBalancerTargetGroupsInput, optFns ...func(*Options)) (*DescribeLoadBalancerTargetGroupsOutput, error)
-	// This API call has been replaced with a new "traffic sources" API call
-	// (DescribeTrafficSources) that can describe multiple traffic sources types. While
-	// we continue to support DescribeLoadBalancers, and you can use both the original
-	// DescribeLoadBalancers API call and the new DescribeTrafficSources API call on
-	// the same Auto Scaling group, we recommend using the new "traffic sources" API
-	// call to simplify how you manage traffic sources. Gets information about the load
-	// balancers for the specified Auto Scaling group. This operation describes only
-	// Classic Load Balancers. If you have Application Load Balancers, Network Load
-	// Balancers, or Gateway Load Balancers, use the DescribeLoadBalancerTargetGroups
-	// API instead. To determine the attachment status of the load balancer, use the
-	// State element in the response. When you attach a load balancer to an Auto
-	// Scaling group, the initial State value is Adding. The state transitions to Added
-	// after all Auto Scaling instances are registered with the load balancer. If
-	// Elastic Load Balancing health checks are enabled for the Auto Scaling group, the
-	// state transitions to InService after at least one Auto Scaling instance passes
-	// the health check. When the load balancer is in the InService state, Amazon EC2
-	// Auto Scaling can terminate and replace any instances that are reported as
-	// unhealthy. If no registered instances pass the health checks, the load balancer
-	// doesn't enter the InService state. Load balancers also have an InService state
-	// if you attach them in the CreateAutoScalingGroup API call. If your load balancer
-	// state is InService, but it is not working properly, check the scaling activities
-	// by calling DescribeScalingActivities and take any corrective actions necessary.
-	// For help with failed health checks, see Troubleshooting Amazon EC2 Auto Scaling:
-	// Health checks
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ts-as-healthchecks.html)
-	// in the Amazon EC2 Auto Scaling User Guide. For more information, see Use Elastic
-	// Load Balancing to distribute traffic across the instances in your Auto Scaling
-	// group
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-load-balancer.html)
+	// This API operation is superseded by DescribeTrafficSources , which can describe
+	// multiple traffic sources types. We recommend using DescribeTrafficSources to
+	// simplify how you manage traffic sources. However, we continue to support
+	// DescribeLoadBalancers . You can use both the original DescribeLoadBalancers API
+	// operation and DescribeTrafficSources on the same Auto Scaling group. Gets
+	// information about the load balancers for the specified Auto Scaling group. This
+	// operation describes only Classic Load Balancers. If you have Application Load
+	// Balancers, Network Load Balancers, or Gateway Load Balancers, use the
+	// DescribeLoadBalancerTargetGroups API instead. To determine the attachment status
+	// of the load balancer, use the State element in the response. When you attach a
+	// load balancer to an Auto Scaling group, the initial State value is Adding . The
+	// state transitions to Added after all Auto Scaling instances are registered with
+	// the load balancer. If Elastic Load Balancing health checks are enabled for the
+	// Auto Scaling group, the state transitions to InService after at least one Auto
+	// Scaling instance passes the health check. When the load balancer is in the
+	// InService state, Amazon EC2 Auto Scaling can terminate and replace any instances
+	// that are reported as unhealthy. If no registered instances pass the health
+	// checks, the load balancer doesn't enter the InService state. Load balancers
+	// also have an InService state if you attach them in the CreateAutoScalingGroup
+	// API call. If your load balancer state is InService , but it is not working
+	// properly, check the scaling activities by calling DescribeScalingActivities and
+	// take any corrective actions necessary. For help with failed health checks, see
+	// Troubleshooting Amazon EC2 Auto Scaling: Health checks (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ts-as-healthchecks.html)
+	// in the Amazon EC2 Auto Scaling User Guide. For more information, see Use
+	// Elastic Load Balancing to distribute traffic across the instances in your Auto
+	// Scaling group (https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-load-balancer.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	DescribeLoadBalancers(ctx context.Context, params *DescribeLoadBalancersInput, optFns ...func(*Options)) (*DescribeLoadBalancersOutput, error)
 	// Describes the available CloudWatch metrics for Amazon EC2 Auto Scaling.
@@ -351,14 +298,13 @@ type ASG interface {
 	// Gets information about the scaling activities in the account and Region. When
 	// scaling events occur, you see a record of the scaling activity in the scaling
 	// activities. For more information, see Verifying a scaling activity for an Auto
-	// Scaling group
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-verify-scaling-activity.html)
+	// Scaling group (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-verify-scaling-activity.html)
 	// in the Amazon EC2 Auto Scaling User Guide. If the scaling event succeeds, the
-	// value of the StatusCode element in the response is Successful. If an attempt to
+	// value of the StatusCode element in the response is Successful . If an attempt to
 	// launch instances failed, the StatusCode value is Failed or Cancelled and the
 	// StatusMessage element in the response indicates the cause of the failure. For
-	// help interpreting the StatusMessage, see Troubleshooting Amazon EC2 Auto Scaling
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/CHAP_Troubleshooting.html)
+	// help interpreting the StatusMessage , see Troubleshooting Amazon EC2 Auto
+	// Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/CHAP_Troubleshooting.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	DescribeScalingActivities(ctx context.Context, params *DescribeScalingActivitiesInput, optFns ...func(*Options)) (*DescribeScalingActivitiesOutput, error)
 	// Describes the scaling process types for use with the ResumeProcesses and
@@ -374,24 +320,21 @@ type ASG interface {
 	// specified values for it to be included in the results. You can also specify
 	// multiple filters. The result includes information for a particular tag only if
 	// it matches all the filters. If there's no match, no special message is returned.
-	// For more information, see Tag Auto Scaling groups and instances
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-tagging.html)
+	// For more information, see Tag Auto Scaling groups and instances (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-tagging.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	DescribeTags(ctx context.Context, params *DescribeTagsInput, optFns ...func(*Options)) (*DescribeTagsOutput, error)
 	// Describes the termination policies supported by Amazon EC2 Auto Scaling. For
-	// more information, see Work with Amazon EC2 Auto Scaling termination policies
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-termination-policies.html)
+	// more information, see Work with Amazon EC2 Auto Scaling termination policies (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-termination-policies.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	DescribeTerminationPolicyTypes(ctx context.Context, params *DescribeTerminationPolicyTypesInput, optFns ...func(*Options)) (*DescribeTerminationPolicyTypesOutput, error)
-	// Gets information about the traffic sources for the specified Auto Scaling group.
-	// You can optionally provide a traffic source type. If you provide a traffic
-	// source type, then the results only include that traffic source type. If you do
-	// not provide a traffic source type, then the results include all the traffic
-	// sources for the specified Auto Scaling group.
+	// Gets information about the traffic sources for the specified Auto Scaling
+	// group. You can optionally provide a traffic source type. If you provide a
+	// traffic source type, then the results only include that traffic source type. If
+	// you do not provide a traffic source type, then the results include all the
+	// traffic sources for the specified Auto Scaling group.
 	DescribeTrafficSources(ctx context.Context, params *DescribeTrafficSourcesInput, optFns ...func(*Options)) (*DescribeTrafficSourcesOutput, error)
 	// Gets information about a warm pool and its instances. For more information, see
-	// Warm pools for Amazon EC2 Auto Scaling
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-warm-pools.html)
+	// Warm pools for Amazon EC2 Auto Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-warm-pools.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	DescribeWarmPool(ctx context.Context, params *DescribeWarmPoolInput, optFns ...func(*Options)) (*DescribeWarmPoolOutput, error)
 	// Removes one or more instances from the specified Auto Scaling group. After the
@@ -401,41 +344,39 @@ type ASG interface {
 	// detached. If there is a Classic Load Balancer attached to the Auto Scaling
 	// group, the instances are deregistered from the load balancer. If there are
 	// target groups attached to the Auto Scaling group, the instances are deregistered
-	// from the target groups. For more information, see Detach EC2 instances from your
-	// Auto Scaling group
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/detach-instance-asg.html)
+	// from the target groups. For more information, see Detach EC2 instances from
+	// your Auto Scaling group (https://docs.aws.amazon.com/autoscaling/ec2/userguide/detach-instance-asg.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	DetachInstances(ctx context.Context, params *DetachInstancesInput, optFns ...func(*Options)) (*DetachInstancesOutput, error)
-	// This API call has been replaced with a new "traffic sources" API call
-	// (DetachTrafficSources) that can detach multiple traffic sources types. While we
-	// continue to support DetachLoadBalancerTargetGroups, and you can use both the
-	// original DetachLoadBalancerTargetGroups API call and the new
-	// DetachTrafficSources API call on the same Auto Scaling group, we recommend using
-	// the new "traffic sources" API call to simplify how you manage traffic sources.
-	// Detaches one or more target groups from the specified Auto Scaling group. When
-	// you detach a target group, it enters the Removing state while deregistering the
-	// instances in the group. When all instances are deregistered, then you can no
-	// longer describe the target group using the DescribeLoadBalancerTargetGroups API
-	// call. The instances remain running. You can use this operation to detach target
-	// groups that were attached by using AttachLoadBalancerTargetGroups, but not for
-	// target groups that were attached by using AttachTrafficSources.
+	// This API operation is superseded by DetachTrafficSources , which can detach
+	// multiple traffic sources types. We recommend using DetachTrafficSources to
+	// simplify how you manage traffic sources. However, we continue to support
+	// DetachLoadBalancerTargetGroups . You can use both the original
+	// DetachLoadBalancerTargetGroups API operation and DetachTrafficSources on the
+	// same Auto Scaling group. Detaches one or more target groups from the specified
+	// Auto Scaling group. When you detach a target group, it enters the Removing
+	// state while deregistering the instances in the group. When all instances are
+	// deregistered, then you can no longer describe the target group using the
+	// DescribeLoadBalancerTargetGroups API call. The instances remain running. You can
+	// use this operation to detach target groups that were attached by using
+	// AttachLoadBalancerTargetGroups , but not for target groups that were attached by
+	// using AttachTrafficSources .
 	DetachLoadBalancerTargetGroups(ctx context.Context, params *DetachLoadBalancerTargetGroupsInput, optFns ...func(*Options)) (*DetachLoadBalancerTargetGroupsOutput, error)
-	// This API call has been replaced with a new "traffic sources" API call
-	// (DetachTrafficSources) that can detach multiple traffic sources types. While we
-	// continue to support DetachLoadBalancers, and you can use both the original
-	// DetachLoadBalancers API call and the new DetachTrafficSources API call on the
-	// same Auto Scaling group, we recommend using the new "traffic sources" API call
-	// to simplify how you manage traffic sources. Detaches one or more Classic Load
-	// Balancers from the specified Auto Scaling group. This operation detaches only
-	// Classic Load Balancers. If you have Application Load Balancers, Network Load
-	// Balancers, or Gateway Load Balancers, use the DetachLoadBalancerTargetGroups API
-	// instead. When you detach a load balancer, it enters the Removing state while
-	// deregistering the instances in the group. When all instances are deregistered,
-	// then you can no longer describe the load balancer using the
-	// DescribeLoadBalancers API call. The instances remain running.
+	// This API operation is superseded by DetachTrafficSources , which can detach
+	// multiple traffic sources types. We recommend using DetachTrafficSources to
+	// simplify how you manage traffic sources. However, we continue to support
+	// DetachLoadBalancers . You can use both the original DetachLoadBalancers API
+	// operation and DetachTrafficSources on the same Auto Scaling group. Detaches one
+	// or more Classic Load Balancers from the specified Auto Scaling group. This
+	// operation detaches only Classic Load Balancers. If you have Application Load
+	// Balancers, Network Load Balancers, or Gateway Load Balancers, use the
+	// DetachLoadBalancerTargetGroups API instead. When you detach a load balancer, it
+	// enters the Removing state while deregistering the instances in the group. When
+	// all instances are deregistered, then you can no longer describe the load
+	// balancer using the DescribeLoadBalancers API call. The instances remain running.
 	DetachLoadBalancers(ctx context.Context, params *DetachLoadBalancersInput, optFns ...func(*Options)) (*DetachLoadBalancersOutput, error)
-	// Detaches one or more traffic sources from the specified Auto Scaling group. When
-	// you detach a taffic, it enters the Removing state while deregistering the
+	// Detaches one or more traffic sources from the specified Auto Scaling group.
+	// When you detach a taffic, it enters the Removing state while deregistering the
 	// instances in the group. When all instances are deregistered, then you can no
 	// longer describe the traffic source using the DescribeTrafficSources API call.
 	// The instances continue to run.
@@ -446,28 +387,25 @@ type ASG interface {
 	// use these metrics to track changes in an Auto Scaling group and to set alarms on
 	// threshold values. You can view group metrics using the Amazon EC2 Auto Scaling
 	// console or the CloudWatch console. For more information, see Monitor CloudWatch
-	// metrics for your Auto Scaling groups and instances
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-cloudwatch-monitoring.html)
+	// metrics for your Auto Scaling groups and instances (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-cloudwatch-monitoring.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	EnableMetricsCollection(ctx context.Context, params *EnableMetricsCollectionInput, optFns ...func(*Options)) (*EnableMetricsCollectionOutput, error)
-	// Moves the specified instances into the standby state. If you choose to decrement
-	// the desired capacity of the Auto Scaling group, the instances can enter standby
-	// as long as the desired capacity of the Auto Scaling group after the instances
-	// are placed into standby is equal to or greater than the minimum capacity of the
-	// group. If you choose not to decrement the desired capacity of the Auto Scaling
-	// group, the Auto Scaling group launches new instances to replace the instances on
-	// standby. For more information, see Temporarily removing instances from your Auto
-	// Scaling group
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-enter-exit-standby.html)
+	// Moves the specified instances into the standby state. If you choose to
+	// decrement the desired capacity of the Auto Scaling group, the instances can
+	// enter standby as long as the desired capacity of the Auto Scaling group after
+	// the instances are placed into standby is equal to or greater than the minimum
+	// capacity of the group. If you choose not to decrement the desired capacity of
+	// the Auto Scaling group, the Auto Scaling group launches new instances to replace
+	// the instances on standby. For more information, see Temporarily removing
+	// instances from your Auto Scaling group (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-enter-exit-standby.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	EnterStandby(ctx context.Context, params *EnterStandbyInput, optFns ...func(*Options)) (*EnterStandbyOutput, error)
-	// Executes the specified policy. This can be useful for testing the design of your
-	// scaling policy.
+	// Executes the specified policy. This can be useful for testing the design of
+	// your scaling policy.
 	ExecutePolicy(ctx context.Context, params *ExecutePolicyInput, optFns ...func(*Options)) (*ExecutePolicyOutput, error)
 	// Moves the specified instances out of the standby state. After you put the
 	// instances back in service, the desired capacity is incremented. For more
-	// information, see Temporarily removing instances from your Auto Scaling group
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-enter-exit-standby.html)
+	// information, see Temporarily removing instances from your Auto Scaling group (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-enter-exit-standby.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	ExitStandby(ctx context.Context, params *ExitStandbyInput, optFns ...func(*Options)) (*ExitStandbyOutput, error)
 	// Retrieves the forecast data for a predictive scaling policy. Load forecasts are
@@ -476,9 +414,8 @@ type ASG interface {
 	// predicted values for the minimum capacity that is needed on an hourly basis,
 	// based on the hourly load forecast. A minimum of 24 hours of data is required to
 	// create the initial forecasts. However, having a full 14 days of historical data
-	// results in more accurate forecasts. For more information, see Predictive scaling
-	// for Amazon EC2 Auto Scaling
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-predictive-scaling.html)
+	// results in more accurate forecasts. For more information, see Predictive
+	// scaling for Amazon EC2 Auto Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-predictive-scaling.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	GetPredictiveScalingForecast(ctx context.Context, params *GetPredictiveScalingForecastInput, optFns ...func(*Options)) (*GetPredictiveScalingForecastOutput, error)
 	// Creates or updates a lifecycle hook for the specified Auto Scaling group.
@@ -486,35 +423,24 @@ type ASG interface {
 	// Scaling instance lifecycle, and then perform a custom action on instances when
 	// the corresponding lifecycle event occurs. This step is a part of the procedure
 	// for adding a lifecycle hook to an Auto Scaling group:
+	//   - (Optional) Create a launch template or launch configuration with a user
+	//     data script that runs while an instance is in a wait state due to a lifecycle
+	//     hook.
+	//   - (Optional) Create a Lambda function and a rule that allows Amazon
+	//     EventBridge to invoke your Lambda function when an instance is put into a wait
+	//     state due to a lifecycle hook.
+	//   - (Optional) Create a notification target and an IAM role. The target can be
+	//     either an Amazon SQS queue or an Amazon SNS topic. The role allows Amazon EC2
+	//     Auto Scaling to publish lifecycle notifications to the target.
+	//   - Create the lifecycle hook. Specify whether the hook is used when the
+	//     instances launch or terminate.
+	//   - If you need more time, record the lifecycle action heartbeat to keep the
+	//     instance in a wait state using the RecordLifecycleActionHeartbeat API call.
+	//   - If you finish before the timeout period ends, send a callback by using the
+	//     CompleteLifecycleAction API call.
 	//
-	// * (Optional) Create a
-	// launch template or launch configuration with a user data script that runs while
-	// an instance is in a wait state due to a lifecycle hook.
-	//
-	// * (Optional) Create a
-	// Lambda function and a rule that allows Amazon EventBridge to invoke your Lambda
-	// function when an instance is put into a wait state due to a lifecycle hook.
-	//
-	// *
-	// (Optional) Create a notification target and an IAM role. The target can be
-	// either an Amazon SQS queue or an Amazon SNS topic. The role allows Amazon EC2
-	// Auto Scaling to publish lifecycle notifications to the target.
-	//
-	// * Create the
-	// lifecycle hook. Specify whether the hook is used when the instances launch or
-	// terminate.
-	//
-	// * If you need more time, record the lifecycle action heartbeat to
-	// keep the instance in a wait state using the RecordLifecycleActionHeartbeat API
-	// call.
-	//
-	// * If you finish before the timeout period ends, send a callback by using
-	// the CompleteLifecycleAction API call.
-	//
-	// For more information, see Amazon EC2 Auto
-	// Scaling lifecycle hooks
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/lifecycle-hooks.html) in
-	// the Amazon EC2 Auto Scaling User Guide. If you exceed your maximum limit of
+	// For more information, see Amazon EC2 Auto Scaling lifecycle hooks (https://docs.aws.amazon.com/autoscaling/ec2/userguide/lifecycle-hooks.html)
+	// in the Amazon EC2 Auto Scaling User Guide. If you exceed your maximum limit of
 	// lifecycle hooks, which by default is 50 per Auto Scaling group, the call fails.
 	// You can view the lifecycle hooks for an Auto Scaling group using the
 	// DescribeLifecycleHooks API call. If you are no longer using a lifecycle hook,
@@ -524,8 +450,7 @@ type ASG interface {
 	// take place. Subscribers to the specified topic can have messages delivered to an
 	// endpoint such as a web server or an email address. This configuration overwrites
 	// any existing configuration. For more information, see Getting Amazon SNS
-	// notifications when your Auto Scaling group scales
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ASGettingNotifications.html)
+	// notifications when your Auto Scaling group scales (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ASGettingNotifications.html)
 	// in the Amazon EC2 Auto Scaling User Guide. If you exceed your maximum limit of
 	// SNS topics, which is 10 per Auto Scaling group, the call fails.
 	PutNotificationConfiguration(ctx context.Context, params *PutNotificationConfigurationInput, optFns ...func(*Options)) (*PutNotificationConfigurationOutput, error)
@@ -533,32 +458,28 @@ type ASG interface {
 	// are used to scale an Auto Scaling group based on configurable metrics. If no
 	// policies are defined, the dynamic scaling and predictive scaling features are
 	// not used. For more information about using dynamic scaling, see Target tracking
-	// scaling policies
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-target-tracking.html)
-	// and Step and simple scaling policies
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-simple-step.html)
+	// scaling policies (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-target-tracking.html)
+	// and Step and simple scaling policies (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-simple-step.html)
 	// in the Amazon EC2 Auto Scaling User Guide. For more information about using
-	// predictive scaling, see Predictive scaling for Amazon EC2 Auto Scaling
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-predictive-scaling.html)
+	// predictive scaling, see Predictive scaling for Amazon EC2 Auto Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-predictive-scaling.html)
 	// in the Amazon EC2 Auto Scaling User Guide. You can view the scaling policies for
 	// an Auto Scaling group using the DescribePolicies API call. If you are no longer
 	// using a scaling policy, you can delete it by calling the DeletePolicy API.
 	PutScalingPolicy(ctx context.Context, params *PutScalingPolicyInput, optFns ...func(*Options)) (*PutScalingPolicyOutput, error)
 	// Creates or updates a scheduled scaling action for an Auto Scaling group. For
-	// more information, see Scheduled scaling
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/schedule_time.html) in
-	// the Amazon EC2 Auto Scaling User Guide. You can view the scheduled actions for
-	// an Auto Scaling group using the DescribeScheduledActions API call. If you are no
-	// longer using a scheduled action, you can delete it by calling the
+	// more information, see Scheduled scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/schedule_time.html)
+	// in the Amazon EC2 Auto Scaling User Guide. You can view the scheduled actions
+	// for an Auto Scaling group using the DescribeScheduledActions API call. If you
+	// are no longer using a scheduled action, you can delete it by calling the
 	// DeleteScheduledAction API. If you try to schedule your action in the past,
 	// Amazon EC2 Auto Scaling returns an error message.
 	PutScheduledUpdateGroupAction(ctx context.Context, params *PutScheduledUpdateGroupActionInput, optFns ...func(*Options)) (*PutScheduledUpdateGroupActionOutput, error)
-	// Creates or updates a warm pool for the specified Auto Scaling group. A warm pool
-	// is a pool of pre-initialized EC2 instances that sits alongside the Auto Scaling
-	// group. Whenever your application needs to scale out, the Auto Scaling group can
-	// draw on the warm pool to meet its new desired capacity. For more information and
-	// example configurations, see Warm pools for Amazon EC2 Auto Scaling
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-warm-pools.html)
+	// Creates or updates a warm pool for the specified Auto Scaling group. A warm
+	// pool is a pool of pre-initialized EC2 instances that sits alongside the Auto
+	// Scaling group. Whenever your application needs to scale out, the Auto Scaling
+	// group can draw on the warm pool to meet its new desired capacity. For more
+	// information and example configurations, see Warm pools for Amazon EC2 Auto
+	// Scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-warm-pools.html)
 	// in the Amazon EC2 Auto Scaling User Guide. This operation must be called from
 	// the Region in which the Auto Scaling group was created. This operation cannot be
 	// called on an Auto Scaling group that has a mixed instances policy or a launch
@@ -566,96 +487,75 @@ type ASG interface {
 	// instances in the warm pool using the DescribeWarmPool API call. If you are no
 	// longer using a warm pool, you can delete it by calling the DeleteWarmPool API.
 	PutWarmPool(ctx context.Context, params *PutWarmPoolInput, optFns ...func(*Options)) (*PutWarmPoolOutput, error)
-	// Records a heartbeat for the lifecycle action associated with the specified token
-	// or instance. This extends the timeout by the length of time defined using the
-	// PutLifecycleHook API call. This step is a part of the procedure for adding a
-	// lifecycle hook to an Auto Scaling group:
+	// Records a heartbeat for the lifecycle action associated with the specified
+	// token or instance. This extends the timeout by the length of time defined using
+	// the PutLifecycleHook API call. This step is a part of the procedure for adding
+	// a lifecycle hook to an Auto Scaling group:
+	//   - (Optional) Create a launch template or launch configuration with a user
+	//     data script that runs while an instance is in a wait state due to a lifecycle
+	//     hook.
+	//   - (Optional) Create a Lambda function and a rule that allows Amazon
+	//     EventBridge to invoke your Lambda function when an instance is put into a wait
+	//     state due to a lifecycle hook.
+	//   - (Optional) Create a notification target and an IAM role. The target can be
+	//     either an Amazon SQS queue or an Amazon SNS topic. The role allows Amazon EC2
+	//     Auto Scaling to publish lifecycle notifications to the target.
+	//   - Create the lifecycle hook. Specify whether the hook is used when the
+	//     instances launch or terminate.
+	//   - If you need more time, record the lifecycle action heartbeat to keep the
+	//     instance in a wait state.
+	//   - If you finish before the timeout period ends, send a callback by using the
+	//     CompleteLifecycleAction API call.
 	//
-	// * (Optional) Create a launch template
-	// or launch configuration with a user data script that runs while an instance is
-	// in a wait state due to a lifecycle hook.
-	//
-	// * (Optional) Create a Lambda function
-	// and a rule that allows Amazon EventBridge to invoke your Lambda function when an
-	// instance is put into a wait state due to a lifecycle hook.
-	//
-	// * (Optional) Create
-	// a notification target and an IAM role. The target can be either an Amazon SQS
-	// queue or an Amazon SNS topic. The role allows Amazon EC2 Auto Scaling to publish
-	// lifecycle notifications to the target.
-	//
-	// * Create the lifecycle hook. Specify
-	// whether the hook is used when the instances launch or terminate.
-	//
-	// * If you need
-	// more time, record the lifecycle action heartbeat to keep the instance in a wait
-	// state.
-	//
-	// * If you finish before the timeout period ends, send a callback by using
-	// the CompleteLifecycleAction API call.
-	//
-	// For more information, see Amazon EC2 Auto
-	// Scaling lifecycle hooks
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/lifecycle-hooks.html) in
-	// the Amazon EC2 Auto Scaling User Guide.
+	// For more information, see Amazon EC2 Auto Scaling lifecycle hooks (https://docs.aws.amazon.com/autoscaling/ec2/userguide/lifecycle-hooks.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	RecordLifecycleActionHeartbeat(ctx context.Context, params *RecordLifecycleActionHeartbeatInput, optFns ...func(*Options)) (*RecordLifecycleActionHeartbeatOutput, error)
 	// Resumes the specified suspended auto scaling processes, or all suspended
 	// process, for the specified Auto Scaling group. For more information, see
-	// Suspending and resuming scaling processes
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-suspend-resume-processes.html)
+	// Suspending and resuming scaling processes (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-suspend-resume-processes.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	ResumeProcesses(ctx context.Context, params *ResumeProcessesInput, optFns ...func(*Options)) (*ResumeProcessesOutput, error)
 	// Cancels an instance refresh that is in progress and rolls back any changes that
 	// it made. Amazon EC2 Auto Scaling replaces any instances that were replaced
 	// during the instance refresh. This restores your Auto Scaling group to the
 	// configuration that it was using before the start of the instance refresh. This
-	// operation is part of the instance refresh feature
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
+	// operation is part of the instance refresh feature (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
 	// in Amazon EC2 Auto Scaling, which helps you update instances in your Auto
 	// Scaling group after you make configuration changes. A rollback is not supported
 	// in the following situations:
+	//   - There is no desired configuration specified for the instance refresh.
+	//   - The Auto Scaling group has a launch template that uses an Amazon Web
+	//     Services Systems Manager parameter instead of an AMI ID for the ImageId
+	//     property.
+	//   - The Auto Scaling group uses the launch template's $Latest or $Default
+	//     version.
 	//
-	// * There is no desired configuration specified for
-	// the instance refresh.
-	//
-	// * The Auto Scaling group has a launch template that uses
-	// an Amazon Web Services Systems Manager parameter instead of an AMI ID for the
-	// ImageId property.
-	//
-	// * The Auto Scaling group uses the launch template's $Latest
-	// or $Default version.
-	//
-	// When you receive a successful response from this
-	// operation, Amazon EC2 Auto Scaling immediately begins replacing instances. You
-	// can check the status of this operation through the DescribeInstanceRefreshes API
-	// operation.
+	// When you receive a successful response from this operation, Amazon EC2 Auto
+	// Scaling immediately begins replacing instances. You can check the status of this
+	// operation through the DescribeInstanceRefreshes API operation.
 	RollbackInstanceRefresh(ctx context.Context, params *RollbackInstanceRefreshInput, optFns ...func(*Options)) (*RollbackInstanceRefreshOutput, error)
-	// Sets the size of the specified Auto Scaling group. If a scale-in activity occurs
-	// as a result of a new DesiredCapacity value that is lower than the current size
-	// of the group, the Auto Scaling group uses its termination policy to determine
-	// which instances to terminate. For more information, see Manual scaling
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-manual-scaling.html)
+	// Sets the size of the specified Auto Scaling group. If a scale-in activity
+	// occurs as a result of a new DesiredCapacity value that is lower than the
+	// current size of the group, the Auto Scaling group uses its termination policy to
+	// determine which instances to terminate. For more information, see Manual scaling (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-manual-scaling.html)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	SetDesiredCapacity(ctx context.Context, params *SetDesiredCapacityInput, optFns ...func(*Options)) (*SetDesiredCapacityOutput, error)
 	// Sets the health status of the specified instance. For more information, see
-	// Health checks for Auto Scaling instances
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/healthcheck.html) in the
-	// Amazon EC2 Auto Scaling User Guide.
+	// Health checks for Auto Scaling instances (https://docs.aws.amazon.com/autoscaling/ec2/userguide/healthcheck.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	SetInstanceHealth(ctx context.Context, params *SetInstanceHealthInput, optFns ...func(*Options)) (*SetInstanceHealthOutput, error)
 	// Updates the instance protection settings of the specified instances. This
 	// operation cannot be called on instances in a warm pool. For more information
 	// about preventing instances that are part of an Auto Scaling group from
-	// terminating on scale in, see Using instance scale-in protection
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-instance-protection.html)
+	// terminating on scale in, see Using instance scale-in protection (https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-instance-protection.html)
 	// in the Amazon EC2 Auto Scaling User Guide. If you exceed your maximum limit of
 	// instance IDs, which is 50 per Auto Scaling group, the call fails.
 	SetInstanceProtection(ctx context.Context, params *SetInstanceProtectionInput, optFns ...func(*Options)) (*SetInstanceProtectionOutput, error)
 	// Starts an instance refresh. During an instance refresh, Amazon EC2 Auto Scaling
 	// performs a rolling update of instances in an Auto Scaling group. Instances are
 	// terminated first and then replaced, which temporarily reduces the capacity
-	// available within your Auto Scaling group. This operation is part of the instance
-	// refresh feature
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
+	// available within your Auto Scaling group. This operation is part of the
+	// instance refresh feature (https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html)
 	// in Amazon EC2 Auto Scaling, which helps you update instances in your Auto
 	// Scaling group. This feature is helpful, for example, when you have a new AMI or
 	// a new user data script. You just need to create a new launch template that
@@ -670,34 +570,32 @@ type ASG interface {
 	// misconfigured health checks, or not ignoring or allowing the termination of
 	// instances that are in Standby state or protected from scale in. You can monitor
 	// for failed EC2 launches using the scaling activities. To find the scaling
-	// activities, call the DescribeScalingActivities API. If you enable auto rollback,
-	// your Auto Scaling group will be rolled back automatically when the instance
-	// refresh fails. You can enable this feature before starting an instance refresh
-	// by specifying the AutoRollback property in the instance refresh preferences.
-	// Otherwise, to roll back an instance refresh before it finishes, use the
-	// RollbackInstanceRefresh API.
+	// activities, call the DescribeScalingActivities API. If you enable auto
+	// rollback, your Auto Scaling group will be rolled back automatically when the
+	// instance refresh fails. You can enable this feature before starting an instance
+	// refresh by specifying the AutoRollback property in the instance refresh
+	// preferences. Otherwise, to roll back an instance refresh before it finishes, use
+	// the RollbackInstanceRefresh API.
 	StartInstanceRefresh(ctx context.Context, params *StartInstanceRefreshInput, optFns ...func(*Options)) (*StartInstanceRefreshOutput, error)
 	// Suspends the specified auto scaling processes, or all processes, for the
 	// specified Auto Scaling group. If you suspend either the Launch or Terminate
 	// process types, it can prevent other process types from functioning properly. For
-	// more information, see Suspending and resuming scaling processes
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-suspend-resume-processes.html)
+	// more information, see Suspending and resuming scaling processes (https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-suspend-resume-processes.html)
 	// in the Amazon EC2 Auto Scaling User Guide. To resume processes that have been
 	// suspended, call the ResumeProcesses API.
 	SuspendProcesses(ctx context.Context, params *SuspendProcessesInput, optFns ...func(*Options)) (*SuspendProcessesOutput, error)
-	// Terminates the specified instance and optionally adjusts the desired group size.
-	// This operation cannot be called on instances in a warm pool. This call simply
-	// makes a termination request. The instance is not terminated immediately. When an
-	// instance is terminated, the instance status changes to terminated. You can't
-	// connect to or start an instance after you've terminated it. If you do not
+	// Terminates the specified instance and optionally adjusts the desired group
+	// size. This operation cannot be called on instances in a warm pool. This call
+	// simply makes a termination request. The instance is not terminated immediately.
+	// When an instance is terminated, the instance status changes to terminated . You
+	// can't connect to or start an instance after you've terminated it. If you do not
 	// specify the option to decrement the desired capacity, Amazon EC2 Auto Scaling
 	// launches instances to replace the ones that are terminated. By default, Amazon
 	// EC2 Auto Scaling balances instances across all Availability Zones. If you
 	// decrement the desired capacity, your Auto Scaling group can become unbalanced
 	// between Availability Zones. Amazon EC2 Auto Scaling tries to rebalance the
 	// group, and rebalancing might terminate instances in other zones. For more
-	// information, see Rebalancing activities
-	// (https://docs.aws.amazon.com/autoscaling/ec2/userguide/auto-scaling-benefits.html#AutoScalingBehavior.InstanceUsage)
+	// information, see Rebalancing activities (https://docs.aws.amazon.com/autoscaling/ec2/userguide/auto-scaling-benefits.html#AutoScalingBehavior.InstanceUsage)
 	// in the Amazon EC2 Auto Scaling User Guide.
 	TerminateInstanceInAutoScalingGroup(ctx context.Context, params *TerminateInstanceInAutoScalingGroupInput, optFns ...func(*Options)) (*TerminateInstanceInAutoScalingGroupOutput, error)
 	// We strongly recommend that all Auto Scaling groups use launch templates to
@@ -717,27 +615,22 @@ type ASG interface {
 	// gradually terminated and relaunched as Spot Instances. When replacing instances,
 	// Amazon EC2 Auto Scaling launches new instances before terminating the old ones,
 	// so that updating your group does not compromise the performance or availability
-	// of your application. Note the following about changing DesiredCapacity, MaxSize,
-	// or MinSize:
+	// of your application. Note the following about changing DesiredCapacity , MaxSize
+	// , or MinSize :
+	//   - If a scale-in activity occurs as a result of a new DesiredCapacity value
+	//     that is lower than the current size of the group, the Auto Scaling group uses
+	//     its termination policy to determine which instances to terminate.
+	//   - If you specify a new value for MinSize without specifying a value for
+	//     DesiredCapacity , and the new MinSize is larger than the current size of the
+	//     group, this sets the group's DesiredCapacity to the new MinSize value.
+	//   - If you specify a new value for MaxSize without specifying a value for
+	//     DesiredCapacity , and the new MaxSize is smaller than the current size of the
+	//     group, this sets the group's DesiredCapacity to the new MaxSize value.
 	//
-	// * If a scale-in activity occurs as a result of a new
-	// DesiredCapacity value that is lower than the current size of the group, the Auto
-	// Scaling group uses its termination policy to determine which instances to
-	// terminate.
-	//
-	// * If you specify a new value for MinSize without specifying a value
-	// for DesiredCapacity, and the new MinSize is larger than the current size of the
-	// group, this sets the group's DesiredCapacity to the new MinSize value.
-	//
-	// * If you
-	// specify a new value for MaxSize without specifying a value for DesiredCapacity,
-	// and the new MaxSize is smaller than the current size of the group, this sets the
-	// group's DesiredCapacity to the new MaxSize value.
-	//
-	// To see which properties have
-	// been set, call the DescribeAutoScalingGroups API. To view the scaling policies
-	// for an Auto Scaling group, call the DescribePolicies API. If the group has
-	// scaling policies, you can update them by calling the PutScalingPolicy API.
+	// To see which properties have been set, call the DescribeAutoScalingGroups API.
+	// To view the scaling policies for an Auto Scaling group, call the
+	// DescribePolicies API. If the group has scaling policies, you can update them by
+	// calling the PutScalingPolicy API.
 	UpdateAutoScalingGroup(ctx context.Context, params *UpdateAutoScalingGroupInput, optFns ...func(*Options)) (*UpdateAutoScalingGroupOutput, error)
 }
 

--- a/pkg/awsapi/cloudformation.go
+++ b/pkg/awsapi/cloudformation.go
@@ -11,19 +11,16 @@ import (
 // CloudFormation provides an interface to the AWS CloudFormation service.
 type CloudFormation interface {
 	// Activates a public third-party extension, making it available for use in stack
-	// templates. For more information, see Using public extensions
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html)
+	// templates. For more information, see Using public extensions (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html)
 	// in the CloudFormation User Guide. Once you have activated a public third-party
 	// extension in your account and region, use SetTypeConfiguration to specify
 	// configuration properties for the extension. For more information, see
-	// Configuring extensions at the account level
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-register.html#registry-set-configuration)
+	// Configuring extensions at the account level (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-register.html#registry-set-configuration)
 	// in the CloudFormation User Guide.
 	ActivateType(ctx context.Context, params *ActivateTypeInput, optFns ...func(*Options)) (*ActivateTypeOutput, error)
-	// Returns configuration data for the specified CloudFormation extensions, from the
-	// CloudFormation registry for the account and region. For more information, see
-	// Configuring extensions at the account level
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-register.html#registry-set-configuration)
+	// Returns configuration data for the specified CloudFormation extensions, from
+	// the CloudFormation registry for the account and region. For more information,
+	// see Configuring extensions at the account level (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-register.html#registry-set-configuration)
 	// in the CloudFormation User Guide.
 	BatchDescribeTypeConfigurations(ctx context.Context, params *BatchDescribeTypeConfigurationsInput, optFns ...func(*Options)) (*BatchDescribeTypeConfigurationsOutput, error)
 	// Cancels an update on the specified stack. If the call completes successfully,
@@ -31,9 +28,8 @@ type CloudFormation interface {
 	// You can cancel only stacks that are in the UPDATE_IN_PROGRESS state.
 	CancelUpdateStack(ctx context.Context, params *CancelUpdateStackInput, optFns ...func(*Options)) (*CancelUpdateStackOutput, error)
 	// For a specified stack that's in the UPDATE_ROLLBACK_FAILED state, continues
-	// rolling it back to the UPDATE_ROLLBACK_COMPLETE state. Depending on the cause of
-	// the failure, you can manually  fix the error
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/troubleshooting.html#troubleshooting-errors-update-rollback-failed)
+	// rolling it back to the UPDATE_ROLLBACK_COMPLETE state. Depending on the cause
+	// of the failure, you can manually fix the error (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/troubleshooting.html#troubleshooting-errors-update-rollback-failed)
 	// and continue the rollback. By continuing the rollback, you can return your stack
 	// to a working state (the UPDATE_ROLLBACK_COMPLETE state), and then try to update
 	// the stack again. A stack goes into the UPDATE_ROLLBACK_FAILED state when
@@ -43,39 +39,39 @@ type CloudFormation interface {
 	// the database was deleted, it assumes that the database instance still exists and
 	// attempts to roll back to it, causing the update rollback to fail.
 	ContinueUpdateRollback(ctx context.Context, params *ContinueUpdateRollbackInput, optFns ...func(*Options)) (*ContinueUpdateRollbackOutput, error)
-	// Creates a list of changes that will be applied to a stack so that you can review
-	// the changes before executing them. You can create a change set for a stack that
-	// doesn't exist or an existing stack. If you create a change set for a stack that
-	// doesn't exist, the change set shows all of the resources that CloudFormation
-	// will create. If you create a change set for an existing stack, CloudFormation
-	// compares the stack's information with the information that you submit in the
-	// change set and lists the differences. Use change sets to understand which
-	// resources CloudFormation will create or change, and how it will change resources
-	// in an existing stack, before you create or update a stack. To create a change
-	// set for a stack that doesn't exist, for the ChangeSetType parameter, specify
-	// CREATE. To create a change set for an existing stack, specify UPDATE for the
-	// ChangeSetType parameter. To create a change set for an import operation, specify
-	// IMPORT for the ChangeSetType parameter. After the CreateChangeSet call
-	// successfully completes, CloudFormation starts creating the change set. To check
-	// the status of the change set or to review it, use the DescribeChangeSet action.
-	// When you are satisfied with the changes the change set will make, execute the
-	// change set by using the ExecuteChangeSet action. CloudFormation doesn't make
-	// changes until you execute the change set. To create a change set for the entire
-	// stack hierarchy, set IncludeNestedStacks to True.
+	// Creates a list of changes that will be applied to a stack so that you can
+	// review the changes before executing them. You can create a change set for a
+	// stack that doesn't exist or an existing stack. If you create a change set for a
+	// stack that doesn't exist, the change set shows all of the resources that
+	// CloudFormation will create. If you create a change set for an existing stack,
+	// CloudFormation compares the stack's information with the information that you
+	// submit in the change set and lists the differences. Use change sets to
+	// understand which resources CloudFormation will create or change, and how it will
+	// change resources in an existing stack, before you create or update a stack. To
+	// create a change set for a stack that doesn't exist, for the ChangeSetType
+	// parameter, specify CREATE . To create a change set for an existing stack,
+	// specify UPDATE for the ChangeSetType parameter. To create a change set for an
+	// import operation, specify IMPORT for the ChangeSetType parameter. After the
+	// CreateChangeSet call successfully completes, CloudFormation starts creating the
+	// change set. To check the status of the change set or to review it, use the
+	// DescribeChangeSet action. When you are satisfied with the changes the change set
+	// will make, execute the change set by using the ExecuteChangeSet action.
+	// CloudFormation doesn't make changes until you execute the change set. To create
+	// a change set for the entire stack hierarchy, set IncludeNestedStacks to True .
 	CreateChangeSet(ctx context.Context, params *CreateChangeSetInput, optFns ...func(*Options)) (*CreateChangeSetOutput, error)
 	// Creates a stack as specified in the template. After the call completes
 	// successfully, the stack creation starts. You can check the status of the stack
-	// through the DescribeStacksoperation.
+	// through the DescribeStacks operation.
 	CreateStack(ctx context.Context, params *CreateStackInput, optFns ...func(*Options)) (*CreateStackOutput, error)
 	// Creates stack instances for the specified accounts, within the specified Amazon
 	// Web Services Regions. A stack instance refers to a stack in a specific account
 	// and Region. You must specify at least one value for either Accounts or
-	// DeploymentTargets, and you must specify at least one value for Regions.
+	// DeploymentTargets , and you must specify at least one value for Regions .
 	CreateStackInstances(ctx context.Context, params *CreateStackInstancesInput, optFns ...func(*Options)) (*CreateStackInstancesOutput, error)
 	// Creates a stack set.
 	CreateStackSet(ctx context.Context, params *CreateStackSetInput, optFns ...func(*Options)) (*CreateStackSetOutput, error)
-	// Deactivates a public extension that was previously activated in this account and
-	// region. Once deactivated, an extension can't be used in any CloudFormation
+	// Deactivates a public extension that was previously activated in this account
+	// and region. Once deactivated, an extension can't be used in any CloudFormation
 	// operation. This includes stack update operations where the stack template
 	// includes the extension, even if no updates are being made to the extension. In
 	// addition, deactivated extensions aren't automatically updated if a new version
@@ -87,7 +83,7 @@ type CloudFormation interface {
 	// specifies True during the creation of the nested change set, then
 	// DeleteChangeSet will delete all change sets that belong to the stacks hierarchy
 	// and will also delete all change sets for nested stacks with the status of
-	// REVIEW_IN_PROGRESS.
+	// REVIEW_IN_PROGRESS .
 	DeleteChangeSet(ctx context.Context, params *DeleteChangeSetInput, optFns ...func(*Options)) (*DeleteChangeSetOutput, error)
 	// Deletes a specified stack. Once the call completes successfully, stack deletion
 	// starts. Deleted stacks don't show up in the DescribeStacks operation if the
@@ -98,7 +94,7 @@ type CloudFormation interface {
 	DeleteStackInstances(ctx context.Context, params *DeleteStackInstancesInput, optFns ...func(*Options)) (*DeleteStackInstancesOutput, error)
 	// Deletes a stack set. Before you can delete a stack set, all its member stack
 	// instances must be deleted. For more information about how to complete this, see
-	// DeleteStackInstances.
+	// DeleteStackInstances .
 	DeleteStackSet(ctx context.Context, params *DeleteStackSetInput, optFns ...func(*Options)) (*DeleteStackSetOutput, error)
 	// Marks an extension or extension version as DEPRECATED in the CloudFormation
 	// registry, removing it from active use. Deprecated extensions or extension
@@ -110,36 +106,29 @@ type CloudFormation interface {
 	// extension if there are other active version of that extension. If you do
 	// deregister the default version of an extension, the extension type itself is
 	// deregistered as well and marked as deprecated. To view the deprecation status of
-	// an extension or extension version, use DescribeType
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DescribeType.html).
+	// an extension or extension version, use DescribeType (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DescribeType.html)
+	// .
 	DeregisterType(ctx context.Context, params *DeregisterTypeInput, optFns ...func(*Options)) (*DeregisterTypeOutput, error)
 	// Retrieves your account's CloudFormation limits, such as the maximum number of
 	// stacks that you can create in your account. For more information about account
-	// limits, see CloudFormation Quotas
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html)
+	// limits, see CloudFormation Quotas (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html)
 	// in the CloudFormation User Guide.
 	DescribeAccountLimits(ctx context.Context, params *DescribeAccountLimitsInput, optFns ...func(*Options)) (*DescribeAccountLimitsOutput, error)
 	// Returns the inputs for the change set and a list of changes that CloudFormation
 	// will make if you execute the change set. For more information, see Updating
-	// Stacks Using Change Sets
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-changesets.html)
+	// Stacks Using Change Sets (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-changesets.html)
 	// in the CloudFormation User Guide.
 	DescribeChangeSet(ctx context.Context, params *DescribeChangeSetInput, optFns ...func(*Options)) (*DescribeChangeSetOutput, error)
 	// Returns hook-related information for the change set and a list of changes that
 	// CloudFormation makes when you run the change set.
 	DescribeChangeSetHooks(ctx context.Context, params *DescribeChangeSetHooksInput, optFns ...func(*Options)) (*DescribeChangeSetHooksOutput, error)
 	// Returns information about a CloudFormation extension publisher. If you don't
-	// supply a PublisherId, and you have registered as an extension publisher,
+	// supply a PublisherId , and you have registered as an extension publisher,
 	// DescribePublisher returns information about your own publisher account. For more
 	// information about registering as a publisher, see:
-	//
-	// * RegisterPublisher
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_RegisterPublisher.html)
-	//
-	// *
-	// Publishing extensions to make them available for public use
-	// (https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/publish-extension.html)
-	// in the CloudFormation CLI User Guide
+	//   - RegisterPublisher (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_RegisterPublisher.html)
+	//   - Publishing extensions to make them available for public use (https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/publish-extension.html)
+	//     in the CloudFormation CLI User Guide
 	DescribePublisher(ctx context.Context, params *DescribePublisherInput, optFns ...func(*Options)) (*DescribePublisherOutput, error)
 	// Returns information about a stack drift detection operation. A stack drift
 	// detection operation detects whether a stack's actual configuration differs, or
@@ -147,24 +136,22 @@ type CloudFormation interface {
 	// and any values specified as template parameters. A stack is considered to have
 	// drifted if one or more of its resources have drifted. For more information about
 	// stack and resource drift, see Detecting Unregulated Configuration Changes to
-	// Stacks and Resources
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html).
-	// Use DetectStackDrift to initiate a stack drift detection operation.
+	// Stacks and Resources (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html)
+	// . Use DetectStackDrift to initiate a stack drift detection operation.
 	// DetectStackDrift returns a StackDriftDetectionId you can use to monitor the
-	// progress of the operation using DescribeStackDriftDetectionStatus. Once the
+	// progress of the operation using DescribeStackDriftDetectionStatus . Once the
 	// drift detection operation has completed, use DescribeStackResourceDrifts to
 	// return drift information about the stack and its resources.
 	DescribeStackDriftDetectionStatus(ctx context.Context, params *DescribeStackDriftDetectionStatusInput, optFns ...func(*Options)) (*DescribeStackDriftDetectionStatusOutput, error)
 	// Returns all stack related events for a specified stack in reverse chronological
-	// order. For more information about a stack's event history, go to Stacks
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/concept-stack.html)
+	// order. For more information about a stack's event history, go to Stacks (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/concept-stack.html)
 	// in the CloudFormation User Guide. You can list events for stacks that have
 	// failed to create or have been deleted by specifying the unique stack identifier
 	// (stack ID).
 	DescribeStackEvents(ctx context.Context, params *DescribeStackEventsInput, optFns ...func(*Options)) (*DescribeStackEventsOutput, error)
 	// Returns the stack instance that's associated with the specified stack set,
 	// Amazon Web Services account, and Region. For a list of stack instances that are
-	// associated with a specific stack set, use ListStackInstances.
+	// associated with a specific stack set, use ListStackInstances .
 	DescribeStackInstance(ctx context.Context, params *DescribeStackInstanceInput, optFns ...func(*Options)) (*DescribeStackInstanceOutput, error)
 	// Returns a description of the specified resource in the specified stack. For
 	// deleted stacks, DescribeStackResource returns resource information for up to 90
@@ -177,44 +164,43 @@ type CloudFormation interface {
 	// checked for drift. Resources that haven't yet been checked for drift aren't
 	// included. Resources that don't currently support drift detection aren't checked,
 	// and so not included. For a list of resources that support drift detection, see
-	// Resources that Support Drift Detection
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift-resource-list.html).
-	// Use DetectStackResourceDrift to detect drift on individual resources, or
+	// Resources that Support Drift Detection (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift-resource-list.html)
+	// . Use DetectStackResourceDrift to detect drift on individual resources, or
 	// DetectStackDrift to detect drift on all supported resources for a given stack.
 	DescribeStackResourceDrifts(ctx context.Context, params *DescribeStackResourceDriftsInput, optFns ...func(*Options)) (*DescribeStackResourceDriftsOutput, error)
 	// Returns Amazon Web Services resource descriptions for running and deleted
-	// stacks. If StackName is specified, all the associated resources that are part of
-	// the stack are returned. If PhysicalResourceId is specified, the associated
+	// stacks. If StackName is specified, all the associated resources that are part
+	// of the stack are returned. If PhysicalResourceId is specified, the associated
 	// resources of the stack that the resource belongs to are returned. Only the first
 	// 100 resources will be returned. If your stack has more resources than this, you
 	// should use ListStackResources instead. For deleted stacks,
 	// DescribeStackResources returns resource information for up to 90 days after the
-	// stack has been deleted. You must specify either StackName or PhysicalResourceId,
-	// but not both. In addition, you can specify LogicalResourceId to filter the
-	// returned result. For more information about resources, the LogicalResourceId and
-	// PhysicalResourceId, go to the CloudFormation User Guide
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/). A
-	// ValidationError is returned if you specify both StackName and PhysicalResourceId
-	// in the same request.
+	// stack has been deleted. You must specify either StackName or PhysicalResourceId
+	// , but not both. In addition, you can specify LogicalResourceId to filter the
+	// returned result. For more information about resources, the LogicalResourceId
+	// and PhysicalResourceId , go to the CloudFormation User Guide (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/)
+	// . A ValidationError is returned if you specify both StackName and
+	// PhysicalResourceId in the same request.
 	DescribeStackResources(ctx context.Context, params *DescribeStackResourcesInput, optFns ...func(*Options)) (*DescribeStackResourcesOutput, error)
 	// Returns the description of the specified stack set.
 	DescribeStackSet(ctx context.Context, params *DescribeStackSetInput, optFns ...func(*Options)) (*DescribeStackSetOutput, error)
 	// Returns the description of the specified stack set operation.
 	DescribeStackSetOperation(ctx context.Context, params *DescribeStackSetOperationInput, optFns ...func(*Options)) (*DescribeStackSetOperationOutput, error)
-	// Returns the description for the specified stack; if no stack name was specified,
-	// then it returns the description for all the stacks created. If the stack doesn't
-	// exist, an ValidationError is returned.
+	// Returns the description for the specified stack; if no stack name was
+	// specified, then it returns the description for all the stacks created. If the
+	// stack doesn't exist, an ValidationError is returned.
 	DescribeStacks(ctx context.Context, params *DescribeStacksInput, optFns ...func(*Options)) (*DescribeStacksOutput, error)
-	// Returns detailed information about an extension that has been registered. If you
-	// specify a VersionId, DescribeType returns information about that specific
+	// Returns detailed information about an extension that has been registered. If
+	// you specify a VersionId , DescribeType returns information about that specific
 	// extension version. Otherwise, it returns information about the default extension
 	// version.
 	DescribeType(ctx context.Context, params *DescribeTypeInput, optFns ...func(*Options)) (*DescribeTypeOutput, error)
 	// Returns information about an extension's registration, including its current
 	// status and type and version identifiers. When you initiate a registration
-	// request using RegisterType, you can then use DescribeTypeRegistration to monitor
-	// the progress of that registration request. Once the registration request has
-	// completed, use DescribeType to return detailed information about an extension.
+	// request using RegisterType , you can then use DescribeTypeRegistration to
+	// monitor the progress of that registration request. Once the registration request
+	// has completed, use DescribeType to return detailed information about an
+	// extension.
 	DescribeTypeRegistration(ctx context.Context, params *DescribeTypeRegistrationInput, optFns ...func(*Options)) (*DescribeTypeRegistrationOutput, error)
 	// Detects whether a stack's actual configuration differs, or has drifted, from
 	// it's expected configuration, as defined in the stack template and any values
@@ -224,14 +210,12 @@ type CloudFormation interface {
 	// explicitly defined in the stack template are checked for drift. A stack is
 	// considered to have drifted if one or more of its resources differ from their
 	// expected template configurations. For more information, see Detecting
-	// Unregulated Configuration Changes to Stacks and Resources
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html).
-	// Use DetectStackDrift to detect drift on all supported resources for a given
+	// Unregulated Configuration Changes to Stacks and Resources (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html)
+	// . Use DetectStackDrift to detect drift on all supported resources for a given
 	// stack, or DetectStackResourceDrift to detect drift on individual resources. For
 	// a list of stack resources that currently support drift detection, see Resources
-	// that Support Drift Detection
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift-resource-list.html).
-	// DetectStackDrift can take up to several minutes, depending on the number of
+	// that Support Drift Detection (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift-resource-list.html)
+	// . DetectStackDrift can take up to several minutes, depending on the number of
 	// resources contained within the stack. Use DescribeStackDriftDetectionStatus to
 	// monitor the progress of a detect stack drift operation. Once the drift detection
 	// operation has completed, use DescribeStackResourceDrifts to return drift
@@ -245,61 +229,53 @@ type CloudFormation interface {
 	// actual and expected property values for resources in which CloudFormation
 	// detects drift. Only resource properties explicitly defined in the stack template
 	// are checked for drift. For more information about stack and resource drift, see
-	// Detecting Unregulated Configuration Changes to Stacks and Resources
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html).
-	// Use DetectStackResourceDrift to detect drift on individual resources, or
+	// Detecting Unregulated Configuration Changes to Stacks and Resources (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html)
+	// . Use DetectStackResourceDrift to detect drift on individual resources, or
 	// DetectStackDrift to detect drift on all resources in a given stack that support
 	// drift detection. Resources that don't currently support drift detection can't be
 	// checked. For a list of resources that support drift detection, see Resources
-	// that Support Drift Detection
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift-resource-list.html).
+	// that Support Drift Detection (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift-resource-list.html)
+	// .
 	DetectStackResourceDrift(ctx context.Context, params *DetectStackResourceDriftInput, optFns ...func(*Options)) (*DetectStackResourceDriftOutput, error)
 	// Detect drift on a stack set. When CloudFormation performs drift detection on a
 	// stack set, it performs drift detection on the stack associated with each stack
-	// instance in the stack set. For more information, see How CloudFormation performs
-	// drift detection on a stack set
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-drift.html).
-	// DetectStackSetDrift returns the OperationId of the stack set drift detection
+	// instance in the stack set. For more information, see How CloudFormation
+	// performs drift detection on a stack set (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-drift.html)
+	// . DetectStackSetDrift returns the OperationId of the stack set drift detection
 	// operation. Use this operation id with DescribeStackSetOperation to monitor the
 	// progress of the drift detection operation. The drift detection operation may
 	// take some time, depending on the number of stack instances included in the stack
 	// set, in addition to the number of resources included in each stack. Once the
-	// operation has completed, use the following actions to return drift
-	// information:
+	// operation has completed, use the following actions to return drift information:
+	//   - Use DescribeStackSet to return detailed information about the stack set,
+	//     including detailed information about the last completed drift operation
+	//     performed on the stack set. (Information about drift operations that are in
+	//     progress isn't included.)
+	//   - Use ListStackInstances to return a list of stack instances belonging to the
+	//     stack set, including the drift status and last drift time checked of each
+	//     instance.
+	//   - Use DescribeStackInstance to return detailed information about a specific
+	//     stack instance, including its drift status and last drift time checked.
 	//
-	// * Use DescribeStackSet to return detailed information about the
-	// stack set, including detailed information about the last completed drift
-	// operation performed on the stack set. (Information about drift operations that
-	// are in progress isn't included.)
-	//
-	// * Use ListStackInstances to return a list of
-	// stack instances belonging to the stack set, including the drift status and last
-	// drift time checked of each instance.
-	//
-	// * Use DescribeStackInstance to return
-	// detailed information about a specific stack instance, including its drift status
-	// and last drift time checked.
-	//
-	// For more information about performing a drift
-	// detection operation on a stack set, see Detecting unmanaged changes in stack
-	// sets
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-drift.html).
-	// You can only run a single drift detection operation on a given stack set at one
-	// time. To stop a drift detection stack set operation, use StopStackSetOperation.
+	// For more information about performing a drift detection operation on a stack
+	// set, see Detecting unmanaged changes in stack sets (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-drift.html)
+	// . You can only run a single drift detection operation on a given stack set at
+	// one time. To stop a drift detection stack set operation, use
+	// StopStackSetOperation .
 	DetectStackSetDrift(ctx context.Context, params *DetectStackSetDriftInput, optFns ...func(*Options)) (*DetectStackSetDriftOutput, error)
 	// Returns the estimated monthly cost of a template. The return value is an Amazon
 	// Web Services Simple Monthly Calculator URL with a query string that describes
 	// the resources required to run the template.
 	EstimateTemplateCost(ctx context.Context, params *EstimateTemplateCostInput, optFns ...func(*Options)) (*EstimateTemplateCostOutput, error)
-	// Updates a stack using the input information that was provided when the specified
-	// change set was created. After the call successfully completes, CloudFormation
-	// starts updating the stack. Use the DescribeStacks action to view the status of
-	// the update. When you execute a change set, CloudFormation deletes all other
-	// change sets associated with the stack because they aren't valid for the updated
-	// stack. If a stack policy is associated with the stack, CloudFormation enforces
-	// the policy during the update. You can't specify a temporary stack policy that
-	// overrides the current policy. To create a change set for the entire stack
-	// hierarchy, IncludeNestedStacks must have been set to True.
+	// Updates a stack using the input information that was provided when the
+	// specified change set was created. After the call successfully completes,
+	// CloudFormation starts updating the stack. Use the DescribeStacks action to view
+	// the status of the update. When you execute a change set, CloudFormation deletes
+	// all other change sets associated with the stack because they aren't valid for
+	// the updated stack. If a stack policy is associated with the stack,
+	// CloudFormation enforces the policy during the update. You can't specify a
+	// temporary stack policy that overrides the current policy. To create a change set
+	// for the entire stack hierarchy, IncludeNestedStacks must have been set to True .
 	ExecuteChangeSet(ctx context.Context, params *ExecuteChangeSetInput, optFns ...func(*Options)) (*ExecuteChangeSetOutput, error)
 	// Returns the stack policy for a specified stack. If a stack doesn't have a
 	// policy, a null value is returned.
@@ -312,10 +288,10 @@ type CloudFormation interface {
 	// Returns information about a new or existing template. The GetTemplateSummary
 	// action is useful for viewing parameter information, such as default parameter
 	// values and parameter types, before you create or update a stack or stack set.
-	// You can use the GetTemplateSummary action when you submit a template, or you can
-	// get template information for a stack set, or a running or deleted stack. For
-	// deleted stacks, GetTemplateSummary returns the template information for up to 90
-	// days after the stack has been deleted. If the template doesn't exist, a
+	// You can use the GetTemplateSummary action when you submit a template, or you
+	// can get template information for a stack set, or a running or deleted stack. For
+	// deleted stacks, GetTemplateSummary returns the template information for up to
+	// 90 days after the stack has been deleted. If the template doesn't exist, a
 	// ValidationError is returned.
 	GetTemplateSummary(ctx context.Context, params *GetTemplateSummaryInput, optFns ...func(*Options)) (*GetTemplateSummaryOutput, error)
 	// Import existing stacks into a new stack sets. Use the stack import operation to
@@ -330,17 +306,15 @@ type CloudFormation interface {
 	ListChangeSets(ctx context.Context, params *ListChangeSetsInput, optFns ...func(*Options)) (*ListChangeSetsOutput, error)
 	// Lists all exported output values in the account and Region in which you call
 	// this action. Use this action to see the exported output values that you can
-	// import into other stacks. To import values, use the Fn::ImportValue
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-importvalue.html)
-	// function. For more information, see  CloudFormation export stack output values
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-exports.html).
+	// import into other stacks. To import values, use the Fn::ImportValue (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-importvalue.html)
+	// function. For more information, see CloudFormation export stack output values (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-exports.html)
+	// .
 	ListExports(ctx context.Context, params *ListExportsInput, optFns ...func(*Options)) (*ListExportsOutput, error)
 	// Lists all stacks that are importing an exported output value. To modify or
 	// remove an exported output value, first use this action to see which stacks are
-	// using it. To see the exported output values in your account, see ListExports.
+	// using it. To see the exported output values in your account, see ListExports .
 	// For more information about importing an exported output value, see the
-	// Fn::ImportValue
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-importvalue.html)
+	// Fn::ImportValue (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-importvalue.html)
 	// function.
 	ListImports(ctx context.Context, params *ListImportsInput, optFns ...func(*Options)) (*ListImportsOutput, error)
 	// Returns summary information about stack instances that are associated with the
@@ -356,22 +330,16 @@ type CloudFormation interface {
 	ListStackSetOperationResults(ctx context.Context, params *ListStackSetOperationResultsInput, optFns ...func(*Options)) (*ListStackSetOperationResultsOutput, error)
 	// Returns summary information about operations performed on a stack set.
 	ListStackSetOperations(ctx context.Context, params *ListStackSetOperationsInput, optFns ...func(*Options)) (*ListStackSetOperationsOutput, error)
-	// Returns summary information about stack sets that are associated with the
-	// user.
-	//
-	// * [Self-managed permissions] If you set the CallAs parameter to SELF
-	// while signed in to your Amazon Web Services account, ListStackSets returns all
-	// self-managed stack sets in your Amazon Web Services account.
-	//
-	// * [Service-managed
-	// permissions] If you set the CallAs parameter to SELF while signed in to the
-	// organization's management account, ListStackSets returns all stack sets in the
-	// management account.
-	//
-	// * [Service-managed permissions] If you set the CallAs
-	// parameter to DELEGATED_ADMIN while signed in to your member account,
-	// ListStackSets returns all stack sets with service-managed permissions in the
-	// management account.
+	// Returns summary information about stack sets that are associated with the user.
+	//   - [Self-managed permissions] If you set the CallAs parameter to SELF while
+	//     signed in to your Amazon Web Services account, ListStackSets returns all
+	//     self-managed stack sets in your Amazon Web Services account.
+	//   - [Service-managed permissions] If you set the CallAs parameter to SELF while
+	//     signed in to the organization's management account, ListStackSets returns all
+	//     stack sets in the management account.
+	//   - [Service-managed permissions] If you set the CallAs parameter to
+	//     DELEGATED_ADMIN while signed in to your member account, ListStackSets returns
+	//     all stack sets with service-managed permissions in the management account.
 	ListStackSets(ctx context.Context, params *ListStackSetsInput, optFns ...func(*Options)) (*ListStackSetsOutput, error)
 	// Returns the summary information for stacks whose status matches the specified
 	// StackStatusFilter. Summary information for stacks that have been deleted is kept
@@ -389,94 +357,78 @@ type CloudFormation interface {
 	// Publishes the specified extension to the CloudFormation registry as a public
 	// extension in this region. Public extensions are available for use by all
 	// CloudFormation users. For more information about publishing extensions, see
-	// Publishing extensions to make them available for public use
-	// (https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/publish-extension.html)
+	// Publishing extensions to make them available for public use (https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/publish-extension.html)
 	// in the CloudFormation CLI User Guide. To publish an extension, you must be
 	// registered as a publisher with CloudFormation. For more information, see
-	// RegisterPublisher
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_RegisterPublisher.html).
+	// RegisterPublisher (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_RegisterPublisher.html)
+	// .
 	PublishType(ctx context.Context, params *PublishTypeInput, optFns ...func(*Options)) (*PublishTypeOutput, error)
 	// Reports progress of a resource handler to CloudFormation. Reserved for use by
-	// the CloudFormation CLI
-	// (https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html).
-	// Don't use this API in your code.
+	// the CloudFormation CLI (https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html)
+	// . Don't use this API in your code.
 	RecordHandlerProgress(ctx context.Context, params *RecordHandlerProgressInput, optFns ...func(*Options)) (*RecordHandlerProgressOutput, error)
-	// Registers your account as a publisher of public extensions in the CloudFormation
-	// registry. Public extensions are available for use by all CloudFormation users.
-	// This publisher ID applies to your account in all Amazon Web Services Regions.
-	// For information about requirements for registering as a public extension
-	// publisher, see Registering your account to publish CloudFormation extensions
-	// (https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/publish-extension.html#publish-extension-prereqs)
+	// Registers your account as a publisher of public extensions in the
+	// CloudFormation registry. Public extensions are available for use by all
+	// CloudFormation users. This publisher ID applies to your account in all Amazon
+	// Web Services Regions. For information about requirements for registering as a
+	// public extension publisher, see Registering your account to publish
+	// CloudFormation extensions (https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/publish-extension.html#publish-extension-prereqs)
 	// in the CloudFormation CLI User Guide.
 	RegisterPublisher(ctx context.Context, params *RegisterPublisherInput, optFns ...func(*Options)) (*RegisterPublisherOutput, error)
-	// Registers an extension with the CloudFormation service. Registering an extension
-	// makes it available for use in CloudFormation templates in your Amazon Web
-	// Services account, and includes:
+	// Registers an extension with the CloudFormation service. Registering an
+	// extension makes it available for use in CloudFormation templates in your Amazon
+	// Web Services account, and includes:
+	//   - Validating the extension schema.
+	//   - Determining which handlers, if any, have been specified for the extension.
+	//   - Making the extension available for use in your account.
 	//
-	// * Validating the extension schema.
-	//
-	// *
-	// Determining which handlers, if any, have been specified for the extension.
-	//
-	// *
-	// Making the extension available for use in your account.
-	//
-	// For more information
-	// about how to develop extensions and ready them for registration, see Creating
-	// Resource Providers
-	// (https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-types.html)
+	// For more information about how to develop extensions and ready them for
+	// registration, see Creating Resource Providers (https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-types.html)
 	// in the CloudFormation CLI User Guide. You can have a maximum of 50 resource
 	// extension versions registered at a time. This maximum is per account and per
 	// region. Use DeregisterType to deregister specific extension versions if
-	// necessary. Once you have initiated a registration request using RegisterType,
-	// you can use DescribeTypeRegistration to monitor the progress of the registration
-	// request. Once you have registered a private extension in your account and
-	// region, use SetTypeConfiguration to specify configuration properties for the
-	// extension. For more information, see Configuring extensions at the account level
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-register.html#registry-set-configuration)
+	// necessary. Once you have initiated a registration request using RegisterType ,
+	// you can use DescribeTypeRegistration to monitor the progress of the
+	// registration request. Once you have registered a private extension in your
+	// account and region, use SetTypeConfiguration to specify configuration
+	// properties for the extension. For more information, see Configuring extensions
+	// at the account level (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-register.html#registry-set-configuration)
 	// in the CloudFormation User Guide.
 	RegisterType(ctx context.Context, params *RegisterTypeInput, optFns ...func(*Options)) (*RegisterTypeOutput, error)
-	// When specifying RollbackStack, you preserve the state of previously provisioned
+	// When specifying RollbackStack , you preserve the state of previously provisioned
 	// resources when an operation fails. You can check the status of the stack through
 	// the DescribeStacks operation. Rolls back the specified stack to the last known
 	// stable state from CREATE_FAILED or UPDATE_FAILED stack statuses. This operation
 	// will delete a stack if it doesn't contain a last known stable state. A last
-	// known stable state includes any status in a *_COMPLETE. This includes the
+	// known stable state includes any status in a *_COMPLETE . This includes the
 	// following stack statuses.
-	//
-	// * CREATE_COMPLETE
-	//
-	// * UPDATE_COMPLETE
-	//
-	// *
-	// UPDATE_ROLLBACK_COMPLETE
-	//
-	// * IMPORT_COMPLETE
-	//
-	// * IMPORT_ROLLBACK_COMPLETE
+	//   - CREATE_COMPLETE
+	//   - UPDATE_COMPLETE
+	//   - UPDATE_ROLLBACK_COMPLETE
+	//   - IMPORT_COMPLETE
+	//   - IMPORT_ROLLBACK_COMPLETE
 	RollbackStack(ctx context.Context, params *RollbackStackInput, optFns ...func(*Options)) (*RollbackStackOutput, error)
 	// Sets a stack policy for a specified stack.
 	SetStackPolicy(ctx context.Context, params *SetStackPolicyInput, optFns ...func(*Options)) (*SetStackPolicyOutput, error)
 	// Specifies the configuration data for a registered CloudFormation extension, in
 	// the given account and region. To view the current configuration data for an
-	// extension, refer to the ConfigurationSchema element of DescribeType. For more
-	// information, see Configuring extensions at the account level
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-register.html#registry-set-configuration)
+	// extension, refer to the ConfigurationSchema element of DescribeType . For more
+	// information, see Configuring extensions at the account level (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-register.html#registry-set-configuration)
 	// in the CloudFormation User Guide. It's strongly recommended that you use dynamic
 	// references to restrict sensitive configuration definitions, such as third-party
 	// credentials. For more details on dynamic references, see Using dynamic
 	// references to specify template values (https://docs.aws.amazon.com/) in the
 	// CloudFormation User Guide.
 	SetTypeConfiguration(ctx context.Context, params *SetTypeConfigurationInput, optFns ...func(*Options)) (*SetTypeConfigurationOutput, error)
-	// Specify the default version of an extension. The default version of an extension
-	// will be used in CloudFormation operations.
+	// Specify the default version of an extension. The default version of an
+	// extension will be used in CloudFormation operations.
 	SetTypeDefaultVersion(ctx context.Context, params *SetTypeDefaultVersionInput, optFns ...func(*Options)) (*SetTypeDefaultVersionOutput, error)
 	// Sends a signal to the specified resource with a success or failure status. You
 	// can use the SignalResource operation in conjunction with a creation policy or
 	// update policy. CloudFormation doesn't proceed with a stack creation or update
 	// until resources receive the required number of signals or the timeout period is
-	// exceeded. The SignalResource operation is useful in cases where you want to send
-	// signals from anywhere other than an Amazon EC2 instance.
+	// exceeded. The SignalResource operation is useful in cases where you want to
+	// send signals from anywhere other than an Amazon EC2 instance.
 	SignalResource(ctx context.Context, params *SignalResourceInput, optFns ...func(*Options)) (*SignalResourceOutput, error)
 	// Stops an in-progress operation on a stack set and its associated stack
 	// instances. StackSets will cancel all the unstarted stack instance deployments
@@ -484,74 +436,62 @@ type CloudFormation interface {
 	StopStackSetOperation(ctx context.Context, params *StopStackSetOperationInput, optFns ...func(*Options)) (*StopStackSetOperationOutput, error)
 	// Tests a registered extension to make sure it meets all necessary requirements
 	// for being published in the CloudFormation registry.
+	//   - For resource types, this includes passing all contracts tests defined for
+	//     the type.
+	//   - For modules, this includes determining if the module's model meets all
+	//     necessary requirements.
 	//
-	// * For resource types, this
-	// includes passing all contracts tests defined for the type.
-	//
-	// * For modules, this
-	// includes determining if the module's model meets all necessary
-	// requirements.
-	//
-	// For more information, see Testing your public extension prior to
-	// publishing
-	// (https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/publish-extension.html#publish-extension-testing)
+	// For more information, see Testing your public extension prior to publishing (https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/publish-extension.html#publish-extension-testing)
 	// in the CloudFormation CLI User Guide. If you don't specify a version,
 	// CloudFormation uses the default version of the extension in your account and
 	// region for testing. To perform testing, CloudFormation assumes the execution
 	// role specified when the type was registered. For more information, see
-	// RegisterType. Once you've initiated testing on an extension using TestType, you
-	// can pass the returned TypeVersionArn into DescribeType
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DescribeType.html)
+	// RegisterType . Once you've initiated testing on an extension using TestType ,
+	// you can pass the returned TypeVersionArn into DescribeType (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DescribeType.html)
 	// to monitor the current test status and test status description for the
 	// extension. An extension must have a test status of PASSED before it can be
 	// published. For more information, see Publishing extensions to make them
-	// available for public use
-	// (https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-publish.html)
+	// available for public use (https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-publish.html)
 	// in the CloudFormation CLI User Guide.
 	TestType(ctx context.Context, params *TestTypeInput, optFns ...func(*Options)) (*TestTypeOutput, error)
 	// Updates a stack as specified in the template. After the call completes
 	// successfully, the stack update starts. You can check the status of the stack
-	// through the DescribeStacks action. To get a copy of the template for an existing
-	// stack, you can use the GetTemplate action. For more information about creating
-	// an update template, updating a stack, and monitoring the progress of the update,
-	// see Updating a Stack
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks.html).
+	// through the DescribeStacks action. To get a copy of the template for an
+	// existing stack, you can use the GetTemplate action. For more information about
+	// creating an update template, updating a stack, and monitoring the progress of
+	// the update, see Updating a Stack (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks.html)
+	// .
 	UpdateStack(ctx context.Context, params *UpdateStackInput, optFns ...func(*Options)) (*UpdateStackOutput, error)
 	// Updates the parameter values for stack instances for the specified accounts,
 	// within the specified Amazon Web Services Regions. A stack instance refers to a
 	// stack in a specific account and Region. You can only update stack instances in
 	// Amazon Web Services Regions and accounts where they already exist; to create
-	// additional stack instances, use CreateStackInstances
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStackInstances.html).
-	// During stack set updates, any parameters overridden for a stack instance aren't
-	// updated, but retain their overridden value. You can only update the parameter
-	// values that are specified in the stack set; to add or delete a parameter itself,
-	// use UpdateStackSet
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStackSet.html)
+	// additional stack instances, use CreateStackInstances (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStackInstances.html)
+	// . During stack set updates, any parameters overridden for a stack instance
+	// aren't updated, but retain their overridden value. You can only update the
+	// parameter values that are specified in the stack set; to add or delete a
+	// parameter itself, use UpdateStackSet (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStackSet.html)
 	// to update the stack set template. If you add a parameter to a template, before
 	// you can override the parameter value specified in the stack set you must first
-	// use UpdateStackSet
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStackSet.html)
+	// use UpdateStackSet (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStackSet.html)
 	// to update all stack instances with the updated template and parameter value
 	// specified in the stack set. Once a stack instance has been updated with the new
-	// parameter, you can then override the parameter value using UpdateStackInstances.
+	// parameter, you can then override the parameter value using UpdateStackInstances .
 	UpdateStackInstances(ctx context.Context, params *UpdateStackInstancesInput, optFns ...func(*Options)) (*UpdateStackInstancesOutput, error)
 	// Updates the stack set, and associated stack instances in the specified accounts
 	// and Amazon Web Services Regions. Even if the stack set operation created by
 	// updating the stack set fails (completely or partially, below or above a
 	// specified failure tolerance), the stack set is updated with your changes.
-	// Subsequent CreateStackInstances calls on the specified stack set use the updated
-	// stack set.
+	// Subsequent CreateStackInstances calls on the specified stack set use the
+	// updated stack set.
 	UpdateStackSet(ctx context.Context, params *UpdateStackSetInput, optFns ...func(*Options)) (*UpdateStackSetOutput, error)
 	// Updates termination protection for the specified stack. If a user attempts to
 	// delete a stack with termination protection enabled, the operation fails and the
-	// stack remains unchanged. For more information, see Protecting a Stack From Being
-	// Deleted
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-protect-stacks.html)
-	// in the CloudFormation User Guide. For nested stacks
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-nested-stacks.html),
-	// termination protection is set on the root stack and can't be changed directly on
-	// the nested stack.
+	// stack remains unchanged. For more information, see Protecting a Stack From
+	// Being Deleted (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-protect-stacks.html)
+	// in the CloudFormation User Guide. For nested stacks (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-nested-stacks.html)
+	// , termination protection is set on the root stack and can't be changed directly
+	// on the nested stack.
 	UpdateTerminationProtection(ctx context.Context, params *UpdateTerminationProtectionInput, optFns ...func(*Options)) (*UpdateTerminationProtectionOutput, error)
 	// Validates a specified template. CloudFormation first checks if the template is
 	// valid JSON. If it isn't, CloudFormation checks if the template is valid YAML. If

--- a/pkg/awsapi/cloudtrail.go
+++ b/pkg/awsapi/cloudtrail.go
@@ -10,8 +10,8 @@ import (
 
 // CloudTrail provides an interface to the AWS CloudTrail service.
 type CloudTrail interface {
-	// Adds one or more tags to a trail, event data store, or channel, up to a limit of
-	// 50. Overwrites an existing tag's value when a new value is specified for an
+	// Adds one or more tags to a trail, event data store, or channel, up to a limit
+	// of 50. Overwrites an existing tag's value when a new value is specified for an
 	// existing tag key. Tag key names must be unique; you cannot have two keys with
 	// the same name but different values. If you specify a key without a value, the
 	// tag will be created with the specified key and a value of null. You can tag a
@@ -19,10 +19,10 @@ type CloudTrail interface {
 	// from the Region in which the trail or event data store was created (also known
 	// as its home region).
 	AddTags(ctx context.Context, params *AddTagsInput, optFns ...func(*Options)) (*AddTagsOutput, error)
-	// Cancels a query if the query is not in a terminated state, such as CANCELLED,
-	// FAILED, TIMED_OUT, or FINISHED. You must specify an ARN value for
-	// EventDataStore. The ID of the query that you want to cancel is also required.
-	// When you run CancelQuery, the query status might show as CANCELLED even if the
+	// Cancels a query if the query is not in a terminated state, such as CANCELLED ,
+	// FAILED , TIMED_OUT , or FINISHED . You must specify an ARN value for
+	// EventDataStore . The ID of the query that you want to cancel is also required.
+	// When you run CancelQuery , the query status might show as CANCELLED even if the
 	// operation is not yet finished.
 	CancelQuery(ctx context.Context, params *CancelQueryInput, optFns ...func(*Options)) (*CancelQueryOutput, error)
 	// Creates a channel for CloudTrail to ingest events from a partner or external
@@ -36,31 +36,31 @@ type CloudTrail interface {
 	CreateTrail(ctx context.Context, params *CreateTrailInput, optFns ...func(*Options)) (*CreateTrailOutput, error)
 	// Deletes a channel.
 	DeleteChannel(ctx context.Context, params *DeleteChannelInput, optFns ...func(*Options)) (*DeleteChannelOutput, error)
-	// Disables the event data store specified by EventDataStore, which accepts an
-	// event data store ARN. After you run DeleteEventDataStore, the event data store
+	// Disables the event data store specified by EventDataStore , which accepts an
+	// event data store ARN. After you run DeleteEventDataStore , the event data store
 	// enters a PENDING_DELETION state, and is automatically deleted after a wait
 	// period of seven days. TerminationProtectionEnabled must be set to False on the
 	// event data store; this operation cannot work if TerminationProtectionEnabled is
-	// True. After you run DeleteEventDataStore on an event data store, you cannot run
-	// ListQueries, DescribeQuery, or GetQueryResults on queries that are using an
-	// event data store in a PENDING_DELETION state. An event data store in the
+	// True . After you run DeleteEventDataStore on an event data store, you cannot
+	// run ListQueries , DescribeQuery , or GetQueryResults on queries that are using
+	// an event data store in a PENDING_DELETION state. An event data store in the
 	// PENDING_DELETION state does not incur costs.
 	DeleteEventDataStore(ctx context.Context, params *DeleteEventDataStoreInput, optFns ...func(*Options)) (*DeleteEventDataStoreOutput, error)
 	// Deletes the resource-based policy attached to the CloudTrail channel.
 	DeleteResourcePolicy(ctx context.Context, params *DeleteResourcePolicyInput, optFns ...func(*Options)) (*DeleteResourcePolicyOutput, error)
 	// Deletes a trail. This operation must be called from the region in which the
-	// trail was created. DeleteTrail cannot be called on the shadow trails (replicated
-	// trails in other regions) of a trail that is enabled in all regions.
+	// trail was created. DeleteTrail cannot be called on the shadow trails
+	// (replicated trails in other regions) of a trail that is enabled in all regions.
 	DeleteTrail(ctx context.Context, params *DeleteTrailInput, optFns ...func(*Options)) (*DeleteTrailOutput, error)
 	// Removes CloudTrail delegated administrator permissions from a member account in
 	// an organization.
 	DeregisterOrganizationDelegatedAdmin(ctx context.Context, params *DeregisterOrganizationDelegatedAdminInput, optFns ...func(*Options)) (*DeregisterOrganizationDelegatedAdminOutput, error)
-	// Returns metadata about a query, including query run time in milliseconds, number
-	// of events scanned and matched, and query status. You must specify an ARN for
-	// EventDataStore, and a value for QueryID.
+	// Returns metadata about a query, including query run time in milliseconds,
+	// number of events scanned and matched, and query status. You must specify an ARN
+	// for EventDataStore , and a value for QueryID .
 	DescribeQuery(ctx context.Context, params *DescribeQueryInput, optFns ...func(*Options)) (*DescribeQueryOutput, error)
-	// Retrieves settings for one or more trails associated with the current region for
-	// your account.
+	// Retrieves settings for one or more trails associated with the current region
+	// for your account.
 	DescribeTrails(ctx context.Context, params *DescribeTrailsInput, optFns ...func(*Options)) (*DescribeTrailsOutput, error)
 	// Returns information about a specific channel.
 	GetChannel(ctx context.Context, params *GetChannelInput, optFns ...func(*Options)) (*GetChannelOutput, error)
@@ -68,29 +68,18 @@ type CloudTrail interface {
 	// ID portion of the ARN.
 	GetEventDataStore(ctx context.Context, params *GetEventDataStoreInput, optFns ...func(*Options)) (*GetEventDataStoreOutput, error)
 	// Describes the settings for the event selectors that you configured for your
-	// trail. The information returned for your event selectors includes the
-	// following:
+	// trail. The information returned for your event selectors includes the following:
 	//
-	// * If your event selector includes read-only events, write-only
-	// events, or all events. This applies to both management events and data
-	// events.
-	//
-	// * If your event selector includes management events.
-	//
-	// * If your event
-	// selector includes data events, the resources on which you are logging data
-	// events.
+	//   - If your event selector includes read-only events, write-only events, or all
+	//     events. This applies to both management events and data events.
+	//   - If your event selector includes management events.
+	//   - If your event selector includes data events, the resources on which you are
+	//     logging data events.
 	//
 	// For more information about logging management and data events, see the
 	// following topics in the CloudTrail User Guide:
-	//
-	// * Logging management events for
-	// trails
-	// (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-management-events-with-cloudtrail.html)
-	//
-	// *
-	// Logging data events for trails
-	// (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-data-events-with-cloudtrail.html)
+	//   - Logging management events for trails  (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-management-events-with-cloudtrail.html)
+	//   - Logging data events for trails  (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-data-events-with-cloudtrail.html)
 	GetEventSelectors(ctx context.Context, params *GetEventSelectorsInput, optFns ...func(*Options)) (*GetEventSelectorsOutput, error)
 	// Returns information about a specific import.
 	GetImport(ctx context.Context, params *GetImportInput, optFns ...func(*Options)) (*GetImportOutput, error)
@@ -99,12 +88,11 @@ type CloudTrail interface {
 	// enabled on the trail, and if it is, which insight types are enabled. If you run
 	// GetInsightSelectors on a trail that does not have Insights events enabled, the
 	// operation throws the exception InsightNotEnabledException For more information,
-	// see Logging CloudTrail Insights Events for Trails
-	// (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-insights-events-with-cloudtrail.html)
+	// see Logging CloudTrail Insights Events for Trails  (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-insights-events-with-cloudtrail.html)
 	// in the CloudTrail User Guide.
 	GetInsightSelectors(ctx context.Context, params *GetInsightSelectorsInput, optFns ...func(*Options)) (*GetInsightSelectorsOutput, error)
 	// Gets event data results of a query. You must specify the QueryID value returned
-	// by the StartQuery operation, and an ARN for EventDataStore.
+	// by the StartQuery operation, and an ARN for EventDataStore .
 	GetQueryResults(ctx context.Context, params *GetQueryResultsInput, optFns ...func(*Options)) (*GetQueryResultsOutput, error)
 	// Retrieves the JSON text of the resource-based policy document attached to the
 	// CloudTrail channel.
@@ -125,7 +113,7 @@ type CloudTrail interface {
 	// Returns a list of failures for the specified import.
 	ListImportFailures(ctx context.Context, params *ListImportFailuresInput, optFns ...func(*Options)) (*ListImportFailuresOutput, error)
 	// Returns information on all imports, or a select set of imports by ImportStatus
-	// or Destination.
+	// or Destination .
 	ListImports(ctx context.Context, params *ListImportsInput, optFns ...func(*Options)) (*ListImportsOutput, error)
 	// Returns all public keys whose private keys were used to sign the digest files
 	// within the specified time range. The public key is needed to validate digest
@@ -136,56 +124,41 @@ type CloudTrail interface {
 	// key.
 	ListPublicKeys(ctx context.Context, params *ListPublicKeysInput, optFns ...func(*Options)) (*ListPublicKeysOutput, error)
 	// Returns a list of queries and query statuses for the past seven days. You must
-	// specify an ARN value for EventDataStore. Optionally, to shorten the list of
+	// specify an ARN value for EventDataStore . Optionally, to shorten the list of
 	// results, you can specify a time range, formatted as timestamps, by adding
 	// StartTime and EndTime parameters, and a QueryStatus value. Valid values for
-	// QueryStatus include QUEUED, RUNNING, FINISHED, FAILED, TIMED_OUT, or CANCELLED.
+	// QueryStatus include QUEUED , RUNNING , FINISHED , FAILED , TIMED_OUT , or
+	// CANCELLED .
 	ListQueries(ctx context.Context, params *ListQueriesInput, optFns ...func(*Options)) (*ListQueriesOutput, error)
 	// Lists the tags for the trail, event data store, or channel in the current
 	// region.
 	ListTags(ctx context.Context, params *ListTagsInput, optFns ...func(*Options)) (*ListTagsOutput, error)
 	// Lists trails that are in the current account.
 	ListTrails(ctx context.Context, params *ListTrailsInput, optFns ...func(*Options)) (*ListTrailsOutput, error)
-	// Looks up management events
-	// (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-concepts.html#cloudtrail-concepts-management-events)
-	// or CloudTrail Insights events
-	// (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-concepts.html#cloudtrail-concepts-insights-events)
+	// Looks up management events (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-concepts.html#cloudtrail-concepts-management-events)
+	// or CloudTrail Insights events (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-concepts.html#cloudtrail-concepts-insights-events)
 	// that are captured by CloudTrail. You can look up events that occurred in a
 	// region within the last 90 days. Lookup supports the following attributes for
 	// management events:
-	//
-	// * Amazon Web Services access key
-	//
-	// * Event ID
-	//
-	// * Event
-	// name
-	//
-	// * Event source
-	//
-	// * Read only
-	//
-	// * Resource name
-	//
-	// * Resource type
-	//
-	// * User
-	// name
+	//   - Amazon Web Services access key
+	//   - Event ID
+	//   - Event name
+	//   - Event source
+	//   - Read only
+	//   - Resource name
+	//   - Resource type
+	//   - User name
 	//
 	// Lookup supports the following attributes for Insights events:
+	//   - Event ID
+	//   - Event name
+	//   - Event source
 	//
-	// * Event
-	// ID
-	//
-	// * Event name
-	//
-	// * Event source
-	//
-	// All attributes are optional. The default
-	// number of results returned is 50, with a maximum of 50 possible. The response
-	// includes a token that you can use to get the next page of results. The rate of
-	// lookup requests is limited to two per second, per account, per region. If this
-	// limit is exceeded, a throttling error occurs.
+	// All attributes are optional. The default number of results returned is 50, with
+	// a maximum of 50 possible. The response includes a token that you can use to get
+	// the next page of results. The rate of lookup requests is limited to two per
+	// second, per account, per region. If this limit is exceeded, a throttling error
+	// occurs.
 	LookupEvents(ctx context.Context, params *LookupEventsInput, optFns ...func(*Options)) (*LookupEventsOutput, error)
 	// Configures an event selector or advanced event selectors for your trail. Use
 	// event selectors or advanced event selectors to specify management and data event
@@ -196,53 +169,41 @@ type CloudTrail interface {
 	// the event matches any event selector, the trail processes and logs the event. If
 	// the event doesn't match any event selector, the trail doesn't log the event.
 	// Example
+	//   - You create an event selector for a trail and specify that you want
+	//     write-only events.
+	//   - The EC2 GetConsoleOutput and RunInstances API operations occur in your
+	//     account.
+	//   - CloudTrail evaluates whether the events match your event selectors.
+	//   - The RunInstances is a write-only event and it matches your event selector.
+	//     The trail logs the event.
+	//   - The GetConsoleOutput is a read-only event that doesn't match your event
+	//     selector. The trail doesn't log the event.
 	//
-	// * You create an event selector for a trail and specify that you want
-	// write-only events.
-	//
-	// * The EC2 GetConsoleOutput and RunInstances API operations
-	// occur in your account.
-	//
-	// * CloudTrail evaluates whether the events match your
-	// event selectors.
-	//
-	// * The RunInstances is a write-only event and it matches your
-	// event selector. The trail logs the event.
-	//
-	// * The GetConsoleOutput is a read-only
-	// event that doesn't match your event selector. The trail doesn't log the
-	// event.
-	//
-	// The PutEventSelectors operation must be called from the region in which
-	// the trail was created; otherwise, an InvalidHomeRegionException exception is
+	// The PutEventSelectors operation must be called from the region in which the
+	// trail was created; otherwise, an InvalidHomeRegionException exception is
 	// thrown. You can configure up to five event selectors for each trail. For more
-	// information, see Logging management events for trails
-	// (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-management-events-with-cloudtrail.html),
-	// Logging data events for trails
-	// (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-data-events-with-cloudtrail.html),
-	// and Quotas in CloudTrail
-	// (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/WhatIsCloudTrail-Limits.html)
+	// information, see Logging management events for trails  (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-management-events-with-cloudtrail.html)
+	// , Logging data events for trails  (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-data-events-with-cloudtrail.html)
+	// , and Quotas in CloudTrail (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/WhatIsCloudTrail-Limits.html)
 	// in the CloudTrail User Guide. You can add advanced event selectors, and
 	// conditions for your advanced event selectors, up to a maximum of 500 values for
 	// all conditions and selectors on a trail. You can use either
-	// AdvancedEventSelectors or EventSelectors, but not both. If you apply
+	// AdvancedEventSelectors or EventSelectors , but not both. If you apply
 	// AdvancedEventSelectors to a trail, any existing EventSelectors are overwritten.
-	// For more information about advanced event selectors, see Logging data events for
-	// trails
-	// (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-data-events-with-cloudtrail.html)
+	// For more information about advanced event selectors, see Logging data events
+	// for trails (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-data-events-with-cloudtrail.html)
 	// in the CloudTrail User Guide.
 	PutEventSelectors(ctx context.Context, params *PutEventSelectorsInput, optFns ...func(*Options)) (*PutEventSelectorsOutput, error)
-	// Lets you enable Insights event logging by specifying the Insights selectors that
-	// you want to enable on an existing trail. You also use PutInsightSelectors to
-	// turn off Insights event logging, by passing an empty list of insight types. The
-	// valid Insights event types in this release are ApiErrorRateInsight and
-	// ApiCallRateInsight.
+	// Lets you enable Insights event logging by specifying the Insights selectors
+	// that you want to enable on an existing trail. You also use PutInsightSelectors
+	// to turn off Insights event logging, by passing an empty list of insight types.
+	// The valid Insights event types in this release are ApiErrorRateInsight and
+	// ApiCallRateInsight .
 	PutInsightSelectors(ctx context.Context, params *PutInsightSelectorsInput, optFns ...func(*Options)) (*PutInsightSelectorsOutput, error)
-	// Attaches a resource-based permission policy to a CloudTrail channel that is used
-	// for an integration with an event source outside of Amazon Web Services. For more
-	// information about resource-based policies, see CloudTrail resource-based policy
-	// examples
-	// (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/security_iam_resource-based-policy-examples.html)
+	// Attaches a resource-based permission policy to a CloudTrail channel that is
+	// used for an integration with an event source outside of Amazon Web Services. For
+	// more information about resource-based policies, see CloudTrail resource-based
+	// policy examples (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/security_iam_resource-based-policy-examples.html)
 	// in the CloudTrail User Guide.
 	PutResourcePolicy(ctx context.Context, params *PutResourcePolicyInput, optFns ...func(*Options)) (*PutResourcePolicyOutput, error)
 	// Registers an organization’s member account as the CloudTrail delegated
@@ -250,28 +211,26 @@ type CloudTrail interface {
 	RegisterOrganizationDelegatedAdmin(ctx context.Context, params *RegisterOrganizationDelegatedAdminInput, optFns ...func(*Options)) (*RegisterOrganizationDelegatedAdminOutput, error)
 	// Removes the specified tags from a trail, event data store, or channel.
 	RemoveTags(ctx context.Context, params *RemoveTagsInput, optFns ...func(*Options)) (*RemoveTagsOutput, error)
-	// Restores a deleted event data store specified by EventDataStore, which accepts
+	// Restores a deleted event data store specified by EventDataStore , which accepts
 	// an event data store ARN. You can only restore a deleted event data store within
 	// the seven-day wait period after deletion. Restoring an event data store can take
 	// several minutes, depending on the size of the event data store.
 	RestoreEventDataStore(ctx context.Context, params *RestoreEventDataStoreInput, optFns ...func(*Options)) (*RestoreEventDataStoreOutput, error)
-	// Starts an import of logged trail events from a source S3 bucket to a destination
-	// event data store. By default, CloudTrail only imports events contained in the S3
-	// bucket's CloudTrail prefix and the prefixes inside the CloudTrail prefix, and
-	// does not check prefixes for other Amazon Web Services services. If you want to
-	// import CloudTrail events contained in another prefix, you must include the
-	// prefix in the S3LocationUri. For more considerations about importing trail
-	// events, see Considerations
-	// (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-copy-trail-to-lake.html#cloudtrail-trail-copy-considerations).
-	// When you start a new import, the Destinations and ImportSource parameters are
+	// Starts an import of logged trail events from a source S3 bucket to a
+	// destination event data store. By default, CloudTrail only imports events
+	// contained in the S3 bucket's CloudTrail prefix and the prefixes inside the
+	// CloudTrail prefix, and does not check prefixes for other Amazon Web Services
+	// services. If you want to import CloudTrail events contained in another prefix,
+	// you must include the prefix in the S3LocationUri . For more considerations about
+	// importing trail events, see Considerations (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-copy-trail-to-lake.html#cloudtrail-trail-copy-considerations)
+	// . When you start a new import, the Destinations and ImportSource parameters are
 	// required. Before starting a new import, disable any access control lists (ACLs)
 	// attached to the source S3 bucket. For more information about disabling ACLs, see
-	// Controlling ownership of objects and disabling ACLs for your bucket
-	// (https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html).
-	// When you retry an import, the ImportID parameter is required. If the destination
-	// event data store is for an organization, you must use the management account to
-	// import trail events. You cannot use the delegated administrator account for the
-	// organization.
+	// Controlling ownership of objects and disabling ACLs for your bucket (https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html)
+	// . When you retry an import, the ImportID parameter is required. If the
+	// destination event data store is for an organization, you must use the management
+	// account to import trail events. You cannot use the delegated administrator
+	// account for the organization.
 	StartImport(ctx context.Context, params *StartImportInput, optFns ...func(*Options)) (*StartImportOutput, error)
 	// Starts the recording of Amazon Web Services API calls and log file delivery for
 	// a trail. For a trail that is enabled in all regions, this operation must be
@@ -302,8 +261,8 @@ type CloudTrail interface {
 	// in days, and valid values are integers between 90 and 2557. By default,
 	// TerminationProtection is enabled. For event data stores for CloudTrail events,
 	// AdvancedEventSelectors includes or excludes management and data events in your
-	// event data store. For more information about AdvancedEventSelectors, see
-	// PutEventSelectorsRequest$AdvancedEventSelectors. For event data stores for
+	// event data store. For more information about AdvancedEventSelectors , see
+	// PutEventSelectorsRequest$AdvancedEventSelectors . For event data stores for
 	// Config configuration items, Audit Manager evidence, or non-Amazon Web Services
 	// events, AdvancedEventSelectors includes events of that type in your event data
 	// store.

--- a/pkg/awsapi/cloudwatchlogs.go
+++ b/pkg/awsapi/cloudwatchlogs.go
@@ -10,19 +10,18 @@ import (
 
 // CloudWatchLogs provides an interface to the AWS CloudWatchLogs service.
 type CloudWatchLogs interface {
-	// Associates the specified KMS key with the specified log group. Associating a KMS
-	// key with a log group overrides any existing associations between the log group
-	// and a KMS key. After a KMS key is associated with a log group, all newly
+	// Associates the specified KMS key with the specified log group. Associating a
+	// KMS key with a log group overrides any existing associations between the log
+	// group and a KMS key. After a KMS key is associated with a log group, all newly
 	// ingested data for the log group is encrypted using the KMS key. This association
 	// is stored as long as the data encrypted with the KMS keyis still within
 	// CloudWatch Logs. This enables CloudWatch Logs to decrypt this data whenever it
 	// is requested. CloudWatch Logs supports only symmetric KMS keys. Do not use an
 	// associate an asymmetric KMS key with your log group. For more information, see
-	// Using Symmetric and Asymmetric Keys
-	// (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html).
-	// It can take up to 5 minutes for this operation to take effect. If you attempt to
-	// associate a KMS key with a log group but the KMS key does not exist or the KMS
-	// key is disabled, you receive an InvalidParameterException error.
+	// Using Symmetric and Asymmetric Keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+	// . It can take up to 5 minutes for this operation to take effect. If you attempt
+	// to associate a KMS key with a log group but the KMS key does not exist or the
+	// KMS key is disabled, you receive an InvalidParameterException error.
 	AssociateKmsKey(ctx context.Context, params *AssociateKmsKeyInput, optFns ...func(*Options)) (*AssociateKmsKeyOutput, error)
 	// Cancels the specified export task. The task must be in the PENDING or RUNNING
 	// state.
@@ -36,45 +35,38 @@ type CloudWatchLogs interface {
 	// are encrypted with AES-256 is supported. This is an asynchronous call. If all
 	// the required information is provided, this operation initiates an export task
 	// and responds with the ID of the task. After the task has started, you can use
-	// DescribeExportTasks
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeExportTasks.html)
-	// to get the status of the export task. Each account can only have one active
-	// (RUNNING or PENDING) export task at a time. To cancel an export task, use
-	// CancelExportTask
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CancelExportTask.html).
-	// You can export logs from multiple log groups or multiple time ranges to the same
-	// S3 bucket. To separate log data for each export task, specify a prefix to be
-	// used as the Amazon S3 key prefix for all exported objects. Time-based sorting on
-	// chunks of log data inside an exported file is not guaranteed. You can sort the
-	// exported log field data by using Linux utilities.
+	// DescribeExportTasks (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeExportTasks.html)
+	// to get the status of the export task. Each account can only have one active (
+	// RUNNING or PENDING ) export task at a time. To cancel an export task, use
+	// CancelExportTask (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CancelExportTask.html)
+	// . You can export logs from multiple log groups or multiple time ranges to the
+	// same S3 bucket. To separate log data for each export task, specify a prefix to
+	// be used as the Amazon S3 key prefix for all exported objects. Time-based sorting
+	// on chunks of log data inside an exported file is not guaranteed. You can sort
+	// the exported log field data by using Linux utilities.
 	CreateExportTask(ctx context.Context, params *CreateExportTaskInput, optFns ...func(*Options)) (*CreateExportTaskOutput, error)
 	// Creates a log group with the specified name. You can create up to 20,000 log
 	// groups per account. You must use the following guidelines when naming a log
 	// group:
+	//   - Log group names must be unique within a Region for an Amazon Web Services
+	//     account.
+	//   - Log group names can be between 1 and 512 characters long.
+	//   - Log group names consist of the following characters: a-z, A-Z, 0-9, '_'
+	//     (underscore), '-' (hyphen), '/' (forward slash), '.' (period), and '#' (number
+	//     sign)
 	//
-	// * Log group names must be unique within a Region for an Amazon Web
-	// Services account.
-	//
-	// * Log group names can be between 1 and 512 characters
-	// long.
-	//
-	// * Log group names consist of the following characters: a-z, A-Z, 0-9, '_'
-	// (underscore), '-' (hyphen), '/' (forward slash), '.' (period), and '#' (number
-	// sign)
-	//
-	// When you create a log group, by default the log events in the log group
-	// do not expire. To set a retention policy so that events expire and are deleted
-	// after a specified time, use PutRetentionPolicy
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html).
-	// If you associate an KMS key with the log group, ingested data is encrypted using
-	// the KMS key. This association is stored as long as the data encrypted with the
-	// KMS key is still within CloudWatch Logs. This enables CloudWatch Logs to decrypt
-	// this data whenever it is requested. If you attempt to associate a KMS key with
-	// the log group but the KMS keydoes not exist or the KMS key is disabled, you
-	// receive an InvalidParameterException error. CloudWatch Logs supports only
+	// When you create a log group, by default the log events in the log group do not
+	// expire. To set a retention policy so that events expire and are deleted after a
+	// specified time, use PutRetentionPolicy (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html)
+	// . If you associate an KMS key with the log group, ingested data is encrypted
+	// using the KMS key. This association is stored as long as the data encrypted with
+	// the KMS key is still within CloudWatch Logs. This enables CloudWatch Logs to
+	// decrypt this data whenever it is requested. If you attempt to associate a KMS
+	// key with the log group but the KMS keydoes not exist or the KMS key is disabled,
+	// you receive an InvalidParameterException error. CloudWatch Logs supports only
 	// symmetric KMS keys. Do not associate an asymmetric KMS key with your log group.
-	// For more information, see Using Symmetric and Asymmetric Keys
-	// (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html).
+	// For more information, see Using Symmetric and Asymmetric Keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+	// .
 	CreateLogGroup(ctx context.Context, params *CreateLogGroupInput, optFns ...func(*Options)) (*CreateLogGroupOutput, error)
 	// Creates a log stream for the specified log group. A log stream is a sequence of
 	// log events that originate from a single source, such as an application instance
@@ -82,18 +74,13 @@ type CloudWatchLogs interface {
 	// streams that you can create for a log group. There is a limit of 50 TPS on
 	// CreateLogStream operations, after which transactions are throttled. You must use
 	// the following guidelines when naming a log stream:
-	//
-	// * Log stream names must be
-	// unique within the log group.
-	//
-	// * Log stream names can be between 1 and 512
-	// characters long.
-	//
-	// * Don't use ':' (colon) or '*' (asterisk) characters.
+	//   - Log stream names must be unique within the log group.
+	//   - Log stream names can be between 1 and 512 characters long.
+	//   - Don't use ':' (colon) or '*' (asterisk) characters.
 	CreateLogStream(ctx context.Context, params *CreateLogStreamInput, optFns ...func(*Options)) (*CreateLogStreamOutput, error)
 	// Deletes the data protection policy from the specified log group. For more
-	// information about data protection policies, see PutDataProtectionPolicy
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutDataProtectionPolicy.html).
+	// information about data protection policies, see PutDataProtectionPolicy (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutDataProtectionPolicy.html)
+	// .
 	DeleteDataProtectionPolicy(ctx context.Context, params *DeleteDataProtectionPolicyInput, optFns ...func(*Options)) (*DeleteDataProtectionPolicyOutput, error)
 	// Deletes the specified destination, and eventually disables all the subscription
 	// filters that publish to it. This operation does not delete the physical resource
@@ -131,23 +118,22 @@ type CloudWatchLogs interface {
 	// action by using the aws:ResourceTag/key-name  condition key. Other CloudWatch
 	// Logs actions do support the use of the aws:ResourceTag/key-name  condition key
 	// to control access. For more information about using tags to control access, see
-	// Controlling access to Amazon Web Services resources using tags
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html). If you are
-	// using CloudWatch cross-account observability, you can use this operation in a
-	// monitoring account and view data from the linked source accounts. For more
-	// information, see CloudWatch cross-account observability
-	// (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html).
+	// Controlling access to Amazon Web Services resources using tags (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html)
+	// . If you are using CloudWatch cross-account observability, you can use this
+	// operation in a monitoring account and view data from the linked source accounts.
+	// For more information, see CloudWatch cross-account observability (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html)
+	// .
 	DescribeLogGroups(ctx context.Context, params *DescribeLogGroupsInput, optFns ...func(*Options)) (*DescribeLogGroupsOutput, error)
 	// Lists the log streams for the specified log group. You can list all the log
 	// streams or filter the results by prefix. You can also control how the results
 	// are ordered. You can specify the log group to search by using either
-	// logGroupIdentifier or logGroupName. You must include one of these two
+	// logGroupIdentifier or logGroupName . You must include one of these two
 	// parameters, but you can't include both. This operation has a limit of five
 	// transactions per second, after which transactions are throttled. If you are
 	// using CloudWatch cross-account observability, you can use this operation in a
 	// monitoring account and view data from the linked source accounts. For more
-	// information, see CloudWatch cross-account observability
-	// (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html).
+	// information, see CloudWatch cross-account observability (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html)
+	// .
 	DescribeLogStreams(ctx context.Context, params *DescribeLogStreamsInput, optFns ...func(*Options)) (*DescribeLogStreamsOutput, error)
 	// Lists the specified metric filters. You can list all of the metric filters or
 	// filter the results by log name, prefix, metric name, or metric namespace. The
@@ -164,22 +150,22 @@ type CloudWatchLogs interface {
 	DescribeQueryDefinitions(ctx context.Context, params *DescribeQueryDefinitionsInput, optFns ...func(*Options)) (*DescribeQueryDefinitionsOutput, error)
 	// Lists the resource policies in this account.
 	DescribeResourcePolicies(ctx context.Context, params *DescribeResourcePoliciesInput, optFns ...func(*Options)) (*DescribeResourcePoliciesOutput, error)
-	// Lists the subscription filters for the specified log group. You can list all the
-	// subscription filters or filter the results by prefix. The results are
+	// Lists the subscription filters for the specified log group. You can list all
+	// the subscription filters or filter the results by prefix. The results are
 	// ASCII-sorted by filter name.
 	DescribeSubscriptionFilters(ctx context.Context, params *DescribeSubscriptionFiltersInput, optFns ...func(*Options)) (*DescribeSubscriptionFiltersOutput, error)
-	// Disassociates the associated KMS key from the specified log group. After the KMS
-	// key is disassociated from the log group, CloudWatch Logs stops encrypting newly
-	// ingested data for the log group. All previously ingested data remains encrypted,
-	// and CloudWatch Logs requires permissions for the KMS key whenever the encrypted
-	// data is requested. Note that it can take up to 5 minutes for this operation to
-	// take effect.
+	// Disassociates the associated KMS key from the specified log group. After the
+	// KMS key is disassociated from the log group, CloudWatch Logs stops encrypting
+	// newly ingested data for the log group. All previously ingested data remains
+	// encrypted, and CloudWatch Logs requires permissions for the KMS key whenever the
+	// encrypted data is requested. Note that it can take up to 5 minutes for this
+	// operation to take effect.
 	DisassociateKmsKey(ctx context.Context, params *DisassociateKmsKeyInput, optFns ...func(*Options)) (*DisassociateKmsKeyOutput, error)
 	// Lists log events from the specified log group. You can list all the log events
 	// or filter the results using a filter pattern, a time range, and the name of the
 	// log stream. You must have the logs;FilterLogEvents permission to perform this
 	// operation. You can specify the log group to search by using either
-	// logGroupIdentifier or logGroupName. You must include one of these two
+	// logGroupIdentifier or logGroupName . You must include one of these two
 	// parameters, but you can't include both. By default, this operation returns as
 	// many log events as can fit in 1 MB (up to 10,000 log events) or all the events
 	// found within the specified time range. If the results include a token, that
@@ -190,8 +176,8 @@ type CloudWatchLogs interface {
 	// was ingested by CloudWatch Logs, and the ID of the PutLogEvents request. If you
 	// are using CloudWatch cross-account observability, you can use this operation in
 	// a monitoring account and view data from the linked source accounts. For more
-	// information, see CloudWatch cross-account observability
-	// (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html).
+	// information, see CloudWatch cross-account observability (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html)
+	// .
 	FilterLogEvents(ctx context.Context, params *FilterLogEventsInput, optFns ...func(*Options)) (*FilterLogEventsOutput, error)
 	// Returns information about a log group data protection policy.
 	GetDataProtectionPolicy(ctx context.Context, params *GetDataProtectionPolicyInput, optFns ...func(*Options)) (*GetDataProtectionPolicyOutput, error)
@@ -203,55 +189,50 @@ type CloudWatchLogs interface {
 	// available through the token. If you are using CloudWatch cross-account
 	// observability, you can use this operation in a monitoring account and view data
 	// from the linked source accounts. For more information, see CloudWatch
-	// cross-account observability
-	// (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html).
-	// You can specify the log group to search by using either logGroupIdentifier or
-	// logGroupName. You must include one of these two parameters, but you can't
+	// cross-account observability (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html)
+	// . You can specify the log group to search by using either logGroupIdentifier or
+	// logGroupName . You must include one of these two parameters, but you can't
 	// include both.
 	GetLogEvents(ctx context.Context, params *GetLogEventsInput, optFns ...func(*Options)) (*GetLogEventsOutput, error)
 	// Returns a list of the fields that are included in log events in the specified
 	// log group. Includes the percentage of log events that contain each field. The
 	// search is limited to a time period that you specify. You can specify the log
-	// group to search by using either logGroupIdentifier or logGroupName. You must
+	// group to search by using either logGroupIdentifier or logGroupName . You must
 	// specify one of these parameters, but you can't specify both. In the results,
 	// fields that start with @ are fields generated by CloudWatch Logs. For example,
 	// @timestamp is the timestamp of each log event. For more information about the
 	// fields that are generated by CloudWatch logs, see Supported Logs and Discovered
-	// Fields
-	// (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_AnalyzeLogData-discoverable-fields.html).
-	// The response results are sorted by the frequency percentage, starting with the
+	// Fields (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_AnalyzeLogData-discoverable-fields.html)
+	// . The response results are sorted by the frequency percentage, starting with the
 	// highest percentage. If you are using CloudWatch cross-account observability, you
 	// can use this operation in a monitoring account and view data from the linked
 	// source accounts. For more information, see CloudWatch cross-account
-	// observability
-	// (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html).
+	// observability (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html)
+	// .
 	GetLogGroupFields(ctx context.Context, params *GetLogGroupFieldsInput, optFns ...func(*Options)) (*GetLogGroupFieldsOutput, error)
 	// Retrieves all of the fields and values of a single log event. All fields are
 	// retrieved, even if the original query that produced the logRecordPointer
 	// retrieved only a subset of fields. Fields are returned as field name/field value
-	// pairs. The full unparsed log event is returned within @message.
+	// pairs. The full unparsed log event is returned within @message .
 	GetLogRecord(ctx context.Context, params *GetLogRecordInput, optFns ...func(*Options)) (*GetLogRecordOutput, error)
 	// Returns the results from the specified query. Only the fields requested in the
-	// query are returned, along with a @ptr field, which is the identifier for the log
-	// record. You can use the value of @ptr in a GetLogRecord
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogRecord.html)
+	// query are returned, along with a @ptr field, which is the identifier for the
+	// log record. You can use the value of @ptr in a GetLogRecord (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogRecord.html)
 	// operation to get the full log record. GetQueryResults does not start running a
-	// query. To run a query, use StartQuery
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_StartQuery.html).
-	// If the value of the Status field in the output is Running, this operation
-	// returns only partial results. If you see a value of Scheduled or Running for the
-	// status, you can retry the operation later to see the final results. If you are
-	// using CloudWatch cross-account observability, you can use this operation in a
-	// monitoring account to start queries in linked source accounts. For more
-	// information, see CloudWatch cross-account observability
-	// (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html).
+	// query. To run a query, use StartQuery (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_StartQuery.html)
+	// . If the value of the Status field in the output is Running , this operation
+	// returns only partial results. If you see a value of Scheduled or Running for
+	// the status, you can retry the operation later to see the final results. If you
+	// are using CloudWatch cross-account observability, you can use this operation in
+	// a monitoring account to start queries in linked source accounts. For more
+	// information, see CloudWatch cross-account observability (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html)
+	// .
 	GetQueryResults(ctx context.Context, params *GetQueryResultsInput, optFns ...func(*Options)) (*GetQueryResultsOutput, error)
 	// Displays the tags associated with a CloudWatch Logs resource. Currently, log
 	// groups and destinations support tagging.
 	ListTagsForResource(ctx context.Context, params *ListTagsForResourceInput, optFns ...func(*Options)) (*ListTagsForResourceOutput, error)
 	// The ListTagsLogGroup operation is on the path to deprecation. We recommend that
-	// you use ListTagsForResource
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_ListTagsForResource.html)
+	// you use ListTagsForResource (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_ListTagsForResource.html)
 	// instead. Lists the tags for the specified log group.
 	//
 	// Deprecated: Please use the generic tagging API ListTagsForResource
@@ -263,112 +244,93 @@ type CloudWatchLogs interface {
 	// policy, log events ingested into the log group before that time are not masked.
 	// By default, when a user views a log event that includes masked data, the
 	// sensitive data is replaced by asterisks. A user who has the logs:Unmask
-	// permission can use a GetLogEvents
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogEvents.html)
-	// or FilterLogEvents
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilterLogEvents.html)
-	// operation with the unmask parameter set to true to view the unmasked log events.
-	// Users with the logs:Unmask can also view unmasked data in the CloudWatch Logs
-	// console by running a CloudWatch Logs Insights query with the unmask query
-	// command. For more information, including a list of types of data that can be
-	// audited and masked, see Protect sensitive log data with masking
-	// (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html).
+	// permission can use a GetLogEvents (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogEvents.html)
+	// or FilterLogEvents (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilterLogEvents.html)
+	// operation with the unmask parameter set to true to view the unmasked log
+	// events. Users with the logs:Unmask can also view unmasked data in the
+	// CloudWatch Logs console by running a CloudWatch Logs Insights query with the
+	// unmask query command. For more information, including a list of types of data
+	// that can be audited and masked, see Protect sensitive log data with masking (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html)
+	// .
 	PutDataProtectionPolicy(ctx context.Context, params *PutDataProtectionPolicyInput, optFns ...func(*Options)) (*PutDataProtectionPolicyOutput, error)
 	// Creates or updates a destination. This operation is used only to create
 	// destinations for cross-account subscriptions. A destination encapsulates a
 	// physical resource (such as an Amazon Kinesis stream). With a destination, you
 	// can subscribe to a real-time stream of log events for a different account,
-	// ingested using PutLogEvents
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html).
-	// Through an access policy, a destination controls what is written to it. By
+	// ingested using PutLogEvents (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html)
+	// . Through an access policy, a destination controls what is written to it. By
 	// default, PutDestination does not set any access policy with the destination,
-	// which means a cross-account user cannot call PutSubscriptionFilter
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutSubscriptionFilter.html)
+	// which means a cross-account user cannot call PutSubscriptionFilter (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutSubscriptionFilter.html)
 	// against this destination. To enable this, the destination owner must call
-	// PutDestinationPolicy
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutDestinationPolicy.html)
-	// after PutDestination. To perform a PutDestination operation, you must also have
-	// the iam:PassRole permission.
+	// PutDestinationPolicy (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutDestinationPolicy.html)
+	// after PutDestination . To perform a PutDestination operation, you must also
+	// have the iam:PassRole permission.
 	PutDestination(ctx context.Context, params *PutDestinationInput, optFns ...func(*Options)) (*PutDestinationOutput, error)
 	// Creates or updates an access policy associated with an existing destination. An
-	// access policy is an IAM policy document
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies_overview.html) that
-	// is used to authorize claims to register a subscription filter against a given
-	// destination.
+	// access policy is an IAM policy document (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies_overview.html)
+	// that is used to authorize claims to register a subscription filter against a
+	// given destination.
 	PutDestinationPolicy(ctx context.Context, params *PutDestinationPolicyInput, optFns ...func(*Options)) (*PutDestinationPolicyOutput, error)
-	// Uploads a batch of log events to the specified log stream. The sequence token is
-	// now ignored in PutLogEvents actions. PutLogEvents actions are always accepted
-	// and never return InvalidSequenceTokenException or DataAlreadyAcceptedException
-	// even if the sequence token is not valid. You can use parallel PutLogEvents
-	// actions on the same log stream. The batch of events must satisfy the following
-	// constraints:
+	// Uploads a batch of log events to the specified log stream. The sequence token
+	// is now ignored in PutLogEvents actions. PutLogEvents actions are always
+	// accepted and never return InvalidSequenceTokenException or
+	// DataAlreadyAcceptedException even if the sequence token is not valid. You can
+	// use parallel PutLogEvents actions on the same log stream. The batch of events
+	// must satisfy the following constraints:
+	//   - The maximum batch size is 1,048,576 bytes. This size is calculated as the
+	//     sum of all event messages in UTF-8, plus 26 bytes for each log event.
+	//   - None of the log events in the batch can be more than 2 hours in the future.
+	//   - None of the log events in the batch can be more than 14 days in the past.
+	//     Also, none of the log events can be from earlier than the retention period of
+	//     the log group.
+	//   - The log events in the batch must be in chronological order by their
+	//     timestamp. The timestamp is the time that the event occurred, expressed as the
+	//     number of milliseconds after Jan 1, 1970 00:00:00 UTC . (In Amazon Web
+	//     Services Tools for PowerShell and the Amazon Web Services SDK for .NET, the
+	//     timestamp is specified in .NET format: yyyy-mm-ddThh:mm:ss . For example,
+	//     2017-09-15T13:45:30 .)
+	//   - A batch of log events in a single request cannot span more than 24 hours.
+	//     Otherwise, the operation fails.
+	//   - The maximum number of log events in a batch is 10,000.
+	//   - The quota of five requests per second per log stream has been removed.
+	//     Instead, PutLogEvents actions are throttled based on a per-second per-account
+	//     quota. You can request an increase to the per-second throttling quota by using
+	//     the Service Quotas service.
 	//
-	// * The maximum batch size is 1,048,576 bytes. This size is
-	// calculated as the sum of all event messages in UTF-8, plus 26 bytes for each log
-	// event.
-	//
-	// * None of the log events in the batch can be more than 2 hours in the
-	// future.
-	//
-	// * None of the log events in the batch can be more than 14 days in the
-	// past. Also, none of the log events can be from earlier than the retention period
-	// of the log group.
-	//
-	// * The log events in the batch must be in chronological order
-	// by their timestamp. The timestamp is the time that the event occurred, expressed
-	// as the number of milliseconds after Jan 1, 1970 00:00:00 UTC. (In Amazon Web
-	// Services Tools for PowerShell and the Amazon Web Services SDK for .NET, the
-	// timestamp is specified in .NET format: yyyy-mm-ddThh:mm:ss. For example,
-	// 2017-09-15T13:45:30.)
-	//
-	// * A batch of log events in a single request cannot span
-	// more than 24 hours. Otherwise, the operation fails.
-	//
-	// * The maximum number of log
-	// events in a batch is 10,000.
-	//
-	// * The quota of five requests per second per log
-	// stream has been removed. Instead, PutLogEvents actions are throttled based on a
-	// per-second per-account quota. You can request an increase to the per-second
-	// throttling quota by using the Service Quotas service.
-	//
-	// If a call to PutLogEvents
-	// returns "UnrecognizedClientException" the most likely cause is a non-valid
-	// Amazon Web Services access key ID or secret key.
+	// If a call to PutLogEvents returns "UnrecognizedClientException" the most likely
+	// cause is a non-valid Amazon Web Services access key ID or secret key.
 	PutLogEvents(ctx context.Context, params *PutLogEventsInput, optFns ...func(*Options)) (*PutLogEventsOutput, error)
 	// Creates or updates a metric filter and associates it with the specified log
 	// group. With metric filters, you can configure rules to extract metric data from
-	// log events ingested through PutLogEvents
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html).
-	// The maximum number of metric filters that can be associated with a log group is
-	// 100. When you create a metric filter, you can also optionally assign a unit and
-	// dimensions to the metric that is created. Metrics extracted from log events are
-	// charged as custom metrics. To prevent unexpected high charges, do not specify
-	// high-cardinality fields such as IPAddress or requestID as dimensions. Each
-	// different value found for a dimension is treated as a separate metric and
+	// log events ingested through PutLogEvents (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html)
+	// . The maximum number of metric filters that can be associated with a log group
+	// is 100. When you create a metric filter, you can also optionally assign a unit
+	// and dimensions to the metric that is created. Metrics extracted from log events
+	// are charged as custom metrics. To prevent unexpected high charges, do not
+	// specify high-cardinality fields such as IPAddress or requestID as dimensions.
+	// Each different value found for a dimension is treated as a separate metric and
 	// accrues charges as a separate custom metric. CloudWatch Logs disables a metric
 	// filter if it generates 1,000 different name/value pairs for your specified
 	// dimensions within a certain amount of time. This helps to prevent accidental
 	// high charges. You can also set up a billing alarm to alert you if your charges
-	// are higher than expected. For more information, see  Creating a Billing Alarm to
-	// Monitor Your Estimated Amazon Web Services Charges
-	// (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/monitor_estimated_charges_with_cloudwatch.html).
+	// are higher than expected. For more information, see Creating a Billing Alarm to
+	// Monitor Your Estimated Amazon Web Services Charges (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/monitor_estimated_charges_with_cloudwatch.html)
+	// .
 	PutMetricFilter(ctx context.Context, params *PutMetricFilterInput, optFns ...func(*Options)) (*PutMetricFilterOutput, error)
 	// Creates or updates a query definition for CloudWatch Logs Insights. For more
-	// information, see Analyzing Log Data with CloudWatch Logs Insights
-	// (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html).
-	// To update a query definition, specify its queryDefinitionId in your request. The
-	// values of name, queryString, and logGroupNames are changed to the values that
-	// you specify in your update operation. No current values are retained from the
-	// current query definition. For example, imagine updating a current query
+	// information, see Analyzing Log Data with CloudWatch Logs Insights (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html)
+	// . To update a query definition, specify its queryDefinitionId in your request.
+	// The values of name , queryString , and logGroupNames are changed to the values
+	// that you specify in your update operation. No current values are retained from
+	// the current query definition. For example, imagine updating a current query
 	// definition that includes log groups. If you don't specify the logGroupNames
 	// parameter in your update operation, the query definition changes to contain no
 	// log groups. You must have the logs:PutQueryDefinition permission to be able to
 	// perform this operation.
 	PutQueryDefinition(ctx context.Context, params *PutQueryDefinitionInput, optFns ...func(*Options)) (*PutQueryDefinitionOutput, error)
-	// Creates or updates a resource policy allowing other Amazon Web Services services
-	// to put log events to this account, such as Amazon Route 53. An account can have
-	// up to 10 resource policies per Amazon Web Services Region.
+	// Creates or updates a resource policy allowing other Amazon Web Services
+	// services to put log events to this account, such as Amazon Route 53. An account
+	// can have up to 10 resource policies per Amazon Web Services Region.
 	PutResourcePolicy(ctx context.Context, params *PutResourcePolicyInput, optFns ...func(*Options)) (*PutResourcePolicyOutput, error)
 	// Sets the retention of the specified log group. With a retention policy, you can
 	// configure the number of days for which to retain log events in the specified log
@@ -385,66 +347,52 @@ type CloudWatchLogs interface {
 	PutRetentionPolicy(ctx context.Context, params *PutRetentionPolicyInput, optFns ...func(*Options)) (*PutRetentionPolicyOutput, error)
 	// Creates or updates a subscription filter and associates it with the specified
 	// log group. With subscription filters, you can subscribe to a real-time stream of
-	// log events ingested through PutLogEvents
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html)
+	// log events ingested through PutLogEvents (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html)
 	// and have them delivered to a specific destination. When log events are sent to
 	// the receiving service, they are Base64 encoded and compressed with the GZIP
 	// format. The following destinations are supported for subscription filters:
+	//   - An Amazon Kinesis data stream belonging to the same account as the
+	//     subscription filter, for same-account delivery.
+	//   - A logical destination that belongs to a different account, for
+	//     cross-account delivery.
+	//   - An Amazon Kinesis Data Firehose delivery stream that belongs to the same
+	//     account as the subscription filter, for same-account delivery.
+	//   - An Lambda function that belongs to the same account as the subscription
+	//     filter, for same-account delivery.
 	//
-	// * An
-	// Amazon Kinesis data stream belonging to the same account as the subscription
-	// filter, for same-account delivery.
-	//
-	// * A logical destination that belongs to a
-	// different account, for cross-account delivery.
-	//
-	// * An Amazon Kinesis Data
-	// Firehose delivery stream that belongs to the same account as the subscription
-	// filter, for same-account delivery.
-	//
-	// * An Lambda function that belongs to the
-	// same account as the subscription filter, for same-account delivery.
-	//
-	// Each log
-	// group can have up to two subscription filters associated with it. If you are
-	// updating an existing filter, you must specify the correct name in filterName. To
-	// perform a PutSubscriptionFilter operation, you must also have the iam:PassRole
-	// permission.
+	// Each log group can have up to two subscription filters associated with it. If
+	// you are updating an existing filter, you must specify the correct name in
+	// filterName . To perform a PutSubscriptionFilter operation, you must also have
+	// the iam:PassRole permission.
 	PutSubscriptionFilter(ctx context.Context, params *PutSubscriptionFilterInput, optFns ...func(*Options)) (*PutSubscriptionFilterOutput, error)
-	// Schedules a query of a log group using CloudWatch Logs Insights. You specify the
-	// log group and time range to query and the query string to use. For more
-	// information, see CloudWatch Logs Insights Query Syntax
-	// (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html).
-	// Queries time out after 15 minutes of runtime. If your queries are timing out,
+	// Schedules a query of a log group using CloudWatch Logs Insights. You specify
+	// the log group and time range to query and the query string to use. For more
+	// information, see CloudWatch Logs Insights Query Syntax (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html)
+	// . Queries time out after 15 minutes of runtime. If your queries are timing out,
 	// reduce the time range being searched or partition your query into a number of
 	// queries. If you are using CloudWatch cross-account observability, you can use
 	// this operation in a monitoring account to start a query in a linked source
-	// account. For more information, see CloudWatch cross-account observability
-	// (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html).
-	// For a cross-account StartQuery operation, the query definition must be defined
-	// in the monitoring account. You can have up to 20 concurrent CloudWatch Logs
-	// insights queries, including queries that have been added to dashboards.
+	// account. For more information, see CloudWatch cross-account observability (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html)
+	// . For a cross-account StartQuery operation, the query definition must be
+	// defined in the monitoring account. You can have up to 20 concurrent CloudWatch
+	// Logs insights queries, including queries that have been added to dashboards.
 	StartQuery(ctx context.Context, params *StartQueryInput, optFns ...func(*Options)) (*StartQueryOutput, error)
 	// Stops a CloudWatch Logs Insights query that is in progress. If the query has
 	// already ended, the operation returns an error indicating that the specified
 	// query is not running.
 	StopQuery(ctx context.Context, params *StopQueryInput, optFns ...func(*Options)) (*StopQueryOutput, error)
 	// The TagLogGroup operation is on the path to deprecation. We recommend that you
-	// use TagResource
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_TagResource.html)
+	// use TagResource (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_TagResource.html)
 	// instead. Adds or updates the specified tags for the specified log group. To list
-	// the tags for a log group, use ListTagsForResource
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_ListTagsForResource.html).
-	// To remove tags, use UntagResource
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_UntagResource.html).
-	// For more information about tags, see Tag Log Groups in Amazon CloudWatch Logs
-	// (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#log-group-tagging)
+	// the tags for a log group, use ListTagsForResource (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_ListTagsForResource.html)
+	// . To remove tags, use UntagResource (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_UntagResource.html)
+	// . For more information about tags, see Tag Log Groups in Amazon CloudWatch Logs (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#log-group-tagging)
 	// in the Amazon CloudWatch Logs User Guide. CloudWatch Logs doesn’t support IAM
 	// policies that prevent users from assigning specified tags to log groups using
 	// the aws:Resource/key-name  or aws:TagKeys condition keys. For more information
 	// about using tags to control access, see Controlling access to Amazon Web
-	// Services resources using tags
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html).
+	// Services resources using tags (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html)
+	// .
 	//
 	// Deprecated: Please use the generic tagging API TagResource
 	TagLogGroup(ctx context.Context, params *TagLogGroupInput, optFns ...func(*Options)) (*TagLogGroupOutput, error)
@@ -465,15 +413,12 @@ type CloudWatchLogs interface {
 	// messages. You can use this operation to validate the correctness of a metric
 	// filter pattern.
 	TestMetricFilter(ctx context.Context, params *TestMetricFilterInput, optFns ...func(*Options)) (*TestMetricFilterOutput, error)
-	// The UntagLogGroup operation is on the path to deprecation. We recommend that you
-	// use UntagResource
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_UntagResource.html)
+	// The UntagLogGroup operation is on the path to deprecation. We recommend that
+	// you use UntagResource (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_UntagResource.html)
 	// instead. Removes the specified tags from the specified log group. To list the
-	// tags for a log group, use ListTagsForResource
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_ListTagsForResource.html).
-	// To add tags, use TagResource
-	// (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_TagResource.html).
-	// CloudWatch Logs doesn’t support IAM policies that prevent users from assigning
+	// tags for a log group, use ListTagsForResource (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_ListTagsForResource.html)
+	// . To add tags, use TagResource (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_TagResource.html)
+	// . CloudWatch Logs doesn’t support IAM policies that prevent users from assigning
 	// specified tags to log groups using the aws:Resource/key-name  or aws:TagKeys
 	// condition keys.
 	//

--- a/pkg/awsapi/eks.go
+++ b/pkg/awsapi/eks.go
@@ -20,16 +20,14 @@ type EKS interface {
 	// provider configuration and associate it to your cluster. After configuring
 	// authentication to your cluster you can create Kubernetes roles and clusterroles
 	// to assign permissions to the roles, and then bind the roles to the identities
-	// using Kubernetes rolebindings and clusterrolebindings. For more information see
-	// Using RBAC Authorization
-	// (https://kubernetes.io/docs/reference/access-authn-authz/rbac/) in the
-	// Kubernetes documentation.
+	// using Kubernetes rolebindings and clusterrolebindings . For more information see
+	// Using RBAC Authorization (https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+	// in the Kubernetes documentation.
 	AssociateIdentityProviderConfig(ctx context.Context, params *AssociateIdentityProviderConfigInput, optFns ...func(*Options)) (*AssociateIdentityProviderConfigOutput, error)
 	// Creates an Amazon EKS add-on. Amazon EKS add-ons help to automate the
 	// provisioning and lifecycle management of common operational software for Amazon
-	// EKS clusters. For more information, see Amazon EKS add-ons
-	// (https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html) in the
-	// Amazon EKS User Guide.
+	// EKS clusters. For more information, see Amazon EKS add-ons (https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html)
+	// in the Amazon EKS User Guide.
 	CreateAddon(ctx context.Context, params *CreateAddonInput, optFns ...func(*Options)) (*CreateAddonOutput, error)
 	// Creates an Amazon EKS control plane. The Amazon EKS control plane consists of
 	// control plane instances that run the Kubernetes software, such as etcd and the
@@ -40,17 +38,15 @@ type EKS interface {
 	// multiple Availability Zones and fronted by an Elastic Load Balancing Network
 	// Load Balancer. Amazon EKS also provisions elastic network interfaces in your VPC
 	// subnets to provide connectivity from the control plane instances to the nodes
-	// (for example, to support kubectl exec, logs, and proxy data flows). Amazon EKS
-	// nodes run in your Amazon Web Services account and connect to your cluster's
+	// (for example, to support kubectl exec , logs , and proxy data flows). Amazon
+	// EKS nodes run in your Amazon Web Services account and connect to your cluster's
 	// control plane over the Kubernetes API server endpoint and a certificate file
 	// that is created for your cluster. In most cases, it takes several minutes to
 	// create a cluster. After you create an Amazon EKS cluster, you must configure
 	// your Kubernetes tooling to communicate with the API server and launch nodes into
-	// your cluster. For more information, see Managing Cluster Authentication
-	// (https://docs.aws.amazon.com/eks/latest/userguide/managing-auth.html) and
-	// Launching Amazon EKS nodes
-	// (https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html) in the
-	// Amazon EKS User Guide.
+	// your cluster. For more information, see Managing Cluster Authentication (https://docs.aws.amazon.com/eks/latest/userguide/managing-auth.html)
+	// and Launching Amazon EKS nodes (https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html)
+	// in the Amazon EKS User Guide.
 	CreateCluster(ctx context.Context, params *CreateClusterInput, optFns ...func(*Options)) (*CreateClusterOutput, error)
 	// Creates an Fargate profile for your Amazon EKS cluster. You must have at least
 	// one Fargate profile in a cluster to be able to run pods on Fargate. The Fargate
@@ -63,40 +59,35 @@ type EKS interface {
 	// selectors in the Fargate profile, then that pod is run on Fargate. When you
 	// create a Fargate profile, you must specify a pod execution role to use with the
 	// pods that are scheduled with the profile. This role is added to the cluster's
-	// Kubernetes Role Based Access Control
-	// (https://kubernetes.io/docs/admin/authorization/rbac/) (RBAC) for authorization
-	// so that the kubelet that is running on the Fargate infrastructure can register
-	// with your Amazon EKS cluster so that it can appear in your cluster as a node.
-	// The pod execution role also provides IAM permissions to the Fargate
-	// infrastructure to allow read access to Amazon ECR image repositories. For more
-	// information, see Pod Execution Role
-	// (https://docs.aws.amazon.com/eks/latest/userguide/pod-execution-role.html) in
-	// the Amazon EKS User Guide. Fargate profiles are immutable. However, you can
+	// Kubernetes Role Based Access Control (https://kubernetes.io/docs/admin/authorization/rbac/)
+	// (RBAC) for authorization so that the kubelet that is running on the Fargate
+	// infrastructure can register with your Amazon EKS cluster so that it can appear
+	// in your cluster as a node. The pod execution role also provides IAM permissions
+	// to the Fargate infrastructure to allow read access to Amazon ECR image
+	// repositories. For more information, see Pod Execution Role (https://docs.aws.amazon.com/eks/latest/userguide/pod-execution-role.html)
+	// in the Amazon EKS User Guide. Fargate profiles are immutable. However, you can
 	// create a new updated profile to replace an existing profile and then delete the
 	// original after the updated profile has finished creating. If any Fargate
-	// profiles in a cluster are in the DELETING status, you must wait for that Fargate
-	// profile to finish deleting before you can create any other profiles in that
-	// cluster. For more information, see Fargate Profile
-	// (https://docs.aws.amazon.com/eks/latest/userguide/fargate-profile.html) in the
-	// Amazon EKS User Guide.
+	// profiles in a cluster are in the DELETING status, you must wait for that
+	// Fargate profile to finish deleting before you can create any other profiles in
+	// that cluster. For more information, see Fargate Profile (https://docs.aws.amazon.com/eks/latest/userguide/fargate-profile.html)
+	// in the Amazon EKS User Guide.
 	CreateFargateProfile(ctx context.Context, params *CreateFargateProfileInput, optFns ...func(*Options)) (*CreateFargateProfileOutput, error)
 	// Creates a managed node group for an Amazon EKS cluster. You can only create a
 	// node group for your cluster that is equal to the current Kubernetes version for
 	// the cluster. All node groups are created with the latest AMI release version for
 	// the respective minor Kubernetes version of the cluster, unless you deploy a
 	// custom AMI using a launch template. For more information about using launch
-	// templates, see Launch template support
-	// (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html). An
-	// Amazon EKS managed node group is an Amazon EC2 Auto Scaling group and associated
-	// Amazon EC2 instances that are managed by Amazon Web Services for an Amazon EKS
-	// cluster. For more information, see Managed node groups
-	// (https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) in
-	// the Amazon EKS User Guide. Windows AMI types are only supported for commercial
-	// Regions that support Windows Amazon EKS.
+	// templates, see Launch template support (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html)
+	// . An Amazon EKS managed node group is an Amazon EC2 Auto Scaling group and
+	// associated Amazon EC2 instances that are managed by Amazon Web Services for an
+	// Amazon EKS cluster. For more information, see Managed node groups (https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html)
+	// in the Amazon EKS User Guide. Windows AMI types are only supported for
+	// commercial Regions that support Windows Amazon EKS.
 	CreateNodegroup(ctx context.Context, params *CreateNodegroupInput, optFns ...func(*Options)) (*CreateNodegroupOutput, error)
-	// Delete an Amazon EKS add-on. When you remove the add-on, it will also be deleted
-	// from the cluster. You can always manually start an add-on on the cluster using
-	// the Kubernetes API.
+	// Delete an Amazon EKS add-on. When you remove the add-on, it will also be
+	// deleted from the cluster. You can always manually start an add-on on the cluster
+	// using the Kubernetes API.
 	DeleteAddon(ctx context.Context, params *DeleteAddonInput, optFns ...func(*Options)) (*DeleteAddonOutput, error)
 	// Deletes the Amazon EKS cluster control plane. If you have active services in
 	// your cluster that are associated with a load balancer, you must delete those
@@ -106,7 +97,7 @@ type EKS interface {
 	// Cluster (https://docs.aws.amazon.com/eks/latest/userguide/delete-cluster.html)
 	// in the Amazon EKS User Guide. If you have managed node groups or Fargate
 	// profiles attached to the cluster, you must delete them first. For more
-	// information, see DeleteNodegroup and DeleteFargateProfile.
+	// information, see DeleteNodegroup and DeleteFargateProfile .
 	DeleteCluster(ctx context.Context, params *DeleteClusterInput, optFns ...func(*Options)) (*DeleteClusterOutput, error)
 	// Deletes an Fargate profile. When you delete a Fargate profile, any pods running
 	// on Fargate that were created with the profile are deleted. If those pods match
@@ -126,16 +117,15 @@ type EKS interface {
 	// Returns configuration options.
 	DescribeAddonConfiguration(ctx context.Context, params *DescribeAddonConfigurationInput, optFns ...func(*Options)) (*DescribeAddonConfigurationOutput, error)
 	// Describes the versions for an add-on. Information such as the Kubernetes
-	// versions that you can use the add-on with, the owner, publisher, and the type of
-	// the add-on are returned.
+	// versions that you can use the add-on with, the owner , publisher , and the type
+	// of the add-on are returned.
 	DescribeAddonVersions(ctx context.Context, params *DescribeAddonVersionsInput, optFns ...func(*Options)) (*DescribeAddonVersionsOutput, error)
 	// Returns descriptive information about an Amazon EKS cluster. The API server
 	// endpoint and certificate authority data returned by this operation are required
-	// for kubelet and kubectl to communicate with your Kubernetes API server. For more
-	// information, see Create a kubeconfig for Amazon EKS
-	// (https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html). The
-	// API server endpoint and certificate authority data aren't available until the
-	// cluster reaches the ACTIVE state.
+	// for kubelet and kubectl to communicate with your Kubernetes API server. For
+	// more information, see Create a kubeconfig for Amazon EKS (https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html)
+	// . The API server endpoint and certificate authority data aren't available until
+	// the cluster reaches the ACTIVE state.
 	DescribeCluster(ctx context.Context, params *DescribeClusterInput, optFns ...func(*Options)) (*DescribeClusterOutput, error)
 	// Returns descriptive information about an Fargate profile.
 	DescribeFargateProfile(ctx context.Context, params *DescribeFargateProfileInput, optFns ...func(*Options)) (*DescribeFargateProfileOutput, error)
@@ -145,8 +135,8 @@ type EKS interface {
 	DescribeNodegroup(ctx context.Context, params *DescribeNodegroupInput, optFns ...func(*Options)) (*DescribeNodegroupOutput, error)
 	// Returns descriptive information about an update against your Amazon EKS cluster
 	// or associated managed node group or Amazon EKS add-on. When the status of the
-	// update is Succeeded, the update is complete. If an update fails, the status is
-	// Failed, and an error detail explains the reason for the failure.
+	// update is Succeeded , the update is complete. If an update fails, the status is
+	// Failed , and an error detail explains the reason for the failure.
 	DescribeUpdate(ctx context.Context, params *DescribeUpdateInput, optFns ...func(*Options)) (*DescribeUpdateOutput, error)
 	// Disassociates an identity provider configuration from a cluster. If you
 	// disassociate an identity provider from your cluster, users included in the
@@ -169,23 +159,22 @@ type EKS interface {
 	ListNodegroups(ctx context.Context, params *ListNodegroupsInput, optFns ...func(*Options)) (*ListNodegroupsOutput, error)
 	// List the tags for an Amazon EKS resource.
 	ListTagsForResource(ctx context.Context, params *ListTagsForResourceInput, optFns ...func(*Options)) (*ListTagsForResourceOutput, error)
-	// Lists the updates associated with an Amazon EKS cluster or managed node group in
-	// your Amazon Web Services account, in the specified Region.
+	// Lists the updates associated with an Amazon EKS cluster or managed node group
+	// in your Amazon Web Services account, in the specified Region.
 	ListUpdates(ctx context.Context, params *ListUpdatesInput, optFns ...func(*Options)) (*ListUpdatesOutput, error)
 	// Connects a Kubernetes cluster to the Amazon EKS control plane. Any Kubernetes
 	// cluster can be connected to the Amazon EKS control plane to view current
 	// information about the cluster and its nodes. Cluster connection requires two
 	// steps. First, send a RegisterClusterRequest to add it to the Amazon EKS control
-	// plane. Second, a Manifest
-	// (https://amazon-eks.s3.us-west-2.amazonaws.com/eks-connector/manifests/eks-connector/latest/eks-connector.yaml)
-	// containing the activationID and activationCode must be applied to the Kubernetes
-	// cluster through it's native provider to provide visibility. After the Manifest
-	// is updated and applied, then the connected cluster is visible to the Amazon EKS
-	// control plane. If the Manifest is not applied within three days, then the
-	// connected cluster will no longer be visible and must be deregistered. See
-	// DeregisterCluster.
+	// plane. Second, a Manifest (https://amazon-eks.s3.us-west-2.amazonaws.com/eks-connector/manifests/eks-connector/latest/eks-connector.yaml)
+	// containing the activationID and activationCode must be applied to the
+	// Kubernetes cluster through it's native provider to provide visibility. After the
+	// Manifest is updated and applied, then the connected cluster is visible to the
+	// Amazon EKS control plane. If the Manifest is not applied within three days, then
+	// the connected cluster will no longer be visible and must be deregistered. See
+	// DeregisterCluster .
 	RegisterCluster(ctx context.Context, params *RegisterClusterInput, optFns ...func(*Options)) (*RegisterClusterOutput, error)
-	// Associates the specified tags to a resource with the specified resourceArn. If
+	// Associates the specified tags to a resource with the specified resourceArn . If
 	// existing tags on a resource are not specified in the request parameters, they
 	// are not changed. When a resource is deleted, the tags associated with that
 	// resource are deleted as well. Tags that you create for Amazon EKS resources do
@@ -203,21 +192,19 @@ type EKS interface {
 	// You can use this API operation to enable or disable exporting the Kubernetes
 	// control plane logs for your cluster to CloudWatch Logs. By default, cluster
 	// control plane logs aren't exported to CloudWatch Logs. For more information, see
-	// Amazon EKS Cluster Control Plane Logs
-	// (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) in
-	// the Amazon EKS User Guide . CloudWatch Logs ingestion, archive storage, and data
-	// scanning rates apply to exported control plane logs. For more information, see
-	// CloudWatch Pricing (http://aws.amazon.com/cloudwatch/pricing/). You can also use
-	// this API operation to enable or disable public and private access to your
-	// cluster's Kubernetes API server endpoint. By default, public access is enabled,
-	// and private access is disabled. For more information, see Amazon EKS cluster
-	// endpoint access control
-	// (https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html) in the
-	// Amazon EKS User Guide . You can't update the subnets or security group IDs for
-	// an existing cluster. Cluster updates are asynchronous, and they should finish
-	// within a few minutes. During an update, the cluster status moves to UPDATING
-	// (this status transition is eventually consistent). When the update is complete
-	// (either Failed or Successful), the cluster status moves to Active.
+	// Amazon EKS Cluster Control Plane Logs (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)
+	// in the Amazon EKS User Guide . CloudWatch Logs ingestion, archive storage, and
+	// data scanning rates apply to exported control plane logs. For more information,
+	// see CloudWatch Pricing (http://aws.amazon.com/cloudwatch/pricing/) . You can
+	// also use this API operation to enable or disable public and private access to
+	// your cluster's Kubernetes API server endpoint. By default, public access is
+	// enabled, and private access is disabled. For more information, see Amazon EKS
+	// cluster endpoint access control (https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html)
+	// in the Amazon EKS User Guide . You can't update the subnets or security group
+	// IDs for an existing cluster. Cluster updates are asynchronous, and they should
+	// finish within a few minutes. During an update, the cluster status moves to
+	// UPDATING (this status transition is eventually consistent). When the update is
+	// complete (either Failed or Successful ), the cluster status moves to Active .
 	UpdateClusterConfig(ctx context.Context, params *UpdateClusterConfigInput, optFns ...func(*Options)) (*UpdateClusterConfigOutput, error)
 	// Updates an Amazon EKS cluster to the specified Kubernetes version. Your cluster
 	// continues to function during the update. The response output includes an update
@@ -225,7 +212,7 @@ type EKS interface {
 	// DescribeUpdate API operation. Cluster updates are asynchronous, and they should
 	// finish within a few minutes. During an update, the cluster status moves to
 	// UPDATING (this status transition is eventually consistent). When the update is
-	// complete (either Failed or Successful), the cluster status moves to Active. If
+	// complete (either Failed or Successful ), the cluster status moves to Active . If
 	// your cluster has managed node groups attached to it, all of your node groups’
 	// Kubernetes versions must match the cluster’s Kubernetes version in order to
 	// update the cluster to a new Kubernetes version.
@@ -247,11 +234,9 @@ type EKS interface {
 	// Kubernetes version in the request. You can update to the latest AMI version of
 	// your cluster's current Kubernetes version by specifying your cluster's
 	// Kubernetes version in the request. For information about Linux versions, see
-	// Amazon EKS optimized Amazon Linux AMI versions
-	// (https://docs.aws.amazon.com/eks/latest/userguide/eks-linux-ami-versions.html)
-	// in the Amazon EKS User Guide. For information about Windows versions, see Amazon
-	// EKS optimized Windows AMI versions
-	// (https://docs.aws.amazon.com/eks/latest/userguide/eks-ami-versions-windows.html)
+	// Amazon EKS optimized Amazon Linux AMI versions (https://docs.aws.amazon.com/eks/latest/userguide/eks-linux-ami-versions.html)
+	// in the Amazon EKS User Guide. For information about Windows versions, see
+	// Amazon EKS optimized Windows AMI versions (https://docs.aws.amazon.com/eks/latest/userguide/eks-ami-versions-windows.html)
 	// in the Amazon EKS User Guide. You cannot roll back a node group to an earlier
 	// Kubernetes version or AMI version. When a node in a managed node group is
 	// terminated due to a scaling action or update, the pods in that node are drained

--- a/pkg/awsapi/elasticloadbalancing.go
+++ b/pkg/awsapi/elasticloadbalancing.go
@@ -13,41 +13,37 @@ type ELB interface {
 	// Adds the specified tags to the specified load balancer. Each load balancer can
 	// have a maximum of 10 tags. Each tag consists of a key and an optional value. If
 	// a tag with the same key is already associated with the load balancer, AddTags
-	// updates its value. For more information, see Tag Your Classic Load Balancer
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/add-remove-tags.html)
+	// updates its value. For more information, see Tag Your Classic Load Balancer (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/add-remove-tags.html)
 	// in the Classic Load Balancers Guide.
 	AddTags(ctx context.Context, params *AddTagsInput, optFns ...func(*Options)) (*AddTagsOutput, error)
 	// Associates one or more security groups with your load balancer in a virtual
 	// private cloud (VPC). The specified security groups override the previously
 	// associated security groups. For more information, see Security Groups for Load
-	// Balancers in a VPC
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-groups.html#elb-vpc-security-groups)
+	// Balancers in a VPC (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-groups.html#elb-vpc-security-groups)
 	// in the Classic Load Balancers Guide.
 	ApplySecurityGroupsToLoadBalancer(ctx context.Context, params *ApplySecurityGroupsToLoadBalancerInput, optFns ...func(*Options)) (*ApplySecurityGroupsToLoadBalancerOutput, error)
-	// Adds one or more subnets to the set of configured subnets for the specified load
-	// balancer. The load balancer evenly distributes requests across all registered
-	// subnets. For more information, see Add or Remove Subnets for Your Load Balancer
-	// in a VPC
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-manage-subnets.html)
+	// Adds one or more subnets to the set of configured subnets for the specified
+	// load balancer. The load balancer evenly distributes requests across all
+	// registered subnets. For more information, see Add or Remove Subnets for Your
+	// Load Balancer in a VPC (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-manage-subnets.html)
 	// in the Classic Load Balancers Guide.
 	AttachLoadBalancerToSubnets(ctx context.Context, params *AttachLoadBalancerToSubnetsInput, optFns ...func(*Options)) (*AttachLoadBalancerToSubnetsOutput, error)
 	// Specifies the health check settings to use when evaluating the health state of
 	// your EC2 instances. For more information, see Configure Health Checks for Your
-	// Load Balancer
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-healthchecks.html)
+	// Load Balancer (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-healthchecks.html)
 	// in the Classic Load Balancers Guide.
 	ConfigureHealthCheck(ctx context.Context, params *ConfigureHealthCheckInput, optFns ...func(*Options)) (*ConfigureHealthCheckOutput, error)
 	// Generates a stickiness policy with sticky session lifetimes that follow that of
 	// an application-generated cookie. This policy can be associated only with
 	// HTTP/HTTPS listeners. This policy is similar to the policy created by
-	// CreateLBCookieStickinessPolicy, except that the lifetime of the special Elastic
-	// Load Balancing cookie, AWSELB, follows the lifetime of the application-generated
-	// cookie specified in the policy configuration. The load balancer only inserts a
-	// new stickiness cookie when the application response includes a new application
-	// cookie. If the application cookie is explicitly removed or expires, the session
-	// stops being sticky until a new application cookie is issued. For more
-	// information, see Application-Controlled Session Stickiness
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-sticky-sessions.html#enable-sticky-sessions-application)
+	// CreateLBCookieStickinessPolicy , except that the lifetime of the special Elastic
+	// Load Balancing cookie, AWSELB , follows the lifetime of the
+	// application-generated cookie specified in the policy configuration. The load
+	// balancer only inserts a new stickiness cookie when the application response
+	// includes a new application cookie. If the application cookie is explicitly
+	// removed or expires, the session stops being sticky until a new application
+	// cookie is issued. For more information, see Application-Controlled Session
+	// Stickiness (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-sticky-sessions.html#enable-sticky-sessions-application)
 	// in the Classic Load Balancers Guide.
 	CreateAppCookieStickinessPolicy(ctx context.Context, params *CreateAppCookieStickinessPolicyInput, optFns ...func(*Options)) (*CreateAppCookieStickinessPolicyOutput, error)
 	// Generates a stickiness policy with sticky session lifetimes controlled by the
@@ -61,27 +57,24 @@ type ELB interface {
 	// load-balancing algorithm. A cookie is inserted into the response for binding
 	// subsequent requests from the same user to that server. The validity of the
 	// cookie is based on the cookie expiration time, which is specified in the policy
-	// configuration. For more information, see Duration-Based Session Stickiness
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-sticky-sessions.html#enable-sticky-sessions-duration)
+	// configuration. For more information, see Duration-Based Session Stickiness (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-sticky-sessions.html#enable-sticky-sessions-duration)
 	// in the Classic Load Balancers Guide.
 	CreateLBCookieStickinessPolicy(ctx context.Context, params *CreateLBCookieStickinessPolicyInput, optFns ...func(*Options)) (*CreateLBCookieStickinessPolicyOutput, error)
 	// Creates a Classic Load Balancer. You can add listeners, security groups,
 	// subnets, and tags when you create your load balancer, or you can add them later
-	// using CreateLoadBalancerListeners, ApplySecurityGroupsToLoadBalancer,
-	// AttachLoadBalancerToSubnets, and AddTags. To describe your current load
-	// balancers, see DescribeLoadBalancers. When you are finished with a load
-	// balancer, you can delete it using DeleteLoadBalancer. You can create up to 20
+	// using CreateLoadBalancerListeners , ApplySecurityGroupsToLoadBalancer ,
+	// AttachLoadBalancerToSubnets , and AddTags . To describe your current load
+	// balancers, see DescribeLoadBalancers . When you are finished with a load
+	// balancer, you can delete it using DeleteLoadBalancer . You can create up to 20
 	// load balancers per region per account. You can request an increase for the
 	// number of load balancers for your account. For more information, see Limits for
-	// Your Classic Load Balancer
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-limits.html)
+	// Your Classic Load Balancer (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-limits.html)
 	// in the Classic Load Balancers Guide.
 	CreateLoadBalancer(ctx context.Context, params *CreateLoadBalancerInput, optFns ...func(*Options)) (*CreateLoadBalancerOutput, error)
 	// Creates one or more listeners for the specified load balancer. If a listener
 	// with the specified port does not already exist, it is created; otherwise, the
 	// properties of the new listener must match the properties of the existing
-	// listener. For more information, see Listeners for Your Classic Load Balancer
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-listener-config.html)
+	// listener. For more information, see Listeners for Your Classic Load Balancer (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-listener-config.html)
 	// in the Classic Load Balancers Guide.
 	CreateLoadBalancerListeners(ctx context.Context, params *CreateLoadBalancerListenersInput, optFns ...func(*Options)) (*CreateLoadBalancerListenersOutput, error)
 	// Creates a policy with the specified attributes for the specified load balancer.
@@ -105,13 +98,11 @@ type ELB interface {
 	// instance is deregistered, it no longer receives traffic from the load balancer.
 	// You can use DescribeLoadBalancers to verify that the instance is deregistered
 	// from the load balancer. For more information, see Register or De-Register EC2
-	// Instances
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-deregister-register-instances.html)
+	// Instances (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-deregister-register-instances.html)
 	// in the Classic Load Balancers Guide.
 	DeregisterInstancesFromLoadBalancer(ctx context.Context, params *DeregisterInstancesFromLoadBalancerInput, optFns ...func(*Options)) (*DeregisterInstancesFromLoadBalancerOutput, error)
 	// Describes the current Elastic Load Balancing resource limits for your AWS
-	// account. For more information, see Limits for Your Classic Load Balancer
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-limits.html)
+	// account. For more information, see Limits for Your Classic Load Balancer (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-limits.html)
 	// in the Classic Load Balancers Guide.
 	DescribeAccountLimits(ctx context.Context, params *DescribeAccountLimitsInput, optFns ...func(*Options)) (*DescribeAccountLimitsOutput, error)
 	// Describes the state of the specified instances with respect to the specified
@@ -134,10 +125,10 @@ type ELB interface {
 	// types. The description of each type indicates how it can be used. For example,
 	// some policies can be used only with layer 7 listeners, some policies can be used
 	// only with layer 4 listeners, and some policies can be used only with your EC2
-	// instances. You can use CreateLoadBalancerPolicy to create a policy configuration
-	// for any of these policy types. Then, depending on the policy type, use either
-	// SetLoadBalancerPoliciesOfListener or SetLoadBalancerPoliciesForBackendServer to
-	// set the policy.
+	// instances. You can use CreateLoadBalancerPolicy to create a policy
+	// configuration for any of these policy types. Then, depending on the policy type,
+	// use either SetLoadBalancerPoliciesOfListener or
+	// SetLoadBalancerPoliciesForBackendServer to set the policy.
 	DescribeLoadBalancerPolicyTypes(ctx context.Context, params *DescribeLoadBalancerPolicyTypesInput, optFns ...func(*Options)) (*DescribeLoadBalancerPolicyTypesOutput, error)
 	// Describes the specified the load balancers. If no load balancers are specified,
 	// the call describes all of your load balancers.
@@ -151,44 +142,31 @@ type ELB interface {
 	DetachLoadBalancerFromSubnets(ctx context.Context, params *DetachLoadBalancerFromSubnetsInput, optFns ...func(*Options)) (*DetachLoadBalancerFromSubnetsOutput, error)
 	// Removes the specified Availability Zones from the set of Availability Zones for
 	// the specified load balancer in EC2-Classic or a default VPC. For load balancers
-	// in a non-default VPC, use DetachLoadBalancerFromSubnets. There must be at least
+	// in a non-default VPC, use DetachLoadBalancerFromSubnets . There must be at least
 	// one Availability Zone registered with a load balancer at all times. After an
 	// Availability Zone is removed, all instances registered with the load balancer
 	// that are in the removed Availability Zone go into the OutOfService state. Then,
 	// the load balancer attempts to equally balance the traffic among its remaining
-	// Availability Zones. For more information, see Add or Remove Availability Zones
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-disable-az.html)
+	// Availability Zones. For more information, see Add or Remove Availability Zones (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-disable-az.html)
 	// in the Classic Load Balancers Guide.
 	DisableAvailabilityZonesForLoadBalancer(ctx context.Context, params *DisableAvailabilityZonesForLoadBalancerInput, optFns ...func(*Options)) (*DisableAvailabilityZonesForLoadBalancerOutput, error)
 	// Adds the specified Availability Zones to the set of Availability Zones for the
 	// specified load balancer in EC2-Classic or a default VPC. For load balancers in a
-	// non-default VPC, use AttachLoadBalancerToSubnets. The load balancer evenly
+	// non-default VPC, use AttachLoadBalancerToSubnets . The load balancer evenly
 	// distributes requests across all its registered Availability Zones that contain
-	// instances. For more information, see Add or Remove Availability Zones
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-disable-az.html)
+	// instances. For more information, see Add or Remove Availability Zones (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-disable-az.html)
 	// in the Classic Load Balancers Guide.
 	EnableAvailabilityZonesForLoadBalancer(ctx context.Context, params *EnableAvailabilityZonesForLoadBalancerInput, optFns ...func(*Options)) (*EnableAvailabilityZonesForLoadBalancerOutput, error)
 	// Modifies the attributes of the specified load balancer. You can modify the load
-	// balancer attributes, such as AccessLogs, ConnectionDraining, and
+	// balancer attributes, such as AccessLogs , ConnectionDraining , and
 	// CrossZoneLoadBalancing by either enabling or disabling them. Or, you can modify
 	// the load balancer attribute ConnectionSettings by specifying an idle connection
 	// timeout value for your load balancer. For more information, see the following in
 	// the Classic Load Balancers Guide:
-	//
-	// * Cross-Zone Load Balancing
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-disable-crosszone-lb.html)
-	//
-	// *
-	// Connection Draining
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-conn-drain.html)
-	//
-	// *
-	// Access Logs
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/access-log-collection.html)
-	//
-	// *
-	// Idle Connection Timeout
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-idle-timeout.html)
+	//   - Cross-Zone Load Balancing (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-disable-crosszone-lb.html)
+	//   - Connection Draining (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-conn-drain.html)
+	//   - Access Logs (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/access-log-collection.html)
+	//   - Idle Connection Timeout (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-idle-timeout.html)
 	ModifyLoadBalancerAttributes(ctx context.Context, params *ModifyLoadBalancerAttributesInput, optFns ...func(*Options)) (*ModifyLoadBalancerAttributesOutput, error)
 	// Adds the specified instances to the specified load balancer. The instance must
 	// be a running instance in the same network as the load balancer (EC2-Classic or
@@ -198,15 +176,14 @@ type ELB interface {
 	// VPC. Note that RegisterInstanceWithLoadBalancer completes when the request has
 	// been registered. Instance registration takes a little time to complete. To check
 	// the state of the registered instances, use DescribeLoadBalancers or
-	// DescribeInstanceHealth. After the instance is registered, it starts receiving
+	// DescribeInstanceHealth . After the instance is registered, it starts receiving
 	// traffic and requests from the load balancer. Any instance that is not in one of
 	// the Availability Zones registered for the load balancer is moved to the
 	// OutOfService state. If an Availability Zone is added to the load balancer later,
 	// any instances registered with the load balancer move to the InService state. To
 	// deregister instances from a load balancer, use
-	// DeregisterInstancesFromLoadBalancer. For more information, see Register or
-	// De-Register EC2 Instances
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-deregister-register-instances.html)
+	// DeregisterInstancesFromLoadBalancer . For more information, see Register or
+	// De-Register EC2 Instances (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-deregister-register-instances.html)
 	// in the Classic Load Balancers Guide.
 	RegisterInstancesWithLoadBalancer(ctx context.Context, params *RegisterInstancesWithLoadBalancerInput, optFns ...func(*Options)) (*RegisterInstancesWithLoadBalancerOutput, error)
 	// Removes one or more tags from the specified load balancer.
@@ -214,34 +191,28 @@ type ELB interface {
 	// Sets the certificate that terminates the specified listener's SSL connections.
 	// The specified certificate replaces any prior certificate that was used on the
 	// same load balancer and port. For more information about updating your SSL
-	// certificate, see Replace the SSL Certificate for Your Load Balancer
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-update-ssl-cert.html)
+	// certificate, see Replace the SSL Certificate for Your Load Balancer (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-update-ssl-cert.html)
 	// in the Classic Load Balancers Guide.
 	SetLoadBalancerListenerSSLCertificate(ctx context.Context, params *SetLoadBalancerListenerSSLCertificateInput, optFns ...func(*Options)) (*SetLoadBalancerListenerSSLCertificateOutput, error)
-	// Replaces the set of policies associated with the specified port on which the EC2
-	// instance is listening with a new set of policies. At this time, only the
+	// Replaces the set of policies associated with the specified port on which the
+	// EC2 instance is listening with a new set of policies. At this time, only the
 	// back-end server authentication policy type can be applied to the instance ports;
 	// this policy type is composed of multiple public key policies. Each time you use
 	// SetLoadBalancerPoliciesForBackendServer to enable the policies, use the
 	// PolicyNames parameter to list the policies that you want to enable. You can use
 	// DescribeLoadBalancers or DescribeLoadBalancerPolicies to verify that the policy
 	// is associated with the EC2 instance. For more information about enabling
-	// back-end instance authentication, see Configure Back-end Instance Authentication
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-create-https-ssl-load-balancer.html#configure_backendauth_clt)
+	// back-end instance authentication, see Configure Back-end Instance Authentication (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-create-https-ssl-load-balancer.html#configure_backendauth_clt)
 	// in the Classic Load Balancers Guide. For more information about Proxy Protocol,
-	// see Configure Proxy Protocol Support
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-proxy-protocol.html)
+	// see Configure Proxy Protocol Support (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-proxy-protocol.html)
 	// in the Classic Load Balancers Guide.
 	SetLoadBalancerPoliciesForBackendServer(ctx context.Context, params *SetLoadBalancerPoliciesForBackendServerInput, optFns ...func(*Options)) (*SetLoadBalancerPoliciesForBackendServerOutput, error)
 	// Replaces the current set of policies for the specified load balancer port with
 	// the specified set of policies. To enable back-end server authentication, use
-	// SetLoadBalancerPoliciesForBackendServer. For more information about setting
-	// policies, see Update the SSL Negotiation Configuration
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/ssl-config-update.html),
-	// Duration-Based Session Stickiness
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-sticky-sessions.html#enable-sticky-sessions-duration),
-	// and Application-Controlled Session Stickiness
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-sticky-sessions.html#enable-sticky-sessions-application)
+	// SetLoadBalancerPoliciesForBackendServer . For more information about setting
+	// policies, see Update the SSL Negotiation Configuration (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/ssl-config-update.html)
+	// , Duration-Based Session Stickiness (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-sticky-sessions.html#enable-sticky-sessions-duration)
+	// , and Application-Controlled Session Stickiness (https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-sticky-sessions.html#enable-sticky-sessions-application)
 	// in the Classic Load Balancers Guide.
 	SetLoadBalancerPoliciesOfListener(ctx context.Context, params *SetLoadBalancerPoliciesOfListenerInput, optFns ...func(*Options)) (*SetLoadBalancerPoliciesOfListenerOutput, error)
 }

--- a/pkg/awsapi/elasticloadbalancingv2.go
+++ b/pkg/awsapi/elasticloadbalancingv2.go
@@ -13,10 +13,8 @@ type ELBV2 interface {
 	// Adds the specified SSL server certificate to the certificate list for the
 	// specified HTTPS or TLS listener. If the certificate in already in the
 	// certificate list, the call is successful but the certificate is not added again.
-	// For more information, see HTTPS listeners
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html)
-	// in the Application Load Balancers Guide or TLS listeners
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html)
+	// For more information, see HTTPS listeners (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html)
+	// in the Application Load Balancers Guide or TLS listeners (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html)
 	// in the Network Load Balancers Guide.
 	AddListenerCertificates(ctx context.Context, params *AddListenerCertificatesInput, optFns ...func(*Options)) (*AddListenerCertificatesOutput, error)
 	// Adds the specified tags to the specified Elastic Load Balancing resource. You
@@ -27,72 +25,43 @@ type ELBV2 interface {
 	AddTags(ctx context.Context, params *AddTagsInput, optFns ...func(*Options)) (*AddTagsOutput, error)
 	// Creates a listener for the specified Application Load Balancer, Network Load
 	// Balancer, or Gateway Load Balancer. For more information, see the following:
+	//   - Listeners for your Application Load Balancers (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html)
+	//   - Listeners for your Network Load Balancers (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-listeners.html)
+	//   - Listeners for your Gateway Load Balancers (https://docs.aws.amazon.com/elasticloadbalancing/latest/gateway/gateway-listeners.html)
 	//
-	// *
-	// Listeners for your Application Load Balancers
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html)
-	//
-	// *
-	// Listeners for your Network Load Balancers
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-listeners.html)
-	//
-	// *
-	// Listeners for your Gateway Load Balancers
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/gateway/gateway-listeners.html)
-	//
-	// This
-	// operation is idempotent, which means that it completes at most one time. If you
-	// attempt to create multiple listeners with the same settings, each call succeeds.
+	// This operation is idempotent, which means that it completes at most one time.
+	// If you attempt to create multiple listeners with the same settings, each call
+	// succeeds.
 	CreateListener(ctx context.Context, params *CreateListenerInput, optFns ...func(*Options)) (*CreateListenerOutput, error)
 	// Creates an Application Load Balancer, Network Load Balancer, or Gateway Load
 	// Balancer. For more information, see the following:
+	//   - Application Load Balancers (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html)
+	//   - Network Load Balancers (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html)
+	//   - Gateway Load Balancers (https://docs.aws.amazon.com/elasticloadbalancing/latest/gateway/gateway-load-balancers.html)
 	//
-	// * Application Load Balancers
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html)
-	//
-	// *
-	// Network Load Balancers
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html)
-	//
-	// *
-	// Gateway Load Balancers
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/gateway/gateway-load-balancers.html)
-	//
-	// This
-	// operation is idempotent, which means that it completes at most one time. If you
-	// attempt to create multiple load balancers with the same settings, each call
-	// succeeds.
+	// This operation is idempotent, which means that it completes at most one time.
+	// If you attempt to create multiple load balancers with the same settings, each
+	// call succeeds.
 	CreateLoadBalancer(ctx context.Context, params *CreateLoadBalancerInput, optFns ...func(*Options)) (*CreateLoadBalancerOutput, error)
 	// Creates a rule for the specified listener. The listener must be associated with
 	// an Application Load Balancer. Each rule consists of a priority, one or more
 	// actions, and one or more conditions. Rules are evaluated in priority order, from
 	// the lowest value to the highest value. When the conditions for a rule are met,
 	// its actions are performed. If the conditions for no rules are met, the actions
-	// for the default rule are performed. For more information, see Listener rules
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html#listener-rules)
+	// for the default rule are performed. For more information, see Listener rules (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html#listener-rules)
 	// in the Application Load Balancers Guide.
 	CreateRule(ctx context.Context, params *CreateRuleInput, optFns ...func(*Options)) (*CreateRuleOutput, error)
 	// Creates a target group. For more information, see the following:
+	//   - Target groups for your Application Load Balancers (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html)
+	//   - Target groups for your Network Load Balancers (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html)
+	//   - Target groups for your Gateway Load Balancers (https://docs.aws.amazon.com/elasticloadbalancing/latest/gateway/target-groups.html)
 	//
-	// * Target
-	// groups for your Application Load Balancers
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html)
-	//
-	// *
-	// Target groups for your Network Load Balancers
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html)
-	//
-	// *
-	// Target groups for your Gateway Load Balancers
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/gateway/target-groups.html)
-	//
-	// This
-	// operation is idempotent, which means that it completes at most one time. If you
-	// attempt to create multiple target groups with the same settings, each call
-	// succeeds.
+	// This operation is idempotent, which means that it completes at most one time.
+	// If you attempt to create multiple target groups with the same settings, each
+	// call succeeds.
 	CreateTargetGroup(ctx context.Context, params *CreateTargetGroupInput, optFns ...func(*Options)) (*CreateTargetGroupOutput, error)
-	// Deletes the specified listener. Alternatively, your listener is deleted when you
-	// delete the load balancer to which it is attached.
+	// Deletes the specified listener. Alternatively, your listener is deleted when
+	// you delete the load balancer to which it is attached.
 	DeleteListener(ctx context.Context, params *DeleteListenerInput, optFns ...func(*Options)) (*DeleteListenerOutput, error)
 	// Deletes the specified Application Load Balancer, Network Load Balancer, or
 	// Gateway Load Balancer. Deleting a load balancer also deletes its listeners. You
@@ -112,49 +81,32 @@ type ELBV2 interface {
 	// Deregisters the specified targets from the specified target group. After the
 	// targets are deregistered, they no longer receive traffic from the load balancer.
 	DeregisterTargets(ctx context.Context, params *DeregisterTargetsInput, optFns ...func(*Options)) (*DeregisterTargetsOutput, error)
-	// Describes the current Elastic Load Balancing resource limits for your Amazon Web
-	// Services account. For more information, see the following:
-	//
-	// * Quotas for your
-	// Application Load Balancers
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-limits.html)
-	//
-	// *
-	// Quotas for your Network Load Balancers
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-limits.html)
-	//
-	// *
-	// Quotas for your Gateway Load Balancers
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/gateway/quotas-limits.html)
+	// Describes the current Elastic Load Balancing resource limits for your Amazon
+	// Web Services account. For more information, see the following:
+	//   - Quotas for your Application Load Balancers (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-limits.html)
+	//   - Quotas for your Network Load Balancers (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-limits.html)
+	//   - Quotas for your Gateway Load Balancers (https://docs.aws.amazon.com/elasticloadbalancing/latest/gateway/quotas-limits.html)
 	DescribeAccountLimits(ctx context.Context, params *DescribeAccountLimitsInput, optFns ...func(*Options)) (*DescribeAccountLimitsOutput, error)
 	// Describes the default certificate and the certificate list for the specified
 	// HTTPS or TLS listener. If the default certificate is also in the certificate
 	// list, it appears twice in the results (once with IsDefault set to true and once
-	// with IsDefault set to false). For more information, see SSL certificates
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#https-listener-certificates)
-	// in the Application Load Balancers Guide or Server certificates
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html#tls-listener-certificate)
+	// with IsDefault set to false). For more information, see SSL certificates (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#https-listener-certificates)
+	// in the Application Load Balancers Guide or Server certificates (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html#tls-listener-certificate)
 	// in the Network Load Balancers Guide.
 	DescribeListenerCertificates(ctx context.Context, params *DescribeListenerCertificatesInput, optFns ...func(*Options)) (*DescribeListenerCertificatesOutput, error)
-	// Describes the specified listeners or the listeners for the specified Application
-	// Load Balancer, Network Load Balancer, or Gateway Load Balancer. You must specify
-	// either a load balancer or one or more listeners.
+	// Describes the specified listeners or the listeners for the specified
+	// Application Load Balancer, Network Load Balancer, or Gateway Load Balancer. You
+	// must specify either a load balancer or one or more listeners.
 	DescribeListeners(ctx context.Context, params *DescribeListenersInput, optFns ...func(*Options)) (*DescribeListenersOutput, error)
 	// Describes the attributes for the specified Application Load Balancer, Network
 	// Load Balancer, or Gateway Load Balancer. For more information, see the
 	// following:
-	//
-	// * Load balancer attributes
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#load-balancer-attributes)
-	// in the Application Load Balancers Guide
-	//
-	// * Load balancer attributes
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#load-balancer-attributes)
-	// in the Network Load Balancers Guide
-	//
-	// * Load balancer attributes
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/gateway/gateway-load-balancers.html#load-balancer-attributes)
-	// in the Gateway Load Balancers Guide
+	//   - Load balancer attributes (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#load-balancer-attributes)
+	//     in the Application Load Balancers Guide
+	//   - Load balancer attributes (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#load-balancer-attributes)
+	//     in the Network Load Balancers Guide
+	//   - Load balancer attributes (https://docs.aws.amazon.com/elasticloadbalancing/latest/gateway/gateway-load-balancers.html#load-balancer-attributes)
+	//     in the Gateway Load Balancers Guide
 	DescribeLoadBalancerAttributes(ctx context.Context, params *DescribeLoadBalancerAttributesInput, optFns ...func(*Options)) (*DescribeLoadBalancerAttributesOutput, error)
 	// Describes the specified load balancers or all of your load balancers.
 	DescribeLoadBalancers(ctx context.Context, params *DescribeLoadBalancersInput, optFns ...func(*Options)) (*DescribeLoadBalancersOutput, error)
@@ -162,10 +114,8 @@ type ELBV2 interface {
 	// specify either a listener or one or more rules.
 	DescribeRules(ctx context.Context, params *DescribeRulesInput, optFns ...func(*Options)) (*DescribeRulesOutput, error)
 	// Describes the specified policies or all policies used for SSL negotiation. For
-	// more information, see Security policies
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies)
-	// in the Application Load Balancers Guide or Security policies
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html#describe-ssl-policies)
+	// more information, see Security policies (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies)
+	// in the Application Load Balancers Guide or Security policies (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html#describe-ssl-policies)
 	// in the Network Load Balancers Guide.
 	DescribeSSLPolicies(ctx context.Context, params *DescribeSSLPoliciesInput, optFns ...func(*Options)) (*DescribeSSLPoliciesOutput, error)
 	// Describes the tags for the specified Elastic Load Balancing resources. You can
@@ -174,18 +124,12 @@ type ELBV2 interface {
 	DescribeTags(ctx context.Context, params *DescribeTagsInput, optFns ...func(*Options)) (*DescribeTagsOutput, error)
 	// Describes the attributes for the specified target group. For more information,
 	// see the following:
-	//
-	// * Target group attributes
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#target-group-attributes)
-	// in the Application Load Balancers Guide
-	//
-	// * Target group attributes
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#target-group-attributes)
-	// in the Network Load Balancers Guide
-	//
-	// * Target group attributes
-	// (https://docs.aws.amazon.com/elasticloadbalancing/latest/gateway/target-groups.html#target-group-attributes)
-	// in the Gateway Load Balancers Guide
+	//   - Target group attributes (https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#target-group-attributes)
+	//     in the Application Load Balancers Guide
+	//   - Target group attributes (https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#target-group-attributes)
+	//     in the Network Load Balancers Guide
+	//   - Target group attributes (https://docs.aws.amazon.com/elasticloadbalancing/latest/gateway/target-groups.html#target-group-attributes)
+	//     in the Gateway Load Balancers Guide
 	DescribeTargetGroupAttributes(ctx context.Context, params *DescribeTargetGroupAttributesInput, optFns ...func(*Options)) (*DescribeTargetGroupAttributesOutput, error)
 	// Describes the specified target groups or all of your target groups. By default,
 	// all target groups are described. Alternatively, you can specify one of the
@@ -194,9 +138,9 @@ type ELBV2 interface {
 	DescribeTargetGroups(ctx context.Context, params *DescribeTargetGroupsInput, optFns ...func(*Options)) (*DescribeTargetGroupsOutput, error)
 	// Describes the health of the specified targets or all of your targets.
 	DescribeTargetHealth(ctx context.Context, params *DescribeTargetHealthInput, optFns ...func(*Options)) (*DescribeTargetHealthOutput, error)
-	// Replaces the specified properties of the specified listener. Any properties that
-	// you do not specify remain unchanged. Changing the protocol from HTTPS to HTTP,
-	// or from TLS to TCP, removes the security policy and default certificate
+	// Replaces the specified properties of the specified listener. Any properties
+	// that you do not specify remain unchanged. Changing the protocol from HTTPS to
+	// HTTP, or from TLS to TCP, removes the security policy and default certificate
 	// properties. If you change the protocol from HTTP to HTTPS, or from TCP to TLS,
 	// you must add the security policy and default certificate properties. To add an
 	// item to a list, remove an item from a list, or update an item in a list, you
@@ -208,9 +152,9 @@ type ELBV2 interface {
 	// attributes can't be modified as requested, the call fails. Any existing
 	// attributes that you do not modify retain their current values.
 	ModifyLoadBalancerAttributes(ctx context.Context, params *ModifyLoadBalancerAttributesInput, optFns ...func(*Options)) (*ModifyLoadBalancerAttributesOutput, error)
-	// Replaces the specified properties of the specified rule. Any properties that you
-	// do not specify are unchanged. To add an item to a list, remove an item from a
-	// list, or update an item in a list, you must provide the entire list. For
+	// Replaces the specified properties of the specified rule. Any properties that
+	// you do not specify are unchanged. To add an item to a list, remove an item from
+	// a list, or update an item in a list, you must provide the entire list. For
 	// example, to add an action, specify a list with the current actions plus the new
 	// action.
 	ModifyRule(ctx context.Context, params *ModifyRuleInput, optFns ...func(*Options)) (*ModifyRuleOutput, error)
@@ -240,9 +184,9 @@ type ELBV2 interface {
 	// Sets the type of IP addresses used by the subnets of the specified load
 	// balancer.
 	SetIpAddressType(ctx context.Context, params *SetIpAddressTypeInput, optFns ...func(*Options)) (*SetIpAddressTypeOutput, error)
-	// Sets the priorities of the specified rules. You can reorder the rules as long as
-	// there are no priority conflicts in the new order. Any existing rules that you do
-	// not specify retain their current priority.
+	// Sets the priorities of the specified rules. You can reorder the rules as long
+	// as there are no priority conflicts in the new order. Any existing rules that you
+	// do not specify retain their current priority.
 	SetRulePriorities(ctx context.Context, params *SetRulePrioritiesInput, optFns ...func(*Options)) (*SetRulePrioritiesOutput, error)
 	// Associates the specified security groups with the specified Application Load
 	// Balancer. The specified security groups override the previously associated

--- a/pkg/awsapi/iam.go
+++ b/pkg/awsapi/iam.go
@@ -19,53 +19,43 @@ type IAM interface {
 	// profile can contain only one role, and this quota cannot be increased. You can
 	// remove the existing role and then add a different role to an instance profile.
 	// You must then wait for the change to appear across all of Amazon Web Services
-	// because of eventual consistency
-	// (https://en.wikipedia.org/wiki/Eventual_consistency). To force the change, you
-	// must disassociate the instance profile
-	// (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DisassociateIamInstanceProfile.html)
-	// and then associate the instance profile
-	// (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssociateIamInstanceProfile.html),
-	// or you can stop your instance and then restart it. The caller of this operation
-	// must be granted the PassRole permission on the IAM role by a permissions policy.
-	// For more information about roles, see Working with roles
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html). For
-	// more information about instance profiles, see About instance profiles
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html).
+	// because of eventual consistency (https://en.wikipedia.org/wiki/Eventual_consistency)
+	// . To force the change, you must disassociate the instance profile (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DisassociateIamInstanceProfile.html)
+	// and then associate the instance profile (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssociateIamInstanceProfile.html)
+	// , or you can stop your instance and then restart it. The caller of this
+	// operation must be granted the PassRole permission on the IAM role by a
+	// permissions policy. For more information about roles, see Working with roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html)
+	// . For more information about instance profiles, see About instance profiles (https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html)
+	// .
 	AddRoleToInstanceProfile(ctx context.Context, params *AddRoleToInstanceProfileInput, optFns ...func(*Options)) (*AddRoleToInstanceProfileOutput, error)
 	// Adds the specified user to the specified group.
 	AddUserToGroup(ctx context.Context, params *AddUserToGroupInput, optFns ...func(*Options)) (*AddUserToGroupOutput, error)
 	// Attaches the specified managed policy to the specified IAM group. You use this
 	// operation to attach a managed policy to a group. To embed an inline policy in a
-	// group, use PutGroupPolicy. As a best practice, you can validate your IAM
-	// policies. To learn more, see Validating IAM policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_policy-validator.html)
-	// in the IAM User Guide. For more information about policies, see Managed policies
-	// and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// group, use PutGroupPolicy . As a best practice, you can validate your IAM
+	// policies. To learn more, see Validating IAM policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_policy-validator.html)
+	// in the IAM User Guide. For more information about policies, see Managed
+	// policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide.
 	AttachGroupPolicy(ctx context.Context, params *AttachGroupPolicyInput, optFns ...func(*Options)) (*AttachGroupPolicyOutput, error)
-	// Attaches the specified managed policy to the specified IAM role. When you attach
-	// a managed policy to a role, the managed policy becomes part of the role's
+	// Attaches the specified managed policy to the specified IAM role. When you
+	// attach a managed policy to a role, the managed policy becomes part of the role's
 	// permission (access) policy. You cannot use a managed policy as the role's trust
 	// policy. The role's trust policy is created at the same time as the role, using
-	// CreateRole. You can update a role's trust policy using UpdateAssumeRolePolicy.
+	// CreateRole . You can update a role's trust policy using UpdateAssumeRolePolicy .
 	// Use this operation to attach a managed policy to a role. To embed an inline
-	// policy in a role, use PutRolePolicy. For more information about policies, see
-	// Managed policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// policy in a role, use PutRolePolicy . For more information about policies, see
+	// Managed policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide. As a best practice, you can validate your IAM policies.
-	// To learn more, see Validating IAM policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_policy-validator.html)
+	// To learn more, see Validating IAM policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_policy-validator.html)
 	// in the IAM User Guide.
 	AttachRolePolicy(ctx context.Context, params *AttachRolePolicyInput, optFns ...func(*Options)) (*AttachRolePolicyOutput, error)
 	// Attaches the specified managed policy to the specified user. You use this
 	// operation to attach a managed policy to a user. To embed an inline policy in a
-	// user, use PutUserPolicy. As a best practice, you can validate your IAM policies.
-	// To learn more, see Validating IAM policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_policy-validator.html)
-	// in the IAM User Guide. For more information about policies, see Managed policies
-	// and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// user, use PutUserPolicy . As a best practice, you can validate your IAM
+	// policies. To learn more, see Validating IAM policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_policy-validator.html)
+	// in the IAM User Guide. For more information about policies, see Managed
+	// policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide.
 	AttachUserPolicy(ctx context.Context, params *AttachUserPolicyInput, optFns ...func(*Options)) (*AttachUserPolicyOutput, error)
 	// Changes the password of the IAM user who is calling this operation. This
@@ -74,46 +64,39 @@ type IAM interface {
 	// Amazon Web Services account root user password is not affected by this
 	// operation. Use UpdateLoginProfile to use the CLI, the Amazon Web Services API,
 	// or the Users page in the IAM console to change the password for any IAM user.
-	// For more information about modifying passwords, see Managing passwords
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingLogins.html) in
-	// the IAM User Guide.
+	// For more information about modifying passwords, see Managing passwords (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingLogins.html)
+	// in the IAM User Guide.
 	ChangePassword(ctx context.Context, params *ChangePasswordInput, optFns ...func(*Options)) (*ChangePasswordOutput, error)
-	// Creates a new Amazon Web Services secret access key and corresponding Amazon Web
-	// Services access key ID for the specified user. The default status for new keys
-	// is Active. If you do not specify a user name, IAM determines the user name
+	// Creates a new Amazon Web Services secret access key and corresponding Amazon
+	// Web Services access key ID for the specified user. The default status for new
+	// keys is Active . If you do not specify a user name, IAM determines the user name
 	// implicitly based on the Amazon Web Services access key ID signing the request.
 	// This operation works for access keys under the Amazon Web Services account.
 	// Consequently, you can use this operation to manage Amazon Web Services account
 	// root user credentials. This is true even if the Amazon Web Services account has
 	// no associated users. For information about quotas on the number of keys you can
-	// create, see IAM and STS quotas
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) in
-	// the IAM User Guide. To ensure the security of your Amazon Web Services account,
-	// the secret access key is accessible only during key and user creation. You must
-	// save the key (for example, in a text file) if you want to be able to access it
-	// again. If a secret key is lost, you can delete the access keys for the
+	// create, see IAM and STS quotas (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html)
+	// in the IAM User Guide. To ensure the security of your Amazon Web Services
+	// account, the secret access key is accessible only during key and user creation.
+	// You must save the key (for example, in a text file) if you want to be able to
+	// access it again. If a secret key is lost, you can delete the access keys for the
 	// associated user and then create new keys.
 	CreateAccessKey(ctx context.Context, params *CreateAccessKeyInput, optFns ...func(*Options)) (*CreateAccessKeyOutput, error)
 	// Creates an alias for your Amazon Web Services account. For information about
 	// using an Amazon Web Services account alias, see Using an alias for your Amazon
-	// Web Services account ID
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/AccountAlias.html) in the IAM
-	// User Guide.
+	// Web Services account ID (https://docs.aws.amazon.com/IAM/latest/UserGuide/AccountAlias.html)
+	// in the IAM User Guide.
 	CreateAccountAlias(ctx context.Context, params *CreateAccountAliasInput, optFns ...func(*Options)) (*CreateAccountAliasOutput, error)
 	// Creates a new group. For information about the number of groups you can create,
-	// see IAM and STS quotas
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) in
-	// the IAM User Guide.
+	// see IAM and STS quotas (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html)
+	// in the IAM User Guide.
 	CreateGroup(ctx context.Context, params *CreateGroupInput, optFns ...func(*Options)) (*CreateGroupOutput, error)
 	// Creates a new instance profile. For information about instance profiles, see
-	// Using roles for applications on Amazon EC2
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html)
-	// in the IAM User Guide, and Instance profiles
-	// (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#ec2-instance-profile)
+	// Using roles for applications on Amazon EC2 (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html)
+	// in the IAM User Guide, and Instance profiles (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#ec2-instance-profile)
 	// in the Amazon EC2 User Guide. For information about the number of instance
-	// profiles you can create, see IAM object quotas
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) in
-	// the IAM User Guide.
+	// profiles you can create, see IAM object quotas (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html)
+	// in the IAM User Guide.
 	CreateInstanceProfile(ctx context.Context, params *CreateInstanceProfileInput, optFns ...func(*Options)) (*CreateInstanceProfileOutput, error)
 	// Creates a password for the specified IAM user. A password allows an IAM user to
 	// access Amazon Web Services services through the Amazon Web Services Management
@@ -121,12 +104,11 @@ type IAM interface {
 	// the IAM console to create a password for any IAM user. Use ChangePassword to
 	// update your own existing password in the My Security Credentials page in the
 	// Amazon Web Services Management Console. For more information about managing
-	// passwords, see Managing passwords
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingLogins.html) in
-	// the IAM User Guide.
+	// passwords, see Managing passwords (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingLogins.html)
+	// in the IAM User Guide.
 	CreateLoginProfile(ctx context.Context, params *CreateLoginProfileInput, optFns ...func(*Options)) (*CreateLoginProfileOutput, error)
 	// Creates an IAM entity to describe an identity provider (IdP) that supports
-	// OpenID Connect (OIDC) (http://openid.net/connect/). The OIDC provider that you
+	// OpenID Connect (OIDC) (http://openid.net/connect/) . The OIDC provider that you
 	// create with this operation can be used as a principal in a role's trust policy.
 	// Such a policy establishes a trust relationship between Amazon Web Services and
 	// the OIDC provider. If you are using an OIDC identity provider from Google,
@@ -134,46 +116,34 @@ type IAM interface {
 	// provider. These OIDC identity providers are already built-in to Amazon Web
 	// Services and are available for your use. Instead, you can move directly to
 	// creating new roles using your identity provider. To learn more, see Creating a
-	// role for web identity or OpenID connect federation
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html)
+	// role for web identity or OpenID connect federation (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html)
 	// in the IAM User Guide. When you create the IAM OIDC provider, you specify the
 	// following:
+	//   - The URL of the OIDC identity provider (IdP) to trust
+	//   - A list of client IDs (also known as audiences) that identify the
+	//     application or applications allowed to authenticate using the OIDC provider
+	//   - A list of tags that are attached to the specified IAM OIDC provider
+	//   - A list of thumbprints of one or more server certificates that the IdP uses
 	//
-	// * The URL of the OIDC identity provider (IdP) to trust
-	//
-	// * A list of
-	// client IDs (also known as audiences) that identify the application or
-	// applications allowed to authenticate using the OIDC provider
-	//
-	// * A list of tags
-	// that are attached to the specified IAM OIDC provider
-	//
-	// * A list of thumbprints of
-	// one or more server certificates that the IdP uses
-	//
-	// You get all of this
-	// information from the OIDC IdP you want to use to access Amazon Web Services.
-	// Amazon Web Services secures communication with some OIDC identity providers
-	// (IdPs) through our library of trusted certificate authorities (CAs) instead of
-	// using a certificate thumbprint to verify your IdP server certificate. These OIDC
-	// IdPs include Google, Auth0, and those that use an Amazon S3 bucket to host a
-	// JSON Web Key Set (JWKS) endpoint. In these cases, your legacy thumbprint remains
-	// in your configuration, but is no longer used for validation. The trust for the
-	// OIDC provider is derived from the IAM provider that this operation creates.
-	// Therefore, it is best to limit access to the CreateOpenIDConnectProvider
-	// operation to highly privileged users.
+	// You get all of this information from the OIDC IdP you want to use to access
+	// Amazon Web Services. Amazon Web Services secures communication with some OIDC
+	// identity providers (IdPs) through our library of trusted certificate authorities
+	// (CAs) instead of using a certificate thumbprint to verify your IdP server
+	// certificate. These OIDC IdPs include Google, Auth0, and those that use an Amazon
+	// S3 bucket to host a JSON Web Key Set (JWKS) endpoint. In these cases, your
+	// legacy thumbprint remains in your configuration, but is no longer used for
+	// validation. The trust for the OIDC provider is derived from the IAM provider
+	// that this operation creates. Therefore, it is best to limit access to the
+	// CreateOpenIDConnectProvider operation to highly privileged users.
 	CreateOpenIDConnectProvider(ctx context.Context, params *CreateOpenIDConnectProviderInput, optFns ...func(*Options)) (*CreateOpenIDConnectProviderOutput, error)
 	// Creates a new managed policy for your Amazon Web Services account. This
 	// operation creates a policy version with a version identifier of v1 and sets v1
 	// as the policy's default version. For more information about policy versions, see
-	// Versioning for managed policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html)
+	// Versioning for managed policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html)
 	// in the IAM User Guide. As a best practice, you can validate your IAM policies.
-	// To learn more, see Validating IAM policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_policy-validator.html)
+	// To learn more, see Validating IAM policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_policy-validator.html)
 	// in the IAM User Guide. For more information about managed policies in general,
-	// see Managed policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// see Managed policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide.
 	CreatePolicy(ctx context.Context, params *CreatePolicyInput, optFns ...func(*Options)) (*CreatePolicyOutput, error)
 	// Creates a new version of the specified managed policy. To update a managed
@@ -183,17 +153,14 @@ type IAM interface {
 	// set the new version as the policy's default version. The default version is the
 	// version that is in effect for the IAM users, groups, and roles to which the
 	// policy is attached. For more information about managed policy versions, see
-	// Versioning for managed policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html)
+	// Versioning for managed policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html)
 	// in the IAM User Guide.
 	CreatePolicyVersion(ctx context.Context, params *CreatePolicyVersionInput, optFns ...func(*Options)) (*CreatePolicyVersionOutput, error)
 	// Creates a new role for your Amazon Web Services account. For more information
-	// about roles, see IAM roles
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html). For
-	// information about quotas for role names and the number of roles you can create,
-	// see IAM and STS quotas
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) in
-	// the IAM User Guide.
+	// about roles, see IAM roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html)
+	// . For information about quotas for role names and the number of roles you can
+	// create, see IAM and STS quotas (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html)
+	// in the IAM User Guide.
 	CreateRole(ctx context.Context, params *CreateRoleInput, optFns ...func(*Options)) (*CreateRoleOutput, error)
 	// Creates an IAM resource that describes an identity provider (IdP) that supports
 	// SAML 2.0. The SAML provider resource that you create with this operation can be
@@ -206,13 +173,10 @@ type IAM interface {
 	// expiration information, and keys that can be used to validate the SAML
 	// authentication response (assertions) that the IdP sends. You must generate the
 	// metadata document using the identity management software that is used as your
-	// organization's IdP. This operation requires Signature Version 4
-	// (https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). For
-	// more information, see Enabling SAML 2.0 federated users to access the Amazon Web
-	// Services Management Console
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-saml.html)
-	// and About SAML 2.0-based federation
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html)
+	// organization's IdP. This operation requires Signature Version 4 (https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
+	// . For more information, see Enabling SAML 2.0 federated users to access the
+	// Amazon Web Services Management Console (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-saml.html)
+	// and About SAML 2.0-based federation (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html)
 	// in the IAM User Guide.
 	CreateSAMLProvider(ctx context.Context, params *CreateSAMLProviderInput, optFns ...func(*Options)) (*CreateSAMLProviderOutput, error)
 	// Creates an IAM role that is linked to a specific Amazon Web Services service.
@@ -221,8 +185,7 @@ type IAM interface {
 	// deleted role, which could put your Amazon Web Services resources into an unknown
 	// state. Allowing the service to control the role helps improve service stability
 	// and proper cleanup when a service and its role are no longer needed. For more
-	// information, see Using service-linked roles
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/using-service-linked-roles.html)
+	// information, see Using service-linked roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/using-service-linked-roles.html)
 	// in the IAM User Guide. To attach a policy to this service-linked role, you must
 	// make the request using the Amazon Web Services service that depends on this
 	// role.
@@ -233,37 +196,32 @@ type IAM interface {
 	// maximum of two sets of service-specific credentials for each supported service
 	// per user. You can create service-specific credentials for CodeCommit and Amazon
 	// Keyspaces (for Apache Cassandra). You can reset the password to a new
-	// service-generated value by calling ResetServiceSpecificCredential. For more
+	// service-generated value by calling ResetServiceSpecificCredential . For more
 	// information about service-specific credentials, see Using IAM with CodeCommit:
-	// Git credentials, SSH keys, and Amazon Web Services access keys
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_ssh-keys.html)
+	// Git credentials, SSH keys, and Amazon Web Services access keys (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_ssh-keys.html)
 	// in the IAM User Guide.
 	CreateServiceSpecificCredential(ctx context.Context, params *CreateServiceSpecificCredentialInput, optFns ...func(*Options)) (*CreateServiceSpecificCredentialOutput, error)
 	// Creates a new IAM user for your Amazon Web Services account. For information
-	// about quotas for the number of IAM users you can create, see IAM and STS quotas
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) in
-	// the IAM User Guide.
+	// about quotas for the number of IAM users you can create, see IAM and STS quotas (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html)
+	// in the IAM User Guide.
 	CreateUser(ctx context.Context, params *CreateUserInput, optFns ...func(*Options)) (*CreateUserOutput, error)
 	// Creates a new virtual MFA device for the Amazon Web Services account. After
-	// creating the virtual MFA, use EnableMFADevice to attach the MFA device to an IAM
-	// user. For more information about creating and working with virtual MFA devices,
-	// see Using a virtual MFA device
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_VirtualMFA.html) in the
-	// IAM User Guide. For information about the maximum number of MFA devices you can
-	// create, see IAM and STS quotas
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) in
-	// the IAM User Guide. The seed information contained in the QR code and the Base32
-	// string should be treated like any other secret access information. In other
-	// words, protect the seed information as you would your Amazon Web Services access
-	// keys or your passwords. After you provision your virtual device, you should
-	// ensure that the information is destroyed following secure procedures.
+	// creating the virtual MFA, use EnableMFADevice to attach the MFA device to an
+	// IAM user. For more information about creating and working with virtual MFA
+	// devices, see Using a virtual MFA device (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_VirtualMFA.html)
+	// in the IAM User Guide. For information about the maximum number of MFA devices
+	// you can create, see IAM and STS quotas (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html)
+	// in the IAM User Guide. The seed information contained in the QR code and the
+	// Base32 string should be treated like any other secret access information. In
+	// other words, protect the seed information as you would your Amazon Web Services
+	// access keys or your passwords. After you provision your virtual device, you
+	// should ensure that the information is destroyed following secure procedures.
 	CreateVirtualMFADevice(ctx context.Context, params *CreateVirtualMFADeviceInput, optFns ...func(*Options)) (*CreateVirtualMFADeviceOutput, error)
 	// Deactivates the specified MFA device and removes it from association with the
 	// user name for which it was originally enabled. For more information about
 	// creating and working with virtual MFA devices, see Enabling a virtual
-	// multi-factor authentication (MFA) device
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_VirtualMFA.html) in the
-	// IAM User Guide.
+	// multi-factor authentication (MFA) device (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_VirtualMFA.html)
+	// in the IAM User Guide.
 	DeactivateMFADevice(ctx context.Context, params *DeactivateMFADeviceInput, optFns ...func(*Options)) (*DeactivateMFADeviceOutput, error)
 	// Deletes the access key pair associated with the specified IAM user. If you do
 	// not specify a user name, IAM determines the user name implicitly based on the
@@ -274,9 +232,8 @@ type IAM interface {
 	DeleteAccessKey(ctx context.Context, params *DeleteAccessKeyInput, optFns ...func(*Options)) (*DeleteAccessKeyOutput, error)
 	// Deletes the specified Amazon Web Services account alias. For information about
 	// using an Amazon Web Services account alias, see Using an alias for your Amazon
-	// Web Services account ID
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/AccountAlias.html) in the IAM
-	// User Guide.
+	// Web Services account ID (https://docs.aws.amazon.com/IAM/latest/UserGuide/AccountAlias.html)
+	// in the IAM User Guide.
 	DeleteAccountAlias(ctx context.Context, params *DeleteAccountAliasInput, optFns ...func(*Options)) (*DeleteAccountAliasOutput, error)
 	// Deletes the password policy for the Amazon Web Services account. There are no
 	// parameters.
@@ -284,32 +241,30 @@ type IAM interface {
 	// Deletes the specified IAM group. The group must not contain any users or have
 	// any attached policies.
 	DeleteGroup(ctx context.Context, params *DeleteGroupInput, optFns ...func(*Options)) (*DeleteGroupOutput, error)
-	// Deletes the specified inline policy that is embedded in the specified IAM group.
-	// A group can also have managed policies attached to it. To detach a managed
-	// policy from a group, use DetachGroupPolicy. For more information about policies,
-	// refer to Managed policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// Deletes the specified inline policy that is embedded in the specified IAM
+	// group. A group can also have managed policies attached to it. To detach a
+	// managed policy from a group, use DetachGroupPolicy . For more information about
+	// policies, refer to Managed policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide.
 	DeleteGroupPolicy(ctx context.Context, params *DeleteGroupPolicyInput, optFns ...func(*Options)) (*DeleteGroupPolicyOutput, error)
 	// Deletes the specified instance profile. The instance profile must not have an
 	// associated role. Make sure that you do not have any Amazon EC2 instances running
 	// with the instance profile you are about to delete. Deleting a role or instance
 	// profile that is associated with a running instance will break any applications
-	// running on the instance. For more information about instance profiles, see About
-	// instance profiles
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html).
+	// running on the instance. For more information about instance profiles, see
+	// About instance profiles (https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html)
+	// .
 	DeleteInstanceProfile(ctx context.Context, params *DeleteInstanceProfileInput, optFns ...func(*Options)) (*DeleteInstanceProfileOutput, error)
 	// Deletes the password for the specified IAM user, For more information, see
-	// Managing passwords for IAM users
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_admin-change-user.html).
-	// You can use the CLI, the Amazon Web Services API, or the Users page in the IAM
+	// Managing passwords for IAM users (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_admin-change-user.html)
+	// . You can use the CLI, the Amazon Web Services API, or the Users page in the IAM
 	// console to delete a password for any IAM user. You can use ChangePassword to
 	// update, but not delete, your own password in the My Security Credentials page in
 	// the Amazon Web Services Management Console. Deleting a user's password does not
 	// prevent a user from accessing Amazon Web Services through the command line
 	// interface or the API. To prevent all user access, you must also either make any
 	// access keys inactive or delete them. For more information about making keys
-	// inactive or deleting them, see UpdateAccessKey and DeleteAccessKey.
+	// inactive or deleting them, see UpdateAccessKey and DeleteAccessKey .
 	DeleteLoginProfile(ctx context.Context, params *DeleteLoginProfileInput, optFns ...func(*Options)) (*DeleteLoginProfileOutput, error)
 	// Deletes an OpenID Connect identity provider (IdP) resource object in IAM.
 	// Deleting an IAM OIDC provider resource does not update any roles that reference
@@ -322,58 +277,42 @@ type IAM interface {
 	// you must first detach the policy from all users, groups, and roles that it is
 	// attached to. In addition, you must delete all the policy's versions. The
 	// following steps describe the process for deleting a managed policy:
+	//   - Detach the policy from all users, groups, and roles that the policy is
+	//     attached to, using DetachUserPolicy , DetachGroupPolicy , or DetachRolePolicy
+	//     . To list all the users, groups, and roles that a policy is attached to, use
+	//     ListEntitiesForPolicy .
+	//   - Delete all versions of the policy using DeletePolicyVersion . To list the
+	//     policy's versions, use ListPolicyVersions . You cannot use DeletePolicyVersion
+	//     to delete the version that is marked as the default version. You delete the
+	//     policy's default version in the next step of the process.
+	//   - Delete the policy (this automatically deletes the policy's default version)
+	//     using this operation.
 	//
-	// * Detach
-	// the policy from all users, groups, and roles that the policy is attached to,
-	// using DetachUserPolicy, DetachGroupPolicy, or DetachRolePolicy. To list all the
-	// users, groups, and roles that a policy is attached to, use
-	// ListEntitiesForPolicy.
-	//
-	// * Delete all versions of the policy using
-	// DeletePolicyVersion. To list the policy's versions, use ListPolicyVersions. You
-	// cannot use DeletePolicyVersion to delete the version that is marked as the
-	// default version. You delete the policy's default version in the next step of the
-	// process.
-	//
-	// * Delete the policy (this automatically deletes the policy's default
-	// version) using this operation.
-	//
-	// For information about managed policies, see
-	// Managed policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// For information about managed policies, see Managed policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide.
 	DeletePolicy(ctx context.Context, params *DeletePolicyInput, optFns ...func(*Options)) (*DeletePolicyOutput, error)
 	// Deletes the specified version from the specified managed policy. You cannot
 	// delete the default version from a policy using this operation. To delete the
-	// default version from a policy, use DeletePolicy. To find out which version of a
-	// policy is marked as the default version, use ListPolicyVersions. For information
-	// about versions for managed policies, see Versioning for managed policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html)
+	// default version from a policy, use DeletePolicy . To find out which version of a
+	// policy is marked as the default version, use ListPolicyVersions . For
+	// information about versions for managed policies, see Versioning for managed
+	// policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html)
 	// in the IAM User Guide.
 	DeletePolicyVersion(ctx context.Context, params *DeletePolicyVersionInput, optFns ...func(*Options)) (*DeletePolicyVersionOutput, error)
 	// Deletes the specified role. Unlike the Amazon Web Services Management Console,
 	// when you delete a role programmatically, you must delete the items attached to
 	// the role manually, or the deletion fails. For more information, see Deleting an
-	// IAM role
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_delete.html#roles-managingrole-deleting-cli).
-	// Before attempting to delete a role, remove the following attached items:
+	// IAM role (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_delete.html#roles-managingrole-deleting-cli)
+	// . Before attempting to delete a role, remove the following attached items:
+	//   - Inline policies ( DeleteRolePolicy )
+	//   - Attached managed policies ( DetachRolePolicy )
+	//   - Instance profile ( RemoveRoleFromInstanceProfile )
+	//   - Optional – Delete instance profile after detaching from role for resource
+	//     clean up ( DeleteInstanceProfile )
 	//
-	// *
-	// Inline policies (DeleteRolePolicy)
-	//
-	// * Attached managed policies
-	// (DetachRolePolicy)
-	//
-	// * Instance profile (RemoveRoleFromInstanceProfile)
-	//
-	// *
-	// Optional – Delete instance profile after detaching from role for resource clean
-	// up (DeleteInstanceProfile)
-	//
-	// Make sure that you do not have any Amazon EC2
-	// instances running with the role you are about to delete. Deleting a role or
-	// instance profile that is associated with a running instance will break any
-	// applications running on the instance.
+	// Make sure that you do not have any Amazon EC2 instances running with the role
+	// you are about to delete. Deleting a role or instance profile that is associated
+	// with a running instance will break any applications running on the instance.
 	DeleteRole(ctx context.Context, params *DeleteRoleInput, optFns ...func(*Options)) (*DeleteRoleOutput, error)
 	// Deletes the permissions boundary for the specified IAM role. You cannot set the
 	// boundary for a service-linked role. Deleting the permissions boundary for a role
@@ -382,28 +321,25 @@ type IAM interface {
 	DeleteRolePermissionsBoundary(ctx context.Context, params *DeleteRolePermissionsBoundaryInput, optFns ...func(*Options)) (*DeleteRolePermissionsBoundaryOutput, error)
 	// Deletes the specified inline policy that is embedded in the specified IAM role.
 	// A role can also have managed policies attached to it. To detach a managed policy
-	// from a role, use DetachRolePolicy. For more information about policies, refer to
-	// Managed policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// from a role, use DetachRolePolicy . For more information about policies, refer
+	// to Managed policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide.
 	DeleteRolePolicy(ctx context.Context, params *DeleteRolePolicyInput, optFns ...func(*Options)) (*DeleteRolePolicyOutput, error)
-	// Deletes a SAML provider resource in IAM. Deleting the provider resource from IAM
-	// does not update any roles that reference the SAML provider resource's ARN as a
-	// principal in their trust policies. Any attempt to assume a role that references
-	// a non-existent provider resource ARN fails. This operation requires Signature
-	// Version 4
-	// (https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
+	// Deletes a SAML provider resource in IAM. Deleting the provider resource from
+	// IAM does not update any roles that reference the SAML provider resource's ARN as
+	// a principal in their trust policies. Any attempt to assume a role that
+	// references a non-existent provider resource ARN fails. This operation requires
+	// Signature Version 4 (https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
+	// .
 	DeleteSAMLProvider(ctx context.Context, params *DeleteSAMLProviderInput, optFns ...func(*Options)) (*DeleteSAMLProviderOutput, error)
 	// Deletes the specified SSH public key. The SSH public key deleted by this
 	// operation is used only for authenticating the associated IAM user to an
 	// CodeCommit repository. For more information about using SSH keys to authenticate
-	// to an CodeCommit repository, see Set up CodeCommit for SSH connections
-	// (https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html)
+	// to an CodeCommit repository, see Set up CodeCommit for SSH connections (https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html)
 	// in the CodeCommit User Guide.
 	DeleteSSHPublicKey(ctx context.Context, params *DeleteSSHPublicKeyInput, optFns ...func(*Options)) (*DeleteSSHPublicKeyOutput, error)
 	// Deletes the specified server certificate. For more information about working
-	// with server certificates, see Working with server certificates
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
+	// with server certificates, see Working with server certificates (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
 	// in the IAM User Guide. This topic also includes a list of Amazon Web Services
 	// services that can use the server certificates that you manage with IAM. If you
 	// are using a server certificate with Elastic Load Balancing, deleting the
@@ -412,28 +348,25 @@ type IAM interface {
 	// use the certificates. This could cause Elastic Load Balancing to stop accepting
 	// traffic. We recommend that you remove the reference to the certificate from
 	// Elastic Load Balancing before using this command to delete the certificate. For
-	// more information, see DeleteLoadBalancerListeners
-	// (https://docs.aws.amazon.com/ElasticLoadBalancing/latest/APIReference/API_DeleteLoadBalancerListeners.html)
+	// more information, see DeleteLoadBalancerListeners (https://docs.aws.amazon.com/ElasticLoadBalancing/latest/APIReference/API_DeleteLoadBalancerListeners.html)
 	// in the Elastic Load Balancing API Reference.
 	DeleteServerCertificate(ctx context.Context, params *DeleteServerCertificateInput, optFns ...func(*Options)) (*DeleteServerCertificateOutput, error)
-	// Submits a service-linked role deletion request and returns a DeletionTaskId,
+	// Submits a service-linked role deletion request and returns a DeletionTaskId ,
 	// which you can use to check the status of the deletion. Before you call this
 	// operation, confirm that the role has no active sessions and that any resources
 	// used by the role in the linked service are deleted. If you call this operation
 	// more than once for the same service-linked role and an earlier deletion task is
-	// not complete, then the DeletionTaskId of the earlier request is returned. If you
-	// submit a deletion request for a service-linked role whose linked service is
+	// not complete, then the DeletionTaskId of the earlier request is returned. If
+	// you submit a deletion request for a service-linked role whose linked service is
 	// still accessing a resource, then the deletion task fails. If it fails, the
 	// GetServiceLinkedRoleDeletionStatus operation returns the reason for the failure,
 	// usually including the resources that must be deleted. To delete the
 	// service-linked role, you must first remove those resources from the linked
 	// service and then submit the deletion request again. Resources are specific to
 	// the service that is linked to the role. For more information about removing
-	// resources from a service, see the Amazon Web Services documentation
-	// (http://docs.aws.amazon.com/) for your service. For more information about
-	// service-linked roles, see Roles terms and concepts: Amazon Web Services
-	// service-linked role
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#iam-term-service-linked-role)
+	// resources from a service, see the Amazon Web Services documentation (http://docs.aws.amazon.com/)
+	// for your service. For more information about service-linked roles, see Roles
+	// terms and concepts: Amazon Web Services service-linked role (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#iam-term-service-linked-role)
 	// in the IAM User Guide.
 	DeleteServiceLinkedRole(ctx context.Context, params *DeleteServiceLinkedRoleInput, optFns ...func(*Options)) (*DeleteServiceLinkedRoleOutput, error)
 	// Deletes the specified service-specific credential.
@@ -448,33 +381,18 @@ type IAM interface {
 	// Deletes the specified IAM user. Unlike the Amazon Web Services Management
 	// Console, when you delete a user programmatically, you must delete the items
 	// attached to the user manually, or the deletion fails. For more information, see
-	// Deleting an IAM user
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_manage.html#id_users_deleting_cli).
-	// Before attempting to delete a user, remove the following items:
-	//
-	// * Password
-	// (DeleteLoginProfile)
-	//
-	// * Access keys (DeleteAccessKey)
-	//
-	// * Signing certificate
-	// (DeleteSigningCertificate)
-	//
-	// * SSH public key (DeleteSSHPublicKey)
-	//
-	// * Git
-	// credentials (DeleteServiceSpecificCredential)
-	//
-	// * Multi-factor authentication
-	// (MFA) device (DeactivateMFADevice, DeleteVirtualMFADevice)
-	//
-	// * Inline policies
-	// (DeleteUserPolicy)
-	//
-	// * Attached managed policies (DetachUserPolicy)
-	//
-	// * Group
-	// memberships (RemoveUserFromGroup)
+	// Deleting an IAM user (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_manage.html#id_users_deleting_cli)
+	// . Before attempting to delete a user, remove the following items:
+	//   - Password ( DeleteLoginProfile )
+	//   - Access keys ( DeleteAccessKey )
+	//   - Signing certificate ( DeleteSigningCertificate )
+	//   - SSH public key ( DeleteSSHPublicKey )
+	//   - Git credentials ( DeleteServiceSpecificCredential )
+	//   - Multi-factor authentication (MFA) device ( DeactivateMFADevice ,
+	//     DeleteVirtualMFADevice )
+	//   - Inline policies ( DeleteUserPolicy )
+	//   - Attached managed policies ( DetachUserPolicy )
+	//   - Group memberships ( RemoveUserFromGroup )
 	DeleteUser(ctx context.Context, params *DeleteUserInput, optFns ...func(*Options)) (*DeleteUserOutput, error)
 	// Deletes the permissions boundary for the specified IAM user. Deleting the
 	// permissions boundary for a user might increase its permissions by allowing the
@@ -482,34 +400,30 @@ type IAM interface {
 	DeleteUserPermissionsBoundary(ctx context.Context, params *DeleteUserPermissionsBoundaryInput, optFns ...func(*Options)) (*DeleteUserPermissionsBoundaryOutput, error)
 	// Deletes the specified inline policy that is embedded in the specified IAM user.
 	// A user can also have managed policies attached to it. To detach a managed policy
-	// from a user, use DetachUserPolicy. For more information about policies, refer to
-	// Managed policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// from a user, use DetachUserPolicy . For more information about policies, refer
+	// to Managed policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide.
 	DeleteUserPolicy(ctx context.Context, params *DeleteUserPolicyInput, optFns ...func(*Options)) (*DeleteUserPolicyOutput, error)
 	// Deletes a virtual MFA device. You must deactivate a user's virtual MFA device
 	// before you can delete it. For information about deactivating MFA devices, see
-	// DeactivateMFADevice.
+	// DeactivateMFADevice .
 	DeleteVirtualMFADevice(ctx context.Context, params *DeleteVirtualMFADeviceInput, optFns ...func(*Options)) (*DeleteVirtualMFADeviceOutput, error)
 	// Removes the specified managed policy from the specified IAM group. A group can
 	// also have inline policies embedded with it. To delete an inline policy, use
-	// DeleteGroupPolicy. For information about policies, see Managed policies and
-	// inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// DeleteGroupPolicy . For information about policies, see Managed policies and
+	// inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide.
 	DetachGroupPolicy(ctx context.Context, params *DetachGroupPolicyInput, optFns ...func(*Options)) (*DetachGroupPolicyOutput, error)
 	// Removes the specified managed policy from the specified role. A role can also
 	// have inline policies embedded with it. To delete an inline policy, use
-	// DeleteRolePolicy. For information about policies, see Managed policies and
-	// inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// DeleteRolePolicy . For information about policies, see Managed policies and
+	// inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide.
 	DetachRolePolicy(ctx context.Context, params *DetachRolePolicyInput, optFns ...func(*Options)) (*DetachRolePolicyOutput, error)
 	// Removes the specified managed policy from the specified user. A user can also
 	// have inline policies embedded with it. To delete an inline policy, use
-	// DeleteUserPolicy. For information about policies, see Managed policies and
-	// inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// DeleteUserPolicy . For information about policies, see Managed policies and
+	// inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide.
 	DetachUserPolicy(ctx context.Context, params *DetachUserPolicyInput, optFns ...func(*Options)) (*DetachUserPolicyOutput, error)
 	// Enables the specified MFA device and associates it with the specified IAM user.
@@ -517,9 +431,8 @@ type IAM interface {
 	// user associated with the device.
 	EnableMFADevice(ctx context.Context, params *EnableMFADeviceInput, optFns ...func(*Options)) (*EnableMFADeviceOutput, error)
 	// Generates a credential report for the Amazon Web Services account. For more
-	// information about the credential report, see Getting credential reports
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/credential-reports.html) in
-	// the IAM User Guide.
+	// information about the credential report, see Getting credential reports (https://docs.aws.amazon.com/IAM/latest/UserGuide/credential-reports.html)
+	// in the IAM User Guide.
 	GenerateCredentialReport(ctx context.Context, params *GenerateCredentialReportInput, optFns ...func(*Options)) (*GenerateCredentialReportOutput, error)
 	// Generates a report for service last accessed data for Organizations. You can
 	// generate a report for any entities (organization root, organizational unit, or
@@ -528,8 +441,7 @@ type IAM interface {
 	// your long-term IAM user or root user credentials, or temporary credentials from
 	// assuming an IAM role. SCPs must be enabled for your organization root. You must
 	// have the required IAM and Organizations permissions. For more information, see
-	// Refining permissions using service last accessed data
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html)
+	// Refining permissions using service last accessed data (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html)
 	// in the IAM User Guide. You can generate a service last accessed data report for
 	// entities by specifying only the entity's path. This data includes a list of
 	// services that are allowed by any service control policies (SCPs) that apply to
@@ -540,8 +452,7 @@ type IAM interface {
 	// that the policy allows to account principals in the entity or the entity's
 	// children. For important information about the data, reporting period,
 	// permissions required, troubleshooting, and supported Regions see Reducing
-	// permissions using service last accessed data
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html)
+	// permissions using service last accessed data (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html)
 	// in the IAM User Guide. The data includes all attempts to access Amazon Web
 	// Services, not just the successful ones. This includes all attempts that were
 	// made using the Amazon Web Services Management Console, the Amazon Web Services
@@ -550,86 +461,71 @@ type IAM interface {
 	// compromised, because the request might have been denied. Refer to your
 	// CloudTrail logs as the authoritative source for information about all API calls
 	// and whether they were successful or denied access. For more information, see
-	// Logging IAM events with CloudTrail
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html)
-	// in the IAM User Guide. This operation returns a JobId. Use this parameter in the
-	// GetOrganizationsAccessReport operation to check the status of the report
+	// Logging IAM events with CloudTrail (https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html)
+	// in the IAM User Guide. This operation returns a JobId . Use this parameter in
+	// the GetOrganizationsAccessReport operation to check the status of the report
 	// generation. To check the status of this request, use the JobId parameter in the
 	// GetOrganizationsAccessReport operation and test the JobStatus response
 	// parameter. When the job is complete, you can retrieve the report. To generate a
 	// service last accessed data report for entities, specify an entity path without
 	// specifying the optional Organizations policy ID. The type of entity that you
 	// specify determines the data returned in the report.
+	//   - Root – When you specify the organizations root as the entity, the resulting
+	//     report lists all of the services allowed by SCPs that are attached to your root.
+	//     For each service, the report includes data for all accounts in your organization
+	//     except the management account, because the management account is not limited by
+	//     SCPs.
+	//   - OU – When you specify an organizational unit (OU) as the entity, the
+	//     resulting report lists all of the services allowed by SCPs that are attached to
+	//     the OU and its parents. For each service, the report includes data for all
+	//     accounts in the OU or its children. This data excludes the management account,
+	//     because the management account is not limited by SCPs.
+	//   - management account – When you specify the management account, the resulting
+	//     report lists all Amazon Web Services services, because the management account is
+	//     not limited by SCPs. For each service, the report includes data for only the
+	//     management account.
+	//   - Account – When you specify another account as the entity, the resulting
+	//     report lists all of the services allowed by SCPs that are attached to the
+	//     account and its parents. For each service, the report includes data for only the
+	//     specified account.
 	//
-	// * Root – When you specify
-	// the organizations root as the entity, the resulting report lists all of the
-	// services allowed by SCPs that are attached to your root. For each service, the
-	// report includes data for all accounts in your organization except the management
-	// account, because the management account is not limited by SCPs.
-	//
-	// * OU – When you
-	// specify an organizational unit (OU) as the entity, the resulting report lists
-	// all of the services allowed by SCPs that are attached to the OU and its parents.
-	// For each service, the report includes data for all accounts in the OU or its
-	// children. This data excludes the management account, because the management
-	// account is not limited by SCPs.
-	//
-	// * management account – When you specify the
-	// management account, the resulting report lists all Amazon Web Services services,
-	// because the management account is not limited by SCPs. For each service, the
-	// report includes data for only the management account.
-	//
-	// * Account – When you
-	// specify another account as the entity, the resulting report lists all of the
-	// services allowed by SCPs that are attached to the account and its parents. For
-	// each service, the report includes data for only the specified account.
-	//
-	// To
-	// generate a service last accessed data report for policies, specify an entity
+	// To generate a service last accessed data report for policies, specify an entity
 	// path and the optional Organizations policy ID. The type of entity that you
 	// specify determines the data returned for each service.
+	//   - Root – When you specify the root entity and a policy ID, the resulting
+	//     report lists all of the services that are allowed by the specified SCP. For each
+	//     service, the report includes data for all accounts in your organization to which
+	//     the SCP applies. This data excludes the management account, because the
+	//     management account is not limited by SCPs. If the SCP is not attached to any
+	//     entities in the organization, then the report will return a list of services
+	//     with no data.
+	//   - OU – When you specify an OU entity and a policy ID, the resulting report
+	//     lists all of the services that are allowed by the specified SCP. For each
+	//     service, the report includes data for all accounts in the OU or its children to
+	//     which the SCP applies. This means that other accounts outside the OU that are
+	//     affected by the SCP might not be included in the data. This data excludes the
+	//     management account, because the management account is not limited by SCPs. If
+	//     the SCP is not attached to the OU or one of its children, the report will return
+	//     a list of services with no data.
+	//   - management account – When you specify the management account, the resulting
+	//     report lists all Amazon Web Services services, because the management account is
+	//     not limited by SCPs. If you specify a policy ID in the CLI or API, the policy is
+	//     ignored. For each service, the report includes data for only the management
+	//     account.
+	//   - Account – When you specify another account entity and a policy ID, the
+	//     resulting report lists all of the services that are allowed by the specified
+	//     SCP. For each service, the report includes data for only the specified account.
+	//     This means that other accounts in the organization that are affected by the SCP
+	//     might not be included in the data. If the SCP is not attached to the account,
+	//     the report will return a list of services with no data.
 	//
-	// * Root – When you
-	// specify the root entity and a policy ID, the resulting report lists all of the
-	// services that are allowed by the specified SCP. For each service, the report
-	// includes data for all accounts in your organization to which the SCP applies.
-	// This data excludes the management account, because the management account is not
-	// limited by SCPs. If the SCP is not attached to any entities in the organization,
-	// then the report will return a list of services with no data.
-	//
-	// * OU – When you
-	// specify an OU entity and a policy ID, the resulting report lists all of the
-	// services that are allowed by the specified SCP. For each service, the report
-	// includes data for all accounts in the OU or its children to which the SCP
-	// applies. This means that other accounts outside the OU that are affected by the
-	// SCP might not be included in the data. This data excludes the management
-	// account, because the management account is not limited by SCPs. If the SCP is
-	// not attached to the OU or one of its children, the report will return a list of
-	// services with no data.
-	//
-	// * management account – When you specify the management
-	// account, the resulting report lists all Amazon Web Services services, because
-	// the management account is not limited by SCPs. If you specify a policy ID in the
-	// CLI or API, the policy is ignored. For each service, the report includes data
-	// for only the management account.
-	//
-	// * Account – When you specify another account
-	// entity and a policy ID, the resulting report lists all of the services that are
-	// allowed by the specified SCP. For each service, the report includes data for
-	// only the specified account. This means that other accounts in the organization
-	// that are affected by the SCP might not be included in the data. If the SCP is
-	// not attached to the account, the report will return a list of services with no
-	// data.
-	//
-	// Service last accessed data does not use other policy types when
-	// determining whether a principal could access a service. These other policy types
-	// include identity-based policies, resource-based policies, access control lists,
-	// IAM permissions boundaries, and STS assume role policies. It only applies SCP
-	// logic. For more about the evaluation of policy types, see Evaluating policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics)
+	// Service last accessed data does not use other policy types when determining
+	// whether a principal could access a service. These other policy types include
+	// identity-based policies, resource-based policies, access control lists, IAM
+	// permissions boundaries, and STS assume role policies. It only applies SCP logic.
+	// For more about the evaluation of policy types, see Evaluating policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics)
 	// in the IAM User Guide. For more information about service last accessed data,
-	// see Reducing policy scope by viewing user activity
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html)
+	// see Reducing policy scope by viewing user activity (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html)
 	// in the IAM User Guide.
 	GenerateOrganizationsAccessReport(ctx context.Context, params *GenerateOrganizationsAccessReportInput, optFns ...func(*Options)) (*GenerateOrganizationsAccessReportOutput, error)
 	// Generates a report that includes details about when an IAM resource (user,
@@ -637,9 +533,8 @@ type IAM interface {
 	// Services services. Recent activity usually appears within four hours. IAM
 	// reports activity for at least the last 400 days, or less if your Region began
 	// supporting this feature within the last year. For more information, see Regions
-	// where data is tracked
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html#access-advisor_tracking-period).
-	// The service last accessed data includes all attempts to access an Amazon Web
+	// where data is tracked (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html#access-advisor_tracking-period)
+	// . The service last accessed data includes all attempts to access an Amazon Web
 	// Services API, not just the successful ones. This includes all attempts that were
 	// made using the Amazon Web Services Management Console, the Amazon Web Services
 	// API through any of the SDKs, or any of the command line tools. An unexpected
@@ -647,39 +542,32 @@ type IAM interface {
 	// compromised, because the request might have been denied. Refer to your
 	// CloudTrail logs as the authoritative source for information about all API calls
 	// and whether they were successful or denied access. For more information, see
-	// Logging IAM events with CloudTrail
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html)
+	// Logging IAM events with CloudTrail (https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html)
 	// in the IAM User Guide. The GenerateServiceLastAccessedDetails operation returns
-	// a JobId. Use this parameter in the following operations to retrieve the
+	// a JobId . Use this parameter in the following operations to retrieve the
 	// following details from your report:
+	//   - GetServiceLastAccessedDetails – Use this operation for users, groups, roles,
+	//     or policies to list every Amazon Web Services service that the resource could
+	//     access using permissions policies. For each service, the response includes
+	//     information about the most recent access attempt. The JobId returned by
+	//     GenerateServiceLastAccessedDetail must be used by the same role within a
+	//     session, or by the same user when used to call GetServiceLastAccessedDetail .
+	//   - GetServiceLastAccessedDetailsWithEntities – Use this operation for groups
+	//     and policies to list information about the associated entities (users or roles)
+	//     that attempted to access a specific Amazon Web Services service.
 	//
-	// * GetServiceLastAccessedDetails – Use this
-	// operation for users, groups, roles, or policies to list every Amazon Web
-	// Services service that the resource could access using permissions policies. For
-	// each service, the response includes information about the most recent access
-	// attempt. The JobId returned by GenerateServiceLastAccessedDetail must be used by
-	// the same role within a session, or by the same user when used to call
-	// GetServiceLastAccessedDetail.
-	//
-	// * GetServiceLastAccessedDetailsWithEntities – Use
-	// this operation for groups and policies to list information about the associated
-	// entities (users or roles) that attempted to access a specific Amazon Web
-	// Services service.
-	//
-	// To check the status of the GenerateServiceLastAccessedDetails
-	// request, use the JobId parameter in the same operations and test the JobStatus
-	// response parameter. For additional information about the permissions policies
-	// that allow an identity (user, group, or role) to access specific services, use
-	// the ListPoliciesGrantingServiceAccess operation. Service last accessed data does
-	// not use other policy types when determining whether a resource could access a
+	// To check the status of the GenerateServiceLastAccessedDetails request, use the
+	// JobId parameter in the same operations and test the JobStatus response
+	// parameter. For additional information about the permissions policies that allow
+	// an identity (user, group, or role) to access specific services, use the
+	// ListPoliciesGrantingServiceAccess operation. Service last accessed data does not
+	// use other policy types when determining whether a resource could access a
 	// service. These other policy types include resource-based policies, access
 	// control lists, Organizations policies, IAM permissions boundaries, and STS
 	// assume role policies. It only applies permissions policy logic. For more about
-	// the evaluation of policy types, see Evaluating policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics)
+	// the evaluation of policy types, see Evaluating policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics)
 	// in the IAM User Guide. For more information about service and action last
-	// accessed data, see Reducing permissions using service last accessed data
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html)
+	// accessed data, see Reducing permissions using service last accessed data (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html)
 	// in the IAM User Guide.
 	GenerateServiceLastAccessedDetails(ctx context.Context, params *GenerateServiceLastAccessedDetailsInput, optFns ...func(*Options)) (*GenerateServiceLastAccessedDetailsOutput, error)
 	// Retrieves information about when the specified access key was last used. The
@@ -691,35 +579,34 @@ type IAM interface {
 	// Amazon Web Services account, including their relationships to one another. Use
 	// this operation to obtain a snapshot of the configuration of IAM permissions
 	// (users, groups, roles, and policies) in your account. Policies returned by this
-	// operation are URL-encoded compliant with RFC 3986
-	// (https://tools.ietf.org/html/rfc3986). You can use a URL decoding method to
-	// convert the policy back to plain JSON text. For example, if you use Java, you
-	// can use the decode method of the java.net.URLDecoder utility class in the Java
-	// SDK. Other languages and SDKs provide similar functionality. You can optionally
-	// filter the results using the Filter parameter. You can paginate the results
-	// using the MaxItems and Marker parameters.
+	// operation are URL-encoded compliant with RFC 3986 (https://tools.ietf.org/html/rfc3986)
+	// . You can use a URL decoding method to convert the policy back to plain JSON
+	// text. For example, if you use Java, you can use the decode method of the
+	// java.net.URLDecoder utility class in the Java SDK. Other languages and SDKs
+	// provide similar functionality. You can optionally filter the results using the
+	// Filter parameter. You can paginate the results using the MaxItems and Marker
+	// parameters.
 	GetAccountAuthorizationDetails(ctx context.Context, params *GetAccountAuthorizationDetailsInput, optFns ...func(*Options)) (*GetAccountAuthorizationDetailsOutput, error)
 	// Retrieves the password policy for the Amazon Web Services account. This tells
 	// you the complexity requirements and mandatory rotation periods for the IAM user
 	// passwords in your account. For more information about using a password policy,
-	// see Managing an IAM password policy
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingPasswordPolicies.html).
+	// see Managing an IAM password policy (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingPasswordPolicies.html)
+	// .
 	GetAccountPasswordPolicy(ctx context.Context, params *GetAccountPasswordPolicyInput, optFns ...func(*Options)) (*GetAccountPasswordPolicyOutput, error)
 	// Retrieves information about IAM entity usage and IAM quotas in the Amazon Web
-	// Services account. For information about IAM quotas, see IAM and STS quotas
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) in
-	// the IAM User Guide.
+	// Services account. For information about IAM quotas, see IAM and STS quotas (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html)
+	// in the IAM User Guide.
 	GetAccountSummary(ctx context.Context, params *GetAccountSummaryInput, optFns ...func(*Options)) (*GetAccountSummaryOutput, error)
 	// Gets a list of all of the context keys referenced in the input policies. The
 	// policies are supplied as a list of one or more strings. To get the context keys
 	// from policies associated with an IAM user, group, or role, use
-	// GetContextKeysForPrincipalPolicy. Context keys are variables maintained by
+	// GetContextKeysForPrincipalPolicy . Context keys are variables maintained by
 	// Amazon Web Services and its services that provide details about the context of
 	// an API query request. Context keys can be evaluated by testing against a value
-	// specified in an IAM policy. Use GetContextKeysForCustomPolicy to understand what
-	// key names and values you must supply when you call SimulateCustomPolicy. Note
-	// that all parameters are shown in unencoded form here for clarity but must be URL
-	// encoded to be included as a part of a real HTML request.
+	// specified in an IAM policy. Use GetContextKeysForCustomPolicy to understand
+	// what key names and values you must supply when you call SimulateCustomPolicy .
+	// Note that all parameters are shown in unencoded form here for clarity but must
+	// be URL encoded to be included as a part of a real HTML request.
 	GetContextKeysForCustomPolicy(ctx context.Context, params *GetContextKeysForCustomPolicyInput, optFns ...func(*Options)) (*GetContextKeysForCustomPolicyOutput, error)
 	// Gets a list of all of the context keys referenced in all the IAM policies that
 	// are attached to the specified IAM entity. The entity can be an IAM user, group,
@@ -734,40 +621,37 @@ type IAM interface {
 	// Amazon Web Services and its services that provide details about the context of
 	// an API query request. Context keys can be evaluated by testing against a value
 	// in an IAM policy. Use GetContextKeysForPrincipalPolicy to understand what key
-	// names and values you must supply when you call SimulatePrincipalPolicy.
+	// names and values you must supply when you call SimulatePrincipalPolicy .
 	GetContextKeysForPrincipalPolicy(ctx context.Context, params *GetContextKeysForPrincipalPolicyInput, optFns ...func(*Options)) (*GetContextKeysForPrincipalPolicyOutput, error)
 	// Retrieves a credential report for the Amazon Web Services account. For more
-	// information about the credential report, see Getting credential reports
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/credential-reports.html) in
-	// the IAM User Guide.
+	// information about the credential report, see Getting credential reports (https://docs.aws.amazon.com/IAM/latest/UserGuide/credential-reports.html)
+	// in the IAM User Guide.
 	GetCredentialReport(ctx context.Context, params *GetCredentialReportInput, optFns ...func(*Options)) (*GetCredentialReportOutput, error)
 	// Returns a list of IAM users that are in the specified IAM group. You can
 	// paginate the results using the MaxItems and Marker parameters.
 	GetGroup(ctx context.Context, params *GetGroupInput, optFns ...func(*Options)) (*GetGroupOutput, error)
-	// Retrieves the specified inline policy document that is embedded in the specified
-	// IAM group. Policies returned by this operation are URL-encoded compliant with
-	// RFC 3986 (https://tools.ietf.org/html/rfc3986). You can use a URL decoding
-	// method to convert the policy back to plain JSON text. For example, if you use
-	// Java, you can use the decode method of the java.net.URLDecoder utility class in
-	// the Java SDK. Other languages and SDKs provide similar functionality. An IAM
-	// group can also have managed policies attached to it. To retrieve a managed
-	// policy document that is attached to a group, use GetPolicy to determine the
-	// policy's default version, then use GetPolicyVersion to retrieve the policy
-	// document. For more information about policies, see Managed policies and inline
-	// policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// Retrieves the specified inline policy document that is embedded in the
+	// specified IAM group. Policies returned by this operation are URL-encoded
+	// compliant with RFC 3986 (https://tools.ietf.org/html/rfc3986) . You can use a
+	// URL decoding method to convert the policy back to plain JSON text. For example,
+	// if you use Java, you can use the decode method of the java.net.URLDecoder
+	// utility class in the Java SDK. Other languages and SDKs provide similar
+	// functionality. An IAM group can also have managed policies attached to it. To
+	// retrieve a managed policy document that is attached to a group, use GetPolicy
+	// to determine the policy's default version, then use GetPolicyVersion to
+	// retrieve the policy document. For more information about policies, see Managed
+	// policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide.
 	GetGroupPolicy(ctx context.Context, params *GetGroupPolicyInput, optFns ...func(*Options)) (*GetGroupPolicyOutput, error)
 	// Retrieves information about the specified instance profile, including the
 	// instance profile's path, GUID, ARN, and role. For more information about
-	// instance profiles, see About instance profiles
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html) in
-	// the IAM User Guide.
+	// instance profiles, see About instance profiles (https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html)
+	// in the IAM User Guide.
 	GetInstanceProfile(ctx context.Context, params *GetInstanceProfileInput, optFns ...func(*Options)) (*GetInstanceProfileOutput, error)
 	// Retrieves the user name for the specified IAM user. A login profile is created
 	// when you create a password for the user to access the Amazon Web Services
 	// Management Console. If the user does not exist or does not have a password, the
-	// operation returns a 404 (NoSuchEntity) error. If you create an IAM user with
+	// operation returns a 404 ( NoSuchEntity ) error. If you create an IAM user with
 	// access to the console, the CreateDate reflects the date you created the initial
 	// password for the user. If you create an IAM user with programmatic access, and
 	// then later add a password for the user to access the Amazon Web Services
@@ -779,15 +663,14 @@ type IAM interface {
 	// object in IAM.
 	GetOpenIDConnectProvider(ctx context.Context, params *GetOpenIDConnectProviderInput, optFns ...func(*Options)) (*GetOpenIDConnectProviderOutput, error)
 	// Retrieves the service last accessed data report for Organizations that was
-	// previously generated using the GenerateOrganizationsAccessReport operation. This
-	// operation retrieves the status of your report job and the report contents.
+	// previously generated using the GenerateOrganizationsAccessReport operation.
+	// This operation retrieves the status of your report job and the report contents.
 	// Depending on the parameters that you passed when you generated the report, the
 	// data returned could include different information. For details, see
-	// GenerateOrganizationsAccessReport. To call this operation, you must be signed in
-	// to the management account in your organization. SCPs must be enabled for your
+	// GenerateOrganizationsAccessReport . To call this operation, you must be signed
+	// in to the management account in your organization. SCPs must be enabled for your
 	// organization root. You must have permissions to perform this operation. For more
-	// information, see Refining permissions using service last accessed data
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html)
+	// information, see Refining permissions using service last accessed data (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html)
 	// in the IAM User Guide. For each service that principals in an account (root
 	// user, IAM users, or IAM roles) could access using SCPs, the operation returns
 	// details about the most recent access attempt. If there was no attempt, the
@@ -795,95 +678,87 @@ type IAM interface {
 	// service. If the operation fails, it returns the reason that it failed. By
 	// default, the list is sorted by service namespace.
 	GetOrganizationsAccessReport(ctx context.Context, params *GetOrganizationsAccessReportInput, optFns ...func(*Options)) (*GetOrganizationsAccessReportOutput, error)
-	// Retrieves information about the specified managed policy, including the policy's
-	// default version and the total number of IAM users, groups, and roles to which
-	// the policy is attached. To retrieve the list of the specific users, groups, and
-	// roles that the policy is attached to, use ListEntitiesForPolicy. This operation
-	// returns metadata about the policy. To retrieve the actual policy document for a
-	// specific version of the policy, use GetPolicyVersion. This operation retrieves
-	// information about managed policies. To retrieve information about an inline
-	// policy that is embedded with an IAM user, group, or role, use GetUserPolicy,
-	// GetGroupPolicy, or GetRolePolicy. For more information about policies, see
-	// Managed policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// Retrieves information about the specified managed policy, including the
+	// policy's default version and the total number of IAM users, groups, and roles to
+	// which the policy is attached. To retrieve the list of the specific users,
+	// groups, and roles that the policy is attached to, use ListEntitiesForPolicy .
+	// This operation returns metadata about the policy. To retrieve the actual policy
+	// document for a specific version of the policy, use GetPolicyVersion . This
+	// operation retrieves information about managed policies. To retrieve information
+	// about an inline policy that is embedded with an IAM user, group, or role, use
+	// GetUserPolicy , GetGroupPolicy , or GetRolePolicy . For more information about
+	// policies, see Managed policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide.
 	GetPolicy(ctx context.Context, params *GetPolicyInput, optFns ...func(*Options)) (*GetPolicyOutput, error)
 	// Retrieves information about the specified version of the specified managed
 	// policy, including the policy document. Policies returned by this operation are
-	// URL-encoded compliant with RFC 3986 (https://tools.ietf.org/html/rfc3986). You
+	// URL-encoded compliant with RFC 3986 (https://tools.ietf.org/html/rfc3986) . You
 	// can use a URL decoding method to convert the policy back to plain JSON text. For
 	// example, if you use Java, you can use the decode method of the
 	// java.net.URLDecoder utility class in the Java SDK. Other languages and SDKs
 	// provide similar functionality. To list the available versions for a policy, use
-	// ListPolicyVersions. This operation retrieves information about managed policies.
-	// To retrieve information about an inline policy that is embedded in a user,
-	// group, or role, use GetUserPolicy, GetGroupPolicy, or GetRolePolicy. For more
-	// information about the types of policies, see Managed policies and inline
-	// policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// ListPolicyVersions . This operation retrieves information about managed
+	// policies. To retrieve information about an inline policy that is embedded in a
+	// user, group, or role, use GetUserPolicy , GetGroupPolicy , or GetRolePolicy .
+	// For more information about the types of policies, see Managed policies and
+	// inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide. For more information about managed policy versions, see
-	// Versioning for managed policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html)
+	// Versioning for managed policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html)
 	// in the IAM User Guide.
 	GetPolicyVersion(ctx context.Context, params *GetPolicyVersionInput, optFns ...func(*Options)) (*GetPolicyVersionOutput, error)
-	// Retrieves information about the specified role, including the role's path, GUID,
-	// ARN, and the role's trust policy that grants permission to assume the role. For
-	// more information about roles, see Working with roles
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html).
-	// Policies returned by this operation are URL-encoded compliant with RFC 3986
-	// (https://tools.ietf.org/html/rfc3986). You can use a URL decoding method to
-	// convert the policy back to plain JSON text. For example, if you use Java, you
-	// can use the decode method of the java.net.URLDecoder utility class in the Java
-	// SDK. Other languages and SDKs provide similar functionality.
+	// Retrieves information about the specified role, including the role's path,
+	// GUID, ARN, and the role's trust policy that grants permission to assume the
+	// role. For more information about roles, see Working with roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html)
+	// . Policies returned by this operation are URL-encoded compliant with RFC 3986 (https://tools.ietf.org/html/rfc3986)
+	// . You can use a URL decoding method to convert the policy back to plain JSON
+	// text. For example, if you use Java, you can use the decode method of the
+	// java.net.URLDecoder utility class in the Java SDK. Other languages and SDKs
+	// provide similar functionality.
 	GetRole(ctx context.Context, params *GetRoleInput, optFns ...func(*Options)) (*GetRoleOutput, error)
 	// Retrieves the specified inline policy document that is embedded with the
 	// specified IAM role. Policies returned by this operation are URL-encoded
-	// compliant with RFC 3986 (https://tools.ietf.org/html/rfc3986). You can use a URL
-	// decoding method to convert the policy back to plain JSON text. For example, if
-	// you use Java, you can use the decode method of the java.net.URLDecoder utility
-	// class in the Java SDK. Other languages and SDKs provide similar functionality.
-	// An IAM role can also have managed policies attached to it. To retrieve a managed
-	// policy document that is attached to a role, use GetPolicy to determine the
-	// policy's default version, then use GetPolicyVersion to retrieve the policy
-	// document. For more information about policies, see Managed policies and inline
-	// policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// compliant with RFC 3986 (https://tools.ietf.org/html/rfc3986) . You can use a
+	// URL decoding method to convert the policy back to plain JSON text. For example,
+	// if you use Java, you can use the decode method of the java.net.URLDecoder
+	// utility class in the Java SDK. Other languages and SDKs provide similar
+	// functionality. An IAM role can also have managed policies attached to it. To
+	// retrieve a managed policy document that is attached to a role, use GetPolicy to
+	// determine the policy's default version, then use GetPolicyVersion to retrieve
+	// the policy document. For more information about policies, see Managed policies
+	// and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide. For more information about roles, see Using roles to
-	// delegate permissions and federate identities
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/roles-toplevel.html).
+	// delegate permissions and federate identities (https://docs.aws.amazon.com/IAM/latest/UserGuide/roles-toplevel.html)
+	// .
 	GetRolePolicy(ctx context.Context, params *GetRolePolicyInput, optFns ...func(*Options)) (*GetRolePolicyOutput, error)
 	// Returns the SAML provider metadocument that was uploaded when the IAM SAML
 	// provider resource object was created or updated. This operation requires
-	// Signature Version 4
-	// (https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
+	// Signature Version 4 (https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
+	// .
 	GetSAMLProvider(ctx context.Context, params *GetSAMLProviderInput, optFns ...func(*Options)) (*GetSAMLProviderOutput, error)
 	// Retrieves the specified SSH public key, including metadata about the key. The
 	// SSH public key retrieved by this operation is used only for authenticating the
 	// associated IAM user to an CodeCommit repository. For more information about
 	// using SSH keys to authenticate to an CodeCommit repository, see Set up
-	// CodeCommit for SSH connections
-	// (https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html)
+	// CodeCommit for SSH connections (https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html)
 	// in the CodeCommit User Guide.
 	GetSSHPublicKey(ctx context.Context, params *GetSSHPublicKeyInput, optFns ...func(*Options)) (*GetSSHPublicKeyOutput, error)
 	// Retrieves information about the specified server certificate stored in IAM. For
-	// more information about working with server certificates, see Working with server
-	// certificates
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
+	// more information about working with server certificates, see Working with
+	// server certificates (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
 	// in the IAM User Guide. This topic includes a list of Amazon Web Services
 	// services that can use the server certificates that you manage with IAM.
 	GetServerCertificate(ctx context.Context, params *GetServerCertificateInput, optFns ...func(*Options)) (*GetServerCertificateOutput, error)
 	// Retrieves a service last accessed report that was created using the
-	// GenerateServiceLastAccessedDetails operation. You can use the JobId parameter in
-	// GetServiceLastAccessedDetails to retrieve the status of your report job. When
-	// the report is complete, you can retrieve the generated report. The report
+	// GenerateServiceLastAccessedDetails operation. You can use the JobId parameter
+	// in GetServiceLastAccessedDetails to retrieve the status of your report job.
+	// When the report is complete, you can retrieve the generated report. The report
 	// includes a list of Amazon Web Services services that the resource (user, group,
 	// role, or managed policy) can access. Service last accessed data does not use
 	// other policy types when determining whether a resource could access a service.
 	// These other policy types include resource-based policies, access control lists,
 	// Organizations policies, IAM permissions boundaries, and STS assume role
 	// policies. It only applies permissions policy logic. For more about the
-	// evaluation of policy types, see Evaluating policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics)
+	// evaluation of policy types, see Evaluating policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics)
 	// in the IAM User Guide. For each service that the resource could access using
 	// permissions policies, the operation returns details about the most recent access
 	// attempt. If there was no attempt, the service is listed without details about
@@ -893,49 +768,38 @@ type IAM interface {
 	// includes the number of entities that have attempted to access the service and
 	// the date and time of the last attempt. It also returns the ARN of the following
 	// entity, depending on the resource ARN that you used to generate the report:
+	//   - User – Returns the user ARN that you used to generate the report
+	//   - Group – Returns the ARN of the group member (user) that last attempted to
+	//     access the service
+	//   - Role – Returns the role ARN that you used to generate the report
+	//   - Policy – Returns the ARN of the user or role that last used the policy to
+	//     attempt to access the service
 	//
-	// *
-	// User – Returns the user ARN that you used to generate the report
-	//
-	// * Group –
-	// Returns the ARN of the group member (user) that last attempted to access the
-	// service
-	//
-	// * Role – Returns the role ARN that you used to generate the report
-	//
-	// *
-	// Policy – Returns the ARN of the user or role that last used the policy to
-	// attempt to access the service
-	//
-	// By default, the list is sorted by service
-	// namespace. If you specified ACTION_LEVEL granularity when you generated the
-	// report, this operation returns service and action last accessed data. This
-	// includes the most recent access attempt for each tracked action within a
-	// service. Otherwise, this operation returns only service data. For more
-	// information about service and action last accessed data, see Reducing
-	// permissions using service last accessed data
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html)
+	// By default, the list is sorted by service namespace. If you specified
+	// ACTION_LEVEL granularity when you generated the report, this operation returns
+	// service and action last accessed data. This includes the most recent access
+	// attempt for each tracked action within a service. Otherwise, this operation
+	// returns only service data. For more information about service and action last
+	// accessed data, see Reducing permissions using service last accessed data (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html)
 	// in the IAM User Guide.
 	GetServiceLastAccessedDetails(ctx context.Context, params *GetServiceLastAccessedDetailsInput, optFns ...func(*Options)) (*GetServiceLastAccessedDetailsOutput, error)
 	// After you generate a group or policy report using the
-	// GenerateServiceLastAccessedDetails operation, you can use the JobId parameter in
-	// GetServiceLastAccessedDetailsWithEntities. This operation retrieves the status
-	// of your report job and a list of entities that could have used group or policy
-	// permissions to access the specified service.
+	// GenerateServiceLastAccessedDetails operation, you can use the JobId parameter
+	// in GetServiceLastAccessedDetailsWithEntities . This operation retrieves the
+	// status of your report job and a list of entities that could have used group or
+	// policy permissions to access the specified service.
+	//   - Group – For a group report, this operation returns a list of users in the
+	//     group that could have used the group’s policies in an attempt to access the
+	//     service.
+	//   - Policy – For a policy report, this operation returns a list of entities
+	//     (users or roles) that could have used the policy in an attempt to access the
+	//     service.
 	//
-	// * Group – For a group report, this
-	// operation returns a list of users in the group that could have used the group’s
-	// policies in an attempt to access the service.
-	//
-	// * Policy – For a policy report,
-	// this operation returns a list of entities (users or roles) that could have used
-	// the policy in an attempt to access the service.
-	//
-	// You can also use this operation
-	// for user or role reports to retrieve details about those entities. If the
-	// operation fails, the GetServiceLastAccessedDetailsWithEntities operation returns
-	// the reason that it failed. By default, the list of associated entities is sorted
-	// by date, with the most recent access listed first.
+	// You can also use this operation for user or role reports to retrieve details
+	// about those entities. If the operation fails, the
+	// GetServiceLastAccessedDetailsWithEntities operation returns the reason that it
+	// failed. By default, the list of associated entities is sorted by date, with the
+	// most recent access listed first.
 	GetServiceLastAccessedDetailsWithEntities(ctx context.Context, params *GetServiceLastAccessedDetailsWithEntitiesInput, optFns ...func(*Options)) (*GetServiceLastAccessedDetailsWithEntitiesOutput, error)
 	// Retrieves the status of your service-linked role deletion. After you use
 	// DeleteServiceLinkedRole to submit a service-linked role for deletion, you can
@@ -948,17 +812,17 @@ type IAM interface {
 	// determines the user name implicitly based on the Amazon Web Services access key
 	// ID used to sign the request to this operation.
 	GetUser(ctx context.Context, params *GetUserInput, optFns ...func(*Options)) (*GetUserOutput, error)
-	// Retrieves the specified inline policy document that is embedded in the specified
-	// IAM user. Policies returned by this operation are URL-encoded compliant with RFC
-	// 3986 (https://tools.ietf.org/html/rfc3986). You can use a URL decoding method to
-	// convert the policy back to plain JSON text. For example, if you use Java, you
-	// can use the decode method of the java.net.URLDecoder utility class in the Java
-	// SDK. Other languages and SDKs provide similar functionality. An IAM user can
-	// also have managed policies attached to it. To retrieve a managed policy document
-	// that is attached to a user, use GetPolicy to determine the policy's default
-	// version. Then use GetPolicyVersion to retrieve the policy document. For more
-	// information about policies, see Managed policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// Retrieves the specified inline policy document that is embedded in the
+	// specified IAM user. Policies returned by this operation are URL-encoded
+	// compliant with RFC 3986 (https://tools.ietf.org/html/rfc3986) . You can use a
+	// URL decoding method to convert the policy back to plain JSON text. For example,
+	// if you use Java, you can use the decode method of the java.net.URLDecoder
+	// utility class in the Java SDK. Other languages and SDKs provide similar
+	// functionality. An IAM user can also have managed policies attached to it. To
+	// retrieve a managed policy document that is attached to a user, use GetPolicy to
+	// determine the policy's default version. Then use GetPolicyVersion to retrieve
+	// the policy document. For more information about policies, see Managed policies
+	// and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide.
 	GetUserPolicy(ctx context.Context, params *GetUserPolicyInput, optFns ...func(*Options)) (*GetUserPolicyOutput, error)
 	// Returns information about the access key IDs associated with the specified IAM
@@ -976,15 +840,13 @@ type IAM interface {
 	ListAccessKeys(ctx context.Context, params *ListAccessKeysInput, optFns ...func(*Options)) (*ListAccessKeysOutput, error)
 	// Lists the account alias associated with the Amazon Web Services account (Note:
 	// you can have only one). For information about using an Amazon Web Services
-	// account alias, see Using an alias for your Amazon Web Services account ID
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/AccountAlias.html) in the IAM
-	// User Guide.
+	// account alias, see Using an alias for your Amazon Web Services account ID (https://docs.aws.amazon.com/IAM/latest/UserGuide/AccountAlias.html)
+	// in the IAM User Guide.
 	ListAccountAliases(ctx context.Context, params *ListAccountAliasesInput, optFns ...func(*Options)) (*ListAccountAliasesOutput, error)
 	// Lists all managed policies that are attached to the specified IAM group. An IAM
 	// group can also have inline policies embedded with it. To list the inline
-	// policies for a group, use ListGroupPolicies. For information about policies, see
-	// Managed policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// policies for a group, use ListGroupPolicies . For information about policies,
+	// see Managed policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide. You can paginate the results using the MaxItems and
 	// Marker parameters. You can use the PathPrefix parameter to limit the list of
 	// policies to only those matching the specified path prefix. If there are no
@@ -993,9 +855,8 @@ type IAM interface {
 	ListAttachedGroupPolicies(ctx context.Context, params *ListAttachedGroupPoliciesInput, optFns ...func(*Options)) (*ListAttachedGroupPoliciesOutput, error)
 	// Lists all managed policies that are attached to the specified IAM role. An IAM
 	// role can also have inline policies embedded with it. To list the inline policies
-	// for a role, use ListRolePolicies. For information about policies, see Managed
-	// policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// for a role, use ListRolePolicies . For information about policies, see Managed
+	// policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide. You can paginate the results using the MaxItems and
 	// Marker parameters. You can use the PathPrefix parameter to limit the list of
 	// policies to only those matching the specified path prefix. If there are no
@@ -1004,9 +865,8 @@ type IAM interface {
 	ListAttachedRolePolicies(ctx context.Context, params *ListAttachedRolePoliciesInput, optFns ...func(*Options)) (*ListAttachedRolePoliciesOutput, error)
 	// Lists all managed policies that are attached to the specified IAM user. An IAM
 	// user can also have inline policies embedded with it. To list the inline policies
-	// for a user, use ListUserPolicies. For information about policies, see Managed
-	// policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// for a user, use ListUserPolicies . For information about policies, see Managed
+	// policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide. You can paginate the results using the MaxItems and
 	// Marker parameters. You can use the PathPrefix parameter to limit the list of
 	// policies to only those matching the specified path prefix. If there are no
@@ -1017,14 +877,13 @@ type IAM interface {
 	// attached to. You can use the optional EntityFilter parameter to limit the
 	// results to a particular type of entity (users, groups, or roles). For example,
 	// to list only the roles that are attached to the specified policy, set
-	// EntityFilter to Role. You can paginate the results using the MaxItems and Marker
-	// parameters.
+	// EntityFilter to Role . You can paginate the results using the MaxItems and
+	// Marker parameters.
 	ListEntitiesForPolicy(ctx context.Context, params *ListEntitiesForPolicyInput, optFns ...func(*Options)) (*ListEntitiesForPolicyOutput, error)
 	// Lists the names of the inline policies that are embedded in the specified IAM
 	// group. An IAM group can also have managed policies attached to it. To list the
-	// managed policies that are attached to a group, use ListAttachedGroupPolicies.
-	// For more information about policies, see Managed policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// managed policies that are attached to a group, use ListAttachedGroupPolicies .
+	// For more information about policies, see Managed policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide. You can paginate the results using the MaxItems and
 	// Marker parameters. If there are no inline policies embedded with the specified
 	// group, the operation returns an empty list.
@@ -1037,31 +896,27 @@ type IAM interface {
 	ListGroupsForUser(ctx context.Context, params *ListGroupsForUserInput, optFns ...func(*Options)) (*ListGroupsForUserOutput, error)
 	// Lists the tags that are attached to the specified IAM instance profile. The
 	// returned list of tags is sorted by tag key. For more information about tagging,
-	// see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	// see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	// in the IAM User Guide.
 	ListInstanceProfileTags(ctx context.Context, params *ListInstanceProfileTagsInput, optFns ...func(*Options)) (*ListInstanceProfileTagsOutput, error)
 	// Lists the instance profiles that have the specified path prefix. If there are
 	// none, the operation returns an empty list. For more information about instance
-	// profiles, see About instance profiles
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html).
-	// IAM resource-listing operations return a subset of the available attributes for
-	// the resource. For example, this operation does not return tags, even though they
-	// are an attribute of the returned object. To view all of the information for an
-	// instance profile, see GetInstanceProfile. You can paginate the results using the
-	// MaxItems and Marker parameters.
+	// profiles, see About instance profiles (https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html)
+	// . IAM resource-listing operations return a subset of the available attributes
+	// for the resource. For example, this operation does not return tags, even though
+	// they are an attribute of the returned object. To view all of the information for
+	// an instance profile, see GetInstanceProfile . You can paginate the results using
+	// the MaxItems and Marker parameters.
 	ListInstanceProfiles(ctx context.Context, params *ListInstanceProfilesInput, optFns ...func(*Options)) (*ListInstanceProfilesOutput, error)
 	// Lists the instance profiles that have the specified associated IAM role. If
 	// there are none, the operation returns an empty list. For more information about
-	// instance profiles, go to About instance profiles
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html).
-	// You can paginate the results using the MaxItems and Marker parameters.
+	// instance profiles, go to About instance profiles (https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html)
+	// . You can paginate the results using the MaxItems and Marker parameters.
 	ListInstanceProfilesForRole(ctx context.Context, params *ListInstanceProfilesForRoleInput, optFns ...func(*Options)) (*ListInstanceProfilesForRoleOutput, error)
 	// Lists the tags that are attached to the specified IAM virtual multi-factor
 	// authentication (MFA) device. The returned list of tags is sorted by tag key. For
-	// more information about tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	// more information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	// in the IAM User Guide.
 	ListMFADeviceTags(ctx context.Context, params *ListMFADeviceTagsInput, optFns ...func(*Options)) (*ListMFADeviceTagsOutput, error)
 	// Lists the MFA devices for an IAM user. If the request includes a IAM user name,
 	// then this operation lists all the MFA devices associated with the specified
@@ -1072,33 +927,30 @@ type IAM interface {
 	ListMFADevices(ctx context.Context, params *ListMFADevicesInput, optFns ...func(*Options)) (*ListMFADevicesOutput, error)
 	// Lists the tags that are attached to the specified OpenID Connect
 	// (OIDC)-compatible identity provider. The returned list of tags is sorted by tag
-	// key. For more information, see About web identity federation
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html).
-	// For more information about tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	// key. For more information, see About web identity federation (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html)
+	// . For more information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	// in the IAM User Guide.
 	ListOpenIDConnectProviderTags(ctx context.Context, params *ListOpenIDConnectProviderTagsInput, optFns ...func(*Options)) (*ListOpenIDConnectProviderTagsOutput, error)
 	// Lists information about the IAM OpenID Connect (OIDC) provider resource objects
 	// defined in the Amazon Web Services account. IAM resource-listing operations
 	// return a subset of the available attributes for the resource. For example, this
 	// operation does not return tags, even though they are an attribute of the
 	// returned object. To view all of the information for an OIDC provider, see
-	// GetOpenIDConnectProvider.
+	// GetOpenIDConnectProvider .
 	ListOpenIDConnectProviders(ctx context.Context, params *ListOpenIDConnectProvidersInput, optFns ...func(*Options)) (*ListOpenIDConnectProvidersOutput, error)
 	// Lists all the managed policies that are available in your Amazon Web Services
 	// account, including your own customer-defined managed policies and all Amazon Web
 	// Services managed policies. You can filter the list of policies that is returned
-	// using the optional OnlyAttached, Scope, and PathPrefix parameters. For example,
-	// to list only the customer managed policies in your Amazon Web Services account,
-	// set Scope to Local. To list only Amazon Web Services managed policies, set Scope
-	// to AWS. You can paginate the results using the MaxItems and Marker parameters.
-	// For more information about managed policies, see Managed policies and inline
-	// policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// using the optional OnlyAttached , Scope , and PathPrefix parameters. For
+	// example, to list only the customer managed policies in your Amazon Web Services
+	// account, set Scope to Local . To list only Amazon Web Services managed policies,
+	// set Scope to AWS . You can paginate the results using the MaxItems and Marker
+	// parameters. For more information about managed policies, see Managed policies
+	// and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide. IAM resource-listing operations return a subset of the
 	// available attributes for the resource. For example, this operation does not
 	// return tags, even though they are an attribute of the returned object. To view
-	// all of the information for a customer manged policy, see GetPolicy.
+	// all of the information for a customer manged policy, see GetPolicy .
 	ListPolicies(ctx context.Context, params *ListPoliciesInput, optFns ...func(*Options)) (*ListPoliciesOutput, error)
 	// Retrieves a list of policies that the IAM identity (user, group, or role) can
 	// use to access each specified service. This operation does not use other policy
@@ -1106,29 +958,22 @@ type IAM interface {
 	// policy types include resource-based policies, access control lists,
 	// Organizations policies, IAM permissions boundaries, and STS assume role
 	// policies. It only applies permissions policy logic. For more about the
-	// evaluation of policy types, see Evaluating policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics)
+	// evaluation of policy types, see Evaluating policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics)
 	// in the IAM User Guide. The list of policies returned by the operation depends on
 	// the ARN of the identity that you provide.
+	//   - User – The list of policies includes the managed and inline policies that
+	//     are attached to the user directly. The list also includes any additional managed
+	//     and inline policies that are attached to the group to which the user belongs.
+	//   - Group – The list of policies includes only the managed and inline policies
+	//     that are attached to the group directly. Policies that are attached to the
+	//     group’s user are not included.
+	//   - Role – The list of policies includes only the managed and inline policies
+	//     that are attached to the role.
 	//
-	// * User – The list of policies
-	// includes the managed and inline policies that are attached to the user directly.
-	// The list also includes any additional managed and inline policies that are
-	// attached to the group to which the user belongs.
-	//
-	// * Group – The list of policies
-	// includes only the managed and inline policies that are attached to the group
-	// directly. Policies that are attached to the group’s user are not included.
-	//
-	// *
-	// Role – The list of policies includes only the managed and inline policies that
-	// are attached to the role.
-	//
-	// For each managed policy, this operation returns the
-	// ARN and policy name. For each inline policy, it returns the policy name and the
-	// entity to which it is attached. Inline policies do not have an ARN. For more
-	// information about these policy types, see Managed policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html)
+	// For each managed policy, this operation returns the ARN and policy name. For
+	// each inline policy, it returns the policy name and the entity to which it is
+	// attached. Inline policies do not have an ARN. For more information about these
+	// policy types, see Managed policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html)
 	// in the IAM User Guide. Policies that are attached to users and roles as
 	// permissions boundaries are not returned. To view which managed policy is
 	// currently used to set the permissions boundary for a user or role, use the
@@ -1136,21 +981,18 @@ type IAM interface {
 	ListPoliciesGrantingServiceAccess(ctx context.Context, params *ListPoliciesGrantingServiceAccessInput, optFns ...func(*Options)) (*ListPoliciesGrantingServiceAccessOutput, error)
 	// Lists the tags that are attached to the specified IAM customer managed policy.
 	// The returned list of tags is sorted by tag key. For more information about
-	// tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	// tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	// in the IAM User Guide.
 	ListPolicyTags(ctx context.Context, params *ListPolicyTagsInput, optFns ...func(*Options)) (*ListPolicyTagsOutput, error)
 	// Lists information about the versions of the specified managed policy, including
 	// the version that is currently set as the policy's default version. For more
-	// information about managed policies, see Managed policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// information about managed policies, see Managed policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide.
 	ListPolicyVersions(ctx context.Context, params *ListPolicyVersionsInput, optFns ...func(*Options)) (*ListPolicyVersionsOutput, error)
 	// Lists the names of the inline policies that are embedded in the specified IAM
 	// role. An IAM role can also have managed policies attached to it. To list the
-	// managed policies that are attached to a role, use ListAttachedRolePolicies. For
-	// more information about policies, see Managed policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// managed policies that are attached to a role, use ListAttachedRolePolicies . For
+	// more information about policies, see Managed policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide. You can paginate the results using the MaxItems and
 	// Marker parameters. If there are no inline policies embedded with the specified
 	// role, the operation returns an empty list.
@@ -1162,127 +1004,115 @@ type IAM interface {
 	ListRoleTags(ctx context.Context, params *ListRoleTagsInput, optFns ...func(*Options)) (*ListRoleTagsOutput, error)
 	// Lists the IAM roles that have the specified path prefix. If there are none, the
 	// operation returns an empty list. For more information about roles, see Working
-	// with roles
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html). IAM
-	// resource-listing operations return a subset of the available attributes for the
-	// resource. For example, this operation does not return tags, even though they are
-	// an attribute of the returned object. To view all of the information for a role,
-	// see GetRole. You can paginate the results using the MaxItems and Marker
+	// with roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html)
+	// . IAM resource-listing operations return a subset of the available attributes
+	// for the resource. For example, this operation does not return tags, even though
+	// they are an attribute of the returned object. To view all of the information for
+	// a role, see GetRole . You can paginate the results using the MaxItems and Marker
 	// parameters.
 	ListRoles(ctx context.Context, params *ListRolesInput, optFns ...func(*Options)) (*ListRolesOutput, error)
 	// Lists the tags that are attached to the specified Security Assertion Markup
 	// Language (SAML) identity provider. The returned list of tags is sorted by tag
-	// key. For more information, see About SAML 2.0-based federation
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html).
-	// For more information about tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	// key. For more information, see About SAML 2.0-based federation (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html)
+	// . For more information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	// in the IAM User Guide.
 	ListSAMLProviderTags(ctx context.Context, params *ListSAMLProviderTagsInput, optFns ...func(*Options)) (*ListSAMLProviderTagsOutput, error)
 	// Lists the SAML provider resource objects defined in IAM in the account. IAM
 	// resource-listing operations return a subset of the available attributes for the
 	// resource. For example, this operation does not return tags, even though they are
 	// an attribute of the returned object. To view all of the information for a SAML
-	// provider, see GetSAMLProvider. This operation requires Signature Version 4
-	// (https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
+	// provider, see GetSAMLProvider . This operation requires Signature Version 4 (https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
+	// .
 	ListSAMLProviders(ctx context.Context, params *ListSAMLProvidersInput, optFns ...func(*Options)) (*ListSAMLProvidersOutput, error)
 	// Returns information about the SSH public keys associated with the specified IAM
 	// user. If none exists, the operation returns an empty list. The SSH public keys
 	// returned by this operation are used only for authenticating the IAM user to an
 	// CodeCommit repository. For more information about using SSH keys to authenticate
-	// to an CodeCommit repository, see Set up CodeCommit for SSH connections
-	// (https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html)
+	// to an CodeCommit repository, see Set up CodeCommit for SSH connections (https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html)
 	// in the CodeCommit User Guide. Although each user is limited to a small number of
 	// keys, you can still paginate the results using the MaxItems and Marker
 	// parameters.
 	ListSSHPublicKeys(ctx context.Context, params *ListSSHPublicKeysInput, optFns ...func(*Options)) (*ListSSHPublicKeysOutput, error)
 	// Lists the tags that are attached to the specified IAM server certificate. The
 	// returned list of tags is sorted by tag key. For more information about tagging,
-	// see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide. For certificates in a Region supported by Certificate Manager (ACM), we
-	// recommend that you don't use IAM server certificates. Instead, use ACM to
-	// provision, manage, and deploy your server certificates. For more information
-	// about IAM server certificates, Working with server certificates
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
+	// see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	// in the IAM User Guide. For certificates in a Region supported by Certificate
+	// Manager (ACM), we recommend that you don't use IAM server certificates. Instead,
+	// use ACM to provision, manage, and deploy your server certificates. For more
+	// information about IAM server certificates, Working with server certificates (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
 	// in the IAM User Guide.
 	ListServerCertificateTags(ctx context.Context, params *ListServerCertificateTagsInput, optFns ...func(*Options)) (*ListServerCertificateTagsOutput, error)
-	// Lists the server certificates stored in IAM that have the specified path prefix.
-	// If none exist, the operation returns an empty list. You can paginate the results
-	// using the MaxItems and Marker parameters. For more information about working
-	// with server certificates, see Working with server certificates
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
+	// Lists the server certificates stored in IAM that have the specified path
+	// prefix. If none exist, the operation returns an empty list. You can paginate the
+	// results using the MaxItems and Marker parameters. For more information about
+	// working with server certificates, see Working with server certificates (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
 	// in the IAM User Guide. This topic also includes a list of Amazon Web Services
 	// services that can use the server certificates that you manage with IAM. IAM
 	// resource-listing operations return a subset of the available attributes for the
 	// resource. For example, this operation does not return tags, even though they are
 	// an attribute of the returned object. To view all of the information for a
-	// servercertificate, see GetServerCertificate.
+	// servercertificate, see GetServerCertificate .
 	ListServerCertificates(ctx context.Context, params *ListServerCertificatesInput, optFns ...func(*Options)) (*ListServerCertificatesOutput, error)
 	// Returns information about the service-specific credentials associated with the
 	// specified IAM user. If none exists, the operation returns an empty list. The
 	// service-specific credentials returned by this operation are used only for
 	// authenticating the IAM user to a specific service. For more information about
 	// using service-specific credentials to authenticate to an Amazon Web Services
-	// service, see Set up service-specific credentials
-	// (https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-gc.html) in
-	// the CodeCommit User Guide.
+	// service, see Set up service-specific credentials (https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-gc.html)
+	// in the CodeCommit User Guide.
 	ListServiceSpecificCredentials(ctx context.Context, params *ListServiceSpecificCredentialsInput, optFns ...func(*Options)) (*ListServiceSpecificCredentialsOutput, error)
-	// Returns information about the signing certificates associated with the specified
-	// IAM user. If none exists, the operation returns an empty list. Although each
-	// user is limited to a small number of signing certificates, you can still
-	// paginate the results using the MaxItems and Marker parameters. If the UserName
-	// field is not specified, the user name is determined implicitly based on the
-	// Amazon Web Services access key ID used to sign the request for this operation.
-	// This operation works for access keys under the Amazon Web Services account.
-	// Consequently, you can use this operation to manage Amazon Web Services account
-	// root user credentials even if the Amazon Web Services account has no associated
-	// users.
+	// Returns information about the signing certificates associated with the
+	// specified IAM user. If none exists, the operation returns an empty list.
+	// Although each user is limited to a small number of signing certificates, you can
+	// still paginate the results using the MaxItems and Marker parameters. If the
+	// UserName field is not specified, the user name is determined implicitly based on
+	// the Amazon Web Services access key ID used to sign the request for this
+	// operation. This operation works for access keys under the Amazon Web Services
+	// account. Consequently, you can use this operation to manage Amazon Web Services
+	// account root user credentials even if the Amazon Web Services account has no
+	// associated users.
 	ListSigningCertificates(ctx context.Context, params *ListSigningCertificatesInput, optFns ...func(*Options)) (*ListSigningCertificatesOutput, error)
 	// Lists the names of the inline policies embedded in the specified IAM user. An
 	// IAM user can also have managed policies attached to it. To list the managed
-	// policies that are attached to a user, use ListAttachedUserPolicies. For more
-	// information about policies, see Managed policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// policies that are attached to a user, use ListAttachedUserPolicies . For more
+	// information about policies, see Managed policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide. You can paginate the results using the MaxItems and
 	// Marker parameters. If there are no inline policies embedded with the specified
 	// user, the operation returns an empty list.
 	ListUserPolicies(ctx context.Context, params *ListUserPoliciesInput, optFns ...func(*Options)) (*ListUserPoliciesOutput, error)
-	// Lists the tags that are attached to the specified IAM user. The returned list of
-	// tags is sorted by tag key. For more information about tagging, see Tagging IAM
-	// resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the
-	// IAM User Guide.
+	// Lists the tags that are attached to the specified IAM user. The returned list
+	// of tags is sorted by tag key. For more information about tagging, see Tagging
+	// IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in
+	// the IAM User Guide.
 	ListUserTags(ctx context.Context, params *ListUserTagsInput, optFns ...func(*Options)) (*ListUserTagsOutput, error)
 	// Lists the IAM users that have the specified path prefix. If no path prefix is
 	// specified, the operation returns all users in the Amazon Web Services account.
 	// If there are none, the operation returns an empty list. IAM resource-listing
 	// operations return a subset of the available attributes for the resource. For
 	// example, this operation does not return tags, even though they are an attribute
-	// of the returned object. To view all of the information for a user, see GetUser.
+	// of the returned object. To view all of the information for a user, see GetUser .
 	// You can paginate the results using the MaxItems and Marker parameters.
 	ListUsers(ctx context.Context, params *ListUsersInput, optFns ...func(*Options)) (*ListUsersOutput, error)
 	// Lists the virtual MFA devices defined in the Amazon Web Services account by
 	// assignment status. If you do not specify an assignment status, the operation
-	// returns a list of all virtual MFA devices. Assignment status can be Assigned,
-	// Unassigned, or Any. IAM resource-listing operations return a subset of the
+	// returns a list of all virtual MFA devices. Assignment status can be Assigned ,
+	// Unassigned , or Any . IAM resource-listing operations return a subset of the
 	// available attributes for the resource. For example, this operation does not
 	// return tags, even though they are an attribute of the returned object. To view
-	// tag information for a virtual MFA device, see ListMFADeviceTags. You can
+	// tag information for a virtual MFA device, see ListMFADeviceTags . You can
 	// paginate the results using the MaxItems and Marker parameters.
 	ListVirtualMFADevices(ctx context.Context, params *ListVirtualMFADevicesInput, optFns ...func(*Options)) (*ListVirtualMFADevicesOutput, error)
 	// Adds or updates an inline policy document that is embedded in the specified IAM
 	// group. A user can also have managed policies attached to it. To attach a managed
-	// policy to a group, use AttachGroupPolicy. To create a new managed policy, use
-	// CreatePolicy. For information about policies, see Managed policies and inline
-	// policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// policy to a group, use AttachGroupPolicy . To create a new managed policy, use
+	// CreatePolicy . For information about policies, see Managed policies and inline
+	// policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide. For information about the maximum number of inline
-	// policies that you can embed in a group, see IAM and STS quotas
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) in
-	// the IAM User Guide. Because policy documents can be large, you should use POST
-	// rather than GET when calling PutGroupPolicy. For general information about using
-	// the Query API with IAM, see Making query requests
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html) in the
-	// IAM User Guide.
+	// policies that you can embed in a group, see IAM and STS quotas (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html)
+	// in the IAM User Guide. Because policy documents can be large, you should use
+	// POST rather than GET when calling PutGroupPolicy . For general information about
+	// using the Query API with IAM, see Making query requests (https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html)
+	// in the IAM User Guide.
 	PutGroupPolicy(ctx context.Context, params *PutGroupPolicyInput, optFns ...func(*Options)) (*PutGroupPolicyOutput, error)
 	// Adds or updates the policy that is specified as the IAM role's permissions
 	// boundary. You can use an Amazon Web Services managed policy or a customer
@@ -1292,29 +1122,25 @@ type IAM interface {
 	// the boundary for a service-linked role. Policies used as permissions boundaries
 	// do not provide permissions. You must also attach a permissions policy to the
 	// role. To learn how the effective permissions for a role are evaluated, see IAM
-	// JSON policy evaluation logic
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html)
+	// JSON policy evaluation logic (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html)
 	// in the IAM User Guide.
 	PutRolePermissionsBoundary(ctx context.Context, params *PutRolePermissionsBoundaryInput, optFns ...func(*Options)) (*PutRolePermissionsBoundaryOutput, error)
 	// Adds or updates an inline policy document that is embedded in the specified IAM
 	// role. When you embed an inline policy in a role, the inline policy is used as
 	// part of the role's access (permissions) policy. The role's trust policy is
-	// created at the same time as the role, using CreateRole. You can update a role's
-	// trust policy using UpdateAssumeRolePolicy. For more information about IAM roles,
-	// see Using roles to delegate permissions and federate identities
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/roles-toplevel.html). A role
-	// can also have a managed policy attached to it. To attach a managed policy to a
-	// role, use AttachRolePolicy. To create a new managed policy, use CreatePolicy.
-	// For information about policies, see Managed policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// created at the same time as the role, using CreateRole . You can update a role's
+	// trust policy using UpdateAssumeRolePolicy . For more information about IAM
+	// roles, see Using roles to delegate permissions and federate identities (https://docs.aws.amazon.com/IAM/latest/UserGuide/roles-toplevel.html)
+	// . A role can also have a managed policy attached to it. To attach a managed
+	// policy to a role, use AttachRolePolicy . To create a new managed policy, use
+	// CreatePolicy . For information about policies, see Managed policies and inline
+	// policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide. For information about the maximum number of inline
-	// policies that you can embed with a role, see IAM and STS quotas
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) in
-	// the IAM User Guide. Because policy documents can be large, you should use POST
-	// rather than GET when calling PutRolePolicy. For general information about using
-	// the Query API with IAM, see Making query requests
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html) in the
-	// IAM User Guide.
+	// policies that you can embed with a role, see IAM and STS quotas (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html)
+	// in the IAM User Guide. Because policy documents can be large, you should use
+	// POST rather than GET when calling PutRolePolicy . For general information about
+	// using the Query API with IAM, see Making query requests (https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html)
+	// in the IAM User Guide.
 	PutRolePolicy(ctx context.Context, params *PutRolePolicyInput, optFns ...func(*Options)) (*PutRolePolicyOutput, error)
 	// Adds or updates the policy that is specified as the IAM user's permissions
 	// boundary. You can use an Amazon Web Services managed policy or a customer
@@ -1323,38 +1149,34 @@ type IAM interface {
 	// advanced feature that can affect the permissions for the user. Policies that are
 	// used as permissions boundaries do not provide permissions. You must also attach
 	// a permissions policy to the user. To learn how the effective permissions for a
-	// user are evaluated, see IAM JSON policy evaluation logic
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html)
+	// user are evaluated, see IAM JSON policy evaluation logic (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html)
 	// in the IAM User Guide.
 	PutUserPermissionsBoundary(ctx context.Context, params *PutUserPermissionsBoundaryInput, optFns ...func(*Options)) (*PutUserPermissionsBoundaryOutput, error)
 	// Adds or updates an inline policy document that is embedded in the specified IAM
 	// user. An IAM user can also have a managed policy attached to it. To attach a
-	// managed policy to a user, use AttachUserPolicy. To create a new managed policy,
-	// use CreatePolicy. For information about policies, see Managed policies and
-	// inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// managed policy to a user, use AttachUserPolicy . To create a new managed policy,
+	// use CreatePolicy . For information about policies, see Managed policies and
+	// inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide. For information about the maximum number of inline
-	// policies that you can embed in a user, see IAM and STS quotas
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) in
-	// the IAM User Guide. Because policy documents can be large, you should use POST
-	// rather than GET when calling PutUserPolicy. For general information about using
-	// the Query API with IAM, see Making query requests
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html) in the
-	// IAM User Guide.
+	// policies that you can embed in a user, see IAM and STS quotas (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html)
+	// in the IAM User Guide. Because policy documents can be large, you should use
+	// POST rather than GET when calling PutUserPolicy . For general information about
+	// using the Query API with IAM, see Making query requests (https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html)
+	// in the IAM User Guide.
 	PutUserPolicy(ctx context.Context, params *PutUserPolicyInput, optFns ...func(*Options)) (*PutUserPolicyOutput, error)
-	// Removes the specified client ID (also known as audience) from the list of client
-	// IDs registered for the specified IAM OpenID Connect (OIDC) provider resource
-	// object. This operation is idempotent; it does not fail or return an error if you
-	// try to remove a client ID that does not exist.
+	// Removes the specified client ID (also known as audience) from the list of
+	// client IDs registered for the specified IAM OpenID Connect (OIDC) provider
+	// resource object. This operation is idempotent; it does not fail or return an
+	// error if you try to remove a client ID that does not exist.
 	RemoveClientIDFromOpenIDConnectProvider(ctx context.Context, params *RemoveClientIDFromOpenIDConnectProviderInput, optFns ...func(*Options)) (*RemoveClientIDFromOpenIDConnectProviderOutput, error)
 	// Removes the specified IAM role from the specified EC2 instance profile. Make
 	// sure that you do not have any Amazon EC2 instances running with the role you are
 	// about to remove from the instance profile. Removing a role from an instance
 	// profile that is associated with a running instance might break any applications
 	// running on the instance. For more information about IAM roles, see Working with
-	// roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html).
-	// For more information about instance profiles, see About instance profiles
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html).
+	// roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html) .
+	// For more information about instance profiles, see About instance profiles (https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html)
+	// .
 	RemoveRoleFromInstanceProfile(ctx context.Context, params *RemoveRoleFromInstanceProfileInput, optFns ...func(*Options)) (*RemoveRoleFromInstanceProfileOutput, error)
 	// Removes the specified user from the specified group.
 	RemoveUserFromGroup(ctx context.Context, params *RemoveUserFromGroupInput, optFns ...func(*Options)) (*RemoveUserFromGroupOutput, error)
@@ -1363,37 +1185,34 @@ type IAM interface {
 	// configured by the user. Resetting the password immediately invalidates the
 	// previous password associated with this user.
 	ResetServiceSpecificCredential(ctx context.Context, params *ResetServiceSpecificCredentialInput, optFns ...func(*Options)) (*ResetServiceSpecificCredentialOutput, error)
-	// Synchronizes the specified MFA device with its IAM resource object on the Amazon
-	// Web Services servers. For more information about creating and working with
-	// virtual MFA devices, see Using a virtual MFA device
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_VirtualMFA.html) in the
-	// IAM User Guide.
+	// Synchronizes the specified MFA device with its IAM resource object on the
+	// Amazon Web Services servers. For more information about creating and working
+	// with virtual MFA devices, see Using a virtual MFA device (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_VirtualMFA.html)
+	// in the IAM User Guide.
 	ResyncMFADevice(ctx context.Context, params *ResyncMFADeviceInput, optFns ...func(*Options)) (*ResyncMFADeviceOutput, error)
 	// Sets the specified version of the specified policy as the policy's default
 	// (operative) version. This operation affects all users, groups, and roles that
 	// the policy is attached to. To list the users, groups, and roles that the policy
-	// is attached to, use ListEntitiesForPolicy. For information about managed
-	// policies, see Managed policies and inline policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
+	// is attached to, use ListEntitiesForPolicy . For information about managed
+	// policies, see Managed policies and inline policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
 	// in the IAM User Guide.
 	SetDefaultPolicyVersion(ctx context.Context, params *SetDefaultPolicyVersionInput, optFns ...func(*Options)) (*SetDefaultPolicyVersionOutput, error)
 	// Sets the specified version of the global endpoint token as the token version
 	// used for the Amazon Web Services account. By default, Security Token Service
 	// (STS) is available as a global service, and all STS requests go to a single
-	// endpoint at https://sts.amazonaws.com. Amazon Web Services recommends using
+	// endpoint at https://sts.amazonaws.com . Amazon Web Services recommends using
 	// Regional STS endpoints to reduce latency, build in redundancy, and increase
 	// session token availability. For information about Regional endpoints for STS,
-	// see Security Token Service endpoints and quotas
-	// (https://docs.aws.amazon.com/general/latest/gr/sts.html) in the Amazon Web
-	// Services General Reference. If you make an STS call to the global endpoint, the
-	// resulting session tokens might be valid in some Regions but not others. It
-	// depends on the version that is set in this operation. Version 1 tokens are valid
-	// only in Amazon Web Services Regions that are available by default. These tokens
-	// do not work in manually enabled Regions, such as Asia Pacific (Hong Kong).
-	// Version 2 tokens are valid in all Regions. However, version 2 tokens are longer
-	// and might affect systems where you temporarily store tokens. For information,
-	// see Activating and deactivating STS in an Amazon Web Services Region
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+	// see Security Token Service endpoints and quotas (https://docs.aws.amazon.com/general/latest/gr/sts.html)
+	// in the Amazon Web Services General Reference. If you make an STS call to the
+	// global endpoint, the resulting session tokens might be valid in some Regions but
+	// not others. It depends on the version that is set in this operation. Version 1
+	// tokens are valid only in Amazon Web Services Regions that are available by
+	// default. These tokens do not work in manually enabled Regions, such as Asia
+	// Pacific (Hong Kong). Version 2 tokens are valid in all Regions. However, version
+	// 2 tokens are longer and might affect systems where you temporarily store tokens.
+	// For information, see Activating and deactivating STS in an Amazon Web Services
+	// Region (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
 	// in the IAM User Guide. To view the current session token version, see the
 	// GlobalEndpointTokenVersion entry in the response of the GetAccountSummary
 	// operation.
@@ -1409,7 +1228,7 @@ type IAM interface {
 	// by Amazon Web Services and its services and which provide details about the
 	// context of an API query request. You can use the Condition element of an IAM
 	// policy to evaluate context keys. To get the list of context keys that the
-	// policies require for correct simulation, use GetContextKeysForCustomPolicy. If
+	// policies require for correct simulation, use GetContextKeysForCustomPolicy . If
 	// the output is long, you can use MaxItems and Marker parameters to paginate the
 	// results. The IAM policy simulator evaluates statements in the identity-based
 	// policy and the inputs that you provide during simulation. The policy simulator
@@ -1417,9 +1236,8 @@ type IAM interface {
 	// that you check your policies against your live Amazon Web Services environment
 	// after testing using the policy simulator to confirm that you have the desired
 	// results. For more information about using the policy simulator, see Testing IAM
-	// policies with the IAM policy simulator
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html)in
-	// the IAM User Guide.
+	// policies with the IAM policy simulator  (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html)
+	// in the IAM User Guide.
 	SimulateCustomPolicy(ctx context.Context, params *SimulateCustomPolicyInput, optFns ...func(*Options)) (*SimulateCustomPolicyOutput, error)
 	// Simulate how a set of IAM policies attached to an IAM entity works with a list
 	// of API operations and Amazon Web Services resources to determine the policies'
@@ -1440,343 +1258,292 @@ type IAM interface {
 	// that provide details about the context of an API query request. You can use the
 	// Condition element of an IAM policy to evaluate context keys. To get the list of
 	// context keys that the policies require for correct simulation, use
-	// GetContextKeysForPrincipalPolicy. If the output is long, you can use the
-	// MaxItems and Marker parameters to paginate the results. The IAM policy simulator
-	// evaluates statements in the identity-based policy and the inputs that you
-	// provide during simulation. The policy simulator results can differ from your
+	// GetContextKeysForPrincipalPolicy . If the output is long, you can use the
+	// MaxItems and Marker parameters to paginate the results. The IAM policy
+	// simulator evaluates statements in the identity-based policy and the inputs that
+	// you provide during simulation. The policy simulator results can differ from your
 	// live Amazon Web Services environment. We recommend that you check your policies
 	// against your live Amazon Web Services environment after testing using the policy
 	// simulator to confirm that you have the desired results. For more information
 	// about using the policy simulator, see Testing IAM policies with the IAM policy
-	// simulator
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html)in
-	// the IAM User Guide.
+	// simulator  (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html)
+	// in the IAM User Guide.
 	SimulatePrincipalPolicy(ctx context.Context, params *SimulatePrincipalPolicyInput, optFns ...func(*Options)) (*SimulatePrincipalPolicyOutput, error)
 	// Adds one or more tags to an IAM instance profile. If a tag with the same key
 	// name already exists, then that tag is overwritten with the new value. Each tag
 	// consists of a key name and an associated value. By assigning tags to your
 	// resources, you can do the following:
 	//
-	// * Administrative grouping and discovery -
-	// Attach tags to resources to aid in organization and search. For example, you
-	// could search for all resources with the key name Project and the value
-	// MyImportantProject. Or search for all resources with the key name Cost Center
-	// and the value 41200.
+	//   - Administrative grouping and discovery - Attach tags to resources to aid in
+	//     organization and search. For example, you could search for all resources with
+	//     the key name Project and the value MyImportantProject. Or search for all
+	//     resources with the key name Cost Center and the value 41200.
 	//
-	// * Access control - Include tags in IAM user-based and
-	// resource-based policies. You can use tags to restrict access to only an IAM
-	// instance profile that has a specified tag attached. For examples of policies
-	// that show how to use tags to control access, see Control access using IAM tags
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html) in the IAM
-	// User Guide.
+	//   - Access control - Include tags in IAM user-based and resource-based
+	//     policies. You can use tags to restrict access to only an IAM instance profile
+	//     that has a specified tag attached. For examples of policies that show how to use
+	//     tags to control access, see Control access using IAM tags (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html)
+	//     in the IAM User Guide.
 	//
-	// * If any one of the tags is invalid or if you exceed the allowed
-	// maximum number of tags, then the entire request fails and the resource is not
-	// created. For more information about tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	//   - If any one of the tags is invalid or if you exceed the allowed maximum
+	//     number of tags, then the entire request fails and the resource is not created.
+	//     For more information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	//     in the IAM User Guide.
 	//
-	// * Amazon Web Services always interprets the tag Value as a single
-	// string. If you need to store an array, you can store comma-separated values in
-	// the string. However, you must interpret the value in your code.
+	//   - Amazon Web Services always interprets the tag Value as a single string. If
+	//     you need to store an array, you can store comma-separated values in the string.
+	//     However, you must interpret the value in your code.
 	TagInstanceProfile(ctx context.Context, params *TagInstanceProfileInput, optFns ...func(*Options)) (*TagInstanceProfileOutput, error)
 	// Adds one or more tags to an IAM virtual multi-factor authentication (MFA)
 	// device. If a tag with the same key name already exists, then that tag is
 	// overwritten with the new value. A tag consists of a key name and an associated
 	// value. By assigning tags to your resources, you can do the following:
 	//
-	// *
-	// Administrative grouping and discovery - Attach tags to resources to aid in
-	// organization and search. For example, you could search for all resources with
-	// the key name Project and the value MyImportantProject. Or search for all
-	// resources with the key name Cost Center and the value 41200.
+	//   - Administrative grouping and discovery - Attach tags to resources to aid in
+	//     organization and search. For example, you could search for all resources with
+	//     the key name Project and the value MyImportantProject. Or search for all
+	//     resources with the key name Cost Center and the value 41200.
 	//
-	// * Access control -
-	// Include tags in IAM user-based and resource-based policies. You can use tags to
-	// restrict access to only an IAM virtual MFA device that has a specified tag
-	// attached. For examples of policies that show how to use tags to control access,
-	// see Control access using IAM tags
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html) in the IAM
-	// User Guide.
+	//   - Access control - Include tags in IAM user-based and resource-based
+	//     policies. You can use tags to restrict access to only an IAM virtual MFA device
+	//     that has a specified tag attached. For examples of policies that show how to use
+	//     tags to control access, see Control access using IAM tags (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html)
+	//     in the IAM User Guide.
 	//
-	// * If any one of the tags is invalid or if you exceed the allowed
-	// maximum number of tags, then the entire request fails and the resource is not
-	// created. For more information about tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	//   - If any one of the tags is invalid or if you exceed the allowed maximum
+	//     number of tags, then the entire request fails and the resource is not created.
+	//     For more information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	//     in the IAM User Guide.
 	//
-	// * Amazon Web Services always interprets the tag Value as a single
-	// string. If you need to store an array, you can store comma-separated values in
-	// the string. However, you must interpret the value in your code.
+	//   - Amazon Web Services always interprets the tag Value as a single string. If
+	//     you need to store an array, you can store comma-separated values in the string.
+	//     However, you must interpret the value in your code.
 	TagMFADevice(ctx context.Context, params *TagMFADeviceInput, optFns ...func(*Options)) (*TagMFADeviceOutput, error)
 	// Adds one or more tags to an OpenID Connect (OIDC)-compatible identity provider.
-	// For more information about these providers, see About web identity federation
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html).
-	// If a tag with the same key name already exists, then that tag is overwritten
+	// For more information about these providers, see About web identity federation (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html)
+	// . If a tag with the same key name already exists, then that tag is overwritten
 	// with the new value. A tag consists of a key name and an associated value. By
 	// assigning tags to your resources, you can do the following:
 	//
-	// * Administrative
-	// grouping and discovery - Attach tags to resources to aid in organization and
-	// search. For example, you could search for all resources with the key name
-	// Project and the value MyImportantProject. Or search for all resources with the
-	// key name Cost Center and the value 41200.
+	//   - Administrative grouping and discovery - Attach tags to resources to aid in
+	//     organization and search. For example, you could search for all resources with
+	//     the key name Project and the value MyImportantProject. Or search for all
+	//     resources with the key name Cost Center and the value 41200.
 	//
-	// * Access control - Include tags in
-	// IAM identity-based and resource-based policies. You can use tags to restrict
-	// access to only an OIDC provider that has a specified tag attached. For examples
-	// of policies that show how to use tags to control access, see Control access
-	// using IAM tags
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html) in the IAM
-	// User Guide.
+	//   - Access control - Include tags in IAM identity-based and resource-based
+	//     policies. You can use tags to restrict access to only an OIDC provider that has
+	//     a specified tag attached. For examples of policies that show how to use tags to
+	//     control access, see Control access using IAM tags (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html)
+	//     in the IAM User Guide.
 	//
-	// * If any one of the tags is invalid or if you exceed the allowed
-	// maximum number of tags, then the entire request fails and the resource is not
-	// created. For more information about tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	//   - If any one of the tags is invalid or if you exceed the allowed maximum
+	//     number of tags, then the entire request fails and the resource is not created.
+	//     For more information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	//     in the IAM User Guide.
 	//
-	// * Amazon Web Services always interprets the tag Value as a single
-	// string. If you need to store an array, you can store comma-separated values in
-	// the string. However, you must interpret the value in your code.
+	//   - Amazon Web Services always interprets the tag Value as a single string. If
+	//     you need to store an array, you can store comma-separated values in the string.
+	//     However, you must interpret the value in your code.
 	TagOpenIDConnectProvider(ctx context.Context, params *TagOpenIDConnectProviderInput, optFns ...func(*Options)) (*TagOpenIDConnectProviderOutput, error)
 	// Adds one or more tags to an IAM customer managed policy. If a tag with the same
 	// key name already exists, then that tag is overwritten with the new value. A tag
 	// consists of a key name and an associated value. By assigning tags to your
 	// resources, you can do the following:
 	//
-	// * Administrative grouping and discovery -
-	// Attach tags to resources to aid in organization and search. For example, you
-	// could search for all resources with the key name Project and the value
-	// MyImportantProject. Or search for all resources with the key name Cost Center
-	// and the value 41200.
+	//   - Administrative grouping and discovery - Attach tags to resources to aid in
+	//     organization and search. For example, you could search for all resources with
+	//     the key name Project and the value MyImportantProject. Or search for all
+	//     resources with the key name Cost Center and the value 41200.
 	//
-	// * Access control - Include tags in IAM user-based and
-	// resource-based policies. You can use tags to restrict access to only an IAM
-	// customer managed policy that has a specified tag attached. For examples of
-	// policies that show how to use tags to control access, see Control access using
-	// IAM tags (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html) in
-	// the IAM User Guide.
+	//   - Access control - Include tags in IAM user-based and resource-based
+	//     policies. You can use tags to restrict access to only an IAM customer managed
+	//     policy that has a specified tag attached. For examples of policies that show how
+	//     to use tags to control access, see Control access using IAM tags (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html)
+	//     in the IAM User Guide.
 	//
-	// * If any one of the tags is invalid or if you exceed the
-	// allowed maximum number of tags, then the entire request fails and the resource
-	// is not created. For more information about tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	//   - If any one of the tags is invalid or if you exceed the allowed maximum
+	//     number of tags, then the entire request fails and the resource is not created.
+	//     For more information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	//     in the IAM User Guide.
 	//
-	// * Amazon Web Services always interprets the tag Value as a single
-	// string. If you need to store an array, you can store comma-separated values in
-	// the string. However, you must interpret the value in your code.
+	//   - Amazon Web Services always interprets the tag Value as a single string. If
+	//     you need to store an array, you can store comma-separated values in the string.
+	//     However, you must interpret the value in your code.
 	TagPolicy(ctx context.Context, params *TagPolicyInput, optFns ...func(*Options)) (*TagPolicyOutput, error)
 	// Adds one or more tags to an IAM role. The role can be a regular role or a
 	// service-linked role. If a tag with the same key name already exists, then that
 	// tag is overwritten with the new value. A tag consists of a key name and an
-	// associated value. By assigning tags to your resources, you can do the
-	// following:
+	// associated value. By assigning tags to your resources, you can do the following:
 	//
-	// * Administrative grouping and discovery - Attach tags to resources
-	// to aid in organization and search. For example, you could search for all
-	// resources with the key name Project and the value MyImportantProject. Or search
-	// for all resources with the key name Cost Center and the value 41200.
+	//   - Administrative grouping and discovery - Attach tags to resources to aid in
+	//     organization and search. For example, you could search for all resources with
+	//     the key name Project and the value MyImportantProject. Or search for all
+	//     resources with the key name Cost Center and the value 41200.
 	//
-	// * Access
-	// control - Include tags in IAM user-based and resource-based policies. You can
-	// use tags to restrict access to only an IAM role that has a specified tag
-	// attached. You can also restrict access to only those resources that have a
-	// certain tag attached. For examples of policies that show how to use tags to
-	// control access, see Control access using IAM tags
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html) in the IAM
-	// User Guide.
+	//   - Access control - Include tags in IAM user-based and resource-based
+	//     policies. You can use tags to restrict access to only an IAM role that has a
+	//     specified tag attached. You can also restrict access to only those resources
+	//     that have a certain tag attached. For examples of policies that show how to use
+	//     tags to control access, see Control access using IAM tags (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html)
+	//     in the IAM User Guide.
 	//
-	// * Cost allocation - Use tags to help track which individuals and
-	// teams are using which Amazon Web Services resources.
+	//   - Cost allocation - Use tags to help track which individuals and teams are
+	//     using which Amazon Web Services resources.
 	//
-	// * If any one of the tags
-	// is invalid or if you exceed the allowed maximum number of tags, then the entire
-	// request fails and the resource is not created. For more information about
-	// tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	//   - If any one of the tags is invalid or if you exceed the allowed maximum
+	//     number of tags, then the entire request fails and the resource is not created.
+	//     For more information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	//     in the IAM User Guide.
 	//
-	// * Amazon Web Services always interprets the tag Value as a single
-	// string. If you need to store an array, you can store comma-separated values in
-	// the string. However, you must interpret the value in your code.
+	//   - Amazon Web Services always interprets the tag Value as a single string. If
+	//     you need to store an array, you can store comma-separated values in the string.
+	//     However, you must interpret the value in your code.
 	//
-	// For more
-	// information about tagging, see Tagging IAM identities
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	// For more information about tagging, see Tagging IAM identities (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	// in the IAM User Guide.
 	TagRole(ctx context.Context, params *TagRoleInput, optFns ...func(*Options)) (*TagRoleOutput, error)
 	// Adds one or more tags to a Security Assertion Markup Language (SAML) identity
 	// provider. For more information about these providers, see About SAML 2.0-based
-	// federation
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html).
-	// If a tag with the same key name already exists, then that tag is overwritten
+	// federation  (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html)
+	// . If a tag with the same key name already exists, then that tag is overwritten
 	// with the new value. A tag consists of a key name and an associated value. By
 	// assigning tags to your resources, you can do the following:
 	//
-	// * Administrative
-	// grouping and discovery - Attach tags to resources to aid in organization and
-	// search. For example, you could search for all resources with the key name
-	// Project and the value MyImportantProject. Or search for all resources with the
-	// key name Cost Center and the value 41200.
+	//   - Administrative grouping and discovery - Attach tags to resources to aid in
+	//     organization and search. For example, you could search for all resources with
+	//     the key name Project and the value MyImportantProject. Or search for all
+	//     resources with the key name Cost Center and the value 41200.
 	//
-	// * Access control - Include tags in
-	// IAM user-based and resource-based policies. You can use tags to restrict access
-	// to only a SAML identity provider that has a specified tag attached. For examples
-	// of policies that show how to use tags to control access, see Control access
-	// using IAM tags
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html) in the IAM
-	// User Guide.
+	//   - Access control - Include tags in IAM user-based and resource-based
+	//     policies. You can use tags to restrict access to only a SAML identity provider
+	//     that has a specified tag attached. For examples of policies that show how to use
+	//     tags to control access, see Control access using IAM tags (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html)
+	//     in the IAM User Guide.
 	//
-	// * If any one of the tags is invalid or if you exceed the allowed
-	// maximum number of tags, then the entire request fails and the resource is not
-	// created. For more information about tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	//   - If any one of the tags is invalid or if you exceed the allowed maximum
+	//     number of tags, then the entire request fails and the resource is not created.
+	//     For more information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	//     in the IAM User Guide.
 	//
-	// * Amazon Web Services always interprets the tag Value as a single
-	// string. If you need to store an array, you can store comma-separated values in
-	// the string. However, you must interpret the value in your code.
+	//   - Amazon Web Services always interprets the tag Value as a single string. If
+	//     you need to store an array, you can store comma-separated values in the string.
+	//     However, you must interpret the value in your code.
 	TagSAMLProvider(ctx context.Context, params *TagSAMLProviderInput, optFns ...func(*Options)) (*TagSAMLProviderOutput, error)
 	// Adds one or more tags to an IAM server certificate. If a tag with the same key
 	// name already exists, then that tag is overwritten with the new value. For
 	// certificates in a Region supported by Certificate Manager (ACM), we recommend
 	// that you don't use IAM server certificates. Instead, use ACM to provision,
 	// manage, and deploy your server certificates. For more information about IAM
-	// server certificates, Working with server certificates
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
+	// server certificates, Working with server certificates (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
 	// in the IAM User Guide. A tag consists of a key name and an associated value. By
 	// assigning tags to your resources, you can do the following:
 	//
-	// * Administrative
-	// grouping and discovery - Attach tags to resources to aid in organization and
-	// search. For example, you could search for all resources with the key name
-	// Project and the value MyImportantProject. Or search for all resources with the
-	// key name Cost Center and the value 41200.
+	//   - Administrative grouping and discovery - Attach tags to resources to aid in
+	//     organization and search. For example, you could search for all resources with
+	//     the key name Project and the value MyImportantProject. Or search for all
+	//     resources with the key name Cost Center and the value 41200.
 	//
-	// * Access control - Include tags in
-	// IAM user-based and resource-based policies. You can use tags to restrict access
-	// to only a server certificate that has a specified tag attached. For examples of
-	// policies that show how to use tags to control access, see Control access using
-	// IAM tags (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html) in
-	// the IAM User Guide.
+	//   - Access control - Include tags in IAM user-based and resource-based
+	//     policies. You can use tags to restrict access to only a server certificate that
+	//     has a specified tag attached. For examples of policies that show how to use tags
+	//     to control access, see Control access using IAM tags (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html)
+	//     in the IAM User Guide.
 	//
-	// * Cost allocation - Use tags to help track which
-	// individuals and teams are using which Amazon Web Services resources.
+	//   - Cost allocation - Use tags to help track which individuals and teams are
+	//     using which Amazon Web Services resources.
 	//
-	// * If any
-	// one of the tags is invalid or if you exceed the allowed maximum number of tags,
-	// then the entire request fails and the resource is not created. For more
-	// information about tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	//   - If any one of the tags is invalid or if you exceed the allowed maximum
+	//     number of tags, then the entire request fails and the resource is not created.
+	//     For more information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	//     in the IAM User Guide.
 	//
-	// * Amazon Web Services always interprets the tag Value as a single
-	// string. If you need to store an array, you can store comma-separated values in
-	// the string. However, you must interpret the value in your code.
+	//   - Amazon Web Services always interprets the tag Value as a single string. If
+	//     you need to store an array, you can store comma-separated values in the string.
+	//     However, you must interpret the value in your code.
 	TagServerCertificate(ctx context.Context, params *TagServerCertificateInput, optFns ...func(*Options)) (*TagServerCertificateOutput, error)
 	// Adds one or more tags to an IAM user. If a tag with the same key name already
 	// exists, then that tag is overwritten with the new value. A tag consists of a key
 	// name and an associated value. By assigning tags to your resources, you can do
 	// the following:
 	//
-	// * Administrative grouping and discovery - Attach tags to
-	// resources to aid in organization and search. For example, you could search for
-	// all resources with the key name Project and the value MyImportantProject. Or
-	// search for all resources with the key name Cost Center and the value 41200.
+	//   - Administrative grouping and discovery - Attach tags to resources to aid in
+	//     organization and search. For example, you could search for all resources with
+	//     the key name Project and the value MyImportantProject. Or search for all
+	//     resources with the key name Cost Center and the value 41200.
 	//
-	// *
-	// Access control - Include tags in IAM identity-based and resource-based policies.
-	// You can use tags to restrict access to only an IAM requesting user that has a
-	// specified tag attached. You can also restrict access to only those resources
-	// that have a certain tag attached. For examples of policies that show how to use
-	// tags to control access, see Control access using IAM tags
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html) in the IAM
-	// User Guide.
+	//   - Access control - Include tags in IAM identity-based and resource-based
+	//     policies. You can use tags to restrict access to only an IAM requesting user
+	//     that has a specified tag attached. You can also restrict access to only those
+	//     resources that have a certain tag attached. For examples of policies that show
+	//     how to use tags to control access, see Control access using IAM tags (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html)
+	//     in the IAM User Guide.
 	//
-	// * Cost allocation - Use tags to help track which individuals and
-	// teams are using which Amazon Web Services resources.
+	//   - Cost allocation - Use tags to help track which individuals and teams are
+	//     using which Amazon Web Services resources.
 	//
-	// * If any one of the tags
-	// is invalid or if you exceed the allowed maximum number of tags, then the entire
-	// request fails and the resource is not created. For more information about
-	// tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	//   - If any one of the tags is invalid or if you exceed the allowed maximum
+	//     number of tags, then the entire request fails and the resource is not created.
+	//     For more information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	//     in the IAM User Guide.
 	//
-	// * Amazon Web Services always interprets the tag Value as a single
-	// string. If you need to store an array, you can store comma-separated values in
-	// the string. However, you must interpret the value in your code.
+	//   - Amazon Web Services always interprets the tag Value as a single string. If
+	//     you need to store an array, you can store comma-separated values in the string.
+	//     However, you must interpret the value in your code.
 	//
-	// For more
-	// information about tagging, see Tagging IAM identities
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	// For more information about tagging, see Tagging IAM identities (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	// in the IAM User Guide.
 	TagUser(ctx context.Context, params *TagUserInput, optFns ...func(*Options)) (*TagUserOutput, error)
 	// Removes the specified tags from the IAM instance profile. For more information
-	// about tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	// about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	// in the IAM User Guide.
 	UntagInstanceProfile(ctx context.Context, params *UntagInstanceProfileInput, optFns ...func(*Options)) (*UntagInstanceProfileOutput, error)
 	// Removes the specified tags from the IAM virtual multi-factor authentication
-	// (MFA) device. For more information about tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	// (MFA) device. For more information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	// in the IAM User Guide.
 	UntagMFADevice(ctx context.Context, params *UntagMFADeviceInput, optFns ...func(*Options)) (*UntagMFADeviceOutput, error)
 	// Removes the specified tags from the specified OpenID Connect (OIDC)-compatible
 	// identity provider in IAM. For more information about OIDC providers, see About
-	// web identity federation
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html).
-	// For more information about tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	// web identity federation (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html)
+	// . For more information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	// in the IAM User Guide.
 	UntagOpenIDConnectProvider(ctx context.Context, params *UntagOpenIDConnectProviderInput, optFns ...func(*Options)) (*UntagOpenIDConnectProviderOutput, error)
 	// Removes the specified tags from the customer managed policy. For more
-	// information about tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	// information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	// in the IAM User Guide.
 	UntagPolicy(ctx context.Context, params *UntagPolicyInput, optFns ...func(*Options)) (*UntagPolicyOutput, error)
 	// Removes the specified tags from the role. For more information about tagging,
-	// see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	// see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	// in the IAM User Guide.
 	UntagRole(ctx context.Context, params *UntagRoleInput, optFns ...func(*Options)) (*UntagRoleOutput, error)
-	// Removes the specified tags from the specified Security Assertion Markup Language
-	// (SAML) identity provider in IAM. For more information about these providers, see
-	// About web identity federation
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html).
-	// For more information about tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	// Removes the specified tags from the specified Security Assertion Markup
+	// Language (SAML) identity provider in IAM. For more information about these
+	// providers, see About web identity federation (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html)
+	// . For more information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	// in the IAM User Guide.
 	UntagSAMLProvider(ctx context.Context, params *UntagSAMLProviderInput, optFns ...func(*Options)) (*UntagSAMLProviderOutput, error)
-	// Removes the specified tags from the IAM server certificate. For more information
-	// about tagging, see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide. For certificates in a Region supported by Certificate Manager (ACM), we
-	// recommend that you don't use IAM server certificates. Instead, use ACM to
-	// provision, manage, and deploy your server certificates. For more information
-	// about IAM server certificates, Working with server certificates
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
+	// Removes the specified tags from the IAM server certificate. For more
+	// information about tagging, see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	// in the IAM User Guide. For certificates in a Region supported by Certificate
+	// Manager (ACM), we recommend that you don't use IAM server certificates. Instead,
+	// use ACM to provision, manage, and deploy your server certificates. For more
+	// information about IAM server certificates, Working with server certificates (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
 	// in the IAM User Guide.
 	UntagServerCertificate(ctx context.Context, params *UntagServerCertificateInput, optFns ...func(*Options)) (*UntagServerCertificateOutput, error)
 	// Removes the specified tags from the user. For more information about tagging,
-	// see Tagging IAM resources
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User
-	// Guide.
+	// see Tagging IAM resources (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
+	// in the IAM User Guide.
 	UntagUser(ctx context.Context, params *UntagUserInput, optFns ...func(*Options)) (*UntagUserOutput, error)
 	// Changes the status of the specified access key from Active to Inactive, or vice
 	// versa. This operation can be used to disable a user's key as part of a key
-	// rotation workflow. If the UserName is not specified, the user name is determined
-	// implicitly based on the Amazon Web Services access key ID used to sign the
-	// request. If a temporary access key is used, then UserName is required. If a
-	// long-term key is assigned to the user, then UserName is not required. This
+	// rotation workflow. If the UserName is not specified, the user name is
+	// determined implicitly based on the Amazon Web Services access key ID used to
+	// sign the request. If a temporary access key is used, then UserName is required.
+	// If a long-term key is assigned to the user, then UserName is not required. This
 	// operation works for access keys under the Amazon Web Services account.
 	// Consequently, you can use this operation to manage Amazon Web Services account
 	// root user credentials even if the Amazon Web Services account has no associated
-	// users. For information about rotating keys, see Managing keys and certificates
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingCredentials.html) in
-	// the IAM User Guide.
+	// users. For information about rotating keys, see Managing keys and certificates (https://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingCredentials.html)
+	// in the IAM User Guide.
 	UpdateAccessKey(ctx context.Context, params *UpdateAccessKeyInput, optFns ...func(*Options)) (*UpdateAccessKeyOutput, error)
 	// Updates the password policy settings for the Amazon Web Services account. This
 	// operation does not support partial updates. No parameters are required, but if
@@ -1785,34 +1552,31 @@ type IAM interface {
 	// Also note that some parameters do not allow the default parameter to be
 	// explicitly set. Instead, to invoke the default value, do not include that
 	// parameter when you invoke the operation. For more information about using a
-	// password policy, see Managing an IAM password policy
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingPasswordPolicies.html)
+	// password policy, see Managing an IAM password policy (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingPasswordPolicies.html)
 	// in the IAM User Guide.
 	UpdateAccountPasswordPolicy(ctx context.Context, params *UpdateAccountPasswordPolicyInput, optFns ...func(*Options)) (*UpdateAccountPasswordPolicyOutput, error)
 	// Updates the policy that grants an IAM entity permission to assume a role. This
 	// is typically referred to as the "role trust policy". For more information about
-	// roles, see Using roles to delegate permissions and federate identities
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/roles-toplevel.html).
+	// roles, see Using roles to delegate permissions and federate identities (https://docs.aws.amazon.com/IAM/latest/UserGuide/roles-toplevel.html)
+	// .
 	UpdateAssumeRolePolicy(ctx context.Context, params *UpdateAssumeRolePolicyInput, optFns ...func(*Options)) (*UpdateAssumeRolePolicyOutput, error)
 	// Updates the name and/or the path of the specified IAM group. You should
 	// understand the implications of changing a group's path or name. For more
-	// information, see Renaming users and groups
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_WorkingWithGroupsAndUsers.html)
+	// information, see Renaming users and groups (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_WorkingWithGroupsAndUsers.html)
 	// in the IAM User Guide. The person making the request (the principal), must have
 	// permission to change the role group with the old name and the new name. For
-	// example, to change the group named Managers to MGRs, the principal must have a
+	// example, to change the group named Managers to MGRs , the principal must have a
 	// policy that allows them to update both groups. If the principal has permission
-	// to update the Managers group, but not the MGRs group, then the update fails. For
-	// more information about permissions, see Access management
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access.html).
+	// to update the Managers group, but not the MGRs group, then the update fails.
+	// For more information about permissions, see Access management (https://docs.aws.amazon.com/IAM/latest/UserGuide/access.html)
+	// .
 	UpdateGroup(ctx context.Context, params *UpdateGroupInput, optFns ...func(*Options)) (*UpdateGroupOutput, error)
-	// Changes the password for the specified IAM user. You can use the CLI, the Amazon
-	// Web Services API, or the Users page in the IAM console to change the password
-	// for any IAM user. Use ChangePassword to change your own password in the My
-	// Security Credentials page in the Amazon Web Services Management Console. For
-	// more information about modifying passwords, see Managing passwords
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingLogins.html) in
-	// the IAM User Guide.
+	// Changes the password for the specified IAM user. You can use the CLI, the
+	// Amazon Web Services API, or the Users page in the IAM console to change the
+	// password for any IAM user. Use ChangePassword to change your own password in
+	// the My Security Credentials page in the Amazon Web Services Management Console.
+	// For more information about modifying passwords, see Managing passwords (https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingLogins.html)
+	// in the IAM User Guide.
 	UpdateLoginProfile(ctx context.Context, params *UpdateLoginProfileInput, optFns ...func(*Options)) (*UpdateLoginProfileOutput, error)
 	// Replaces the existing list of server certificate thumbprints associated with an
 	// OpenID Connect (OIDC) provider resource object with a new list of thumbprints.
@@ -1829,8 +1593,8 @@ type IAM interface {
 	// In these cases, your legacy thumbprint remains in your configuration, but is no
 	// longer used for validation. Trust for the OIDC provider is derived from the
 	// provider certificate and is validated by the thumbprint. Therefore, it is best
-	// to limit access to the UpdateOpenIDConnectProviderThumbprint operation to highly
-	// privileged users.
+	// to limit access to the UpdateOpenIDConnectProviderThumbprint operation to
+	// highly privileged users.
 	UpdateOpenIDConnectProviderThumbprint(ctx context.Context, params *UpdateOpenIDConnectProviderThumbprintInput, optFns ...func(*Options)) (*UpdateOpenIDConnectProviderThumbprintOutput, error)
 	// Updates the description or maximum session duration setting of a role.
 	UpdateRole(ctx context.Context, params *UpdateRoleInput, optFns ...func(*Options)) (*UpdateRoleOutput, error)
@@ -1839,8 +1603,8 @@ type IAM interface {
 	// operation.
 	UpdateRoleDescription(ctx context.Context, params *UpdateRoleDescriptionInput, optFns ...func(*Options)) (*UpdateRoleDescriptionOutput, error)
 	// Updates the metadata document for an existing SAML provider resource object.
-	// This operation requires Signature Version 4
-	// (https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
+	// This operation requires Signature Version 4 (https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
+	// .
 	UpdateSAMLProvider(ctx context.Context, params *UpdateSAMLProviderInput, optFns ...func(*Options)) (*UpdateSAMLProviderOutput, error)
 	// Sets the status of an IAM user's SSH public key to active or inactive. SSH
 	// public keys that are inactive cannot be used for authentication. This operation
@@ -1848,30 +1612,26 @@ type IAM interface {
 	// flow. The SSH public key affected by this operation is used only for
 	// authenticating the associated IAM user to an CodeCommit repository. For more
 	// information about using SSH keys to authenticate to an CodeCommit repository,
-	// see Set up CodeCommit for SSH connections
-	// (https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html)
+	// see Set up CodeCommit for SSH connections (https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html)
 	// in the CodeCommit User Guide.
 	UpdateSSHPublicKey(ctx context.Context, params *UpdateSSHPublicKeyInput, optFns ...func(*Options)) (*UpdateSSHPublicKeyOutput, error)
 	// Updates the name and/or the path of the specified server certificate stored in
 	// IAM. For more information about working with server certificates, see Working
-	// with server certificates
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
+	// with server certificates (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
 	// in the IAM User Guide. This topic also includes a list of Amazon Web Services
 	// services that can use the server certificates that you manage with IAM. You
 	// should understand the implications of changing a server certificate's path or
-	// name. For more information, see Renaming a server certificate
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs_manage.html#RenamingServerCerts)
+	// name. For more information, see Renaming a server certificate (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs_manage.html#RenamingServerCerts)
 	// in the IAM User Guide. The person making the request (the principal), must have
 	// permission to change the server certificate with the old name and the new name.
-	// For example, to change the certificate named ProductionCert to ProdCert, the
+	// For example, to change the certificate named ProductionCert to ProdCert , the
 	// principal must have a policy that allows them to update both certificates. If
 	// the principal has permission to update the ProductionCert group, but not the
 	// ProdCert certificate, then the update fails. For more information about
-	// permissions, see Access management
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access.html) in the IAM User
-	// Guide.
+	// permissions, see Access management (https://docs.aws.amazon.com/IAM/latest/UserGuide/access.html)
+	// in the IAM User Guide.
 	UpdateServerCertificate(ctx context.Context, params *UpdateServerCertificateInput, optFns ...func(*Options)) (*UpdateServerCertificateOutput, error)
-	// Sets the status of a service-specific credential to Active or Inactive.
+	// Sets the status of a service-specific credential to Active or Inactive .
 	// Service-specific credentials that are inactive cannot be used for authentication
 	// to the service. This operation can be used to disable a user's service-specific
 	// credential as part of a credential rotation work flow.
@@ -1887,23 +1647,20 @@ type IAM interface {
 	UpdateSigningCertificate(ctx context.Context, params *UpdateSigningCertificateInput, optFns ...func(*Options)) (*UpdateSigningCertificateOutput, error)
 	// Updates the name and/or the path of the specified IAM user. You should
 	// understand the implications of changing an IAM user's path or name. For more
-	// information, see Renaming an IAM user
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_manage.html#id_users_renaming)
-	// and Renaming an IAM group
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups_manage_rename.html)
+	// information, see Renaming an IAM user (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_manage.html#id_users_renaming)
+	// and Renaming an IAM group (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups_manage_rename.html)
 	// in the IAM User Guide. To change a user name, the requester must have
 	// appropriate permissions on both the source object and the target object. For
 	// example, to change Bob to Robert, the entity making the request must have
 	// permission on Bob and Robert, or must have permission on all (*). For more
-	// information about permissions, see Permissions and policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/PermissionsAndPolicies.html).
+	// information about permissions, see Permissions and policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/PermissionsAndPolicies.html)
+	// .
 	UpdateUser(ctx context.Context, params *UpdateUserInput, optFns ...func(*Options)) (*UpdateUserOutput, error)
-	// Uploads an SSH public key and associates it with the specified IAM user. The SSH
-	// public key uploaded by this operation can be used only for authenticating the
-	// associated IAM user to an CodeCommit repository. For more information about
+	// Uploads an SSH public key and associates it with the specified IAM user. The
+	// SSH public key uploaded by this operation can be used only for authenticating
+	// the associated IAM user to an CodeCommit repository. For more information about
 	// using SSH keys to authenticate to an CodeCommit repository, see Set up
-	// CodeCommit for SSH connections
-	// (https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html)
+	// CodeCommit for SSH connections (https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html)
 	// in the CodeCommit User Guide.
 	UploadSSHPublicKey(ctx context.Context, params *UploadSSHPublicKeyInput, optFns ...func(*Options)) (*UploadSSHPublicKeyOutput, error)
 	// Uploads a server certificate entity for the Amazon Web Services account. The
@@ -1913,46 +1670,40 @@ type IAM interface {
 	// provision, manage, and deploy your server certificates. With ACM you can request
 	// a certificate, deploy it to Amazon Web Services resources, and let ACM handle
 	// certificate renewals for you. Certificates provided by ACM are free. For more
-	// information about using ACM, see the Certificate Manager User Guide
-	// (https://docs.aws.amazon.com/acm/latest/userguide/). For more information about
-	// working with server certificates, see Working with server certificates
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
+	// information about using ACM, see the Certificate Manager User Guide (https://docs.aws.amazon.com/acm/latest/userguide/)
+	// . For more information about working with server certificates, see Working with
+	// server certificates (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
 	// in the IAM User Guide. This topic includes a list of Amazon Web Services
 	// services that can use the server certificates that you manage with IAM. For
 	// information about the number of server certificates you can upload, see IAM and
-	// STS quotas
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) in
-	// the IAM User Guide. Because the body of the public key certificate, private key,
-	// and the certificate chain can be large, you should use POST rather than GET when
-	// calling UploadServerCertificate. For information about setting up signatures and
-	// authorization through the API, see Signing Amazon Web Services API requests
-	// (https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html) in
-	// the Amazon Web Services General Reference. For general information about using
-	// the Query API with IAM, see Calling the API by making HTTP query requests
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/programming.html) in the IAM
-	// User Guide.
+	// STS quotas (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html)
+	// in the IAM User Guide. Because the body of the public key certificate, private
+	// key, and the certificate chain can be large, you should use POST rather than GET
+	// when calling UploadServerCertificate . For information about setting up
+	// signatures and authorization through the API, see Signing Amazon Web Services
+	// API requests (https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html)
+	// in the Amazon Web Services General Reference. For general information about
+	// using the Query API with IAM, see Calling the API by making HTTP query requests (https://docs.aws.amazon.com/IAM/latest/UserGuide/programming.html)
+	// in the IAM User Guide.
 	UploadServerCertificate(ctx context.Context, params *UploadServerCertificateInput, optFns ...func(*Options)) (*UploadServerCertificateOutput, error)
 	// Uploads an X.509 signing certificate and associates it with the specified IAM
 	// user. Some Amazon Web Services services require you to use certificates to
 	// validate requests that are signed with a corresponding private key. When you
-	// upload the certificate, its default status is Active. For information about when
-	// you would use an X.509 signing certificate, see Managing server certificates in
-	// IAM
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
+	// upload the certificate, its default status is Active . For information about
+	// when you would use an X.509 signing certificate, see Managing server
+	// certificates in IAM (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
 	// in the IAM User Guide. If the UserName is not specified, the IAM user name is
 	// determined implicitly based on the Amazon Web Services access key ID used to
 	// sign the request. This operation works for access keys under the Amazon Web
 	// Services account. Consequently, you can use this operation to manage Amazon Web
 	// Services account root user credentials even if the Amazon Web Services account
 	// has no associated users. Because the body of an X.509 certificate can be large,
-	// you should use POST rather than GET when calling UploadSigningCertificate. For
+	// you should use POST rather than GET when calling UploadSigningCertificate . For
 	// information about setting up signatures and authorization through the API, see
-	// Signing Amazon Web Services API requests
-	// (https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html) in
-	// the Amazon Web Services General Reference. For general information about using
-	// the Query API with IAM, see Making query requests
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html) in the
-	// IAM User Guide.
+	// Signing Amazon Web Services API requests (https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html)
+	// in the Amazon Web Services General Reference. For general information about
+	// using the Query API with IAM, see Making query requests (https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html)
+	// in the IAM User Guide.
 	UploadSigningCertificate(ctx context.Context, params *UploadSigningCertificateInput, optFns ...func(*Options)) (*UploadSigningCertificateOutput, error)
 }
 

--- a/pkg/awsapi/outposts.go
+++ b/pkg/awsapi/outposts.go
@@ -27,12 +27,10 @@ type Outposts interface {
 	// Amazon Web Services uses this action to install Outpost servers. Gets
 	// information about the specified connection. Use CloudTrail to monitor this
 	// action or Amazon Web Services managed policy for Amazon Web Services Outposts to
-	// secure it. For more information, see  Amazon Web Services managed policies for
-	// Amazon Web Services Outposts
-	// (https://docs.aws.amazon.com/outposts/latest/userguide/security-iam-awsmanpol.html)
-	// and  Logging Amazon Web Services Outposts API calls with Amazon Web Services
-	// CloudTrail
-	// (https://docs.aws.amazon.com/outposts/latest/userguide/logging-using-cloudtrail.html)
+	// secure it. For more information, see Amazon Web Services managed policies for
+	// Amazon Web Services Outposts (https://docs.aws.amazon.com/outposts/latest/userguide/security-iam-awsmanpol.html)
+	// and Logging Amazon Web Services Outposts API calls with Amazon Web Services
+	// CloudTrail (https://docs.aws.amazon.com/outposts/latest/userguide/logging-using-cloudtrail.html)
 	// in the Amazon Web Services Outposts User Guide.
 	GetConnection(ctx context.Context, params *GetConnectionInput, optFns ...func(*Options)) (*GetConnectionOutput, error)
 	// Gets information about the specified order.
@@ -77,12 +75,10 @@ type Outposts interface {
 	// Amazon Web Services uses this action to install Outpost servers. Starts the
 	// connection required for Outpost server installation. Use CloudTrail to monitor
 	// this action or Amazon Web Services managed policy for Amazon Web Services
-	// Outposts to secure it. For more information, see  Amazon Web Services managed
-	// policies for Amazon Web Services Outposts
-	// (https://docs.aws.amazon.com/outposts/latest/userguide/security-iam-awsmanpol.html)
-	// and  Logging Amazon Web Services Outposts API calls with Amazon Web Services
-	// CloudTrail
-	// (https://docs.aws.amazon.com/outposts/latest/userguide/logging-using-cloudtrail.html)
+	// Outposts to secure it. For more information, see Amazon Web Services managed
+	// policies for Amazon Web Services Outposts (https://docs.aws.amazon.com/outposts/latest/userguide/security-iam-awsmanpol.html)
+	// and Logging Amazon Web Services Outposts API calls with Amazon Web Services
+	// CloudTrail (https://docs.aws.amazon.com/outposts/latest/userguide/logging-using-cloudtrail.html)
 	// in the Amazon Web Services Outposts User Guide.
 	StartConnection(ctx context.Context, params *StartConnectionInput, optFns ...func(*Options)) (*StartConnectionOutput, error)
 	// Adds tags to the specified resource.
@@ -100,10 +96,9 @@ type Outposts interface {
 	UpdateSiteAddress(ctx context.Context, params *UpdateSiteAddressInput, optFns ...func(*Options)) (*UpdateSiteAddressOutput, error)
 	// Update the physical and logistical details for a rack at a site. For more
 	// information about hardware requirements for racks, see Network readiness
-	// checklist
-	// (https://docs.aws.amazon.com/outposts/latest/userguide/outposts-requirements.html#checklist)
+	// checklist (https://docs.aws.amazon.com/outposts/latest/userguide/outposts-requirements.html#checklist)
 	// in the Amazon Web Services Outposts User Guide. To update a rack at a site with
-	// an order of IN_PROGRESS, you must wait for the order to complete or cancel the
+	// an order of IN_PROGRESS , you must wait for the order to complete or cancel the
 	// order.
 	UpdateSiteRackPhysicalProperties(ctx context.Context, params *UpdateSiteRackPhysicalPropertiesInput, optFns ...func(*Options)) (*UpdateSiteRackPhysicalPropertiesOutput, error)
 }

--- a/pkg/awsapi/ssm.go
+++ b/pkg/awsapi/ssm.go
@@ -18,31 +18,22 @@ type SSM interface {
 	// value, both of which you define. For example, you could define a set of tags for
 	// your account's managed nodes that helps you track each node's owner and stack
 	// level. For example:
+	//   - Key=Owner,Value=DbAdmin
+	//   - Key=Owner,Value=SysAdmin
+	//   - Key=Owner,Value=Dev
+	//   - Key=Stack,Value=Production
+	//   - Key=Stack,Value=Pre-Production
+	//   - Key=Stack,Value=Test
 	//
-	// * Key=Owner,Value=DbAdmin
-	//
-	// * Key=Owner,Value=SysAdmin
-	//
-	// *
-	// Key=Owner,Value=Dev
-	//
-	// * Key=Stack,Value=Production
-	//
-	// *
-	// Key=Stack,Value=Pre-Production
-	//
-	// * Key=Stack,Value=Test
-	//
-	// Most resources can have
-	// a maximum of 50 tags. Automations can have a maximum of 5 tags. We recommend
-	// that you devise a set of tag keys that meets your needs for each resource type.
-	// Using a consistent set of tag keys makes it easier for you to manage your
-	// resources. You can search and filter the resources based on the tags you add.
-	// Tags don't have any semantic meaning to and are interpreted strictly as a string
-	// of characters. For more information about using tags with Amazon Elastic Compute
-	// Cloud (Amazon EC2) instances, see Tagging your Amazon EC2 resources
-	// (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html) in the
-	// Amazon EC2 User Guide.
+	// Most resources can have a maximum of 50 tags. Automations can have a maximum of
+	// 5 tags. We recommend that you devise a set of tag keys that meets your needs for
+	// each resource type. Using a consistent set of tag keys makes it easier for you
+	// to manage your resources. You can search and filter the resources based on the
+	// tags you add. Tags don't have any semantic meaning to and are interpreted
+	// strictly as a string of characters. For more information about using tags with
+	// Amazon Elastic Compute Cloud (Amazon EC2) instances, see Tagging your Amazon
+	// EC2 resources (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html)
+	// in the Amazon EC2 User Guide.
 	AddTagsToResource(ctx context.Context, params *AddTagsToResourceInput, optFns ...func(*Options)) (*AddTagsToResourceOutput, error)
 	// Associates a related item to a Systems Manager OpsCenter OpsItem. For example,
 	// you can associate an Incident Manager incident or analysis with an OpsItem.
@@ -53,8 +44,8 @@ type SSM interface {
 	// guarantee that the command will be terminated and the underlying process
 	// stopped.
 	CancelCommand(ctx context.Context, params *CancelCommandInput, optFns ...func(*Options)) (*CancelCommandOutput, error)
-	// Stops a maintenance window execution that is already in progress and cancels any
-	// tasks in the window that haven't already starting running. Tasks already in
+	// Stops a maintenance window execution that is already in progress and cancels
+	// any tasks in the window that haven't already starting running. Tasks already in
 	// progress will continue to completion.
 	CancelMaintenanceWindowExecution(ctx context.Context, params *CancelMaintenanceWindowExecutionInput, optFns ...func(*Options)) (*CancelMaintenanceWindowExecutionOutput, error)
 	// Generates an activation code and activation ID you can use to register your
@@ -64,8 +55,7 @@ type SSM interface {
 	// activation code and ID when installing SSM Agent on machines in your hybrid
 	// environment. For more information about requirements for managing on-premises
 	// machines using Systems Manager, see Setting up Amazon Web Services Systems
-	// Manager for hybrid environments
-	// (https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-managedinstances.html)
+	// Manager for hybrid environments (https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-managedinstances.html)
 	// in the Amazon Web Services Systems Manager User Guide. Amazon Elastic Compute
 	// Cloud (Amazon EC2) instances, edge devices, and on-premises servers and VMs that
 	// are configured for Systems Manager are all called managed nodes.
@@ -94,45 +84,41 @@ type SSM interface {
 	// Creates a Amazon Web Services Systems Manager (SSM document). An SSM document
 	// defines the actions that Systems Manager performs on your managed nodes. For
 	// more information about SSM documents, including information about supported
-	// schemas, features, and syntax, see Amazon Web Services Systems Manager Documents
-	// (https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-ssm-docs.html)
+	// schemas, features, and syntax, see Amazon Web Services Systems Manager Documents (https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-ssm-docs.html)
 	// in the Amazon Web Services Systems Manager User Guide.
 	CreateDocument(ctx context.Context, params *CreateDocumentInput, optFns ...func(*Options)) (*CreateDocumentOutput, error)
 	// Creates a new maintenance window. The value you specify for Duration determines
 	// the specific end time for the maintenance window based on the time it begins. No
 	// maintenance window tasks are permitted to start after the resulting endtime
-	// minus the number of hours you specify for Cutoff. For example, if the
+	// minus the number of hours you specify for Cutoff . For example, if the
 	// maintenance window starts at 3 PM, the duration is three hours, and the value
 	// you specify for Cutoff is one hour, no maintenance window tasks can start after
 	// 5 PM.
 	CreateMaintenanceWindow(ctx context.Context, params *CreateMaintenanceWindowInput, optFns ...func(*Options)) (*CreateMaintenanceWindowOutput, error)
 	// Creates a new OpsItem. You must have permission in Identity and Access
 	// Management (IAM) to create a new OpsItem. For more information, see Getting
-	// started with OpsCenter
-	// (https://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter-getting-started.html)
+	// started with OpsCenter (https://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter-getting-started.html)
 	// in the Amazon Web Services Systems Manager User Guide. Operations engineers and
 	// IT professionals use Amazon Web Services Systems Manager OpsCenter to view,
 	// investigate, and remediate operational issues impacting the performance and
 	// health of their Amazon Web Services resources. For more information, see Amazon
-	// Web Services Systems Manager OpsCenter
-	// (https://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter.html) in
-	// the Amazon Web Services Systems Manager User Guide.
+	// Web Services Systems Manager OpsCenter (https://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter.html)
+	// in the Amazon Web Services Systems Manager User Guide.
 	CreateOpsItem(ctx context.Context, params *CreateOpsItemInput, optFns ...func(*Options)) (*CreateOpsItemOutput, error)
 	// If you create a new application in Application Manager, Amazon Web Services
 	// Systems Manager calls this API operation to specify information about the new
 	// application, including the application type.
 	CreateOpsMetadata(ctx context.Context, params *CreateOpsMetadataInput, optFns ...func(*Options)) (*CreateOpsMetadataOutput, error)
 	// Creates a patch baseline. For information about valid key-value pairs in
-	// PatchFilters for each supported operating system type, see PatchFilter.
+	// PatchFilters for each supported operating system type, see PatchFilter .
 	CreatePatchBaseline(ctx context.Context, params *CreatePatchBaselineInput, optFns ...func(*Options)) (*CreatePatchBaselineOutput, error)
 	// A resource data sync helps you view data from multiple sources in a single
 	// location. Amazon Web Services Systems Manager offers two types of resource data
-	// sync: SyncToDestination and SyncFromSource. You can configure Systems Manager
+	// sync: SyncToDestination and SyncFromSource . You can configure Systems Manager
 	// Inventory to use the SyncToDestination type to synchronize Inventory data from
 	// multiple Amazon Web Services Regions to a single Amazon Simple Storage Service
-	// (Amazon S3) bucket. For more information, see Configuring resource data sync for
-	// Inventory
-	// (https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-inventory-datasync.html)
+	// (Amazon S3) bucket. For more information, see Configuring resource data sync
+	// for Inventory (https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-inventory-datasync.html)
 	// in the Amazon Web Services Systems Manager User Guide. You can configure Systems
 	// Manager Explorer to use the SyncFromSource type to synchronize operational work
 	// items (OpsItems) and operational data (OpsData) from multiple Amazon Web
@@ -140,12 +126,11 @@ type SSM interface {
 	// OpsItems and OpsData from multiple Amazon Web Services accounts and Amazon Web
 	// Services Regions or EntireOrganization by using Organizations. For more
 	// information, see Setting up Systems Manager Explorer to display data from
-	// multiple accounts and Regions
-	// (https://docs.aws.amazon.com/systems-manager/latest/userguide/Explorer-resource-data-sync.html)
+	// multiple accounts and Regions (https://docs.aws.amazon.com/systems-manager/latest/userguide/Explorer-resource-data-sync.html)
 	// in the Amazon Web Services Systems Manager User Guide. A resource data sync is
 	// an asynchronous operation that returns immediately. After a successful initial
 	// sync is completed, the system continuously syncs data. To check the status of a
-	// sync, use the ListResourceDataSync. By default, data isn't encrypted in Amazon
+	// sync, use the ListResourceDataSync . By default, data isn't encrypted in Amazon
 	// S3. We strongly recommend that you enable encryption in Amazon S3 to ensure
 	// secure data storage. We also recommend that you secure access to the Amazon S3
 	// bucket by creating a restrictive bucket policy.
@@ -188,11 +173,11 @@ type SSM interface {
 	// changes to data on managed nodes are no longer synced to or from the target.
 	// Deleting a sync configuration doesn't delete data.
 	DeleteResourceDataSync(ctx context.Context, params *DeleteResourceDataSyncInput, optFns ...func(*Options)) (*DeleteResourceDataSyncOutput, error)
-	// Deletes a Systems Manager resource policy. A resource policy helps you to define
-	// the IAM entity (for example, an Amazon Web Services account) that can manage
-	// your Systems Manager resources. Currently, OpsItemGroup is the only resource
-	// that supports Systems Manager resource policies. The resource policy for
-	// OpsItemGroup enables Amazon Web Services accounts to view and interact with
+	// Deletes a Systems Manager resource policy. A resource policy helps you to
+	// define the IAM entity (for example, an Amazon Web Services account) that can
+	// manage your Systems Manager resources. Currently, OpsItemGroup is the only
+	// resource that supports Systems Manager resource policies. The resource policy
+	// for OpsItemGroup enables Amazon Web Services accounts to view and interact with
 	// OpsCenter operational work items (OpsItems).
 	DeleteResourcePolicy(ctx context.Context, params *DeleteResourcePolicyInput, optFns ...func(*Options)) (*DeleteResourcePolicyOutput, error)
 	// Removes the server or virtual machine from the list of registered servers. You
@@ -205,10 +190,10 @@ type SSM interface {
 	DeregisterTargetFromMaintenanceWindow(ctx context.Context, params *DeregisterTargetFromMaintenanceWindowInput, optFns ...func(*Options)) (*DeregisterTargetFromMaintenanceWindowOutput, error)
 	// Removes a task from a maintenance window.
 	DeregisterTaskFromMaintenanceWindow(ctx context.Context, params *DeregisterTaskFromMaintenanceWindowInput, optFns ...func(*Options)) (*DeregisterTaskFromMaintenanceWindowOutput, error)
-	// Describes details about the activation, such as the date and time the activation
-	// was created, its expiration date, the Identity and Access Management (IAM) role
-	// assigned to the managed nodes in the activation, and the number of nodes
-	// registered by using this activation.
+	// Describes details about the activation, such as the date and time the
+	// activation was created, its expiration date, the Identity and Access Management
+	// (IAM) role assigned to the managed nodes in the activation, and the number of
+	// nodes registered by using this activation.
 	DescribeActivations(ctx context.Context, params *DescribeActivationsInput, optFns ...func(*Options)) (*DescribeActivationsOutput, error)
 	// Describes the association for the specified target or managed node. If you
 	// created the association by using the Targets parameter, then you must retrieve
@@ -274,10 +259,10 @@ type SSM interface {
 	// Lists the targets registered with the maintenance window.
 	DescribeMaintenanceWindowTargets(ctx context.Context, params *DescribeMaintenanceWindowTargetsInput, optFns ...func(*Options)) (*DescribeMaintenanceWindowTargetsOutput, error)
 	// Lists the tasks in a maintenance window. For maintenance window tasks without a
-	// specified target, you can't supply values for --max-errors and
-	// --max-concurrency. Instead, the system inserts a placeholder value of 1, which
-	// may be reported in the response to this command. These values don't affect the
-	// running of your task and can be ignored.
+	// specified target, you can't supply values for --max-errors and --max-concurrency
+	// . Instead, the system inserts a placeholder value of 1 , which may be reported
+	// in the response to this command. These values don't affect the running of your
+	// task and can be ignored.
 	DescribeMaintenanceWindowTasks(ctx context.Context, params *DescribeMaintenanceWindowTasksInput, optFns ...func(*Options)) (*DescribeMaintenanceWindowTasksOutput, error)
 	// Retrieves the maintenance windows in an Amazon Web Services account.
 	DescribeMaintenanceWindows(ctx context.Context, params *DescribeMaintenanceWindowsInput, optFns ...func(*Options)) (*DescribeMaintenanceWindowsOutput, error)
@@ -286,26 +271,25 @@ type SSM interface {
 	DescribeMaintenanceWindowsForTarget(ctx context.Context, params *DescribeMaintenanceWindowsForTargetInput, optFns ...func(*Options)) (*DescribeMaintenanceWindowsForTargetOutput, error)
 	// Query a set of OpsItems. You must have permission in Identity and Access
 	// Management (IAM) to query a list of OpsItems. For more information, see Getting
-	// started with OpsCenter
-	// (https://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter-getting-started.html)
+	// started with OpsCenter (https://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter-getting-started.html)
 	// in the Amazon Web Services Systems Manager User Guide. Operations engineers and
 	// IT professionals use Amazon Web Services Systems Manager OpsCenter to view,
 	// investigate, and remediate operational issues impacting the performance and
 	// health of their Amazon Web Services resources. For more information, see
-	// OpsCenter
-	// (https://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter.html) in
-	// the Amazon Web Services Systems Manager User Guide.
+	// OpsCenter (https://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter.html)
+	// in the Amazon Web Services Systems Manager User Guide.
 	DescribeOpsItems(ctx context.Context, params *DescribeOpsItemsInput, optFns ...func(*Options)) (*DescribeOpsItemsOutput, error)
-	// Get information about a parameter. Request results are returned on a best-effort
-	// basis. If you specify MaxResults in the request, the response includes
-	// information up to the limit specified. The number of items returned, however,
-	// can be between zero and the value of MaxResults. If the service reaches an
-	// internal limit while processing the results, it stops the operation and returns
-	// the matching values up to that point and a NextToken. You can specify the
-	// NextToken in a subsequent call to get the next set of results. If you change the
-	// KMS key alias for the KMS key used to encrypt a parameter, then you must also
-	// update the key alias the parameter uses to reference KMS. Otherwise,
-	// DescribeParameters retrieves whatever the original key alias was referencing.
+	// Get information about a parameter. Request results are returned on a
+	// best-effort basis. If you specify MaxResults in the request, the response
+	// includes information up to the limit specified. The number of items returned,
+	// however, can be between zero and the value of MaxResults . If the service
+	// reaches an internal limit while processing the results, it stops the operation
+	// and returns the matching values up to that point and a NextToken . You can
+	// specify the NextToken in a subsequent call to get the next set of results. If
+	// you change the KMS key alias for the KMS key used to encrypt a parameter, then
+	// you must also update the key alias the parameter uses to reference KMS.
+	// Otherwise, DescribeParameters retrieves whatever the original key alias was
+	// referencing.
 	DescribeParameters(ctx context.Context, params *DescribeParametersInput, optFns ...func(*Options)) (*DescribeParametersOutput, error)
 	// Lists the patch baselines in your Amazon Web Services account.
 	DescribePatchBaselines(ctx context.Context, params *DescribePatchBaselinesInput, optFns ...func(*Options)) (*DescribePatchBaselinesOutput, error)
@@ -317,12 +301,12 @@ type SSM interface {
 	// Lists the properties of available patches organized by product, product family,
 	// classification, severity, and other properties of available patches. You can use
 	// the reported properties in the filters you specify in requests for operations
-	// such as CreatePatchBaseline, UpdatePatchBaseline, DescribeAvailablePatches, and
-	// DescribePatchBaselines. The following section lists the properties that can be
-	// used in filters for each major operating system type: AMAZON_LINUX Valid
-	// properties: PRODUCT | CLASSIFICATION | SEVERITY AMAZON_LINUX_2 Valid properties:
-	// PRODUCT | CLASSIFICATION | SEVERITY CENTOS Valid properties: PRODUCT |
-	// CLASSIFICATION | SEVERITY DEBIAN Valid properties: PRODUCT | PRIORITY MACOS
+	// such as CreatePatchBaseline , UpdatePatchBaseline , DescribeAvailablePatches ,
+	// and DescribePatchBaselines . The following section lists the properties that can
+	// be used in filters for each major operating system type: AMAZON_LINUX Valid
+	// properties: PRODUCT | CLASSIFICATION | SEVERITY AMAZON_LINUX_2 Valid
+	// properties: PRODUCT | CLASSIFICATION | SEVERITY CENTOS Valid properties: PRODUCT
+	// | CLASSIFICATION | SEVERITY DEBIAN Valid properties: PRODUCT | PRIORITY MACOS
 	// Valid properties: PRODUCT | CLASSIFICATION ORACLE_LINUX Valid properties:
 	// PRODUCT | CLASSIFICATION | SEVERITY REDHAT_ENTERPRISE_LINUX Valid properties:
 	// PRODUCT | CLASSIFICATION | SEVERITY SUSE Valid properties: PRODUCT |
@@ -332,9 +316,9 @@ type SSM interface {
 	// Retrieves a list of all active sessions (both connected and disconnected) or
 	// terminated sessions from the past 30 days.
 	DescribeSessions(ctx context.Context, params *DescribeSessionsInput, optFns ...func(*Options)) (*DescribeSessionsOutput, error)
-	// Deletes the association between an OpsItem and a related item. For example, this
-	// API operation can delete an Incident Manager incident from an OpsItem. Incident
-	// Manager is a capability of Amazon Web Services Systems Manager.
+	// Deletes the association between an OpsItem and a related item. For example,
+	// this API operation can delete an Incident Manager incident from an OpsItem.
+	// Incident Manager is a capability of Amazon Web Services Systems Manager.
 	DisassociateOpsItemRelatedItem(ctx context.Context, params *DisassociateOpsItemRelatedItemInput, optFns ...func(*Options)) (*DisassociateOpsItemRelatedItemOutput, error)
 	// Get detailed information about a particular Automation execution.
 	GetAutomationExecution(ctx context.Context, params *GetAutomationExecutionInput, optFns ...func(*Options)) (*GetAutomationExecutionOutput, error)
@@ -343,20 +327,19 @@ type SSM interface {
 	// returns the state of the calendar at that specific time, and returns the next
 	// time that the change calendar state will transition. If you don't specify a
 	// time, GetCalendarState uses the current time. Change Calendar entries have two
-	// possible states: OPEN or CLOSED. If you specify more than one calendar in a
+	// possible states: OPEN or CLOSED . If you specify more than one calendar in a
 	// request, the command returns the status of OPEN only if all calendars in the
 	// request are open. If one or more calendars in the request are closed, the status
-	// returned is CLOSED. For more information about Change Calendar, a capability of
+	// returned is CLOSED . For more information about Change Calendar, a capability of
 	// Amazon Web Services Systems Manager, see Amazon Web Services Systems Manager
-	// Change Calendar
-	// (https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-change-calendar.html)
+	// Change Calendar (https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-change-calendar.html)
 	// in the Amazon Web Services Systems Manager User Guide.
 	GetCalendarState(ctx context.Context, params *GetCalendarStateInput, optFns ...func(*Options)) (*GetCalendarStateOutput, error)
 	// Returns detailed information about command execution for an invocation or
 	// plugin. GetCommandInvocation only gives the execution status of a plugin in a
 	// document. To get the command execution status on a specific managed node, use
-	// ListCommandInvocations. To get the command execution status across managed
-	// nodes, use ListCommands.
+	// ListCommandInvocations . To get the command execution status across managed
+	// nodes, use ListCommands .
 	GetCommandInvocation(ctx context.Context, params *GetCommandInvocationInput, optFns ...func(*Options)) (*GetCommandInvocationOutput, error)
 	// Retrieves the Session Manager connection status for a managed node to determine
 	// whether it is running and ready to receive Session Manager connections.
@@ -380,7 +363,7 @@ type SSM interface {
 	// (SSM document).
 	GetDocument(ctx context.Context, params *GetDocumentInput, optFns ...func(*Options)) (*GetDocumentOutput, error)
 	// Query inventory information. This includes managed node status, such as Stopped
-	// or Terminated.
+	// or Terminated .
 	GetInventory(ctx context.Context, params *GetInventoryInput, optFns ...func(*Options)) (*GetInventoryOutput, error)
 	// Return a list of inventory type names for the account, or return a list of
 	// attribute names for a specific Inventory item type.
@@ -394,24 +377,22 @@ type SSM interface {
 	GetMaintenanceWindowExecutionTask(ctx context.Context, params *GetMaintenanceWindowExecutionTaskInput, optFns ...func(*Options)) (*GetMaintenanceWindowExecutionTaskOutput, error)
 	// Retrieves information about a specific task running on a specific target.
 	GetMaintenanceWindowExecutionTaskInvocation(ctx context.Context, params *GetMaintenanceWindowExecutionTaskInvocationInput, optFns ...func(*Options)) (*GetMaintenanceWindowExecutionTaskInvocationOutput, error)
-	// Retrieves the details of a maintenance window task. For maintenance window tasks
-	// without a specified target, you can't supply values for --max-errors and
-	// --max-concurrency. Instead, the system inserts a placeholder value of 1, which
+	// Retrieves the details of a maintenance window task. For maintenance window
+	// tasks without a specified target, you can't supply values for --max-errors and
+	// --max-concurrency . Instead, the system inserts a placeholder value of 1 , which
 	// may be reported in the response to this command. These values don't affect the
 	// running of your task and can be ignored. To retrieve a list of tasks in a
 	// maintenance window, instead use the DescribeMaintenanceWindowTasks command.
 	GetMaintenanceWindowTask(ctx context.Context, params *GetMaintenanceWindowTaskInput, optFns ...func(*Options)) (*GetMaintenanceWindowTaskOutput, error)
 	// Get information about an OpsItem by using the ID. You must have permission in
 	// Identity and Access Management (IAM) to view information about an OpsItem. For
-	// more information, see Getting started with OpsCenter
-	// (https://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter-getting-started.html)
+	// more information, see Getting started with OpsCenter (https://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter-getting-started.html)
 	// in the Amazon Web Services Systems Manager User Guide. Operations engineers and
 	// IT professionals use Amazon Web Services Systems Manager OpsCenter to view,
 	// investigate, and remediate operational issues impacting the performance and
 	// health of their Amazon Web Services resources. For more information, see
-	// OpsCenter
-	// (https://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter.html) in
-	// the Amazon Web Services Systems Manager User Guide.
+	// OpsCenter (https://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter.html)
+	// in the Amazon Web Services Systems Manager User Guide.
 	GetOpsItem(ctx context.Context, params *GetOpsItemInput, optFns ...func(*Options)) (*GetOpsItemOutput, error)
 	// View operational metadata related to an application in Application Manager.
 	GetOpsMetadata(ctx context.Context, params *GetOpsMetadataInput, optFns ...func(*Options)) (*GetOpsMetadataOutput, error)
@@ -438,9 +419,9 @@ type SSM interface {
 	// Request results are returned on a best-effort basis. If you specify MaxResults
 	// in the request, the response includes information up to the limit specified. The
 	// number of items returned, however, can be between zero and the value of
-	// MaxResults. If the service reaches an internal limit while processing the
+	// MaxResults . If the service reaches an internal limit while processing the
 	// results, it stops the operation and returns the matching values up to that point
-	// and a NextToken. You can specify the NextToken in a subsequent call to get the
+	// and a NextToken . You can specify the NextToken in a subsequent call to get the
 	// next set of results.
 	GetParametersByPath(ctx context.Context, params *GetParametersByPathInput, optFns ...func(*Options)) (*GetParametersByPathOutput, error)
 	// Retrieves information about a patch baseline.
@@ -453,11 +434,11 @@ type SSM interface {
 	// This setting defines how a user interacts with or uses a service or a feature of
 	// a service. For example, if an Amazon Web Services service charges money to the
 	// account based on feature or service usage, then the Amazon Web Services service
-	// team might create a default setting of false. This means the user can't use this
-	// feature unless they change the setting to true and intentionally opt in for a
-	// paid feature. Services map a SettingId object to a setting value. Amazon Web
-	// Services services teams define the default value for a SettingId. You can't
-	// create a new SettingId, but you can overwrite the default value if you have the
+	// team might create a default setting of false . This means the user can't use
+	// this feature unless they change the setting to true and intentionally opt in
+	// for a paid feature. Services map a SettingId object to a setting value. Amazon
+	// Web Services services teams define the default value for a SettingId . You can't
+	// create a new SettingId , but you can overwrite the default value if you have the
 	// ssm:UpdateServiceSetting permission for the setting. Use the
 	// UpdateServiceSetting API operation to change the default setting. Or use the
 	// ResetServiceSetting to change the value back to the original value defined by
@@ -469,35 +450,21 @@ type SSM interface {
 	// automatically saves a new version and increments the version number by one. A
 	// label can help you remember the purpose of a parameter when there are multiple
 	// versions. Parameter labels have the following requirements and restrictions.
-	//
-	// *
-	// A version of a parameter can have a maximum of 10 labels.
-	//
-	// * You can't attach
-	// the same label to different versions of the same parameter. For example, if
-	// version 1 has the label Production, then you can't attach Production to version
-	// 2.
-	//
-	// * You can move a label from one version of a parameter to another.
-	//
-	// * You
-	// can't create a label when you create a new parameter. You must attach a label to
-	// a specific version of a parameter.
-	//
-	// * If you no longer want to use a parameter
-	// label, then you can either delete it or move it to a different version of a
-	// parameter.
-	//
-	// * A label can have a maximum of 100 characters.
-	//
-	// * Labels can
-	// contain letters (case sensitive), numbers, periods (.), hyphens (-), or
-	// underscores (_).
-	//
-	// * Labels can't begin with a number, "aws" or "ssm" (not case
-	// sensitive). If a label fails to meet these requirements, then the label isn't
-	// associated with a parameter and the system displays it in the list of
-	// InvalidLabels.
+	//   - A version of a parameter can have a maximum of 10 labels.
+	//   - You can't attach the same label to different versions of the same
+	//     parameter. For example, if version 1 has the label Production, then you can't
+	//     attach Production to version 2.
+	//   - You can move a label from one version of a parameter to another.
+	//   - You can't create a label when you create a new parameter. You must attach a
+	//     label to a specific version of a parameter.
+	//   - If you no longer want to use a parameter label, then you can either delete
+	//     it or move it to a different version of a parameter.
+	//   - A label can have a maximum of 100 characters.
+	//   - Labels can contain letters (case sensitive), numbers, periods (.), hyphens
+	//     (-), or underscores (_).
+	//   - Labels can't begin with a number, " aws " or " ssm " (not case sensitive).
+	//     If a label fails to meet these requirements, then the label isn't associated
+	//     with a parameter and the system displays it in the list of InvalidLabels.
 	LabelParameterVersion(ctx context.Context, params *LabelParameterVersionInput, optFns ...func(*Options)) (*LabelParameterVersionOutput, error)
 	// Retrieves all versions of an association for a specific association ID.
 	ListAssociationVersions(ctx context.Context, params *ListAssociationVersionsInput, optFns ...func(*Options)) (*ListAssociationVersionsOutput, error)
@@ -542,8 +509,8 @@ type SSM interface {
 	// Lists all related-item resources associated with a Systems Manager OpsCenter
 	// OpsItem. OpsCenter is a capability of Amazon Web Services Systems Manager.
 	ListOpsItemRelatedItems(ctx context.Context, params *ListOpsItemRelatedItemsInput, optFns ...func(*Options)) (*ListOpsItemRelatedItemsOutput, error)
-	// Amazon Web Services Systems Manager calls this API operation when displaying all
-	// Application Manager OpsMetadata objects or blobs.
+	// Amazon Web Services Systems Manager calls this API operation when displaying
+	// all Application Manager OpsMetadata objects or blobs.
 	ListOpsMetadata(ctx context.Context, params *ListOpsMetadataInput, optFns ...func(*Options)) (*ListOpsMetadataOutput, error)
 	// Returns a resource-level summary count. The summary includes information about
 	// compliant and non-compliant statuses and detailed compliance-item severity
@@ -552,7 +519,7 @@ type SSM interface {
 	// Lists your resource data sync configurations. Includes information about the
 	// last time a sync attempted to start, the last sync status, and the last time a
 	// sync successfully completed. The number of sync configurations might be too
-	// large to return using a single call to ListResourceDataSync. You can limit the
+	// large to return using a single call to ListResourceDataSync . You can limit the
 	// number of sync configurations returned by using the MaxResults parameter. To
 	// determine whether there are more sync configurations to list, check the value of
 	// NextToken in the output. If there are more sync configurations to list, you can
@@ -560,7 +527,7 @@ type SSM interface {
 	// of a subsequent call.
 	ListResourceDataSync(ctx context.Context, params *ListResourceDataSyncInput, optFns ...func(*Options)) (*ListResourceDataSyncOutput, error)
 	// Returns a list of the tags assigned to the specified resource. For information
-	// about the ID format for each supported resource type, see AddTagsToResource.
+	// about the ID format for each supported resource type, see AddTagsToResource .
 	ListTagsForResource(ctx context.Context, params *ListTagsForResourceInput, optFns ...func(*Options)) (*ListTagsForResourceOutput, error)
 	// Shares a Amazon Web Services Systems Manager document (SSM document)publicly or
 	// privately. If you share a document privately, you must specify the Amazon Web
@@ -572,51 +539,26 @@ type SSM interface {
 	// resource. This call overwrites existing compliance information on the resource,
 	// so you must provide a full list of compliance items each time that you send the
 	// request. ComplianceType can be one of the following:
-	//
-	// * ExecutionId: The
-	// execution ID when the patch, association, or custom compliance item was
-	// applied.
-	//
-	// * ExecutionType: Specify patch, association, or Custom:string.
-	//
-	// *
-	// ExecutionTime. The time the patch, association, or custom compliance item was
-	// applied to the managed node.
-	//
-	// * Id: The patch, association, or custom compliance
-	// ID.
-	//
-	// * Title: A title.
-	//
-	// * Status: The status of the compliance item. For
-	// example, approved for patches, or Failed for associations.
-	//
-	// * Severity: A patch
-	// severity. For example, Critical.
-	//
-	// * DocumentName: An SSM document name. For
-	// example, AWS-RunPatchBaseline.
-	//
-	// * DocumentVersion: An SSM document version
-	// number. For example, 4.
-	//
-	// * Classification: A patch classification. For example,
-	// security updates.
-	//
-	// * PatchBaselineId: A patch baseline ID.
-	//
-	// * PatchSeverity: A
-	// patch severity. For example, Critical.
-	//
-	// * PatchState: A patch state. For
-	// example, InstancesWithFailedPatches.
-	//
-	// * PatchGroup: The name of a patch
-	// group.
-	//
-	// * InstalledTime: The time the association, patch, or custom compliance
-	// item was applied to the resource. Specify the time by using the following
-	// format: yyyy-MM-dd'T'HH:mm:ss'Z'
+	//   - ExecutionId: The execution ID when the patch, association, or custom
+	//     compliance item was applied.
+	//   - ExecutionType: Specify patch, association, or Custom: string .
+	//   - ExecutionTime. The time the patch, association, or custom compliance item
+	//     was applied to the managed node.
+	//   - Id: The patch, association, or custom compliance ID.
+	//   - Title: A title.
+	//   - Status: The status of the compliance item. For example, approved for
+	//     patches, or Failed for associations.
+	//   - Severity: A patch severity. For example, Critical .
+	//   - DocumentName: An SSM document name. For example, AWS-RunPatchBaseline .
+	//   - DocumentVersion: An SSM document version number. For example, 4.
+	//   - Classification: A patch classification. For example, security updates .
+	//   - PatchBaselineId: A patch baseline ID.
+	//   - PatchSeverity: A patch severity. For example, Critical .
+	//   - PatchState: A patch state. For example, InstancesWithFailedPatches .
+	//   - PatchGroup: The name of a patch group.
+	//   - InstalledTime: The time the association, patch, or custom compliance item
+	//     was applied to the resource. Specify the time by using the following format:
+	//     yyyy-MM-dd'T'HH:mm:ss'Z'
 	PutComplianceItems(ctx context.Context, params *PutComplianceItemsInput, optFns ...func(*Options)) (*PutComplianceItemsOutput, error)
 	// Bulk update custom inventory items on one or more managed nodes. The request
 	// adds an inventory item, if it doesn't already exist, or updates an inventory
@@ -636,7 +578,7 @@ type SSM interface {
 	// full patch baseline Amazon Resource Name (ARN) as the baseline ID value. For
 	// example, for CentOS, specify
 	// arn:aws:ssm:us-east-2:733109147000:patchbaseline/pb-0574b43a65ea646ed instead of
-	// pb-0574b43a65ea646ed.
+	// pb-0574b43a65ea646ed .
 	RegisterDefaultPatchBaseline(ctx context.Context, params *RegisterDefaultPatchBaselineInput, optFns ...func(*Options)) (*RegisterDefaultPatchBaselineOutput, error)
 	// Registers a patch baseline for a patch group.
 	RegisterPatchBaselineForPatchGroup(ctx context.Context, params *RegisterPatchBaselineForPatchGroupInput, optFns ...func(*Options)) (*RegisterPatchBaselineForPatchGroupOutput, error)
@@ -653,8 +595,8 @@ type SSM interface {
 	// team might create a default setting of "false". This means the user can't use
 	// this feature unless they change the setting to "true" and intentionally opt in
 	// for a paid feature. Services map a SettingId object to a setting value. Amazon
-	// Web Services services teams define the default value for a SettingId. You can't
-	// create a new SettingId, but you can overwrite the default value if you have the
+	// Web Services services teams define the default value for a SettingId . You can't
+	// create a new SettingId , but you can overwrite the default value if you have the
 	// ssm:UpdateServiceSetting permission for the setting. Use the GetServiceSetting
 	// API operation to view the current value. Use the UpdateServiceSetting API
 	// operation to change the default setting. Reset the service setting for the
@@ -672,8 +614,8 @@ type SSM interface {
 	SendAutomationSignal(ctx context.Context, params *SendAutomationSignalInput, optFns ...func(*Options)) (*SendAutomationSignalOutput, error)
 	// Runs commands on one or more managed nodes.
 	SendCommand(ctx context.Context, params *SendCommandInput, optFns ...func(*Options)) (*SendCommandOutput, error)
-	// Runs an association immediately and only one time. This operation can be helpful
-	// when troubleshooting associations.
+	// Runs an association immediately and only one time. This operation can be
+	// helpful when troubleshooting associations.
 	StartAssociationsOnce(ctx context.Context, params *StartAssociationsOnceInput, optFns ...func(*Options)) (*StartAssociationsOnceOutput, error)
 	// Initiates execution of an Automation runbook.
 	StartAutomationExecution(ctx context.Context, params *StartAutomationExecutionInput, optFns ...func(*Options)) (*StartAutomationExecutionOutput, error)
@@ -684,10 +626,10 @@ type SSM interface {
 	// Initiates a connection to a target (for example, a managed node) for a Session
 	// Manager session. Returns a URL and token that can be used to open a WebSocket
 	// connection for sending input and receiving outputs. Amazon Web Services CLI
-	// usage: start-session is an interactive command that requires the Session Manager
-	// plugin to be installed on the client machine making the call. For information,
-	// see Install the Session Manager plugin for the Amazon Web Services CLI
-	// (https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
+	// usage: start-session is an interactive command that requires the Session
+	// Manager plugin to be installed on the client machine making the call. For
+	// information, see Install the Session Manager plugin for the Amazon Web Services
+	// CLI (https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
 	// in the Amazon Web Services Systems Manager User Guide. Amazon Web Services Tools
 	// for PowerShell usage: Start-SSMSession isn't currently supported by Amazon Web
 	// Services Tools for PowerShell on Windows local machines.
@@ -702,7 +644,7 @@ type SSM interface {
 	UnlabelParameterVersion(ctx context.Context, params *UnlabelParameterVersionInput, optFns ...func(*Options)) (*UnlabelParameterVersionOutput, error)
 	// Updates an association. You can update the association name and version, the
 	// document version, schedule, parameters, and Amazon Simple Storage Service
-	// (Amazon S3) output. When you call UpdateAssociation, the system removes all
+	// (Amazon S3) output. When you call UpdateAssociation , the system removes all
 	// optional parameters from the request and overwrites the association with null
 	// values for those parameters. This is by design. You must specify all optional
 	// parameters in the call, even if you are not changing the parameters. This
@@ -711,18 +653,18 @@ type SSM interface {
 	// parameters required for your UpdateAssociation call. In order to call this API
 	// operation, a user, group, or role must be granted permission to call the
 	// DescribeAssociation API operation. If you don't have permission to call
-	// DescribeAssociation, then you receive the following error: An error occurred
+	// DescribeAssociation , then you receive the following error: An error occurred
 	// (AccessDeniedException) when calling the UpdateAssociation operation: User:
-	// isn't authorized to perform: ssm:DescribeAssociation on resource:  When you
+	// isn't authorized to perform: ssm:DescribeAssociation on resource: When you
 	// update an association, the association immediately runs against the specified
 	// targets. You can add the ApplyOnlyAtCronInterval parameter to run the
 	// association during the next schedule run.
 	UpdateAssociation(ctx context.Context, params *UpdateAssociationInput, optFns ...func(*Options)) (*UpdateAssociationOutput, error)
 	// Updates the status of the Amazon Web Services Systems Manager document (SSM
-	// document) associated with the specified managed node. UpdateAssociationStatus is
-	// primarily used by the Amazon Web Services Systems Manager Agent (SSM Agent) to
-	// report status updates about your associations and is only used for associations
-	// created with the InstanceId legacy parameter.
+	// document) associated with the specified managed node. UpdateAssociationStatus
+	// is primarily used by the Amazon Web Services Systems Manager Agent (SSM Agent)
+	// to report status updates about your associations and is only used for
+	// associations created with the InstanceId legacy parameter.
 	UpdateAssociationStatus(ctx context.Context, params *UpdateAssociationStatusInput, optFns ...func(*Options)) (*UpdateAssociationStatusOutput, error)
 	// Updates one or more values for an SSM document.
 	UpdateDocument(ctx context.Context, params *UpdateDocumentInput, optFns ...func(*Options)) (*UpdateDocumentOutput, error)
@@ -737,99 +679,81 @@ type SSM interface {
 	// The value you specify for Duration determines the specific end time for the
 	// maintenance window based on the time it begins. No maintenance window tasks are
 	// permitted to start after the resulting endtime minus the number of hours you
-	// specify for Cutoff. For example, if the maintenance window starts at 3 PM, the
+	// specify for Cutoff . For example, if the maintenance window starts at 3 PM, the
 	// duration is three hours, and the value you specify for Cutoff is one hour, no
 	// maintenance window tasks can start after 5 PM.
 	UpdateMaintenanceWindow(ctx context.Context, params *UpdateMaintenanceWindowInput, optFns ...func(*Options)) (*UpdateMaintenanceWindowOutput, error)
 	// Modifies the target of an existing maintenance window. You can change the
 	// following:
-	//
-	// * Name
-	//
-	// * Description
-	//
-	// * Owner
-	//
-	// * IDs for an ID target
-	//
-	// * Tags for a
-	// Tag target
-	//
-	// * From any supported tag type to another. The three supported tag
-	// types are ID target, Tag target, and resource group. For more information, see
-	// Target.
+	//   - Name
+	//   - Description
+	//   - Owner
+	//   - IDs for an ID target
+	//   - Tags for a Tag target
+	//   - From any supported tag type to another. The three supported tag types are
+	//     ID target, Tag target, and resource group. For more information, see Target .
 	//
 	// If a parameter is null, then the corresponding field isn't modified.
 	UpdateMaintenanceWindowTarget(ctx context.Context, params *UpdateMaintenanceWindowTargetInput, optFns ...func(*Options)) (*UpdateMaintenanceWindowTargetOutput, error)
 	// Modifies a task assigned to a maintenance window. You can't change the task
 	// type, but you can change the following values:
+	//   - TaskARN . For example, you can change a RUN_COMMAND task from
+	//     AWS-RunPowerShellScript to AWS-RunShellScript .
+	//   - ServiceRoleArn
+	//   - TaskInvocationParameters
+	//   - Priority
+	//   - MaxConcurrency
+	//   - MaxErrors
 	//
-	// * TaskARN. For example, you can
-	// change a RUN_COMMAND task from AWS-RunPowerShellScript to AWS-RunShellScript.
-	//
-	// *
-	// ServiceRoleArn
-	//
-	// * TaskInvocationParameters
-	//
-	// * Priority
-	//
-	// * MaxConcurrency
-	//
-	// *
-	// MaxErrors
-	//
-	// One or more targets must be specified for maintenance window Run
-	// Command-type tasks. Depending on the task, targets are optional for other
-	// maintenance window task types (Automation, Lambda, and Step Functions). For more
-	// information about running tasks that don't specify targets, see Registering
-	// maintenance window tasks without targets
-	// (https://docs.aws.amazon.com/systems-manager/latest/userguide/maintenance-windows-targetless-tasks.html)
+	// One or more targets must be specified for maintenance window Run Command-type
+	// tasks. Depending on the task, targets are optional for other maintenance window
+	// task types (Automation, Lambda, and Step Functions). For more information about
+	// running tasks that don't specify targets, see Registering maintenance window
+	// tasks without targets (https://docs.aws.amazon.com/systems-manager/latest/userguide/maintenance-windows-targetless-tasks.html)
 	// in the Amazon Web Services Systems Manager User Guide. If the value for a
 	// parameter in UpdateMaintenanceWindowTask is null, then the corresponding field
 	// isn't modified. If you set Replace to true, then all fields required by the
 	// RegisterTaskWithMaintenanceWindow operation are required for this request.
 	// Optional fields that aren't specified are set to null. When you update a
-	// maintenance window task that has options specified in TaskInvocationParameters,
+	// maintenance window task that has options specified in TaskInvocationParameters ,
 	// you must provide again all the TaskInvocationParameters values that you want to
 	// retain. The values you don't specify again are removed. For example, suppose
 	// that when you registered a Run Command task, you specified
-	// TaskInvocationParameters values for Comment, NotificationConfig, and
-	// OutputS3BucketName. If you update the maintenance window task and specify only a
-	// different OutputS3BucketName value, the values for Comment and
+	// TaskInvocationParameters values for Comment , NotificationConfig , and
+	// OutputS3BucketName . If you update the maintenance window task and specify only
+	// a different OutputS3BucketName value, the values for Comment and
 	// NotificationConfig are removed.
 	UpdateMaintenanceWindowTask(ctx context.Context, params *UpdateMaintenanceWindowTaskInput, optFns ...func(*Options)) (*UpdateMaintenanceWindowTaskOutput, error)
 	// Changes the Identity and Access Management (IAM) role that is assigned to the
 	// on-premises server, edge device, or virtual machines (VM). IAM roles are first
 	// assigned to these hybrid nodes during the activation process. For more
-	// information, see CreateActivation.
+	// information, see CreateActivation .
 	UpdateManagedInstanceRole(ctx context.Context, params *UpdateManagedInstanceRoleInput, optFns ...func(*Options)) (*UpdateManagedInstanceRoleOutput, error)
 	// Edit or change an OpsItem. You must have permission in Identity and Access
-	// Management (IAM) to update an OpsItem. For more information, see Getting started
-	// with OpsCenter
-	// (https://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter-getting-started.html)
+	// Management (IAM) to update an OpsItem. For more information, see Getting
+	// started with OpsCenter (https://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter-getting-started.html)
 	// in the Amazon Web Services Systems Manager User Guide. Operations engineers and
 	// IT professionals use Amazon Web Services Systems Manager OpsCenter to view,
 	// investigate, and remediate operational issues impacting the performance and
 	// health of their Amazon Web Services resources. For more information, see
-	// OpsCenter
-	// (https://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter.html) in
-	// the Amazon Web Services Systems Manager User Guide.
+	// OpsCenter (https://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter.html)
+	// in the Amazon Web Services Systems Manager User Guide.
 	UpdateOpsItem(ctx context.Context, params *UpdateOpsItemInput, optFns ...func(*Options)) (*UpdateOpsItemOutput, error)
 	// Amazon Web Services Systems Manager calls this API operation when you edit
 	// OpsMetadata in Application Manager.
 	UpdateOpsMetadata(ctx context.Context, params *UpdateOpsMetadataInput, optFns ...func(*Options)) (*UpdateOpsMetadataOutput, error)
 	// Modifies an existing patch baseline. Fields not specified in the request are
 	// left unchanged. For information about valid key-value pairs in PatchFilters for
-	// each supported operating system type, see PatchFilter.
+	// each supported operating system type, see PatchFilter .
 	UpdatePatchBaseline(ctx context.Context, params *UpdatePatchBaselineInput, optFns ...func(*Options)) (*UpdatePatchBaselineOutput, error)
-	// Update a resource data sync. After you create a resource data sync for a Region,
-	// you can't change the account options for that sync. For example, if you create a
-	// sync in the us-east-2 (Ohio) Region and you choose the Include only the current
-	// account option, you can't edit that sync later and choose the Include all
-	// accounts from my Organizations configuration option. Instead, you must delete
-	// the first resource data sync, and create a new one. This API operation only
-	// supports a resource data sync that was created with a SyncFromSource SyncType.
+	// Update a resource data sync. After you create a resource data sync for a
+	// Region, you can't change the account options for that sync. For example, if you
+	// create a sync in the us-east-2 (Ohio) Region and you choose the Include only
+	// the current account option, you can't edit that sync later and choose the
+	// Include all accounts from my Organizations configuration option. Instead, you
+	// must delete the first resource data sync, and create a new one. This API
+	// operation only supports a resource data sync that was created with a
+	// SyncFromSource SyncType .
 	UpdateResourceDataSync(ctx context.Context, params *UpdateResourceDataSyncInput, optFns ...func(*Options)) (*UpdateResourceDataSyncOutput, error)
 	// ServiceSetting is an account-level setting for an Amazon Web Services service.
 	// This setting defines how a user interacts with or uses a service or a feature of
@@ -838,8 +762,8 @@ type SSM interface {
 	// team might create a default setting of "false". This means the user can't use
 	// this feature unless they change the setting to "true" and intentionally opt in
 	// for a paid feature. Services map a SettingId object to a setting value. Amazon
-	// Web Services services teams define the default value for a SettingId. You can't
-	// create a new SettingId, but you can overwrite the default value if you have the
+	// Web Services services teams define the default value for a SettingId . You can't
+	// create a new SettingId , but you can overwrite the default value if you have the
 	// ssm:UpdateServiceSetting permission for the setting. Use the GetServiceSetting
 	// API operation to view the current value. Or, use the ResetServiceSetting to
 	// change the value back to the original value defined by the Amazon Web Services

--- a/pkg/awsapi/sts.go
+++ b/pkg/awsapi/sts.go
@@ -15,16 +15,13 @@ type STS interface {
 	// key ID, a secret access key, and a security token. Typically, you use AssumeRole
 	// within your account or for cross-account access. For a comparison of AssumeRole
 	// with other API operations that produce temporary credentials, see Requesting
-	// Temporary Security Credentials
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
-	// and Comparing the Amazon Web Services STS API operations
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
+	// Temporary Security Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
+	// and Comparing the Amazon Web Services STS API operations (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
 	// in the IAM User Guide. Permissions The temporary security credentials created by
-	// AssumeRole can be used to make API calls to any Amazon Web Services service with
-	// the following exception: You cannot call the Amazon Web Services STS
+	// AssumeRole can be used to make API calls to any Amazon Web Services service
+	// with the following exception: You cannot call the Amazon Web Services STS
 	// GetFederationToken or GetSessionToken API operations. (Optional) You can pass
-	// inline or managed session policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+	// inline or managed session policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 	// to this operation. You can pass a single JSON policy document to use as an
 	// inline session policy. You can also specify up to 10 managed policy Amazon
 	// Resource Names (ARNs) to use as managed session policies. The plaintext that you
@@ -35,8 +32,7 @@ type STS interface {
 	// credentials in subsequent Amazon Web Services API calls to access resources in
 	// the account that owns the role. You cannot use session policies to grant more
 	// permissions than those allowed by the identity-based policy of the role that is
-	// being assumed. For more information, see Session Policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+	// being assumed. For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 	// in the IAM User Guide. When you create a role, you create two policies: A role
 	// trust policy that specifies who can assume the role and a permissions policy
 	// that specifies what can be done with the role. You specify the trusted principal
@@ -47,37 +43,29 @@ type STS interface {
 	// that access to users in the account. A user who wants to access a role in a
 	// different account must also have permissions that are delegated from the user
 	// account administrator. The administrator must attach a policy that allows the
-	// user to call AssumeRole for the ARN of the role in the other account. To allow a
-	// user to assume a role in the same account, you can do either of the
-	// following:
+	// user to call AssumeRole for the ARN of the role in the other account. To allow
+	// a user to assume a role in the same account, you can do either of the following:
 	//
-	// * Attach a policy to the user that allows the user to call
-	// AssumeRole (as long as the role's trust policy trusts the account).
+	//   - Attach a policy to the user that allows the user to call AssumeRole (as long
+	//     as the role's trust policy trusts the account).
+	//   - Add the user as a principal directly in the role's trust policy.
 	//
-	// * Add the
-	// user as a principal directly in the role's trust policy.
-	//
-	// You can do either
-	// because the role’s trust policy acts as an IAM resource-based policy. When a
-	// resource-based policy grants access to a principal in the same account, no
-	// additional identity-based policy is required. For more information about trust
-	// policies and resource-based policies, see IAM Policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) in the
-	// IAM User Guide. Tags (Optional) You can pass tag key-value pairs to your
+	// You can do either because the role’s trust policy acts as an IAM resource-based
+	// policy. When a resource-based policy grants access to a principal in the same
+	// account, no additional identity-based policy is required. For more information
+	// about trust policies and resource-based policies, see IAM Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html)
+	// in the IAM User Guide. Tags (Optional) You can pass tag key-value pairs to your
 	// session. These tags are called session tags. For more information about session
-	// tags, see Passing Session Tags in STS
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html) in the
-	// IAM User Guide. An administrator must grant you the permissions necessary to
-	// pass session tags. The administrator can also create granular permissions to
+	// tags, see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+	// in the IAM User Guide. An administrator must grant you the permissions necessary
+	// to pass session tags. The administrator can also create granular permissions to
 	// allow you to pass only specific session tags. For more information, see
-	// Tutorial: Using Tags for Attribute-Based Access Control
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html)
+	// Tutorial: Using Tags for Attribute-Based Access Control (https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html)
 	// in the IAM User Guide. You can set the session tags as transitive. Transitive
-	// tags persist during role chaining. For more information, see Chaining Roles with
-	// Session Tags
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_role-chaining)
+	// tags persist during role chaining. For more information, see Chaining Roles
+	// with Session Tags (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_role-chaining)
 	// in the IAM User Guide. Using MFA with AssumeRole (Optional) You can include
-	// multi-factor authentication (MFA) information when you call AssumeRole. This is
+	// multi-factor authentication (MFA) information when you call AssumeRole . This is
 	// useful for cross-account scenarios to ensure that the user that assumes the role
 	// has been authenticated with an Amazon Web Services MFA device. In that scenario,
 	// the trust policy of the role being assumed includes a condition that tests for
@@ -85,22 +73,19 @@ type STS interface {
 	// request to assume the role is denied. The condition in a trust policy that tests
 	// for MFA authentication might look like the following example. "Condition":
 	// {"Bool": {"aws:MultiFactorAuthPresent": true}} For more information, see
-	// Configuring MFA-Protected API Access
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/MFAProtectedAPI.html) in the
-	// IAM User Guide guide. To use MFA with AssumeRole, you pass values for the
-	// SerialNumber and TokenCode parameters. The SerialNumber value identifies the
-	// user's hardware or virtual MFA device. The TokenCode is the time-based one-time
-	// password (TOTP) that the MFA device produces.
+	// Configuring MFA-Protected API Access (https://docs.aws.amazon.com/IAM/latest/UserGuide/MFAProtectedAPI.html)
+	// in the IAM User Guide guide. To use MFA with AssumeRole , you pass values for
+	// the SerialNumber and TokenCode parameters. The SerialNumber value identifies
+	// the user's hardware or virtual MFA device. The TokenCode is the time-based
+	// one-time password (TOTP) that the MFA device produces.
 	AssumeRole(ctx context.Context, params *AssumeRoleInput, optFns ...func(*Options)) (*AssumeRoleOutput, error)
 	// Returns a set of temporary security credentials for users who have been
 	// authenticated via a SAML authentication response. This operation provides a
 	// mechanism for tying an enterprise identity store or directory to role-based
 	// Amazon Web Services access without user-specific credentials or configuration.
 	// For a comparison of AssumeRoleWithSAML with the other API operations that
-	// produce temporary credentials, see Requesting Temporary Security Credentials
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
-	// and Comparing the Amazon Web Services STS API operations
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
+	// produce temporary credentials, see Requesting Temporary Security Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
+	// and Comparing the Amazon Web Services STS API operations (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
 	// in the IAM User Guide. The temporary security credentials returned by this
 	// operation consist of an access key ID, a secret access key, and a security
 	// token. Applications can use these temporary security credentials to sign calls
@@ -113,15 +98,12 @@ type STS interface {
 	// DurationSeconds value from 900 seconds (15 minutes) up to the maximum session
 	// duration setting for the role. This setting can have a value from 1 hour to 12
 	// hours. To learn how to view the maximum value for your role, see View the
-	// Maximum Session Duration Setting for a Role
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session)
+	// Maximum Session Duration Setting for a Role (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session)
 	// in the IAM User Guide. The maximum session duration limit applies when you use
 	// the AssumeRole* API operations or the assume-role* CLI commands. However the
 	// limit does not apply when you use those operations to create a console URL. For
-	// more information, see Using IAM Roles
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html) in the IAM
-	// User Guide. Role chaining
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#iam-term-role-chaining)
+	// more information, see Using IAM Roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html)
+	// in the IAM User Guide. Role chaining (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#iam-term-role-chaining)
 	// limits your CLI or Amazon Web Services API role session to a maximum of one
 	// hour. When you use the AssumeRole API operation to assume a role, you can
 	// specify the duration of your role session with the DurationSeconds parameter.
@@ -132,8 +114,7 @@ type STS interface {
 	// credentials created by AssumeRoleWithSAML can be used to make API calls to any
 	// Amazon Web Services service with the following exception: you cannot call the
 	// STS GetFederationToken or GetSessionToken API operations. (Optional) You can
-	// pass inline or managed session policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+	// pass inline or managed session policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 	// to this operation. You can pass a single JSON policy document to use as an
 	// inline session policy. You can also specify up to 10 managed policy Amazon
 	// Resource Names (ARNs) to use as managed session policies. The plaintext that you
@@ -144,8 +125,7 @@ type STS interface {
 	// credentials in subsequent Amazon Web Services API calls to access resources in
 	// the account that owns the role. You cannot use session policies to grant more
 	// permissions than those allowed by the identity-based policy of the role that is
-	// being assumed. For more information, see Session Policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+	// being assumed. For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 	// in the IAM User Guide. Calling AssumeRoleWithSAML does not require the use of
 	// Amazon Web Services security credentials. The identity of the caller is
 	// validated by using keys in the metadata document that is uploaded for the SAML
@@ -153,16 +133,14 @@ type STS interface {
 	// result in an entry in your CloudTrail logs. The entry includes the value in the
 	// NameID element of the SAML assertion. We recommend that you use a NameIDType
 	// that is not associated with any personally identifiable information (PII). For
-	// example, you could instead use the persistent identifier
-	// (urn:oasis:names:tc:SAML:2.0:nameid-format:persistent). Tags (Optional) You can
+	// example, you could instead use the persistent identifier (
+	// urn:oasis:names:tc:SAML:2.0:nameid-format:persistent ). Tags (Optional) You can
 	// configure your IdP to pass attributes into your SAML assertion as session tags.
 	// Each session tag consists of a key name and an associated value. For more
-	// information about session tags, see Passing Session Tags in STS
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html) in the
-	// IAM User Guide. You can pass up to 50 session tags. The plaintext session tag
-	// keys can’t exceed 128 characters and the values can’t exceed 256 characters. For
-	// these and additional limits, see IAM and STS Character Limits
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length)
+	// information about session tags, see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+	// in the IAM User Guide. You can pass up to 50 session tags. The plaintext session
+	// tag keys can’t exceed 128 characters and the values can’t exceed 256 characters.
+	// For these and additional limits, see IAM and STS Character Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length)
 	// in the IAM User Guide. An Amazon Web Services conversion compresses the passed
 	// inline session policy, managed policy ARNs, and session tags into a packed
 	// binary format that has a separate limit. Your request can fail for this limit
@@ -173,54 +151,39 @@ type STS interface {
 	// override the role's tags with the same key. An administrator must grant you the
 	// permissions necessary to pass session tags. The administrator can also create
 	// granular permissions to allow you to pass only specific session tags. For more
-	// information, see Tutorial: Using Tags for Attribute-Based Access Control
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html)
+	// information, see Tutorial: Using Tags for Attribute-Based Access Control (https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html)
 	// in the IAM User Guide. You can set the session tags as transitive. Transitive
-	// tags persist during role chaining. For more information, see Chaining Roles with
-	// Session Tags
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_role-chaining)
+	// tags persist during role chaining. For more information, see Chaining Roles
+	// with Session Tags (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_role-chaining)
 	// in the IAM User Guide. SAML Configuration Before your application can call
-	// AssumeRoleWithSAML, you must configure your SAML identity provider (IdP) to
+	// AssumeRoleWithSAML , you must configure your SAML identity provider (IdP) to
 	// issue the claims required by Amazon Web Services. Additionally, you must use
 	// Identity and Access Management (IAM) to create a SAML provider entity in your
 	// Amazon Web Services account that represents your identity provider. You must
 	// also create an IAM role that specifies this SAML provider in its trust policy.
 	// For more information, see the following resources:
-	//
-	// * About SAML 2.0-based
-	// Federation
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html)
-	// in the IAM User Guide.
-	//
-	// * Creating SAML Identity Providers
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml.html)
-	// in the IAM User Guide.
-	//
-	// * Configuring a Relying Party and Claims
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_relying-party.html)
-	// in the IAM User Guide.
-	//
-	// * Creating a Role for SAML 2.0 Federation
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_saml.html)
-	// in the IAM User Guide.
+	//   - About SAML 2.0-based Federation (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html)
+	//     in the IAM User Guide.
+	//   - Creating SAML Identity Providers (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml.html)
+	//     in the IAM User Guide.
+	//   - Configuring a Relying Party and Claims (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_relying-party.html)
+	//     in the IAM User Guide.
+	//   - Creating a Role for SAML 2.0 Federation (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_saml.html)
+	//     in the IAM User Guide.
 	AssumeRoleWithSAML(ctx context.Context, params *AssumeRoleWithSAMLInput, optFns ...func(*Options)) (*AssumeRoleWithSAMLOutput, error)
 	// Returns a set of temporary security credentials for users who have been
 	// authenticated in a mobile or web application with a web identity provider.
 	// Example providers include the OAuth 2.0 providers Login with Amazon and
 	// Facebook, or any OpenID Connect-compatible identity provider such as Google or
-	// Amazon Cognito federated identities
-	// (https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html).
-	// For mobile applications, we recommend that you use Amazon Cognito. You can use
-	// Amazon Cognito with the Amazon Web Services SDK for iOS Developer Guide
-	// (http://aws.amazon.com/sdkforios/) and the Amazon Web Services SDK for Android
-	// Developer Guide (http://aws.amazon.com/sdkforandroid/) to uniquely identify a
-	// user. You can also supply the user with a consistent identity throughout the
-	// lifetime of an application. To learn more about Amazon Cognito, see Amazon
-	// Cognito Overview
-	// (https://docs.aws.amazon.com/mobile/sdkforandroid/developerguide/cognito-auth.html#d0e840)
+	// Amazon Cognito federated identities (https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html)
+	// . For mobile applications, we recommend that you use Amazon Cognito. You can use
+	// Amazon Cognito with the Amazon Web Services SDK for iOS Developer Guide (http://aws.amazon.com/sdkforios/)
+	// and the Amazon Web Services SDK for Android Developer Guide (http://aws.amazon.com/sdkforandroid/)
+	// to uniquely identify a user. You can also supply the user with a consistent
+	// identity throughout the lifetime of an application. To learn more about Amazon
+	// Cognito, see Amazon Cognito Overview (https://docs.aws.amazon.com/mobile/sdkforandroid/developerguide/cognito-auth.html#d0e840)
 	// in Amazon Web Services SDK for Android Developer Guide and Amazon Cognito
-	// Overview
-	// (https://docs.aws.amazon.com/mobile/sdkforios/developerguide/cognito-auth.html#d0e664)
+	// Overview (https://docs.aws.amazon.com/mobile/sdkforios/developerguide/cognito-auth.html#d0e664)
 	// in the Amazon Web Services SDK for iOS Developer Guide. Calling
 	// AssumeRoleWithWebIdentity does not require the use of Amazon Web Services
 	// security credentials. Therefore, you can distribute an application (for example,
@@ -230,32 +193,28 @@ type STS interface {
 	// Services credentials. Instead, the identity of the caller is validated by using
 	// a token from the web identity provider. For a comparison of
 	// AssumeRoleWithWebIdentity with the other API operations that produce temporary
-	// credentials, see Requesting Temporary Security Credentials
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
-	// and Comparing the Amazon Web Services STS API operations
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
+	// credentials, see Requesting Temporary Security Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
+	// and Comparing the Amazon Web Services STS API operations (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
 	// in the IAM User Guide. The temporary security credentials returned by this API
 	// consist of an access key ID, a secret access key, and a security token.
 	// Applications can use these temporary security credentials to sign calls to
 	// Amazon Web Services service API operations. Session Duration By default, the
-	// temporary security credentials created by AssumeRoleWithWebIdentity last for one
-	// hour. However, you can use the optional DurationSeconds parameter to specify the
-	// duration of your session. You can provide a value from 900 seconds (15 minutes)
-	// up to the maximum session duration setting for the role. This setting can have a
-	// value from 1 hour to 12 hours. To learn how to view the maximum value for your
-	// role, see View the Maximum Session Duration Setting for a Role
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session)
+	// temporary security credentials created by AssumeRoleWithWebIdentity last for
+	// one hour. However, you can use the optional DurationSeconds parameter to
+	// specify the duration of your session. You can provide a value from 900 seconds
+	// (15 minutes) up to the maximum session duration setting for the role. This
+	// setting can have a value from 1 hour to 12 hours. To learn how to view the
+	// maximum value for your role, see View the Maximum Session Duration Setting for
+	// a Role (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session)
 	// in the IAM User Guide. The maximum session duration limit applies when you use
 	// the AssumeRole* API operations or the assume-role* CLI commands. However the
 	// limit does not apply when you use those operations to create a console URL. For
-	// more information, see Using IAM Roles
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html) in the IAM
-	// User Guide. Permissions The temporary security credentials created by
+	// more information, see Using IAM Roles (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html)
+	// in the IAM User Guide. Permissions The temporary security credentials created by
 	// AssumeRoleWithWebIdentity can be used to make API calls to any Amazon Web
 	// Services service with the following exception: you cannot call the STS
 	// GetFederationToken or GetSessionToken API operations. (Optional) You can pass
-	// inline or managed session policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+	// inline or managed session policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 	// to this operation. You can pass a single JSON policy document to use as an
 	// inline session policy. You can also specify up to 10 managed policy Amazon
 	// Resource Names (ARNs) to use as managed session policies. The plaintext that you
@@ -266,17 +225,14 @@ type STS interface {
 	// credentials in subsequent Amazon Web Services API calls to access resources in
 	// the account that owns the role. You cannot use session policies to grant more
 	// permissions than those allowed by the identity-based policy of the role that is
-	// being assumed. For more information, see Session Policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+	// being assumed. For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 	// in the IAM User Guide. Tags (Optional) You can configure your IdP to pass
 	// attributes into your web identity token as session tags. Each session tag
 	// consists of a key name and an associated value. For more information about
-	// session tags, see Passing Session Tags in STS
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html) in the
-	// IAM User Guide. You can pass up to 50 session tags. The plaintext session tag
-	// keys can’t exceed 128 characters and the values can’t exceed 256 characters. For
-	// these and additional limits, see IAM and STS Character Limits
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length)
+	// session tags, see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+	// in the IAM User Guide. You can pass up to 50 session tags. The plaintext session
+	// tag keys can’t exceed 128 characters and the values can’t exceed 256 characters.
+	// For these and additional limits, see IAM and STS Character Limits (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length)
 	// in the IAM User Guide. An Amazon Web Services conversion compresses the passed
 	// inline session policy, managed policy ARNs, and session tags into a packed
 	// binary format that has a separate limit. Your request can fail for this limit
@@ -287,52 +243,38 @@ type STS interface {
 	// overrides the role tag with the same key. An administrator must grant you the
 	// permissions necessary to pass session tags. The administrator can also create
 	// granular permissions to allow you to pass only specific session tags. For more
-	// information, see Tutorial: Using Tags for Attribute-Based Access Control
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html)
+	// information, see Tutorial: Using Tags for Attribute-Based Access Control (https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html)
 	// in the IAM User Guide. You can set the session tags as transitive. Transitive
-	// tags persist during role chaining. For more information, see Chaining Roles with
-	// Session Tags
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_role-chaining)
+	// tags persist during role chaining. For more information, see Chaining Roles
+	// with Session Tags (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_role-chaining)
 	// in the IAM User Guide. Identities Before your application can call
-	// AssumeRoleWithWebIdentity, you must have an identity token from a supported
+	// AssumeRoleWithWebIdentity , you must have an identity token from a supported
 	// identity provider and create a role that the application can assume. The role
 	// that your application assumes must trust the identity provider that is
 	// associated with the identity token. In other words, the identity provider must
 	// be specified in the role's trust policy. Calling AssumeRoleWithWebIdentity can
-	// result in an entry in your CloudTrail logs. The entry includes the Subject
-	// (http://openid.net/specs/openid-connect-core-1_0.html#Claims) of the provided
-	// web identity token. We recommend that you avoid using any personally
-	// identifiable information (PII) in this field. For example, you could instead use
-	// a GUID or a pairwise identifier, as suggested in the OIDC specification
-	// (http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes). For more
-	// information about how to use web identity federation and the
+	// result in an entry in your CloudTrail logs. The entry includes the Subject (http://openid.net/specs/openid-connect-core-1_0.html#Claims)
+	// of the provided web identity token. We recommend that you avoid using any
+	// personally identifiable information (PII) in this field. For example, you could
+	// instead use a GUID or a pairwise identifier, as suggested in the OIDC
+	// specification (http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes)
+	// . For more information about how to use web identity federation and the
 	// AssumeRoleWithWebIdentity API, see the following resources:
-	//
-	// * Using Web
-	// Identity Federation API Operations for Mobile Apps
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc_manual.html)
-	// and Federation Through a Web-based Identity Provider
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithwebidentity).
-	//
-	// *
-	// Web Identity Federation Playground
-	// (https://aws.amazon.com/blogs/aws/the-aws-web-identity-federation-playground/).
-	// Walk through the process of authenticating through Login with Amazon, Facebook,
-	// or Google, getting temporary security credentials, and then using those
-	// credentials to make a request to Amazon Web Services.
-	//
-	// * Amazon Web Services SDK
-	// for iOS Developer Guide (http://aws.amazon.com/sdkforios/) and Amazon Web
-	// Services SDK for Android Developer Guide (http://aws.amazon.com/sdkforandroid/).
-	// These toolkits contain sample apps that show how to invoke the identity
-	// providers. The toolkits then show how to use the information from these
-	// providers to get and use temporary security credentials.
-	//
-	// * Web Identity
-	// Federation with Mobile Applications
-	// (http://aws.amazon.com/articles/web-identity-federation-with-mobile-applications).
-	// This article discusses web identity federation and shows an example of how to
-	// use web identity federation to get access to content in Amazon S3.
+	//   - Using Web Identity Federation API Operations for Mobile Apps (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc_manual.html)
+	//     and Federation Through a Web-based Identity Provider (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithwebidentity)
+	//     .
+	//   - Web Identity Federation Playground (https://aws.amazon.com/blogs/aws/the-aws-web-identity-federation-playground/)
+	//     . Walk through the process of authenticating through Login with Amazon,
+	//     Facebook, or Google, getting temporary security credentials, and then using
+	//     those credentials to make a request to Amazon Web Services.
+	//   - Amazon Web Services SDK for iOS Developer Guide (http://aws.amazon.com/sdkforios/)
+	//     and Amazon Web Services SDK for Android Developer Guide (http://aws.amazon.com/sdkforandroid/)
+	//     . These toolkits contain sample apps that show how to invoke the identity
+	//     providers. The toolkits then show how to use the information from these
+	//     providers to get and use temporary security credentials.
+	//   - Web Identity Federation with Mobile Applications (http://aws.amazon.com/articles/web-identity-federation-with-mobile-applications)
+	//     . This article discusses web identity federation and shows an example of how to
+	//     use web identity federation to get access to content in Amazon S3.
 	AssumeRoleWithWebIdentity(ctx context.Context, params *AssumeRoleWithWebIdentityInput, optFns ...func(*Options)) (*AssumeRoleWithWebIdentityOutput, error)
 	// Decodes additional information about the authorization status of a request from
 	// an encoded message returned in response to an Amazon Web Services request. For
@@ -346,44 +288,31 @@ type STS interface {
 	// encoded because the details of the authorization status can contain privileged
 	// information that the user who requested the operation should not see. To decode
 	// an authorization status message, a user must be granted permissions through an
-	// IAM policy
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) to
-	// request the DecodeAuthorizationMessage (sts:DecodeAuthorizationMessage) action.
-	// The decoded message includes the following type of information:
-	//
-	// * Whether the
-	// request was denied due to an explicit deny or due to the absence of an explicit
-	// allow. For more information, see Determining Whether a Request is Allowed or
-	// Denied
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-denyallow)
-	// in the IAM User Guide.
-	//
-	// * The principal who made the request.
-	//
-	// * The requested
-	// action.
-	//
-	// * The requested resource.
-	//
-	// * The values of condition keys in the
-	// context of the user's request.
+	// IAM policy (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html)
+	// to request the DecodeAuthorizationMessage ( sts:DecodeAuthorizationMessage )
+	// action. The decoded message includes the following type of information:
+	//   - Whether the request was denied due to an explicit deny or due to the
+	//     absence of an explicit allow. For more information, see Determining Whether a
+	//     Request is Allowed or Denied (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-denyallow)
+	//     in the IAM User Guide.
+	//   - The principal who made the request.
+	//   - The requested action.
+	//   - The requested resource.
+	//   - The values of condition keys in the context of the user's request.
 	DecodeAuthorizationMessage(ctx context.Context, params *DecodeAuthorizationMessageInput, optFns ...func(*Options)) (*DecodeAuthorizationMessageOutput, error)
 	// Returns the account identifier for the specified access key ID. Access keys
-	// consist of two parts: an access key ID (for example, AKIAIOSFODNN7EXAMPLE) and a
-	// secret access key (for example, wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY). For
-	// more information about access keys, see Managing Access Keys for IAM Users
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)
+	// consist of two parts: an access key ID (for example, AKIAIOSFODNN7EXAMPLE ) and
+	// a secret access key (for example, wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY ).
+	// For more information about access keys, see Managing Access Keys for IAM Users (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)
 	// in the IAM User Guide. When you pass an access key ID to this operation, it
 	// returns the ID of the Amazon Web Services account to which the keys belong.
 	// Access key IDs beginning with AKIA are long-term credentials for an IAM user or
 	// the Amazon Web Services account root user. Access key IDs beginning with ASIA
 	// are temporary credentials that are created using STS operations. If the account
 	// in the response belongs to you, you can sign in as the root user and review your
-	// root user access keys. Then, you can pull a credentials report
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_getting-report.html)
+	// root user access keys. Then, you can pull a credentials report (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_getting-report.html)
 	// to learn which IAM user owns the keys. To learn who requested the temporary
-	// credentials for an ASIA access key, view the STS events in your CloudTrail logs
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html)
+	// credentials for an ASIA access key, view the STS events in your CloudTrail logs (https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html)
 	// in the IAM User Guide. This operation does not indicate the state of the access
 	// key. The key might be active, inactive, or deleted. Active keys might not have
 	// permissions to perform an operation. Providing a deleted access key might return
@@ -394,55 +323,45 @@ type STS interface {
 	// administrator adds a policy to your IAM user or role that explicitly denies
 	// access to the sts:GetCallerIdentity action, you can still perform this
 	// operation. Permissions are not required because the same information is returned
-	// when an IAM user or role is denied access. To view an example response, see I Am
-	// Not Authorized to Perform: iam:DeleteVirtualMFADevice
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_access-denied-delete-mfa)
+	// when an IAM user or role is denied access. To view an example response, see I
+	// Am Not Authorized to Perform: iam:DeleteVirtualMFADevice (https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_access-denied-delete-mfa)
 	// in the IAM User Guide.
 	GetCallerIdentity(ctx context.Context, params *GetCallerIdentityInput, optFns ...func(*Options)) (*GetCallerIdentityOutput, error)
-	// Returns a set of temporary security credentials (consisting of an access key ID,
-	// a secret access key, and a security token) for a federated user. A typical use
-	// is in a proxy application that gets temporary security credentials on behalf of
-	// distributed applications inside a corporate network. You must call the
+	// Returns a set of temporary security credentials (consisting of an access key
+	// ID, a secret access key, and a security token) for a federated user. A typical
+	// use is in a proxy application that gets temporary security credentials on behalf
+	// of distributed applications inside a corporate network. You must call the
 	// GetFederationToken operation using the long-term security credentials of an IAM
 	// user. As a result, this call is appropriate in contexts where those credentials
 	// can be safely stored, usually in a server-based application. For a comparison of
 	// GetFederationToken with the other API operations that produce temporary
-	// credentials, see Requesting Temporary Security Credentials
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
-	// and Comparing the Amazon Web Services STS API operations
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
+	// credentials, see Requesting Temporary Security Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
+	// and Comparing the Amazon Web Services STS API operations (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
 	// in the IAM User Guide. You can create a mobile-based or browser-based app that
 	// can authenticate users using a web identity provider like Login with Amazon,
 	// Facebook, Google, or an OpenID Connect-compatible identity provider. In this
 	// case, we recommend that you use Amazon Cognito (http://aws.amazon.com/cognito/)
-	// or AssumeRoleWithWebIdentity. For more information, see Federation Through a
-	// Web-based Identity Provider
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithwebidentity)
+	// or AssumeRoleWithWebIdentity . For more information, see Federation Through a
+	// Web-based Identity Provider (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithwebidentity)
 	// in the IAM User Guide. You can also call GetFederationToken using the security
 	// credentials of an Amazon Web Services account root user, but we do not recommend
 	// it. Instead, we recommend that you create an IAM user for the purpose of the
 	// proxy application. Then attach a policy to the IAM user that limits federated
 	// users to only the actions and resources that they need to access. For more
-	// information, see IAM Best Practices
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html) in the
-	// IAM User Guide. Session duration The temporary credentials are valid for the
-	// specified duration, from 900 seconds (15 minutes) up to a maximum of 129,600
+	// information, see IAM Best Practices (https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html)
+	// in the IAM User Guide. Session duration The temporary credentials are valid for
+	// the specified duration, from 900 seconds (15 minutes) up to a maximum of 129,600
 	// seconds (36 hours). The default session duration is 43,200 seconds (12 hours).
 	// Temporary credentials obtained by using the Amazon Web Services account root
 	// user credentials have a maximum duration of 3,600 seconds (1 hour). Permissions
 	// You can use the temporary credentials created by GetFederationToken in any
 	// Amazon Web Services service with the following exceptions:
+	//   - You cannot call any IAM operations using the CLI or the Amazon Web Services
+	//     API. This limitation does not apply to console sessions.
+	//   - You cannot call any STS operations except GetCallerIdentity .
 	//
-	// * You cannot call
-	// any IAM operations using the CLI or the Amazon Web Services API. This limitation
-	// does not apply to console sessions.
-	//
-	// * You cannot call any STS operations except
-	// GetCallerIdentity.
-	//
-	// You can use temporary credentials for single sign-on (SSO)
-	// to the console. You must pass an inline or managed session policy
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+	// You can use temporary credentials for single sign-on (SSO) to the console. You
+	// must pass an inline or managed session policy (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 	// to this operation. You can pass a single JSON policy document to use as an
 	// inline session policy. You can also specify up to 10 managed policy Amazon
 	// Resource Names (ARNs) to use as managed session policies. The plaintext that you
@@ -453,59 +372,51 @@ type STS interface {
 	// policies and the session policies that you pass. This gives you a way to further
 	// restrict the permissions for a federated user. You cannot use session policies
 	// to grant more permissions than those that are defined in the permissions policy
-	// of the IAM user. For more information, see Session Policies
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+	// of the IAM user. For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
 	// in the IAM User Guide. For information about using GetFederationToken to create
 	// temporary security credentials, see GetFederationToken—Federation Through a
-	// Custom Identity Broker
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_getfederationtoken).
-	// You can use the credentials to access a resource that has a resource-based
+	// Custom Identity Broker (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_getfederationtoken)
+	// . You can use the credentials to access a resource that has a resource-based
 	// policy. If that policy specifically references the federated user session in the
 	// Principal element of the policy, the session has the permissions allowed by the
 	// policy. These permissions are granted in addition to the permissions granted by
 	// the session policies. Tags (Optional) You can pass tag key-value pairs to your
 	// session. These are called session tags. For more information about session tags,
-	// see Passing Session Tags in STS
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html) in the
-	// IAM User Guide. You can create a mobile-based or browser-based app that can
-	// authenticate users using a web identity provider like Login with Amazon,
+	// see Passing Session Tags in STS (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+	// in the IAM User Guide. You can create a mobile-based or browser-based app that
+	// can authenticate users using a web identity provider like Login with Amazon,
 	// Facebook, Google, or an OpenID Connect-compatible identity provider. In this
 	// case, we recommend that you use Amazon Cognito (http://aws.amazon.com/cognito/)
-	// or AssumeRoleWithWebIdentity. For more information, see Federation Through a
-	// Web-based Identity Provider
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithwebidentity)
+	// or AssumeRoleWithWebIdentity . For more information, see Federation Through a
+	// Web-based Identity Provider (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithwebidentity)
 	// in the IAM User Guide. An administrator must grant you the permissions necessary
 	// to pass session tags. The administrator can also create granular permissions to
 	// allow you to pass only specific session tags. For more information, see
-	// Tutorial: Using Tags for Attribute-Based Access Control
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html)
+	// Tutorial: Using Tags for Attribute-Based Access Control (https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html)
 	// in the IAM User Guide. Tag key–value pairs are not case sensitive, but case is
 	// preserved. This means that you cannot have separate Department and department
-	// tag keys. Assume that the user that you are federating has the
-	// Department=Marketing tag and you pass the department=engineering session tag.
-	// Department and department are not saved as separate tags, and the session tag
-	// passed in the request takes precedence over the user tag.
+	// tag keys. Assume that the user that you are federating has the Department =
+	// Marketing tag and you pass the department = engineering session tag. Department
+	// and department are not saved as separate tags, and the session tag passed in
+	// the request takes precedence over the user tag.
 	GetFederationToken(ctx context.Context, params *GetFederationTokenInput, optFns ...func(*Options)) (*GetFederationTokenOutput, error)
-	// Returns a set of temporary credentials for an Amazon Web Services account or IAM
-	// user. The credentials consist of an access key ID, a secret access key, and a
-	// security token. Typically, you use GetSessionToken if you want to use MFA to
+	// Returns a set of temporary credentials for an Amazon Web Services account or
+	// IAM user. The credentials consist of an access key ID, a secret access key, and
+	// a security token. Typically, you use GetSessionToken if you want to use MFA to
 	// protect programmatic calls to specific Amazon Web Services API operations like
-	// Amazon EC2 StopInstances. MFA-enabled IAM users would need to call
+	// Amazon EC2 StopInstances . MFA-enabled IAM users would need to call
 	// GetSessionToken and submit an MFA code that is associated with their MFA device.
 	// Using the temporary security credentials that are returned from the call, IAM
 	// users can then make programmatic calls to API operations that require MFA
 	// authentication. If you do not supply a correct MFA code, then the API returns an
 	// access denied error. For a comparison of GetSessionToken with the other API
-	// operations that produce temporary credentials, see Requesting Temporary Security
-	// Credentials
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
-	// and Comparing the Amazon Web Services STS API operations
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
+	// operations that produce temporary credentials, see Requesting Temporary
+	// Security Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
+	// and Comparing the Amazon Web Services STS API operations (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison)
 	// in the IAM User Guide. No permissions are required for users to perform this
 	// operation. The purpose of the sts:GetSessionToken operation is to authenticate
 	// the user using MFA. You cannot use policies to control authentication
-	// operations. For more information, see Permissions for GetSessionToken
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_getsessiontoken.html)
+	// operations. For more information, see Permissions for GetSessionToken (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_getsessiontoken.html)
 	// in the IAM User Guide. Session Duration The GetSessionToken operation must be
 	// called by using the long-term Amazon Web Services security credentials of the
 	// Amazon Web Services account root user or an IAM user. Credentials that are
@@ -516,18 +427,12 @@ type STS interface {
 	// (1 hour), with a default of 1 hour. Permissions The temporary security
 	// credentials created by GetSessionToken can be used to make API calls to any
 	// Amazon Web Services service with the following exceptions:
+	//   - You cannot call any IAM API operations unless MFA authentication
+	//     information is included in the request.
+	//   - You cannot call any STS API except AssumeRole or GetCallerIdentity .
 	//
-	// * You cannot call
-	// any IAM API operations unless MFA authentication information is included in the
-	// request.
-	//
-	// * You cannot call any STS API except AssumeRole or
-	// GetCallerIdentity.
-	//
-	// We recommend that you do not call GetSessionToken with
-	// Amazon Web Services account root user credentials. Instead, follow our best
-	// practices
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#create-iam-users)
+	// We recommend that you do not call GetSessionToken with Amazon Web Services
+	// account root user credentials. Instead, follow our best practices (https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#create-iam-users)
 	// by creating one or more IAM users, giving them the necessary permissions, and
 	// using IAM users for everyday interaction with Amazon Web Services. The
 	// credentials that are returned by GetSessionToken are based on permissions
@@ -537,8 +442,7 @@ type STS interface {
 	// GetSessionToken is called using the credentials of an IAM user, the temporary
 	// credentials have the same permissions as the IAM user. For more information
 	// about using GetSessionToken to create temporary credentials, go to Temporary
-	// Credentials for Users in Untrusted Environments
-	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_getsessiontoken)
+	// Credentials for Users in Untrusted Environments (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_getsessiontoken)
 	// in the IAM User Guide.
 	GetSessionToken(ctx context.Context, params *GetSessionTokenInput, optFns ...func(*Options)) (*GetSessionTokenOutput, error)
 }

--- a/pkg/flux/flux_test.go
+++ b/pkg/flux/flux_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Flux", func() {
 		fluxClient, err = flux.NewClient(opts)
 		Expect(err).NotTo(HaveOccurred())
 		fluxClient.SetExecutor(fakeExecutor)
-		fakeExecutor.ExecWithOutReturns([]byte("flux version 0.13.3\n"), nil)
+		fakeExecutor.ExecWithOutReturns([]byte("flux version 2.0.0-rc.1\n"), nil)
 
 		binDir, err := os.MkdirTemp("", "bin")
 		Expect(err).NotTo(HaveOccurred())
@@ -96,7 +96,7 @@ var _ = Describe("Flux", func() {
 				})
 
 				It("returns an error saying older versions are not supported", func() {
-					Expect(fluxClient.PreFlight()).To(MatchError("found flux version 0.13.2, eksctl requires >= 0.13.3"))
+					Expect(fluxClient.PreFlight()).To(MatchError(ContainSubstring("found flux version 0.13.2, eksctl requires >= 0.13.3")))
 				})
 			})
 
@@ -116,7 +116,7 @@ var _ = Describe("Flux", func() {
 				})
 
 				It("returns an error", func() {
-					Expect(fluxClient.PreFlight()).To(MatchError("Invalid Semantic Version"))
+					Expect(fluxClient.PreFlight()).To(MatchError(ContainSubstring("failed to parse Flux version")))
 				})
 			})
 		})


### PR DESCRIPTION
### Description
The current validation errors with a hardcoded message `found flux version 0.13.2, eksctl requires >= 0.13.3` if you have the latest flux installed with version `2.0.0-rc.1`
This PR fixes this validation code and outputs correct error messages.

Closes : https://github.com/weaveworks/eksctl-ci/issues/82

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

