### PR TITLE
Revert "Handle K8s service account lifecycle on `eksctl create/delete podidentityassociation` commands"

### DIFF
--- a/pkg/actions/cluster/owned.go
+++ b/pkg/actions/cluster/owned.go
@@ -120,15 +120,7 @@ func (c *OwnedCluster) Delete(ctx context.Context, _, podEvictionWaitPeriod time
 	}
 	newTasksToDeleteAddonIAM := addon.NewRemover(c.stackManager).DeleteAddonIAMTasks
 	newTasksToDeletePodIdentityRoles := func() (*tasks.TaskTree, error) {
-		clientSet, err = c.newClientSet()
-		if err != nil {
-			if force {
-				logger.Warning("error occurred while deleting IAM Role stacks for pod identity associations: %v; force=true so proceeding with cluster deletion", err)
-				return &tasks.TaskTree{}, nil
-			}
-			return nil, err
-		}
-		return podidentityassociation.NewDeleter(c.cfg.Metadata.Name, c.stackManager, c.ctl.AWSProvider.EKS(), clientSet).
+		return podidentityassociation.NewDeleter(c.cfg.Metadata.Name, c.stackManager, c.ctl.AWSProvider.EKS()).
 			DeleteTasks(ctx, []podidentityassociation.Identifier{})
 	}
 

--- a/pkg/actions/podidentityassociation/creator.go
+++ b/pkg/actions/podidentityassociation/creator.go
@@ -4,13 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeclient "k8s.io/client-go/kubernetes"
-
 	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/awsapi"
 	"github.com/weaveworks/eksctl/pkg/cfn/builder"
-	"github.com/weaveworks/eksctl/pkg/kubernetes"
 	"github.com/weaveworks/eksctl/pkg/utils/tasks"
 )
 
@@ -25,15 +21,13 @@ type Creator struct {
 
 	stackCreator StackCreator
 	eksAPI       awsapi.EKS
-	clientSet    kubeclient.Interface
 }
 
-func NewCreator(clusterName string, stackCreator StackCreator, eksAPI awsapi.EKS, clientSet kubeclient.Interface) *Creator {
+func NewCreator(clusterName string, stackCreator StackCreator, eksAPI awsapi.EKS) *Creator {
 	return &Creator{
 		clusterName:  clusterName,
 		stackCreator: stackCreator,
 		eksAPI:       eksAPI,
-		clientSet:    clientSet,
 	}
 }
 
@@ -59,18 +53,6 @@ func (c *Creator) CreateTasks(ctx context.Context, podIdentityAssociations []api
 				stackCreator:           c.stackCreator,
 			})
 		}
