### PR TITLE
Fix readiness probe in HTTP test

### DIFF
--- a/integration/data/test-http.yaml
+++ b/integration/data/test-http.yaml
@@ -62,8 +62,9 @@ spec:
           failureThreshold: 3
           timeoutSeconds: 1
           exec:
-            command: ["/bin/sh", "-c"]
-            args:
-              - |
-                TOKEN=$(curl --fail --silent -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 300" "http://169.254.169.254/latest/api/token")
-                curl --fail --silent -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/local-ipv4"
+            command:
+              - /bin/sh
+              - -c
+              - |-
+                TOKEN=$(curl --fail --silent -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 300" "http://169.254.169.254/latest/api/token");
+                curl --fail --silent -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/local-ipv4";


### PR DESCRIPTION
### Description

The syntax for specifying a pod readiness probe was incorrect in the HTTP test, causing failures in the test suite for CRUD and managed nodegroups. 

Closes #6627 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

