### PR TITLE
Fix generating mocks for aws-sdk-go-v2 interfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ generated_code_deep_copy_helper := pkg/apis/eksctl.io/v1alpha5/zz_generated.deep
 generated_code_aws_sdk_mocks := $(wildcard pkg/eks/mocks/*API.go)
 
 conditionally_generated_files := \
-  $(generated_code_deep_copy_helper) $(generated_code_aws_sdk_mocks) $(generated_code_aws_sdk_v2_mocks)
+  $(generated_code_deep_copy_helper) $(generated_code_aws_sdk_mocks)
 
 .DEFAULT_GOAL := help
 
@@ -144,6 +144,7 @@ generate-always: pkg/addons/default/assets/aws-node.yaml ## Generate code (requi
 	go generate ./pkg/authconfigmap
 	go generate ./pkg/awsapi/...
 	go generate ./pkg/eks
+	AWS_SDK_V2_GO_DIR=$(AWS_SDK_V2_GO_DIR) go generate ./pkg/eks/mocksv2
 	go generate ./pkg/drain
 	go generate ./pkg/actions/...
 	go generate ./pkg/executor
@@ -172,8 +173,6 @@ $(generated_code_deep_copy_helper): $(deep_copy_helper_input) ## Generate Kuber
 $(generated_code_aws_sdk_mocks): $(call godeps,pkg/eks/mocks/mocks.go) ## Generate AWS SDK mocks
 	AWS_SDK_GO_DIR=$(AWS_SDK_GO_DIR) go generate ./pkg/eks/mocks
 
-$(generated_code_aws_sdk_v2_mocks): $(call godeps,pkg/eks/mockv2s/generate.go) ## Generate AWS SDK V2 mocks
-	AWS_SDK_GO_DIR=$(AWS_SDK_V2_GO_DIR) go generate ./pkg/eks/mocksv2
 
 .PHONY: generate-kube-reserved
 generate-kube-reserved: ## Update instance list with respective specs


### PR DESCRIPTION
### Description

Mocks for `aws-sdk-go-v2` interfaces in `pkg/eks/mocksv2` are no longer being generated, even if the interfaces have changed. This is not because of a typo (`pkg/eks/mocksv2/generate.go`) in the prerequisite in https://github.com/weaveworks/eksctl/blob/4759a2ab6a8fe7fb384c210dbc33d21364bf712f/Makefile#L175.  This changelist reverts conditionally generating mocks for aws-sdk-go-v2 interfaces. 

Closes #6776 

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

