### PR TITLE
Subnets availability validation should use AZs resolved by `EC2::DescribeSubnets` call

### DIFF
--- a/pkg/actions/nodegroup/create_test.go
+++ b/pkg/actions/nodegroup/create_test.go
@@ -269,6 +269,7 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 		},
 		expectedErr: fmt.Errorf("all private subnets from vpc-1, that the cluster was originally created on, have been deleted; to create private nodegroups within vpc-1 please manually set valid private subnets via nodeGroup.SubnetIDs"),
 	}),
+
 	Entry("fails when nodegroup uses privateNetworking:false and there's no public subnet within vpc", ngEntry{
 		mockCalls: func(m mockCalls) {
 			mockProviderWithVPCSubnets(m.mockProvider, &vpcSubnets{
@@ -277,6 +278,7 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 		},
 		expectedErr: fmt.Errorf("all public subnets from vpc-1, that the cluster was originally created on, have been deleted; to create public nodegroups within vpc-1 please manually set valid public subnets via nodeGroup.SubnetIDs"),
 	}),
+
 	Entry("fails when nodegroup uses privateNetworking:true and there's no private subnet within az", ngEntry{
 		updateClusterConfig: func(c *api.ClusterConfig) {
 			c.NodeGroups[0].PrivateNetworking = true
@@ -290,9 +292,25 @@ var _ = DescribeTable("Create", func(t ngEntry) {
 		},
 		expectedErr: fmt.Errorf("all private subnets from us-west-2b, that the cluster was originally created on, have been deleted; to create private nodegroups within us-west-2b please manually set valid private subnets via nodeGroup.SubnetIDs"),
 	}),
+
 	Entry("fails when nodegroup uses privateNetworking:false and there's no private subnet within az", ngEntry{
 		updateClusterConfig: func(c *api.ClusterConfig) {
 			c.NodeGroups[0].AvailabilityZones = []string{"us-west-2a", "us-west-2b"}
+			c.VPC.Subnets = &api.ClusterSubnets{
+				Private: api.AZSubnetMapping{
+					"private-1": api.AZSubnetSpec{
+						ID: "subnet-private-1",
+					},
+					"private-2": api.AZSubnetSpec{
+						ID: "subnet-private-2",
+					},
+				},
+				Public: api.AZSubnetMapping{
+					"public-1": api.AZSubnetSpec{
+						ID: "subnet-public-2",
+					},
+				},
+			}
 		},
 		mockCalls: func(m mockCalls) {
 			mockProviderWithVPCSubnets(m.mockProvider, &vpcSubnets{


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

The validation in question was using the subnet keys found in the config file. However, subnet key doesn't necessarily represent the subnet's AZ, but can be a user given alias. Instead, the validation shall use the subnet AZ fetched from  `EC2::DescribeSubnets` call.

Fixes https://github.com/eksctl-io/eksctl/issues/7785

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

