### PR TITLE
Revert "Temporarily remove failing Bottlerocket upgrade test (#6540)"

### DIFF
--- a/integration/tests/managed/managed_nodegroup_test.go
+++ b/integration/tests/managed/managed_nodegroup_test.go
@@ -623,7 +623,7 @@ var _ = Describe("(Integration) Create Managed Nodegroups", func() {
 				}
 
 				upgradeNg(initialAl2Nodegroup)
-				// upgradeNg(bottlerocketNodegroup) See https://github.com/weaveworks/eksctl/issues/6544.
+				upgradeNg(bottlerocketNodegroup)
 			})
 		})
 


### PR DESCRIPTION
This reverts commit eae839257f798def1805444bc43c752ba3cff476.

### Description
Reverting the disabled test since a [new version](https://github.com/bottlerocket-os/bottlerocket/releases/tag/v1.13.4) is out

```
main ✗ $ kubectl get nodes -o wide -A  
NAME                                           STATUS   ROLES    AGE   VERSION               INTERNAL-IP      EXTERNAL-IP      OS-IMAGE                                       KERNEL-VERSION                  CONTAINER-RUNTIME
ip-192-168-20-155.us-west-2.compute.internal   Ready    <none>   60m   v1.25.6               192.168.20.155   54.189.254.199   Ubuntu 20.04.6 LTS                             5.15.0-1035-aws                 containerd://1.6.12
ip-192-168-20-69.us-west-2.compute.internal    Ready    <none>   65m   v1.25.6-eks-232056e   192.168.20.69    52.39.227.219    Bottlerocket OS 1.13.4 (aws-k8s-1.25-nvidia)   5.15.102                        containerd://1.6.19+bottlerocket
ip-192-168-22-200.us-west-2.compute.internal   Ready    <none>   67m   v1.25.7-eks-a59e1f0   192.168.22.200     52.36.157.122    Bottlerocket OS 1.13.4 (aws-k8s-1.26)          5.15.102                        containerd://1.6.19+bottlerocket
ip-192-168-52-165.us-west-2.compute.internal   Ready    <none>   64m   v1.25.6-eks-232056e   192.168.52.165   35.87.133.154    Bottlerocket OS 1.13.4 (aws-k8s-1.25-nvidia)   5.15.102                        containerd://1.6.19+bottlerocket
ip-192-168-67-130.us-west-2.compute.internal   Ready    <none>   46m   v1.26.2-eks-b106822   192.168.67.130   18.237.236.101   Bottlerocket OS 1.13.4 (aws-k8s-1.26)          5.15.102                        containerd://1.6.19+bottlerocket
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

