### PR TITLE
Disallow `overrideBootstrapCommand` and `preBootstrapCommands` for MNG AL2023

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -687,6 +687,22 @@ func validateNodeGroupBase(np NodePool, path string, controlPlaneOnOutposts bool
 		}
 	}
 
+	if ng.AMIFamily == NodeImageFamilyAmazonLinux2023 {
+		fieldNotSupported := func(field string) error {
+			return &unsupportedFieldError{
+				ng:    ng,
+				path:  path,
+				field: field,
+			}
+		}
+		if ng.PreBootstrapCommands != nil {
+			return fieldNotSupported("preBootstrapCommands")
+		}
+		if ng.OverrideBootstrapCommand != nil {
+			return fieldNotSupported("overrideBootstrapCommand")
+		}
+	}
+
 	if ng.CapacityReservation != nil {
 		if ng.CapacityReservation.CapacityReservationPreference != nil {
 			if ng.CapacityReservation.CapacityReservationTarget != nil {
@@ -870,13 +886,6 @@ func ValidateNodeGroup(i int, ng *NodeGroup, cfg *ClusterConfig) error {
 	if IsWindowsImage(ng.AMIFamily) {
 		if ng.KubeletExtraConfig != nil {
 			return fieldNotSupported("kubeletExtraConfig")
-		}
-	} else if ng.AMIFamily == NodeImageFamilyAmazonLinux2023 {
-		if ng.PreBootstrapCommands != nil {
-			return fieldNotSupported("preBootstrapCommands")
-		}
-		if ng.OverrideBootstrapCommand != nil {
-			return fieldNotSupported("overrideBootstrapCommand")
 		}
 	} else if ng.AMIFamily == NodeImageFamilyBottlerocket {
 		if ng.KubeletExtraConfig != nil {


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

This is a temporary solution, as right now `preBootstrapCommands` and `overrideBootstrapCommand` options are not explicitly being disallowed when using AL2023 for managed nodegroups. Instead, they are silently ignored, leading users to believe the options are being applied, when in reality they are not.

The long term solution would be to figure out some equivalents of the two options that can be applied for AL2023 based AMIs. 

Related to  https://github.com/eksctl-io/eksctl/issues/7903

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

