### PR TITLE
Fix CoreDNS probes for Kubernetes 1.26

### DIFF
--- a/pkg/addons/default/assets/coredns-1.26.json
+++ b/pkg/addons/default/assets/coredns-1.26.json
@@ -175,8 +175,8 @@
                 "livenessProbe": {
                   "failureThreshold": 5,
                   "httpGet": {
-                    "path": "/ready",
-                    "port": 8181,
+                    "path": "/health",
+                    "port": 8080,
                     "scheme": "HTTP"
                   },
                   "initialDelaySeconds": 60,
@@ -205,8 +205,8 @@
                 "readinessProbe": {
                   "failureThreshold": 3,
                   "httpGet": {
-                    "path": "/health",
-                    "port": 8080,
+                    "path": "/ready",
+                    "port": 8181,
                     "scheme": "HTTP"
                   },
                   "periodSeconds": 10,

--- a/pkg/addons/default/testdata/sample-1.22.json
+++ b/pkg/addons/default/testdata/sample-1.22.json
@@ -338,7 +338,7 @@
                 "livenessProbe": {
                   "failureThreshold": 5,
                   "httpGet": {
-                    "path": "/ready",
+                    "path": "/health",
                     "port": 8181,
                     "scheme": "HTTP"
                   },
@@ -368,7 +368,7 @@
                 "readinessProbe": {
                   "failureThreshold": 3,
                   "httpGet": {
-                    "path": "/health",
+                    "path": "/ready",
                     "port": 8080,
                     "scheme": "HTTP"
                   },

--- a/pkg/addons/default/testdata/sample-1.25.json
+++ b/pkg/addons/default/testdata/sample-1.25.json
@@ -361,7 +361,7 @@
                 "livenessProbe": {
                   "failureThreshold": 5,
                   "httpGet": {
-                    "path": "/ready",
+                    "path": "/health",
                     "port": 8181,
                     "scheme": "HTTP"
                   },
@@ -391,7 +391,7 @@
                 "readinessProbe": {
                   "failureThreshold": 3,
                   "httpGet": {
-                    "path": "/health",
+                    "path": "/ready",
                     "port": 8080,
                     "scheme": "HTTP"
                   },


### PR DESCRIPTION
### Description

I somehow changed the livenessProbe in 1.26 release instead of the readinessProbe.
for 1.25 and 1.27 it is fine.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

