### PR TITLE
Add support for `preBootstrapCommands` in AL2023

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -767,9 +767,6 @@ func validateNodeGroupBase(np NodePool, path string, controlPlaneOnOutposts bool
 				field: field,
 			}
 		}
-		if ng.PreBootstrapCommands != nil {
-			return fieldNotSupported("preBootstrapCommands")
-		}
 		if ng.OverrideBootstrapCommand != nil {
 			return fieldNotSupported("overrideBootstrapCommand")
 		}

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -2186,15 +2186,6 @@ var _ = Describe("ClusterConfig validation", func() {
 			err := api.ValidateManagedNodeGroup(0, ng)
 			Expect(err).To(MatchError(ContainSubstring("eksctl does not support configuring maxPodsPerNode EKS-managed nodes")))
 		})
-		It("returns an error when setting preBootstrapCommands for self-managed nodegroups", func() {
-			cfg := api.NewClusterConfig()
-			ng := cfg.NewNodeGroup()
-			ng.Name = "node-group"
-			ng.AMI = "ami-1234"
-			ng.AMIFamily = api.NodeImageFamilyAmazonLinux2023
-			ng.PreBootstrapCommands = []string{"echo 'rubarb'"}
-			Expect(api.ValidateNodeGroup(0, ng, cfg)).To(MatchError(ContainSubstring(fmt.Sprintf("preBootstrapCommands is not supported for %s nodegroups", api.NodeImageFamilyAmazonLinux2023))))
-		})
 		It("returns an error when setting overrideBootstrapCommand for self-managed nodegroups", func() {
 			cfg := api.NewClusterConfig()
 			ng := cfg.NewNodeGroup()
@@ -2203,14 +2194,6 @@ var _ = Describe("ClusterConfig validation", func() {
 			ng.AMIFamily = api.NodeImageFamilyAmazonLinux2023
 			ng.OverrideBootstrapCommand = aws.String("echo 'rubarb'")
 			Expect(api.ValidateNodeGroup(0, ng, cfg)).To(MatchError(ContainSubstring(fmt.Sprintf("overrideBootstrapCommand is not supported for %s nodegroups", api.NodeImageFamilyAmazonLinux2023))))
-		})
-		It("returns an error when setting preBootstrapCommands for EKS-managed nodegroups", func() {
-			ng := api.NewManagedNodeGroup()
-			ng.Name = "node-group"
-			ng.AMI = "ami-1234"
-			ng.AMIFamily = api.NodeImageFamilyAmazonLinux2023
-			ng.PreBootstrapCommands = []string{"echo 'rubarb'"}
-			Expect(api.ValidateManagedNodeGroup(0, ng)).To(MatchError(ContainSubstring(fmt.Sprintf("preBootstrapCommands is not supported for %s nodegroups", api.NodeImageFamilyAmazonLinux2023))))
 		})
 		It("returns an error when setting overrideBootstrapCommand for EKS-managed nodegroups", func() {
 			ng := api.NewManagedNodeGroup()

--- a/pkg/nodebootstrap/al2023.go
+++ b/pkg/nodebootstrap/al2023.go
@@ -58,6 +58,11 @@ func (m *AL2023) UserData() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("generating node config: %w", err)
 	}
+
+	for _, command := range m.nodePool.BaseNodeGroup().PreBootstrapCommands {
+		m.scripts = append(m.scripts, "#!/bin/bash\n"+command)
+	}
+
 	if len(m.scripts) == 0 && len(m.cloudboot) == 0 && nodeConfig == nil {
 		return "", nil
 	}


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

AL2023 bootstrapping is achieved via a new `nodeadm` process, as opposed to the old bootstrapping script used by AL2. The bootstrapping part of this `nodeadm` process is being run after the `cloud-init` process. Therefore, any shell script being included in the EC2 userdata is by default considered a `pre-bootstrap command`.

Closes https://github.com/eksctl-io/eksctl/issues/7903

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

