### PR TITLE
Add TagResource perm to EFS wellknown policy

### DIFF
--- a/pkg/cfn/builder/statement.go
+++ b/pkg/cfn/builder/statement.go
@@ -541,6 +541,16 @@ func efsCSIControllerStatements() []cft.MapOfInterfaces {
 		{
 			"Effect":   effectAllow,
 			"Resource": resourceAll,
+			"Action":   []string{"elasticfilesystem:TagResource"},
+			"Condition": map[string]interface{}{
+				"StringLike": map[string]string{
+					"aws:RequestTag/efs.csi.aws.com/cluster": "true",
+				},
+			},
+		},
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
 			"Action":   []string{"elasticfilesystem:DeleteAccessPoint"},
 			"Condition": map[string]interface{}{
 				"StringLike": map[string]string{


### PR DESCRIPTION
### Description

Closes: #6610 
AWS has tightened up IAM policy rules that now require the policy to include permission to apply tags (TagResource operation)

This change takes effect June 30th, 2023

See:
  https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/iam-policy-example.json#L26

Apologies, but I am unable to run unit tests due to various problems:
1. Scripts have hard-coded `/bin/bash` in shebangs (fixed locally, but not committed)
2. 16G machine ran out of memory when running `make test`
3. 32G machine files with:
  .goreleaser-local.yaml                           error=configuration is valid, but uses deprecated properties
  command failed                                   error=1 out of 1 configuration file(s) have issues

### Checklist
- [ ] Added tests that cover your change (if possible): Not sure if any required, as I cannot run the tests
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory): N/A
- [ ] Manually tested: Unable to run tests
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

