### PR TITLE
Make the output stream for eksctl command configurable

### DIFF
--- a/pkg/actions/nodegroup/create_test.go
+++ b/pkg/actions/nodegroup/create_test.go
@@ -3,6 +3,7 @@ package nodegroup_test
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
@@ -204,7 +205,10 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 			})
 		},
 		opts: nodegroup.CreateOpts{
-			DryRun:                    true,
+			DryRunSettings: nodegroup.DryRunSettings{
+				DryRun:    true,
+				OutStream: os.Stdout,
+			},
 			UpdateAuthConfigMap:       true,
 			InstallNeuronDevicePlugin: true,
 			InstallNvidiaDevicePlugin: true,
@@ -228,7 +232,10 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 			})
 		},
 		opts: nodegroup.CreateOpts{
-			DryRun:                    true,
+			DryRunSettings: nodegroup.DryRunSettings{
+				DryRun:    true,
+				OutStream: os.Stdout,
+			},
 			UpdateAuthConfigMap:       true,
 			InstallNeuronDevicePlugin: true,
 			InstallNvidiaDevicePlugin: true,
@@ -257,7 +264,10 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 			})
 		},
 		opts: nodegroup.CreateOpts{
-			DryRun:                    true,
+			DryRunSettings: nodegroup.DryRunSettings{
+				DryRun:    true,
+				OutStream: os.Stdout,
+			},
 			UpdateAuthConfigMap:       true,
 			InstallNeuronDevicePlugin: true,
 			InstallNvidiaDevicePlugin: true,
@@ -283,7 +293,10 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 			defaultProviderMocks(p, defaultOutput)
 		},
 		opts: nodegroup.CreateOpts{
-			DryRun:                    true,
+			DryRunSettings: nodegroup.DryRunSettings{
+				DryRun:    true,
+				OutStream: os.Stdout,
+			},
 			UpdateAuthConfigMap:       true,
 			InstallNeuronDevicePlugin: true,
 			InstallNvidiaDevicePlugin: true,
@@ -310,7 +323,10 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 			})
 		},
 		opts: nodegroup.CreateOpts{
-			DryRun:                    true,
+			DryRunSettings: nodegroup.DryRunSettings{
+				DryRun:    true,
+				OutStream: os.Stdout,
+			},
 			UpdateAuthConfigMap:       true,
 			InstallNeuronDevicePlugin: true,
 			InstallNvidiaDevicePlugin: true,
@@ -347,7 +363,10 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 			}, nil)
 		},
 		opts: nodegroup.CreateOpts{
-			DryRun:                    true,
+			DryRunSettings: nodegroup.DryRunSettings{
+				DryRun:    true,
+				OutStream: os.Stdout,
+			},
 			UpdateAuthConfigMap:       true,
 			InstallNeuronDevicePlugin: true,
 			InstallNvidiaDevicePlugin: true,
@@ -373,7 +392,10 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 			})
 		},
 		opts: nodegroup.CreateOpts{
-			DryRun:                    true,
+			DryRunSettings: nodegroup.DryRunSettings{
+				DryRun:    true,
+				OutStream: os.Stdout,
+			},
 			UpdateAuthConfigMap:       true,
 			InstallNeuronDevicePlugin: true,
 			InstallNvidiaDevicePlugin: true,
@@ -407,7 +429,10 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 			defaultProviderMocks(p, defaultOutput)
 		},
 		opts: nodegroup.CreateOpts{
-			DryRun:                    true,
+			DryRunSettings: nodegroup.DryRunSettings{
+				DryRun:    true,
+				OutStream: os.Stdout,
+			},
 			UpdateAuthConfigMap:       true,
 			InstallNeuronDevicePlugin: true,
 			InstallNvidiaDevicePlugin: true,

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"sync"
 
@@ -297,7 +296,7 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 	}
 
 	if params.DryRun {
-		return cmdutils.PrintDryRunConfig(cfg, os.Stdout)
+		return cmdutils.PrintDryRunConfig(cfg, cmd.CobraCommand.OutOrStdout())
 	}
 
 	if err := nodeGroupService.Normalize(ctx, nodePools, cfg); err != nil {

--- a/pkg/ctl/create/nodegroup.go
+++ b/pkg/ctl/create/nodegroup.go
@@ -72,9 +72,12 @@ func createNodeGroupCmd(cmd *cmdutils.Cmd) {
 			InstallNeuronDevicePlugin: options.InstallNeuronDevicePlugin,
 			InstallNvidiaDevicePlugin: options.InstallNvidiaDevicePlugin,
 			UpdateAuthConfigMap:       options.UpdateAuthConfigMap,
-			DryRun:                    options.DryRun,
-			SkipOutdatedAddonsCheck:   options.SkipOutdatedAddonsCheck,
-			ConfigFileProvided:        cmd.ClusterConfigFile != "",
+			DryRunSettings: nodegroup.DryRunSettings{
+				DryRun:    options.DryRun,
+				OutStream: cmd.CobraCommand.OutOrStdout(),
+			},
+			SkipOutdatedAddonsCheck: options.SkipOutdatedAddonsCheck,
+			ConfigFileProvided:      cmd.ClusterConfigFile != "",
 		}, ngFilter)
 	})
 }

