### PR TITLE
Update vpc-cni to 1.12.6

### DIFF
--- a/pkg/addons/default/assets/aws-node.yaml
+++ b/pkg/addons/default/assets/aws-node.yaml
@@ -1,26 +1,9 @@
 ---
-# Source: aws-vpc-cni/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: aws-node
-  namespace: kube-system
-  labels:
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/instance: aws-vpc-cni
-    k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.3"
----
-# Source: aws-vpc-cni/templates/customresourcedefinition.yaml
+# Source: crds/customresourcedefinition.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: eniconfigs.crd.k8s.amazonaws.com
-  labels:
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/instance: aws-vpc-cni
-    k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.3"
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
@@ -37,6 +20,19 @@ spec:
     plural: eniconfigs
     singular: eniconfig
     kind: ENIConfig
+
+---
+# Source: aws-vpc-cni/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-node
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.12.6"
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -47,7 +43,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.3"
+    app.kubernetes.io/version: "v1.12.6"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -73,7 +69,7 @@ rules:
   - apiGroups: ["", "events.k8s.io"]
     resources:
       - events
-    verbs: ["create", "patch", "list", "get"]
+    verbs: ["create", "patch", "list"]
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -84,7 +80,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.3"
+    app.kubernetes.io/version: "v1.12.6"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -104,7 +100,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.11.3"
+    app.kubernetes.io/version: "v1.12.6"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -125,7 +121,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.3"
+        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6"
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
@@ -143,7 +139,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.3"
+          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.6"
           ports:
             - containerPort: 61678
               name: metrics
@@ -172,8 +168,6 @@ spec:
               value: "true"
             - name: AWS_VPC_ENI_MTU
               value: "9001"
-            - name: AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER
-              value: "false"
             - name: AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG
               value: "false"
             - name: AWS_VPC_K8S_CNI_EXTERNALSNAT
@@ -212,6 +206,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           resources:
             requests:
               cpu: 25m
@@ -219,7 +217,7 @@ spec:
             capabilities:
               add:
               - NET_ADMIN
-            allowPrivilegeEscalation: false
+              - NET_RAW
           volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
@@ -227,8 +225,6 @@ spec:
             name: cni-net-dir
           - mountPath: /host/var/log/aws-routed-eni
             name: log-dir
-          - mountPath: /var/run/dockershim.sock
-            name: dockershim
           - mountPath: /var/run/aws-node
             name: run-dir
           - mountPath: /run/xtables.lock
@@ -240,9 +236,6 @@ spec:
       - name: cni-net-dir
         hostPath:
           path: /etc/cni/net.d
-      - name: dockershim
-        hostPath:
-          path: /var/run/dockershim.sock
       - name: log-dir
         hostPath:
           path: /var/log/aws-routed-eni

--- a/pkg/addons/default/aws_node_generate.go
+++ b/pkg/addons/default/aws_node_generate.go
@@ -1,4 +1,4 @@
 package defaultaddons
 
 // Please refer to https://docs.aws.amazon.com/eks/latest/userguide/cni-upgrades.html
-//go:generate curl --silent --location https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.11.3/config/master/aws-k8s-cni.yaml?raw=1 --output assets/aws-node.yaml
+//go:generate curl --silent --location https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.12.6/config/master/aws-k8s-cni.yaml?raw=1 --output assets/aws-node.yaml

--- a/pkg/addons/default/aws_node_test.go
+++ b/pkg/addons/default/aws_node_test.go
@@ -78,11 +78,11 @@ var _ = Describe("AWS Node", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(awsNode.Spec.Template.Spec.Containers).To(HaveLen(1))
 				Expect(awsNode.Spec.Template.Spec.Containers[0].Image).To(
-					Equal("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:v1.11.3"),
+					Equal("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:v1.12.6"),
 				)
 				Expect(awsNode.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 				Expect(awsNode.Spec.Template.Spec.InitContainers[0].Image).To(
-					Equal("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni-init:v1.11.3"),
+					Equal("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6"),
 				)
 			})
 		})
@@ -98,11 +98,11 @@ var _ = Describe("AWS Node", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(awsNode.Spec.Template.Spec.Containers).To(HaveLen(1))
 				Expect(awsNode.Spec.Template.Spec.Containers[0].Image).To(
-					Equal("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.11.3"),
+					Equal("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.12.6"),
 				)
 				Expect(awsNode.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 				Expect(awsNode.Spec.Template.Spec.InitContainers[0].Image).To(
-					Equal("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.11.3"),
+					Equal("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.12.6"),
 				)
 			})
 		})


### PR DESCRIPTION
### Description

vpc-cni version 1.11 isnt supported for kubernetes 1.26.

see: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
```
Before you upgrade to Kubernetes 1.26, upgrade your Amazon VPC CNI plugin for Kubernetes to version 1.12 or later. If you don't upgrade to Kubernetes 1.26, earlier versions of the Amazon VPC CNI plugin for Kubernetes crash. For more information, see [Working with the Amazon VPC CNI plugin for Kubernetes for Kubernetes Amazon EKS add-on](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html).
```

Also for 1.25 it is suggested to use v1.11.4+
See: 
https://github.com/aws/amazon-vpc-cni-k8s#recommended-version

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

