### PR TITLE
Fix logging stack events logic for Trainium and Inferentia integration tests

### DIFF
--- a/integration/tests/inferentia/inferentia_test.go
+++ b/integration/tests/inferentia/inferentia_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 var (
-	defaultCluster          string
-	noInstallCluster        string
 	params                  *tests.Params
 	clusterWithNeuronPlugin string
 	clusterWithoutPlugin    string
@@ -35,8 +33,8 @@ func init() {
 	// Call testing.Init() prior to tests.NewParams(), as otherwise -test.* will not be recognised. See also: https://golang.org/doc/go1.13#testing
 	testing.Init()
 	params = tests.NewParams("inf1")
-	defaultCluster = params.ClusterName
-	noInstallCluster = params.NewClusterName("inf1-no-plugin")
+	clusterWithNeuronPlugin = params.ClusterName
+	clusterWithoutPlugin = params.NewClusterName("inf1-no-plugin")
 }
 
 func TestInferentia(t *testing.T) {
@@ -53,9 +51,6 @@ var _ = BeforeSuite(func() {
 		params.KubeconfigPath = f.Name()
 		params.KubeconfigTemp = true
 	}
-
-	clusterWithoutPlugin = noInstallCluster
-	clusterWithNeuronPlugin = defaultCluster
 
 	if !params.SkipCreate {
 		cmd := params.EksctlCreateCmd.WithArgs(
@@ -137,7 +132,7 @@ var _ = Describe("(Integration) Inferentia nodes", func() {
 			})
 
 			When("adding an unmanaged nodegroup by default", func() {
-				params.LogStacksEventsOnFailure()
+				params.LogStacksEventsOnFailureForCluster(clusterWithoutPlugin)
 				It("should install without error", func() {
 					cmd := params.EksctlCreateCmd.WithArgs(
 						"nodegroup",

--- a/integration/tests/trainium/trainium_test.go
+++ b/integration/tests/trainium/trainium_test.go
@@ -30,8 +30,6 @@ import (
 )
 
 var (
-	defaultCluster          string
-	noInstallCluster        string
 	params                  *tests.Params
 	clusterWithNeuronPlugin string
 	clusterWithoutPlugin    string
@@ -43,8 +41,8 @@ func init() {
 	// Call testing.Init() prior to tests.NewParams(), as otherwise -test.* will not be recognised. See also: https://golang.org/doc/go1.13#testing
 	testing.Init()
 	params = tests.NewParams("trn1")
-	defaultCluster = params.ClusterName
-	noInstallCluster = params.NewClusterName("trn1-no-plugin")
+	clusterWithNeuronPlugin = params.ClusterName
+	clusterWithoutPlugin = params.NewClusterName("trn1-no-plugin")
 }
 
 func TestTrainium(t *testing.T) {
@@ -61,9 +59,6 @@ var _ = BeforeSuite(func() {
 		params.KubeconfigPath = f.Name()
 		params.KubeconfigTemp = true
 	}
-
-	clusterWithoutPlugin = noInstallCluster
-	clusterWithNeuronPlugin = defaultCluster
 
 	if !params.SkipCreate {
 		cfg := NewConfig(params.Region)


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Related to #6571

This PR initialises cluster names before passing the variable to stack logs print function. We should be able to see some logs on future failures now 🤞 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

