### PR TITLE
Restrict `VPC.SecurityGroup` egress rules validations to self-managed nodes

### DIFF
--- a/pkg/actions/nodegroup/create.go
+++ b/pkg/actions/nodegroup/create.go
@@ -80,9 +80,11 @@ func (m *Manager) Create(ctx context.Context, options CreateOpts, nodegroupFilte
 				return errors.Wrapf(err, "loading VPC spec for cluster %q", meta.Name)
 			}
 			isOwnedCluster = false
-			skipEgressRules, err = validateSecurityGroup(ctx, ctl.AWSProvider.EC2(), cfg.VPC.SecurityGroup)
-			if err != nil {
-				return err
+			if len(cfg.NodeGroups) > 0 {
+				skipEgressRules, err = validateSecurityGroup(ctx, ctl.AWSProvider.EC2(), cfg.VPC.SecurityGroup)
+				if err != nil {
+					return err
+				}
 			}
 
 		default:

--- a/pkg/actions/nodegroup/create_test.go
+++ b/pkg/actions/nodegroup/create_test.go
@@ -1135,4 +1135,9 @@ func makeUnownedClusterConfig(clusterConfig *api.ClusterConfig) {
 			},
 		},
 	}
+	clusterConfig.NodeGroups = append(clusterConfig.NodeGroups, &api.NodeGroup{
+		NodeGroupBase: &api.NodeGroupBase{
+			Name: "ng",
+		},
+	})
 }


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

In the context of creating nodegroups on non-eksctl created clusters, eksctl currently requires that the VPC SG does not contain any outbound rules. This is due to the fact that eksctl adds the ingress and egress rules to the VPC SG using CloudFormation (rules are needed to facilitate communication between self-managed nodes and cluster control plane). In turn, CloudFormation is treated as the only source of truth for SG rules, hence removing any pre-existing rules, leaving users with non-functional clusters due to this undesired behaviour.   

Moreover, this validation is currently applied also when creating EKS-managed nodegroups, despite the fact that eksctl does not add any rules for those. This PR restricts the validation to be applied only when creating self-managed nodegroups, as eksctl does not alter any SG rules when creating EKS-managed nodegroups.


Part of https://github.com/eksctl-io/eksctl/issues/7176

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