-		piaCreationTasks.Append(&tasks.GenericTask{
-			Description: fmt.Sprintf("create service account %q, if it does not already exist", pia.NameString()),
-			Doer: func() error {
-				if err := kubernetes.MaybeCreateServiceAccountOrUpdateMetadata(c.clientSet, v1.ObjectMeta{
-					Name:      pia.ServiceAccountName,
-					Namespace: pia.Namespace,
-				}); err != nil {
-					return fmt.Errorf("failed to create service account %q: %w", pia.NameString(), err)
-				}
-				return nil
-			},
-		})
 		piaCreationTasks.Append(&createPodIdentityAssociationTask{
 			ctx:                    ctx,
 			info:                   fmt.Sprintf("create pod identity association for service account %q", pia.NameString()),

--- a/pkg/actions/podidentityassociation/creator_test.go
+++ b/pkg/actions/podidentityassociation/creator_test.go
@@ -5,11 +5,6 @@ import (
 	"fmt"
 
 	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	kubeclientfakes "k8s.io/client-go/kubernetes/fake"
-	kubeclienttesting "k8s.io/client-go/testing"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
@@ -25,7 +20,6 @@ type createPodIdentityAssociationEntry struct {
 	toBeCreated              []api.PodIdentityAssociation
 	mockEKS                  func(provider *mockprovider.MockProvider)
 	mockCFN                  func(stackCreator *fakes.FakeStackCreator)
-	mockK8s                  func(clientSet *kubeclientfakes.Clientset)
 	expectedCreateStackCalls int
 	expectedErr              string
 }
@@ -34,7 +28,6 @@ var _ = Describe("Create", func() {
 	var (
 		creator          *podidentityassociation.Creator
 		fakeStackCreator *fakes.FakeStackCreator
-		fakeClientSet    *kubeclientfakes.Clientset
 		mockProvider     *mockprovider.MockProvider
 
 		clusterName         = "test-cluster"
@@ -51,17 +44,12 @@ var _ = Describe("Create", func() {
 			e.mockCFN(fakeStackCreator)
 		}
 
-		fakeClientSet = kubeclientfakes.NewSimpleClientset()
-		if e.mockK8s != nil {
-			e.mockK8s(fakeClientSet)
-		}
-
 		mockProvider = mockprovider.NewMockProvider()
 		if e.mockEKS != nil {
 			e.mockEKS(mockProvider)
 		}
 
-		creator = podidentityassociation.NewCreator(clusterName, fakeStackCreator, mockProvider.MockEKS(), fakeClientSet)
+		creator = podidentityassociation.NewCreator(clusterName, fakeStackCreator, mockProvider.MockEKS())
 
 		err := creator.CreatePodIdentityAssociations(context.Background(), e.toBeCreated)
 		if e.expectedErr != "" {
@@ -90,32 +78,6 @@ var _ = Describe("Create", func() {
 				}
 			},
 			expectedErr: "creating IAM role for pod identity association",
-		}),
-
-		Entry("returns an error if creating the service account fails", createPodIdentityAssociationEntry{
-			toBeCreated: []api.PodIdentityAssociation{
-				{
-					Namespace:          namespace,
-					ServiceAccountName: serviceAccountName1,
-					RoleARN:            roleARN,
-				},
-			},
-			mockK8s: func(clientSet *kubeclientfakes.Clientset) {
-				clientSet.PrependReactor("get", "namespaces", func(action kubeclienttesting.Action) (bool, runtime.Object, error) {
-					return true, nil, genericErr
-				})
-			},
-			mockEKS: func(provider *mockprovider.MockProvider) {
-				mockProvider.MockEKS().
-					On("CreatePodIdentityAssociation", mock.Anything, mock.Anything).
-					Run(func(args mock.Arguments) {
-						Expect(args).To(HaveLen(2))
-						Expect(args[1]).To(BeAssignableToTypeOf(&awseks.CreatePodIdentityAssociationInput{}))
-					}).
-					Return(&awseks.CreatePodIdentityAssociationOutput{}, nil).
-					Once()
-			},
-			expectedErr: "failed to create service account",
 		}),
 
 		Entry("returns an error if creating the association fails", createPodIdentityAssociationEntry{

--- a/pkg/actions/podidentityassociation/migrator.go
+++ b/pkg/actions/podidentityassociation/migrator.go
@@ -177,7 +177,7 @@ func (m *Migrator) MigrateToPodIdentity(ctx context.Context, options PodIdentity
 	}
 
 	// add tasks to create pod identity associations
-	createAssociationsTasks := NewCreator(m.clusterName, nil, m.eksAPI, m.clientSet).CreateTasks(ctx, toBeCreated)
+	createAssociationsTasks := NewCreator(m.clusterName, nil, m.eksAPI).CreateTasks(ctx, toBeCreated)
 	if createAssociationsTasks.Len() > 0 {
 		createAssociationsTasks.IsSubTask = true
 		taskTree.Append(createAssociationsTasks)

--- a/pkg/actions/podidentityassociation/migrator_test.go
+++ b/pkg/actions/podidentityassociation/migrator_test.go
@@ -220,8 +220,6 @@ var _ = Describe("Create", func() {
 			validateCustomLoggerOutput: func(output string) {
 				Expect(output).To(ContainSubstring("update trust policy for owned role \"test-role-1\""))
 				Expect(output).To(ContainSubstring("update trust policy for unowned role \"test-role-2\""))
-				Expect(output).To(ContainSubstring("create service account \"default/service-account-1\", if it does not already exist"))
-				Expect(output).To(ContainSubstring("create service account \"default/service-account-2\", if it does not already exist"))
 				Expect(output).To(ContainSubstring("create pod identity association for service account \"default/service-account-1\""))
 				Expect(output).To(ContainSubstring("create pod identity association for service account \"default/service-account-2\""))
 			},

--- a/pkg/actions/podidentityassociation/podidentityassociation_suite_test.go
+++ b/pkg/actions/podidentityassociation/podidentityassociation_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestPodIdentityAssociation(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Pod Identity Association Suite")
+	RunSpecs(t, "Nodegroup Suite")
 }

--- a/pkg/ctl/create/cluster.go
+++ b/pkg/ctl/create/cluster.go
@@ -462,15 +462,10 @@ func doCreateCluster(cmd *cmdutils.Cmd, ngFilter *filter.NodeGroupFilter, params
 		}
 
 		if len(cfg.IAM.PodIdentityAssociations) > 0 {
-			clientSet, err := makeClientSet()
-			if err != nil {
-				return fmt.Errorf("creating pod identity associations: %w", err)
-			}
 			if err := podidentityassociation.NewCreator(
 				cfg.Metadata.Name,
 				stackManager,
 				ctl.AWSProvider.EKS(),
-				clientSet,
 			).CreatePodIdentityAssociations(ctx, cfg.IAM.PodIdentityAssociations); err != nil {
 				return err
 			}

--- a/pkg/ctl/create/pod_identity_association.go
+++ b/pkg/ctl/create/pod_identity_association.go
@@ -45,11 +45,6 @@ func doCreatePodIdentityAssociation(cmd *cmdutils.Cmd) error {
 		return err
 	}
 
-	clientSet, err := ctl.NewStdClientSet(cfg)
-	if err != nil {
-		return err
-	}
-
 	isInstalled, err := podidentityassociation.IsPodIdentityAgentInstalled(ctx, ctl.AWSProvider.EKS(), cfg.Metadata.Name)
 	if err != nil {
 		return err
@@ -60,7 +55,7 @@ func doCreatePodIdentityAssociation(cmd *cmdutils.Cmd) error {
 		return api.ErrPodIdentityAgentNotInstalled(suggestion)
 	}
 
-	return podidentityassociation.NewCreator(cmd.ClusterConfig.Metadata.Name, ctl.NewStackManager(cfg), ctl.AWSProvider.EKS(), clientSet).
+	return podidentityassociation.NewCreator(cmd.ClusterConfig.Metadata.Name, ctl.NewStackManager(cfg), ctl.AWSProvider.EKS()).
 		CreatePodIdentityAssociations(ctx, cmd.ClusterConfig.IAM.PodIdentityAssociations)
 }
 

--- a/pkg/ctl/delete/pod_identity_association.go
+++ b/pkg/ctl/delete/pod_identity_association.go
@@ -59,11 +59,6 @@ func doDeletePodIdentityAssociation(cmd *cmdutils.Cmd, options cmdutils.PodIdent
 		return err
 	}
 
-	clientSet, err := ctl.NewStdClientSet(cfg)
-	if err != nil {
-		return err
-	}
-
 	if cmd.ClusterConfigFile == "" {
 		cmd.ClusterConfig.IAM.PodIdentityAssociations = []api.PodIdentityAssociation{
 			{
@@ -77,7 +72,6 @@ func doDeletePodIdentityAssociation(cmd *cmdutils.Cmd, options cmdutils.PodIdent
 		ClusterName:  cfg.Metadata.Name,
 		StackDeleter: ctl.NewStackManager(cfg),
 		APIDeleter:   ctl.AWSProvider.EKS(),
-		ClientSet:    clientSet,
 	}
 
 	return deleter.Delete(ctx, podidentityassociation.ToIdentifiers(cfg.IAM.PodIdentityAssociations))


### PR DESCRIPTION
Failing integration tests. Reverting to unblock RC.

Reverts eksctl-io/eksctl#7706