### PR TITLE
Aim for namespace uniqueness across parallel integration tests specs

### DIFF
--- a/integration/utilities/kube/kube.go
+++ b/integration/utilities/kube/kube.go
@@ -4,17 +4,16 @@
 package kube
 
 import (
-	"fmt"
-
 	harness "github.com/dlespiau/kube-test-harness"
 	"github.com/dlespiau/kube-test-harness/logger"
+	"github.com/google/uuid"
 	"github.com/onsi/ginkgo/v2"
 )
 
 type tHelper struct{ ginkgo.FullGinkgoTInterface }
 
 func (t *tHelper) Helper()      {}
-func (t *tHelper) Name() string { return "eksctl-test" }
+func (t *tHelper) Name() string { return "eksctl" }
 
 // NewTest creates a new test harness to more easily run integration tests against the provided Kubernetes cluster.
 func NewTest(kubeconfigPath string) (*harness.Test, error) {
@@ -28,7 +27,9 @@ func NewTest(kubeconfigPath string) (*harness.Test, error) {
 		return nil, err
 	}
 	test := h.NewTest(t)
-	test.Namespace += fmt.Sprintf("-%d", t.ParallelProcess())
+	// several parallel test specs may initialize a new harness and close it after completion,
+	// thus, we aim to minimize the chance of conflicting actions against same K8s namespace
+	test.Namespace += uuid.NewString()
 	test.Setup()
 	return test, nil
 }


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Recently, we've been facing a flaky integration test due to parallel specs executing conflicting actions on the same K8s namespace (see error below). This PR aims to reduce the chance of this happening close to 0.

`Error: unrecoverable error evicting pod: eksctl-test-xxxx-ns-1-1/iamserviceaccount-checker-xxxx: pods "iamserviceaccount-checker-xxxx" is forbidden: unable to create new content in namespace eksctl-test-xxxx-ns-1-1 because it is being terminated`

Passing test run against this branch:

https://github.com/eksctl-io/eksctl-ci/actions/runs/8392715725


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

