### PR TITLE
[Pod Identity Associations] Don't allow `--create-service-account` flag when `--config-file` is set

### DIFF
--- a/pkg/ctl/cmdutils/pod_identity_association.go
+++ b/pkg/ctl/cmdutils/pod_identity_association.go
@@ -19,6 +19,7 @@ var (
 		"permission-boundary-arn",
 		"permission-policy-arn",
 		"well-known-policies",
+		"create-service-account",
 	}
 )
 

--- a/pkg/ctl/create/pod_identity_association_test.go
+++ b/pkg/ctl/create/pod_identity_association_test.go
@@ -49,6 +49,10 @@ var _ = Describe("create pod identity association", func() {
 			args:        []string{"--service-account-name", "test-sa-name", "--config-file", configFile},
 			expectedErr: "cannot use --service-account-name when --config-file/-f is set",
 		}),
+		Entry("setting --create-service-account and --config-file at the same time", createPodIdentityAssociationEntry{
+			args:        []string{"--create-service-account", "--config-file", configFile},
+			expectedErr: "cannot use --create-service-account when --config-file/-f is set",
+		}),
 		Entry("missing all --role-arn, --permission-policy-arns and --well-known-policies", createPodIdentityAssociationEntry{
 			args:        defaultArgs,
 			expectedErr: "at least one of the following flags must be specified: --role-arn, --permission-policy-arns, --well-known-policies",


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