--- a/pkg/ctl/get/addon.go
+++ b/pkg/ctl/get/addon.go
@@ -109,7 +109,7 @@ func getAddon(cmd *cmdutils.Cmd, a *api.Addon, params *getCmdParams) error {
 		addAddonSummaryTableColumns(printer.(*printers.TablePrinter))
 	}
 
-	if err := printer.PrintObjWithKind("addons", summaries, os.Stdout); err != nil {
+	if err := printer.PrintObjWithKind("addons", summaries, cmd.CobraCommand.OutOrStdout()); err != nil {
 		return err
 	}
 

--- a/pkg/ctl/get/cluster.go
+++ b/pkg/ctl/get/cluster.go
@@ -88,13 +88,13 @@ func doGetCluster(cmd *cmdutils.Cmd, params *getCmdParams, listAllRegions bool) 
 
 	ctx := context.Background()
 	if cfg.Metadata.Name == "" {
-		return getAndPrinterClusters(ctx, ctl, params, listAllRegions)
+		return getAndPrinterClusters(ctx, cmd, ctl, params, listAllRegions)
 	}
 
-	return getAndPrintCluster(ctx, cfg, ctl, params)
+	return getAndPrintCluster(ctx, cmd, cfg, ctl, params)
 }
 
-func getAndPrinterClusters(ctx context.Context, ctl *eks.ClusterProvider, params *getCmdParams, listAllRegions bool) error {
+func getAndPrinterClusters(ctx context.Context, cmd *cmdutils.Cmd, ctl *eks.ClusterProvider, params *getCmdParams, listAllRegions bool) error {
 	printer, err := printers.NewPrinter(params.output)
 	if err != nil {
 		return err
@@ -109,7 +109,7 @@ func getAndPrinterClusters(ctx context.Context, ctl *eks.ClusterProvider, params
 		return err
 	}
 
-	return printer.PrintObjWithKind("clusters", clusters, os.Stdout)
+	return printer.PrintObjWithKind("clusters", clusters, cmd.CobraCommand.OutOrStdout())
 }
 
 func addGetClustersSummaryTableColumns(printer *printers.TablePrinter) {
@@ -124,7 +124,7 @@ func addGetClustersSummaryTableColumns(printer *printers.TablePrinter) {
 	})
 }
 
-func getAndPrintCluster(ctx context.Context, cfg *api.ClusterConfig, ctl *eks.ClusterProvider, params *getCmdParams) error {
+func getAndPrintCluster(ctx context.Context, cmd *cmdutils.Cmd, cfg *api.ClusterConfig, ctl *eks.ClusterProvider, params *getCmdParams) error {
 	printer, err := printers.NewPrinter(params.output)
 	if err != nil {
 		return err
@@ -139,7 +139,7 @@ func getAndPrintCluster(ctx context.Context, cfg *api.ClusterConfig, ctl *eks.Cl
 		return err
 	}
 
-	return printer.PrintObjWithKind("clusters", []*ekstypes.Cluster{cluster}, os.Stdout)
+	return printer.PrintObjWithKind("clusters", []*ekstypes.Cluster{cluster}, cmd.CobraCommand.OutOrStdout())
 }
 
 func addGetClusterSummaryTableColumns(printer *printers.TablePrinter) {

--- a/pkg/ctl/get/fargate.go
+++ b/pkg/ctl/get/fargate.go
@@ -79,7 +79,7 @@ func doGetFargateProfile(cmd *cmdutils.Cmd, options *options) error {
 	if err != nil {
 		return err
 	}
-	return fargate.PrintProfiles(profiles, os.Stdout, options.output)
+	return fargate.PrintProfiles(profiles, cmd.CobraCommand.OutOrStdout(), options.output)
 }
 
 func getProfiles(ctx context.Context, manager *fargate.Client, name string) ([]*api.FargateProfile, error) {

--- a/pkg/ctl/get/iamidentitymapping.go
+++ b/pkg/ctl/get/iamidentitymapping.go
@@ -104,7 +104,7 @@ func doGetIAMIdentityMapping(cmd *cmdutils.Cmd, params *getCmdParams, arn string
 		addIAMIdentityMappingTableColumns(printer.(*printers.TablePrinter))
 	}
 
-	return printer.PrintObjWithKind("iamidentitymappings", identities, os.Stdout)
+	return printer.PrintObjWithKind("iamidentitymappings", identities, cmd.CobraCommand.OutOrStdout())
 }
 
 func addIAMIdentityMappingTableColumns(printer *printers.TablePrinter) {

--- a/pkg/ctl/get/iamserviceaccount.go
+++ b/pkg/ctl/get/iamserviceaccount.go
@@ -93,7 +93,7 @@ func doGetIAMServiceAccount(cmd *cmdutils.Cmd, options IAMServiceAccountOptions)
 		addIAMServiceAccountSummaryTableColumns(printer.(*printers.TablePrinter))
 	}
 
-	return printer.PrintObjWithKind("iamserviceaccounts", serviceAccounts, os.Stdout)
+	return printer.PrintObjWithKind("iamserviceaccounts", serviceAccounts, cmd.CobraCommand.OutOrStdout())
 }
 
 func addIAMServiceAccountSummaryTableColumns(printer *printers.TablePrinter) {

--- a/pkg/ctl/get/identityprovider.go
+++ b/pkg/ctl/get/identityprovider.go
@@ -81,7 +81,7 @@ func doGetIdentityProvider(cmd *cmdutils.Cmd, params getCmdParams, name string) 
 		addIdentityProviderTableColumns(printer.(*printers.TablePrinter))
 	}
 
-	return printer.PrintObjWithKind("identity provider summary", summaries, os.Stdout)
+	return printer.PrintObjWithKind("identity provider summary", summaries, cmd.CobraCommand.OutOrStdout())
 }
 
 func addIdentityProviderTableColumns(printer *printers.TablePrinter) {

--- a/pkg/ctl/get/labels.go
+++ b/pkg/ctl/get/labels.go
@@ -2,7 +2,6 @@ package get
 
 import (
 	"context"
-	"os"
 
 	"github.com/weaveworks/eksctl/pkg/cfn/manager"
 	"github.com/weaveworks/eksctl/pkg/managed"
@@ -64,7 +63,7 @@ func getLabels(cmd *cmdutils.Cmd, nodeGroupName string) error {
 
 	printer := printers.NewTablePrinter()
 	addColumns(printer.(*printers.TablePrinter))
-	return printer.PrintObjWithKind("labels", labels, os.Stdout)
+	return printer.PrintObjWithKind("labels", labels, cmd.CobraCommand.OutOrStdout())
 }
 
 func addColumns(printer *printers.TablePrinter) {

--- a/pkg/ctl/get/nodegroup.go
+++ b/pkg/ctl/get/nodegroup.go
@@ -106,7 +106,7 @@ func doGetNodeGroup(cmd *cmdutils.Cmd, ng *api.NodeGroup, params *getCmdParams) 
 		addSummaryTableColumns(printer.(*printers.TablePrinter))
 	}
 
-	return printer.PrintObjWithKind("nodegroups", summaries, os.Stdout)
+	return printer.PrintObjWithKind("nodegroups", summaries, cmd.CobraCommand.OutOrStdout())
 }
 
 func addSummaryTableColumns(printer *printers.TablePrinter) {

--- a/pkg/ctl/utils/describe_stacks.go
+++ b/pkg/ctl/utils/describe_stacks.go
@@ -104,7 +104,7 @@ func doDescribeStacksCmd(cmd *cmdutils.Cmd, all, events, trail bool, printer pri
 	}
 
 	if printer != nil {
-		return printer.PrintObj(stacks, os.Stdout)
+		return printer.PrintObj(stacks, cmd.CobraCommand.OutOrStdout())
 	}
 
 	for _, s := range stacks {


### PR DESCRIPTION
### Description

eksctl uses ```CobraCommand``` which supports a configurable buffer to dump the output. Previously, the output stream for eksctl was set to ```os.Stdout``` and therefore, it was not possible to modify the output buffer if required.

Closes https://github.com/weaveworks/eksctl/issues/5738

This PR removes the hard-coded mentions of ```os.Stdout``` for command output and replaces them with ```CobraCommand.OutOrStdout()```. The change has not been made in test files and hence the output of test results will still be directed to ```os.Stdout```

The PR also introduces a change in the ```CreateOpts``` struct on the following lines to introduce the custom ```io.Writer``` param. 

```
type CreateOpts struct {
	...
	DryRunSettings            DryRunSettings
	...
}

type DryRunSettings struct {
	DryRun bool
	Writer io.Writer
} 
```


```make unit-tests succeeded```

```
ok      github.com/weaveworks/eksctl/pkg/actions/addon  8.637s
ok      github.com/weaveworks/eksctl/pkg/actions/anywhere       2.389s
?       github.com/weaveworks/eksctl/pkg/actions/cluster/fakes  [no test files]
?       github.com/weaveworks/eksctl/pkg/actions/flux/fakes     [no test files]
?       github.com/weaveworks/eksctl/pkg/actions/iamidentitymapping     [no test files]
ok      github.com/weaveworks/eksctl/pkg/actions/cluster        3.835s
ok      github.com/weaveworks/eksctl/pkg/actions/fargate        5.207s
ok      github.com/weaveworks/eksctl/pkg/actions/flux   0.603s
ok      github.com/weaveworks/eksctl/pkg/actions/identityproviders      0.505s
ok      github.com/weaveworks/eksctl/pkg/actions/irsa   0.425s
?       github.com/weaveworks/eksctl/pkg/actions/karpenter/fakes        [no test files]
?       github.com/weaveworks/eksctl/pkg/actions/label/fakes    [no test files]
?       github.com/weaveworks/eksctl/pkg/addons [no test files]
ok      github.com/weaveworks/eksctl/pkg/actions/karpenter      4.794s
ok      github.com/weaveworks/eksctl/pkg/actions/label  5.518s
?       github.com/weaveworks/eksctl/pkg/apis/eksctl.io [no test files]
ok      github.com/weaveworks/eksctl/pkg/actions/nodegroup      7.984s
ok      github.com/weaveworks/eksctl/pkg/addons/default 6.062s
?       github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5/fakes  [no test files]
?       github.com/weaveworks/eksctl/pkg/assetutil      [no test files]
ok      github.com/weaveworks/eksctl/pkg/ami    5.709s
ok      github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5        0.493s
?       github.com/weaveworks/eksctl/pkg/awsapi [no test files]
?       github.com/weaveworks/eksctl/pkg/awsapi/generate        [no test files]
ok      github.com/weaveworks/eksctl/pkg/authconfigmap  0.452s
?       github.com/weaveworks/eksctl/pkg/cfn/builder/fakes      [no test files]
?       github.com/weaveworks/eksctl/pkg/cfn/manager/fakes      [no test files]
?       github.com/weaveworks/eksctl/pkg/cfn/template/matchers  [no test files]
?       github.com/weaveworks/eksctl/pkg/credentials/fakes      [no test files]
?       github.com/weaveworks/eksctl/pkg/ctl/associate  [no test files]
ok      github.com/weaveworks/eksctl/pkg/az     7.356s
ok      github.com/weaveworks/eksctl/pkg/cfn/builder    5.607s
?       github.com/weaveworks/eksctl/pkg/ctl/cmdutils/filter/fakes      [no test files]
?       github.com/weaveworks/eksctl/pkg/ctl/cmdutils/filter/filterfakes        [no test files]
ok      github.com/weaveworks/eksctl/pkg/cfn/manager    14.129s
ok      github.com/weaveworks/eksctl/pkg/cfn/outputs    1.457s
ok      github.com/weaveworks/eksctl/pkg/cfn/template   0.693s
ok      github.com/weaveworks/eksctl/pkg/cfn/waiter     0.417s
ok      github.com/weaveworks/eksctl/pkg/cloudconfig    0.604s
ok      github.com/weaveworks/eksctl/pkg/connector      16.123s
ok      github.com/weaveworks/eksctl/pkg/credentials    0.505s
ok      github.com/weaveworks/eksctl/pkg/ctl/cmdutils   13.572s
ok      github.com/weaveworks/eksctl/pkg/ctl/cmdutils/filter    7.551s
ok      github.com/weaveworks/eksctl/pkg/ctl/completion 0.467s
?       github.com/weaveworks/eksctl/pkg/ctl/ctltest    [no test files]
?       github.com/weaveworks/eksctl/pkg/ctl/deregister [no test files]
?       github.com/weaveworks/eksctl/pkg/ctl/register   [no test files]
?       github.com/weaveworks/eksctl/pkg/drain/fakes    [no test files]
?       github.com/weaveworks/eksctl/pkg/drain/evictor  [no test files]
?       github.com/weaveworks/eksctl/pkg/eks/fakes      [no test files]
?       github.com/weaveworks/eksctl/pkg/eks/mocks      [no test files]
?       github.com/weaveworks/eksctl/pkg/eks/mocksv2    [no test files]
?       github.com/weaveworks/eksctl/pkg/eks/waiter     [no test files]
?       github.com/weaveworks/eksctl/pkg/elb    [no test files]
?       github.com/weaveworks/eksctl/pkg/executor       [no test files]
?       github.com/weaveworks/eksctl/pkg/executor/fakes [no test files]
?       github.com/weaveworks/eksctl/pkg/gitops [no test files]
?       github.com/weaveworks/eksctl/pkg/karpenter/fakes        [no test files]
?       github.com/weaveworks/eksctl/pkg/karpenter/providers/fakes      [no test files]
?       github.com/weaveworks/eksctl/pkg/karpenter/providers    [no test files]
?       github.com/weaveworks/eksctl/pkg/kops   [no test files]
?       github.com/weaveworks/eksctl/pkg/nodebootstrap/assets   [no test files]
?       github.com/weaveworks/eksctl/pkg/nodebootstrap/fakes    [no test files]
?       github.com/weaveworks/eksctl/pkg/nodebootstrap/utils    [no test files]
?       github.com/weaveworks/eksctl/pkg/outposts/fakes [no test files]
?       github.com/weaveworks/eksctl/pkg/ssh    [no test files]
?       github.com/weaveworks/eksctl/pkg/testutils      [no test files]
?       github.com/weaveworks/eksctl/pkg/testutils/mockprovider [no test files]
?       github.com/weaveworks/eksctl/pkg/utils/file     [no test files]
?       github.com/weaveworks/eksctl/pkg/utils/kubectl  [no test files]
?       github.com/weaveworks/eksctl/pkg/utils/nodes    [no test files]
?       github.com/weaveworks/eksctl/pkg/utils/waiters  [no test files]
?       github.com/weaveworks/eksctl/pkg/vpc/fakes      [no test files]
?       github.com/weaveworks/eksctl/cmd/eksctl [no test files]
?       github.com/weaveworks/eksctl/cmd/schema [no test files]
ok      github.com/weaveworks/eksctl/pkg/ctl/create     491.924s
ok      github.com/weaveworks/eksctl/pkg/ctl/delete     1.694s
ok      github.com/weaveworks/eksctl/pkg/ctl/disassociate       2.041s [no tests to run]
ok      github.com/weaveworks/eksctl/pkg/ctl/drain      2.810s
ok      github.com/weaveworks/eksctl/pkg/ctl/enable     3.334s
ok      github.com/weaveworks/eksctl/pkg/ctl/get        2.430s
ok      github.com/weaveworks/eksctl/pkg/ctl/scale      0.852s
ok      github.com/weaveworks/eksctl/pkg/ctl/set        0.736s
ok      github.com/weaveworks/eksctl/pkg/ctl/unset      1.346s
ok      github.com/weaveworks/eksctl/pkg/ctl/update     2.417s
ok      github.com/weaveworks/eksctl/pkg/ctl/upgrade    0.789s
ok      github.com/weaveworks/eksctl/pkg/ctl/utils      1.702s
ok      github.com/weaveworks/eksctl/pkg/drain  31.287s
ok      github.com/weaveworks/eksctl/pkg/eks    7.804s
ok      github.com/weaveworks/eksctl/pkg/eks/auth       5.493s [no tests to run]
ok      github.com/weaveworks/eksctl/pkg/fargate        0.514s
ok      github.com/weaveworks/eksctl/pkg/fargate/coredns        0.865s
ok      github.com/weaveworks/eksctl/pkg/flux   1.200s
ok      github.com/weaveworks/eksctl/pkg/iam    0.435s
ok      github.com/weaveworks/eksctl/pkg/iam/oidc       4.332s
ok      github.com/weaveworks/eksctl/pkg/info   0.927s
ok      github.com/weaveworks/eksctl/pkg/karpenter      0.460s
ok      github.com/weaveworks/eksctl/pkg/karpenter/providers/helm       13.194s
ok      github.com/weaveworks/eksctl/pkg/kubernetes     0.961s
ok      github.com/weaveworks/eksctl/pkg/managed        0.511s
ok      github.com/weaveworks/eksctl/pkg/nodebootstrap  0.878s
ok      github.com/weaveworks/eksctl/pkg/outposts       7.533s
ok      github.com/weaveworks/eksctl/pkg/printers       0.861s
ok      github.com/weaveworks/eksctl/pkg/ssh/client     0.843s
ok      github.com/weaveworks/eksctl/pkg/utils  1.391s
ok      github.com/weaveworks/eksctl/pkg/utils/apierrors        1.773s
ok      github.com/weaveworks/eksctl/pkg/utils/dir      1.779s
ok      github.com/weaveworks/eksctl/pkg/utils/instance 1.083s
ok      github.com/weaveworks/eksctl/pkg/utils/ipnet    0.621s
ok      github.com/weaveworks/eksctl/pkg/utils/kubeconfig       1.125s
ok      github.com/weaveworks/eksctl/pkg/utils/names    0.543s
ok      github.com/weaveworks/eksctl/pkg/utils/retry    0.494s
ok      github.com/weaveworks/eksctl/pkg/utils/strings  0.550s
ok      github.com/weaveworks/eksctl/pkg/utils/taints   1.097s
ok      github.com/weaveworks/eksctl/pkg/utils/tasks    0.682s [no tests to run]
ok      github.com/weaveworks/eksctl/pkg/version        0.531s
ok      github.com/weaveworks/eksctl/pkg/version/generate       0.618s
ok      github.com/weaveworks/eksctl/pkg/vpc    2.922s
ok      github.com/weaveworks/eksctl/pkg/windows        0.388s [no tests to run]
```
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
Tested by invocking ```eksctl``` command interface in test code as shown below and ensuring that the output is being directed to the correct buffer.
```
func main() {
	flagGrouping := cmdutils.NewGrouping()
	c := get.Command(flagGrouping)
	c.SetArgs([]string{"cluster", "--name", "test", "--output", "json"})

	buf := bytes.NewBufferString("")
	c.SetOut(buf)
	err := c.Execute()
	if err != nil {
		panic(err)
	}
       fmt.Println("Printing buffer output")
	fmt.Println(buf.String())
```
(code taken from the concerned [issue](https://github.com/weaveworks/eksctl/issues/5738))
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2: