### PR TITLE
Temporarily remove failing Bottlerocket upgrade test

### DIFF
--- a/integration/tests/managed/managed_nodegroup_test.go
+++ b/integration/tests/managed/managed_nodegroup_test.go
@@ -623,7 +623,7 @@ var _ = Describe("(Integration) Create Managed Nodegroups", func() {
 				}
 
 				upgradeNg(initialAl2Nodegroup)
-				upgradeNg(bottlerocketNodegroup)
+				// upgradeNg(bottlerocketNodegroup) See https://github.com/weaveworks/eksctl/issues/6544.
 			})
 		})
 


### PR DESCRIPTION
### Description

Upgrading Bottlerocket nodegroups to 1.26 has been failing with this error:

```Couldn't proceed with upgrade process as new nodes are not joining node group bottlerocket-1```

This is due to https://github.com/bottlerocket-os/bottlerocket/issues/3013. 

This changelist temporarily removes the failing test until https://github.com/bottlerocket-os/bottlerocket/issues/3013 is out for managed nodegroups. 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

