### PR TITLE
Updated wellKnownPolicy for Cluster Autoscaler and LoadBalancer Contr…

### DIFF
--- a/pkg/cfn/builder/statement.go
+++ b/pkg/cfn/builder/statement.go
@@ -14,185 +14,239 @@ const (
 func loadBalancerControllerStatements() []cft.MapOfInterfaces {
 	return []cft.MapOfInterfaces{
 		{
-			"Effect":   effectAllow,
-			"Resource": addARNPartitionPrefix("ec2:*:*:security-group/*"),
-			"Action":   []string{"ec2:CreateTags"},
+			"Effect": effectAllow,
+			"Action": []string{"iam:CreateServiceLinkedRole"},
+			"Resource": resourceAll,
 			"Condition": map[string]interface{}{
 				"StringEquals": map[string]string{
-					"ec2:CreateAction": "CreateSecurityGroup",
-				},
-				"Null": map[string]string{
-					"aws:RequestTag/elbv2.k8s.aws/cluster": "false",
+					"iam:AWSServiceName": "elasticloadbalancing.amazonaws.com",
 				},
 			},
 		},
 		{
-			"Effect":   effectAllow,
-			"Resource": addARNPartitionPrefix("ec2:*:*:security-group/*"),
-			"Action": []string{
-				"ec2:CreateTags",
-				"ec2:DeleteTags",
+            "Effect": effectAllow,
+            "Action": []string{
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeInternetGateways",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeVpcPeeringConnections",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeInstances",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeTags",
+                "ec2:GetCoipPoolUsage",
+                "ec2:DescribeCoipPools",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeListenerCertificates",
+                "elasticloadbalancing:DescribeSSLPolicies",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeTags",
 			},
-			"Condition": map[string]interface{}{
-				"Null": map[string]string{
-					"aws:RequestTag/elbv2.k8s.aws/cluster":  "true",
-					"aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
-				},
-			},
-		},
+            "Resource": resourceAll,
+        },
 		{
-			"Effect":   effectAllow,
-			"Resource": resourceAll,
-			"Action": []string{
-				"elasticloadbalancing:CreateLoadBalancer",
-				"elasticloadbalancing:CreateTargetGroup",
+            "Effect": effectAllow,
+            "Action": []string{
+                "cognito-idp:DescribeUserPoolClient",
+                "acm:ListCertificates",
+                "acm:DescribeCertificate",
+                "iam:ListServerCertificates",
+                "iam:GetServerCertificate",
+                "waf-regional:GetWebACL",
+                "waf-regional:GetWebACLForResource",
+                "waf-regional:AssociateWebACL",
+                "waf-regional:DisassociateWebACL",
+                "wafv2:GetWebACL",
+                "wafv2:GetWebACLForResource",
+                "wafv2:AssociateWebACL",
+                "wafv2:DisassociateWebACL",
+                "shield:GetSubscriptionState",
+                "shield:DescribeProtection",
+                "shield:CreateProtection",
+                "shield:DeleteProtection",
 			},
-			"Condition": map[string]interface{}{
-				"Null": map[string]string{
-					"aws:RequestTag/elbv2.k8s.aws/cluster": "false",
-				},
+            "Resource": resourceAll,
+        },
+        {
+            "Effect": effectAllow,
+            "Action": []string{
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress",
 			},
-		},
+            "Resource": resourceAll,
+        },
 		{
-			"Effect": effectAllow,
-			"Resource": []*gfnt.Value{
-				addARNPartitionPrefix("elasticloadbalancing:*:*:targetgroup/*/*"),
-				addARNPartitionPrefix("elasticloadbalancing:*:*:loadbalancer/net/*/*"),
-				addARNPartitionPrefix("elasticloadbalancing:*:*:loadbalancer/app/*/*"),
+            "Effect": effectAllow,
+            "Action": []string{
+                "ec2:CreateSecurityGroup",
 			},
-			"Action": []string{
-				"elasticloadbalancing:AddTags",
-				"elasticloadbalancing:RemoveTags",
-			},
-			"Condition": map[string]interface{}{
-				"Null": map[string]string{
-					"aws:RequestTag/elbv2.k8s.aws/cluster":  "true",
-					"aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
-				},
-			},
-		},
+            "Resource": resourceAll,
+        },
 		{
-			"Effect": effectAllow,
-			"Resource": []*gfnt.Value{
-				addARNPartitionPrefix("elasticloadbalancing:*:*:listener/net/*/*/*"),
-				addARNPartitionPrefix("elasticloadbalancing:*:*:listener/app/*/*/*"),
-				addARNPartitionPrefix("elasticloadbalancing:*:*:listener-rule/net/*/*/*"),
-				addARNPartitionPrefix("elasticloadbalancing:*:*:listener-rule/app/*/*/*"),
+            "Effect": effectAllow,
+            "Action": []string{
+                "ec2:CreateTags",
 			},
-			"Action": []string{
-				"elasticloadbalancing:AddTags",
-				"elasticloadbalancing:RemoveTags",
-			},
-		},
+            "Resource": addARNPartitionPrefix("ec2:*:*:security-group/*"),
+            "Condition": map[string]interface{}{
+                "StringEquals": map[string]interface{}{
+                    "ec2:CreateAction": "CreateSecurityGroup",
+                },
+                "Null": map[string]string{
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false",
+                },
+            },
+        },
 		{
-			"Effect": effectAllow,
-			"Action": []string{
-				"elasticloadbalancing:AddTags",
+            "Effect": effectAllow,
+            "Action": []string{
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
 			},
-			"Resource": []*gfnt.Value{
-				addARNPartitionPrefix("elasticloadbalancing:*:*:targetgroup/*/*"),
-				addARNPartitionPrefix("elasticloadbalancing:*:*:loadbalancer/net/*/*"),
-				addARNPartitionPrefix("elasticloadbalancing:*:*:loadbalancer/app/*/*"),
+            "Resource": addARNPartitionPrefix("ec2:*:*:security-group/*"),
+            "Condition": map[string]interface{}{
+                "Null": map[string]string{
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
+                },
+            },
+        },
+		{
+            "Effect": effectAllow,
+            "Action": []string{
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DeleteSecurityGroup",
 			},
-			"Condition": map[string]interface{}{
-				"StringEquals": map[string]interface{}{
-					"elasticloadbalancing:CreateAction": []string{
-						"CreateTargetGroup",
-						"CreateLoadBalancer",
+            "Resource": resourceAll,
+            "Condition": map[string]interface{}{
+                "Null": map[string]string{
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
+                },
+            },
+        },
+		{
+            "Effect": effectAllow,
+            "Action": []string{
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateTargetGroup",
+			},
+            "Resource": resourceAll,
+            "Condition": map[string]interface{}{
+                "Null": map[string]string{
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false",
+                },
+            },
+        },
+        {
+            "Effect": effectAllow,
+            "Action": []string{
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:DeleteRule",
+			},
+            "Resource": resourceAll,
+        },
+        {
+            "Effect": effectAllow,
+            "Action": []string{
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags",
+			},
+            "Resource": []*gfnt.Value{
+                addARNPartitionPrefix("elasticloadbalancing:*:*:targetgroup/*/*"),
+                addARNPartitionPrefix("elasticloadbalancing:*:*:loadbalancer/net/*/*"),
+                addARNPartitionPrefix("elasticloadbalancing:*:*:loadbalancer/app/*/*"),
+			},
+            "Condition": map[string]interface{}{
+                "Null": map[string]string{
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
+                },
+            },
+        },
+        {
+            "Effect": effectAllow,
+            "Action": []string{
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags",
+			},
+            "Resource": []*gfnt.Value{
+                addARNPartitionPrefix("elasticloadbalancing:*:*:listener/net/*/*/*"),
+                addARNPartitionPrefix("elasticloadbalancing:*:*:listener/app/*/*/*"),
+                addARNPartitionPrefix("elasticloadbalancing:*:*:listener-rule/net/*/*/*"),
+                addARNPartitionPrefix("elasticloadbalancing:*:*:listener-rule/app/*/*/*"),
+			},
+        },
+        {
+            "Effect": effectAllow,
+            "Action": []string{
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:SetIpAddressType",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:DeleteTargetGroup",
+			},
+            "Resource": resourceAll,
+            "Condition": map[string]interface{}{
+                "Null": map[string]string{
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
+                },
+            },
+        },
+        {
+            "Effect": effectAllow,
+            "Action": []string{
+                "elasticloadbalancing:AddTags",
+			},
+            "Resource": []*gfnt.Value{
+                addARNPartitionPrefix("elasticloadbalancing:*:*:targetgroup/*/*"),
+                addARNPartitionPrefix("elasticloadbalancing:*:*:loadbalancer/net/*/*"),
+                addARNPartitionPrefix("elasticloadbalancing:*:*:loadbalancer/app/*/*"),
+			},
+            "Condition": map[string]interface{}{
+                "StringEquals": map[string]interface{}{
+                    "elasticloadbalancing:CreateAction": []string{
+                        "CreateTargetGroup",
+                        "CreateLoadBalancer",
 					},
-				},
-				"Null": map[string]string{
-					"aws:RequestTag/elbv2.k8s.aws/cluster": "false",
-				},
+                },
+                "Null": map[string]string{
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false",
+                },
+            },
+        },
+        {
+            "Effect": effectAllow,
+            "Action": []string{
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets",
 			},
-		},
-		{
-			"Effect":   effectAllow,
-			"Resource": resourceAll,
-			"Action": []string{
-				"ec2:AuthorizeSecurityGroupIngress",
-				"ec2:RevokeSecurityGroupIngress",
-				"ec2:DeleteSecurityGroup",
-				"elasticloadbalancing:ModifyLoadBalancerAttributes",
-				"elasticloadbalancing:SetIpAddressType",
-				"elasticloadbalancing:SetSecurityGroups",
-				"elasticloadbalancing:SetSubnets",
-				"elasticloadbalancing:DeleteLoadBalancer",
-				"elasticloadbalancing:ModifyTargetGroup",
-				"elasticloadbalancing:ModifyTargetGroupAttributes",
-				"elasticloadbalancing:DeleteTargetGroup",
+            "Resource": addARNPartitionPrefix("elasticloadbalancing:*:*:targetgroup/*/*"),
+        },
+        {
+            "Effect": effectAllow,
+            "Action": []string{
+                "elasticloadbalancing:SetWebAcl",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:AddListenerCertificates",
+                "elasticloadbalancing:RemoveListenerCertificates",
+                "elasticloadbalancing:ModifyRule",
 			},
-			"Condition": map[string]interface{}{
-				"Null": map[string]string{
-					"aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
-				},
-			},
-		},
-		{
-			"Effect":   effectAllow,
-			"Resource": addARNPartitionPrefix("elasticloadbalancing:*:*:targetgroup/*/*"),
-			"Action": []string{
-				"elasticloadbalancing:RegisterTargets",
-				"elasticloadbalancing:DeregisterTargets",
-			},
-		},
-		{
-			"Effect":   effectAllow,
-			"Resource": resourceAll,
-			"Action": []string{
-				"iam:CreateServiceLinkedRole",
-				"ec2:DescribeAccountAttributes",
-				"ec2:DescribeAddresses",
-				"ec2:DescribeAvailabilityZones",
-				"ec2:DescribeInternetGateways",
-				"ec2:DescribeVpcs",
-				"ec2:DescribeSubnets",
-				"ec2:DescribeSecurityGroups",
-				"ec2:DescribeInstances",
-				"ec2:DescribeNetworkInterfaces",
-				"ec2:DescribeTags",
-				"ec2:DescribeVpcPeeringConnections",
-				"elasticloadbalancing:DescribeLoadBalancers",
-				"elasticloadbalancing:DescribeLoadBalancerAttributes",
-				"elasticloadbalancing:DescribeListeners",
-				"elasticloadbalancing:DescribeListenerCertificates",
-				"elasticloadbalancing:DescribeSSLPolicies",
-				"elasticloadbalancing:DescribeRules",
-				"elasticloadbalancing:DescribeTargetGroups",
-				"elasticloadbalancing:DescribeTargetGroupAttributes",
-				"elasticloadbalancing:DescribeTargetHealth",
-				"elasticloadbalancing:DescribeTags",
-				"cognito-idp:DescribeUserPoolClient",
-				"acm:ListCertificates",
-				"acm:DescribeCertificate",
-				"iam:ListServerCertificates",
-				"iam:GetServerCertificate",
-				"waf-regional:GetWebACL",
-				"waf-regional:GetWebACLForResource",
-				"waf-regional:AssociateWebACL",
-				"waf-regional:DisassociateWebACL",
-				"wafv2:GetWebACL",
-				"wafv2:GetWebACLForResource",
-				"wafv2:AssociateWebACL",
-				"wafv2:DisassociateWebACL",
-				"shield:GetSubscriptionState",
-				"shield:DescribeProtection",
-				"shield:CreateProtection",
-				"shield:DeleteProtection",
-				"ec2:AuthorizeSecurityGroupIngress",
-				"ec2:RevokeSecurityGroupIngress",
-				"ec2:CreateSecurityGroup",
-				"elasticloadbalancing:CreateListener",
-				"elasticloadbalancing:DeleteListener",
-				"elasticloadbalancing:CreateRule",
-				"elasticloadbalancing:DeleteRule",
-				"elasticloadbalancing:SetWebAcl",
-				"elasticloadbalancing:ModifyListener",
-				"elasticloadbalancing:AddListenerCertificates",
-				"elasticloadbalancing:RemoveListenerCertificates",
-				"elasticloadbalancing:ModifyRule",
-			},
-		},
+            "Resource": resourceAll,
+        },
 	}
 }
 
@@ -282,11 +336,21 @@ func autoScalerStatements() []cft.MapOfInterfaces {
 				"autoscaling:DescribeAutoScalingGroups",
 				"autoscaling:DescribeAutoScalingInstances",
 				"autoscaling:DescribeLaunchConfigurations",
+				"autoscaling:DescribeScalingActivities",
 				"autoscaling:DescribeTags",
-				"autoscaling:SetDesiredCapacity",
-				"autoscaling:TerminateInstanceInAutoScalingGroup",
 				"ec2:DescribeInstanceTypes",
 				"ec2:DescribeLaunchTemplateVersions",
+			},
+		},
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"autoscaling:SetDesiredCapacity",
+				"autoscaling:TerminateInstanceInAutoScalingGroup",
+				"ec2:DescribeImages",
+				"ec2:GetInstanceTypesFromInstanceRequirements",
+				"eks:DescribeNodegroup",
 			},
 		},
 	}

--- a/pkg/cfn/builder/statement.go
+++ b/pkg/cfn/builder/statement.go
@@ -14,8 +14,8 @@ const (
 func loadBalancerControllerStatements() []cft.MapOfInterfaces {
 	return []cft.MapOfInterfaces{
 		{
-			"Effect": effectAllow,
-			"Action": []string{"iam:CreateServiceLinkedRole"},
+			"Effect":   effectAllow,
+			"Action":   []string{"iam:CreateServiceLinkedRole"},
 			"Resource": resourceAll,
 			"Condition": map[string]interface{}{
 				"StringEquals": map[string]string{
@@ -24,229 +24,229 @@ func loadBalancerControllerStatements() []cft.MapOfInterfaces {
 			},
 		},
 		{
-            "Effect": effectAllow,
-            "Action": []string{
-                "ec2:DescribeAccountAttributes",
-                "ec2:DescribeAddresses",
-                "ec2:DescribeAvailabilityZones",
-                "ec2:DescribeInternetGateways",
-                "ec2:DescribeVpcs",
-                "ec2:DescribeVpcPeeringConnections",
-                "ec2:DescribeSubnets",
-                "ec2:DescribeSecurityGroups",
-                "ec2:DescribeInstances",
-                "ec2:DescribeNetworkInterfaces",
-                "ec2:DescribeTags",
-                "ec2:GetCoipPoolUsage",
-                "ec2:DescribeCoipPools",
-                "elasticloadbalancing:DescribeLoadBalancers",
-                "elasticloadbalancing:DescribeLoadBalancerAttributes",
-                "elasticloadbalancing:DescribeListeners",
-                "elasticloadbalancing:DescribeListenerCertificates",
-                "elasticloadbalancing:DescribeSSLPolicies",
-                "elasticloadbalancing:DescribeRules",
-                "elasticloadbalancing:DescribeTargetGroups",
-                "elasticloadbalancing:DescribeTargetGroupAttributes",
-                "elasticloadbalancing:DescribeTargetHealth",
-                "elasticloadbalancing:DescribeTags",
+			"Effect": effectAllow,
+			"Action": []string{
+				"ec2:DescribeAccountAttributes",
+				"ec2:DescribeAddresses",
+				"ec2:DescribeAvailabilityZones",
+				"ec2:DescribeInternetGateways",
+				"ec2:DescribeVpcs",
+				"ec2:DescribeVpcPeeringConnections",
+				"ec2:DescribeSubnets",
+				"ec2:DescribeSecurityGroups",
+				"ec2:DescribeInstances",
+				"ec2:DescribeNetworkInterfaces",
+				"ec2:DescribeTags",
+				"ec2:GetCoipPoolUsage",
+				"ec2:DescribeCoipPools",
+				"elasticloadbalancing:DescribeLoadBalancers",
+				"elasticloadbalancing:DescribeLoadBalancerAttributes",
+				"elasticloadbalancing:DescribeListeners",
+				"elasticloadbalancing:DescribeListenerCertificates",
+				"elasticloadbalancing:DescribeSSLPolicies",
+				"elasticloadbalancing:DescribeRules",
+				"elasticloadbalancing:DescribeTargetGroups",
+				"elasticloadbalancing:DescribeTargetGroupAttributes",
+				"elasticloadbalancing:DescribeTargetHealth",
+				"elasticloadbalancing:DescribeTags",
 			},
-            "Resource": resourceAll,
-        },
+			"Resource": resourceAll,
+		},
 		{
-            "Effect": effectAllow,
-            "Action": []string{
-                "cognito-idp:DescribeUserPoolClient",
-                "acm:ListCertificates",
-                "acm:DescribeCertificate",
-                "iam:ListServerCertificates",
-                "iam:GetServerCertificate",
-                "waf-regional:GetWebACL",
-                "waf-regional:GetWebACLForResource",
-                "waf-regional:AssociateWebACL",
-                "waf-regional:DisassociateWebACL",
-                "wafv2:GetWebACL",
-                "wafv2:GetWebACLForResource",
-                "wafv2:AssociateWebACL",
-                "wafv2:DisassociateWebACL",
-                "shield:GetSubscriptionState",
-                "shield:DescribeProtection",
-                "shield:CreateProtection",
-                "shield:DeleteProtection",
+			"Effect": effectAllow,
+			"Action": []string{
+				"cognito-idp:DescribeUserPoolClient",
+				"acm:ListCertificates",
+				"acm:DescribeCertificate",
+				"iam:ListServerCertificates",
+				"iam:GetServerCertificate",
+				"waf-regional:GetWebACL",
+				"waf-regional:GetWebACLForResource",
+				"waf-regional:AssociateWebACL",
+				"waf-regional:DisassociateWebACL",
+				"wafv2:GetWebACL",
+				"wafv2:GetWebACLForResource",
+				"wafv2:AssociateWebACL",
+				"wafv2:DisassociateWebACL",
+				"shield:GetSubscriptionState",
+				"shield:DescribeProtection",
+				"shield:CreateProtection",
+				"shield:DeleteProtection",
 			},
-            "Resource": resourceAll,
-        },
-        {
-            "Effect": effectAllow,
-            "Action": []string{
-                "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:RevokeSecurityGroupIngress",
-			},
-            "Resource": resourceAll,
-        },
+			"Resource": resourceAll,
+		},
 		{
-            "Effect": effectAllow,
-            "Action": []string{
-                "ec2:CreateSecurityGroup",
+			"Effect": effectAllow,
+			"Action": []string{
+				"ec2:AuthorizeSecurityGroupIngress",
+				"ec2:RevokeSecurityGroupIngress",
 			},
-            "Resource": resourceAll,
-        },
+			"Resource": resourceAll,
+		},
 		{
-            "Effect": effectAllow,
-            "Action": []string{
-                "ec2:CreateTags",
+			"Effect": effectAllow,
+			"Action": []string{
+				"ec2:CreateSecurityGroup",
 			},
-            "Resource": addARNPartitionPrefix("ec2:*:*:security-group/*"),
-            "Condition": map[string]interface{}{
-                "StringEquals": map[string]interface{}{
-                    "ec2:CreateAction": "CreateSecurityGroup",
-                },
-                "Null": map[string]string{
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false",
-                },
-            },
-        },
+			"Resource": resourceAll,
+		},
 		{
-            "Effect": effectAllow,
-            "Action": []string{
-                "ec2:CreateTags",
-                "ec2:DeleteTags",
+			"Effect": effectAllow,
+			"Action": []string{
+				"ec2:CreateTags",
 			},
-            "Resource": addARNPartitionPrefix("ec2:*:*:security-group/*"),
-            "Condition": map[string]interface{}{
-                "Null": map[string]string{
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
-                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
-                },
-            },
-        },
+			"Resource": addARNPartitionPrefix("ec2:*:*:security-group/*"),
+			"Condition": map[string]interface{}{
+				"StringEquals": map[string]interface{}{
+					"ec2:CreateAction": "CreateSecurityGroup",
+				},
+				"Null": map[string]string{
+					"aws:RequestTag/elbv2.k8s.aws/cluster": "false",
+				},
+			},
+		},
 		{
-            "Effect": effectAllow,
-            "Action": []string{
-                "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:RevokeSecurityGroupIngress",
-                "ec2:DeleteSecurityGroup",
+			"Effect": effectAllow,
+			"Action": []string{
+				"ec2:CreateTags",
+				"ec2:DeleteTags",
 			},
-            "Resource": resourceAll,
-            "Condition": map[string]interface{}{
-                "Null": map[string]string{
-                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
-                },
-            },
-        },
+			"Resource": addARNPartitionPrefix("ec2:*:*:security-group/*"),
+			"Condition": map[string]interface{}{
+				"Null": map[string]string{
+					"aws:RequestTag/elbv2.k8s.aws/cluster":  "true",
+					"aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
+				},
+			},
+		},
 		{
-            "Effect": effectAllow,
-            "Action": []string{
-                "elasticloadbalancing:CreateLoadBalancer",
-                "elasticloadbalancing:CreateTargetGroup",
+			"Effect": effectAllow,
+			"Action": []string{
+				"ec2:AuthorizeSecurityGroupIngress",
+				"ec2:RevokeSecurityGroupIngress",
+				"ec2:DeleteSecurityGroup",
 			},
-            "Resource": resourceAll,
-            "Condition": map[string]interface{}{
-                "Null": map[string]string{
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false",
-                },
-            },
-        },
-        {
-            "Effect": effectAllow,
-            "Action": []string{
-                "elasticloadbalancing:CreateListener",
-                "elasticloadbalancing:DeleteListener",
-                "elasticloadbalancing:CreateRule",
-                "elasticloadbalancing:DeleteRule",
+			"Resource": resourceAll,
+			"Condition": map[string]interface{}{
+				"Null": map[string]string{
+					"aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
+				},
 			},
-            "Resource": resourceAll,
-        },
-        {
-            "Effect": effectAllow,
-            "Action": []string{
-                "elasticloadbalancing:AddTags",
-                "elasticloadbalancing:RemoveTags",
+		},
+		{
+			"Effect": effectAllow,
+			"Action": []string{
+				"elasticloadbalancing:CreateLoadBalancer",
+				"elasticloadbalancing:CreateTargetGroup",
 			},
-            "Resource": []*gfnt.Value{
-                addARNPartitionPrefix("elasticloadbalancing:*:*:targetgroup/*/*"),
-                addARNPartitionPrefix("elasticloadbalancing:*:*:loadbalancer/net/*/*"),
-                addARNPartitionPrefix("elasticloadbalancing:*:*:loadbalancer/app/*/*"),
+			"Resource": resourceAll,
+			"Condition": map[string]interface{}{
+				"Null": map[string]string{
+					"aws:RequestTag/elbv2.k8s.aws/cluster": "false",
+				},
 			},
-            "Condition": map[string]interface{}{
-                "Null": map[string]string{
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
-                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
-                },
-            },
-        },
-        {
-            "Effect": effectAllow,
-            "Action": []string{
-                "elasticloadbalancing:AddTags",
-                "elasticloadbalancing:RemoveTags",
+		},
+		{
+			"Effect": effectAllow,
+			"Action": []string{
+				"elasticloadbalancing:CreateListener",
+				"elasticloadbalancing:DeleteListener",
+				"elasticloadbalancing:CreateRule",
+				"elasticloadbalancing:DeleteRule",
 			},
-            "Resource": []*gfnt.Value{
-                addARNPartitionPrefix("elasticloadbalancing:*:*:listener/net/*/*/*"),
-                addARNPartitionPrefix("elasticloadbalancing:*:*:listener/app/*/*/*"),
-                addARNPartitionPrefix("elasticloadbalancing:*:*:listener-rule/net/*/*/*"),
-                addARNPartitionPrefix("elasticloadbalancing:*:*:listener-rule/app/*/*/*"),
+			"Resource": resourceAll,
+		},
+		{
+			"Effect": effectAllow,
+			"Action": []string{
+				"elasticloadbalancing:AddTags",
+				"elasticloadbalancing:RemoveTags",
 			},
-        },
-        {
-            "Effect": effectAllow,
-            "Action": []string{
-                "elasticloadbalancing:ModifyLoadBalancerAttributes",
-                "elasticloadbalancing:SetIpAddressType",
-                "elasticloadbalancing:SetSecurityGroups",
-                "elasticloadbalancing:SetSubnets",
-                "elasticloadbalancing:DeleteLoadBalancer",
-                "elasticloadbalancing:ModifyTargetGroup",
-                "elasticloadbalancing:ModifyTargetGroupAttributes",
-                "elasticloadbalancing:DeleteTargetGroup",
+			"Resource": []*gfnt.Value{
+				addARNPartitionPrefix("elasticloadbalancing:*:*:targetgroup/*/*"),
+				addARNPartitionPrefix("elasticloadbalancing:*:*:loadbalancer/net/*/*"),
+				addARNPartitionPrefix("elasticloadbalancing:*:*:loadbalancer/app/*/*"),
 			},
-            "Resource": resourceAll,
-            "Condition": map[string]interface{}{
-                "Null": map[string]string{
-                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
-                },
-            },
-        },
-        {
-            "Effect": effectAllow,
-            "Action": []string{
-                "elasticloadbalancing:AddTags",
+			"Condition": map[string]interface{}{
+				"Null": map[string]string{
+					"aws:RequestTag/elbv2.k8s.aws/cluster":  "true",
+					"aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
+				},
 			},
-            "Resource": []*gfnt.Value{
-                addARNPartitionPrefix("elasticloadbalancing:*:*:targetgroup/*/*"),
-                addARNPartitionPrefix("elasticloadbalancing:*:*:loadbalancer/net/*/*"),
-                addARNPartitionPrefix("elasticloadbalancing:*:*:loadbalancer/app/*/*"),
+		},
+		{
+			"Effect": effectAllow,
+			"Action": []string{
+				"elasticloadbalancing:AddTags",
+				"elasticloadbalancing:RemoveTags",
 			},
-            "Condition": map[string]interface{}{
-                "StringEquals": map[string]interface{}{
-                    "elasticloadbalancing:CreateAction": []string{
-                        "CreateTargetGroup",
-                        "CreateLoadBalancer",
+			"Resource": []*gfnt.Value{
+				addARNPartitionPrefix("elasticloadbalancing:*:*:listener/net/*/*/*"),
+				addARNPartitionPrefix("elasticloadbalancing:*:*:listener/app/*/*/*"),
+				addARNPartitionPrefix("elasticloadbalancing:*:*:listener-rule/net/*/*/*"),
+				addARNPartitionPrefix("elasticloadbalancing:*:*:listener-rule/app/*/*/*"),
+			},
+		},
+		{
+			"Effect": effectAllow,
+			"Action": []string{
+				"elasticloadbalancing:ModifyLoadBalancerAttributes",
+				"elasticloadbalancing:SetIpAddressType",
+				"elasticloadbalancing:SetSecurityGroups",
+				"elasticloadbalancing:SetSubnets",
+				"elasticloadbalancing:DeleteLoadBalancer",
+				"elasticloadbalancing:ModifyTargetGroup",
+				"elasticloadbalancing:ModifyTargetGroupAttributes",
+				"elasticloadbalancing:DeleteTargetGroup",
+			},
+			"Resource": resourceAll,
+			"Condition": map[string]interface{}{
+				"Null": map[string]string{
+					"aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
+				},
+			},
+		},
+		{
+			"Effect": effectAllow,
+			"Action": []string{
+				"elasticloadbalancing:AddTags",
+			},
+			"Resource": []*gfnt.Value{
+				addARNPartitionPrefix("elasticloadbalancing:*:*:targetgroup/*/*"),
+				addARNPartitionPrefix("elasticloadbalancing:*:*:loadbalancer/net/*/*"),
+				addARNPartitionPrefix("elasticloadbalancing:*:*:loadbalancer/app/*/*"),
+			},
+			"Condition": map[string]interface{}{
+				"StringEquals": map[string]interface{}{
+					"elasticloadbalancing:CreateAction": []string{
+						"CreateTargetGroup",
+						"CreateLoadBalancer",
 					},
-                },
-                "Null": map[string]string{
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false",
-                },
-            },
-        },
-        {
-            "Effect": effectAllow,
-            "Action": []string{
-                "elasticloadbalancing:RegisterTargets",
-                "elasticloadbalancing:DeregisterTargets",
+				},
+				"Null": map[string]string{
+					"aws:RequestTag/elbv2.k8s.aws/cluster": "false",
+				},
 			},
-            "Resource": addARNPartitionPrefix("elasticloadbalancing:*:*:targetgroup/*/*"),
-        },
-        {
-            "Effect": effectAllow,
-            "Action": []string{
-                "elasticloadbalancing:SetWebAcl",
-                "elasticloadbalancing:ModifyListener",
-                "elasticloadbalancing:AddListenerCertificates",
-                "elasticloadbalancing:RemoveListenerCertificates",
-                "elasticloadbalancing:ModifyRule",
+		},
+		{
+			"Effect": effectAllow,
+			"Action": []string{
+				"elasticloadbalancing:RegisterTargets",
+				"elasticloadbalancing:DeregisterTargets",
 			},
-            "Resource": resourceAll,
-        },
+			"Resource": addARNPartitionPrefix("elasticloadbalancing:*:*:targetgroup/*/*"),
+		},
+		{
+			"Effect": effectAllow,
+			"Action": []string{
+				"elasticloadbalancing:SetWebAcl",
+				"elasticloadbalancing:ModifyListener",
+				"elasticloadbalancing:AddListenerCertificates",
+				"elasticloadbalancing:RemoveListenerCertificates",
+				"elasticloadbalancing:ModifyRule",
+			},
+			"Resource": resourceAll,
+		},
 	}
 }
 


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

The default `wellKnowPolicies` for `awsLoadBalancerController` and `autoScaler` do not reflect the current recommended IAM Policies as shown:
https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/install/iam_policy.json
https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#full-cluster-autoscaler-features-policy-recommended

An eksctl user has expressed confusion on why the default policy hasn't been updated especially considering the default policy is lacking support for a feature of the `cluster-autoscaler` that includes scaling from 0: https://github.com/weaveworks/eksctl/issues/6616

I would like to bring these default policies up to parity with the current recommended policies and would like to know if there is any explanation of why they have not been updated.

`make unit-test` succeeded:
```
ok      github.com/weaveworks/eksctl/pkg/actions/addon  6.740s
ok      github.com/weaveworks/eksctl/pkg/actions/anywhere       1.622s
ok      github.com/weaveworks/eksctl/pkg/actions/cluster        5.018s
?       github.com/weaveworks/eksctl/pkg/actions/cluster/fakes  [no test files]
ok      github.com/weaveworks/eksctl/pkg/actions/fargate        3.113s
ok      github.com/weaveworks/eksctl/pkg/actions/flux   0.579s
?       github.com/weaveworks/eksctl/pkg/actions/flux/fakes     [no test files]
?       github.com/weaveworks/eksctl/pkg/actions/iamidentitymapping     [no test files]
ok      github.com/weaveworks/eksctl/pkg/actions/identityproviders      1.141s
ok      github.com/weaveworks/eksctl/pkg/actions/irsa   0.603s
ok      github.com/weaveworks/eksctl/pkg/actions/karpenter      5.980s
?       github.com/weaveworks/eksctl/pkg/actions/karpenter/fakes        [no test files]
ok      github.com/weaveworks/eksctl/pkg/actions/label  8.543s
?       github.com/weaveworks/eksctl/pkg/actions/label/fakes    [no test files]
ok      github.com/weaveworks/eksctl/pkg/actions/nodegroup      7.072s
?       github.com/weaveworks/eksctl/pkg/addons [no test files]
ok      github.com/weaveworks/eksctl/pkg/addons/default 6.742s
ok      github.com/weaveworks/eksctl/pkg/ami    5.310s
?       github.com/weaveworks/eksctl/pkg/apis/eksctl.io [no test files]
ok      github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5        0.647s
?       github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5/fakes  [no test files]
?       github.com/weaveworks/eksctl/pkg/assetutil      [no test files]
ok      github.com/weaveworks/eksctl/pkg/authconfigmap  0.560s
?       github.com/weaveworks/eksctl/pkg/awsapi [no test files]
?       github.com/weaveworks/eksctl/pkg/awsapi/generate        [no test files]
ok      github.com/weaveworks/eksctl/pkg/az     5.668s
ok      github.com/weaveworks/eksctl/pkg/cfn/builder    3.910s
?       github.com/weaveworks/eksctl/pkg/cfn/builder/fakes      [no test files]
ok      github.com/weaveworks/eksctl/pkg/cfn/manager    6.488s
?       github.com/weaveworks/eksctl/pkg/cfn/manager/fakes      [no test files]
ok      github.com/weaveworks/eksctl/pkg/cfn/outputs    0.535s
ok      github.com/weaveworks/eksctl/pkg/cfn/template   0.852s
?       github.com/weaveworks/eksctl/pkg/cfn/template/matchers  [no test files]
ok      github.com/weaveworks/eksctl/pkg/cfn/waiter     0.715s
ok      github.com/weaveworks/eksctl/pkg/cloudconfig    1.116s
ok      github.com/weaveworks/eksctl/pkg/connector      8.036s
ok      github.com/weaveworks/eksctl/pkg/credentials    1.003s
?       github.com/weaveworks/eksctl/pkg/credentials/fakes      [no test files]
?       github.com/weaveworks/eksctl/pkg/ctl/associate  [no test files]
ok      github.com/weaveworks/eksctl/pkg/ctl/cmdutils   9.587s
ok      github.com/weaveworks/eksctl/pkg/ctl/cmdutils/filter    7.029s
?       github.com/weaveworks/eksctl/pkg/ctl/cmdutils/filter/fakes      [no test files]
?       github.com/weaveworks/eksctl/pkg/ctl/cmdutils/filter/filterfakes  [no test files]
ok      github.com/weaveworks/eksctl/pkg/ctl/completion 0.537s
ok      github.com/weaveworks/eksctl/pkg/ctl/create     498.374s
?       github.com/weaveworks/eksctl/pkg/ctl/ctltest    [no test files]
ok      github.com/weaveworks/eksctl/pkg/ctl/delete     1.836s
?       github.com/weaveworks/eksctl/pkg/ctl/deregister [no test files]
ok      github.com/weaveworks/eksctl/pkg/ctl/disassociate       0.732s [no tests to run]
ok      github.com/weaveworks/eksctl/pkg/ctl/drain      1.191s
ok      github.com/weaveworks/eksctl/pkg/ctl/enable     2.073s
ok      github.com/weaveworks/eksctl/pkg/ctl/get        2.791s
?       github.com/weaveworks/eksctl/pkg/ctl/register   [no test files]
ok      github.com/weaveworks/eksctl/pkg/ctl/scale      2.181s
ok      github.com/weaveworks/eksctl/pkg/ctl/set        2.664s
ok      github.com/weaveworks/eksctl/pkg/ctl/unset      1.022s
ok      github.com/weaveworks/eksctl/pkg/ctl/update     1.109s
ok      github.com/weaveworks/eksctl/pkg/ctl/upgrade    1.781s
ok      github.com/weaveworks/eksctl/pkg/ctl/utils      1.348s
ok      github.com/weaveworks/eksctl/pkg/drain  32.010s
?       github.com/weaveworks/eksctl/pkg/drain/evictor  [no test files]
?       github.com/weaveworks/eksctl/pkg/drain/fakes    [no test files]
ok      github.com/weaveworks/eksctl/pkg/eks    5.647s
ok      github.com/weaveworks/eksctl/pkg/eks/auth       5.875s [no tests to run]
?       github.com/weaveworks/eksctl/pkg/eks/fakes      [no test files]
?       github.com/weaveworks/eksctl/pkg/eks/mocks      [no test files]
?       github.com/weaveworks/eksctl/pkg/eks/mocksv2    [no test files]
?       github.com/weaveworks/eksctl/pkg/eks/waiter     [no test files]
?       github.com/weaveworks/eksctl/pkg/elb    [no test files]
?       github.com/weaveworks/eksctl/pkg/executor       [no test files]
?       github.com/weaveworks/eksctl/pkg/executor/fakes [no test files]
ok      github.com/weaveworks/eksctl/pkg/fargate        1.583s
ok      github.com/weaveworks/eksctl/pkg/fargate/coredns        0.879s
ok      github.com/weaveworks/eksctl/pkg/flux   1.590s
?       github.com/weaveworks/eksctl/pkg/gitops [no test files]
ok      github.com/weaveworks/eksctl/pkg/iam    1.295s
ok      github.com/weaveworks/eksctl/pkg/iam/oidc       5.027s
ok      github.com/weaveworks/eksctl/pkg/info   0.887s
ok      github.com/weaveworks/eksctl/pkg/karpenter      0.678s
?       github.com/weaveworks/eksctl/pkg/karpenter/fakes        [no test files]
?       github.com/weaveworks/eksctl/pkg/karpenter/providers    [no test files]
?       github.com/weaveworks/eksctl/pkg/karpenter/providers/fakes      [no test files]
ok      github.com/weaveworks/eksctl/pkg/karpenter/providers/helm       6.927s
?       github.com/weaveworks/eksctl/pkg/kops   [no test files]
ok      github.com/weaveworks/eksctl/pkg/kubernetes     0.573s
ok      github.com/weaveworks/eksctl/pkg/managed        0.761s
ok      github.com/weaveworks/eksctl/pkg/nodebootstrap  0.578s
?       github.com/weaveworks/eksctl/pkg/nodebootstrap/assets   [no test files]
?       github.com/weaveworks/eksctl/pkg/nodebootstrap/fakes    [no test files]
?       github.com/weaveworks/eksctl/pkg/nodebootstrap/utils    [no test files]
ok      github.com/weaveworks/eksctl/pkg/outposts       4.502s
?       github.com/weaveworks/eksctl/pkg/outposts/fakes [no test files]
ok      github.com/weaveworks/eksctl/pkg/printers       1.198s
?       github.com/weaveworks/eksctl/pkg/ssh    [no test files]
ok      github.com/weaveworks/eksctl/pkg/ssh/client     0.653s
?       github.com/weaveworks/eksctl/pkg/testutils      [no test files]
?       github.com/weaveworks/eksctl/pkg/testutils/mockprovider [no test files]
ok      github.com/weaveworks/eksctl/pkg/utils  0.940s
ok      github.com/weaveworks/eksctl/pkg/utils/apierrors        0.552s
ok      github.com/weaveworks/eksctl/pkg/utils/dir      0.662s
?       github.com/weaveworks/eksctl/pkg/utils/file     [no test files]
ok      github.com/weaveworks/eksctl/pkg/utils/instance 0.659s
ok      github.com/weaveworks/eksctl/pkg/utils/ipnet    0.296s
ok      github.com/weaveworks/eksctl/pkg/utils/kubeconfig       0.964s
?       github.com/weaveworks/eksctl/pkg/utils/kubectl  [no test files]
ok      github.com/weaveworks/eksctl/pkg/utils/names    0.778s
?       github.com/weaveworks/eksctl/pkg/utils/nodes    [no test files]
ok      github.com/weaveworks/eksctl/pkg/utils/retry    0.784s
ok      github.com/weaveworks/eksctl/pkg/utils/strings  1.001s
ok      github.com/weaveworks/eksctl/pkg/utils/taints   1.177s
ok      github.com/weaveworks/eksctl/pkg/utils/tasks    1.212s [no tests to run]
?       github.com/weaveworks/eksctl/pkg/utils/waiters  [no test files]
ok      github.com/weaveworks/eksctl/pkg/version        0.562s
ok      github.com/weaveworks/eksctl/pkg/version/generate       0.702s
ok      github.com/weaveworks/eksctl/pkg/vpc    3.368s
?       github.com/weaveworks/eksctl/pkg/vpc/fakes      [no test files]
ok      github.com/weaveworks/eksctl/pkg/windows        0.455s [no tests to run]
?       github.com/weaveworks/eksctl/cmd/eksctl [no test files]
?       github.com/weaveworks/eksctl/cmd/schema [no test files]
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
Deployed test configuration using command
`eksctl create iamserviceaccount --config-file cluster.yaml --approve`
with configuration file
```
# An example of ClusterConfig with a normal nodegroup and a Fargate profile.
---
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: fargate-cluster
  region: us-west-2

nodeGroups:
  - name: ng-1
    instanceType: m5.large
    desiredCapacity: 1

fargateProfiles:
  - name: fp-default
    selectors:
      # All workloads in the "default" Kubernetes namespace will be
      # scheduled onto Fargate:
      - namespace: default
      # All workloads in the "kube-system" Kubernetes namespace will be
      # scheduled onto Fargate:
      - namespace: kube-system
iam:
  withOIDC: true
  serviceAccounts:
    - metadata:
        name: aws-load-balancer-controller
        namespace: kube-system
      wellKnownPolicies:
        awsLoadBalancerController: true
      roleName: eksctl-aws-lb-controller-testcluster
    - metadata:
        name: cluster-autoscaler
        namespace: kube-system
      wellKnownPolicies:
        autoScaler: true
```
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

