### PR TITLE
Fix E2E tests

### DIFF
--- a/integration/tests/addons/addons_test.go
+++ b/integration/tests/addons/addons_test.go
@@ -807,6 +807,10 @@ var _ = Describe("(Integration) [EKS Addons test]", func() {
 					Status: "DEGRADED",
 				},
 				addonStatus{
+					Name:   "metrics-server",
+					Status: "DEGRADED",
+				},
+				addonStatus{
 					Name:   "kube-proxy",
 					Status: "ACTIVE",
 				},

--- a/integration/tests/custom_ami/custom_ami_test.go
+++ b/integration/tests/custom_ami/custom_ami_test.go
@@ -21,7 +21,9 @@ import (
 	. "github.com/weaveworks/eksctl/integration/matchers"
 	. "github.com/weaveworks/eksctl/integration/runner"
 	"github.com/weaveworks/eksctl/integration/tests"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
 	"github.com/weaveworks/eksctl/pkg/testutils"
+	versionsutils "github.com/weaveworks/eksctl/pkg/utils"
 )
 
 var params *tests.Params
@@ -47,6 +49,12 @@ var (
 var _ = BeforeSuite(func() {
 	cfg := NewConfig(params.Region)
 	ssm := awsssm.NewFromConfig(cfg)
+
+	givenVersionSupportsUbuntu2404, err := versionsutils.IsMinVersion(api.Version1_31, params.Version)
+	Expect(err).ToNot(HaveOccurred())
+	if !givenVersionSupportsUbuntu2404 {
+		params.Version = api.Version1_31
+	}
 
 	// retrieve AL2 AMI
 	input := &awsssm.GetParameterInput{

--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -1293,13 +1293,19 @@
         },
         "serviceIPv4CIDR": {
           "type": "string",
-          "description": "CIDR range from where `ClusterIP`s are assigned",
-          "x-intellij-html-description": "CIDR range from where <code>ClusterIP</code>s are assigned"
+          "description": "IPv4 CIDR range from where `ClusterIP`s are assigned",
+          "x-intellij-html-description": "IPv4 CIDR range from where <code>ClusterIP</code>s are assigned"
+        },
+        "serviceIPv6CIDR": {
+          "type": "string",
+          "description": "IPv6 CIDR range from where `ClusterIP`s are assigned",
+          "x-intellij-html-description": "IPv6 CIDR range from where <code>ClusterIP</code>s are assigned"
         }
       },
       "preferredOrder": [
         "ipFamily",
-        "serviceIPv4CIDR"
+        "serviceIPv4CIDR",
+        "serviceIPv6CIDR"
       ],
       "additionalProperties": false,
       "description": "contains cluster networking options",
@@ -1347,12 +1353,14 @@
         },
         "amiFamily": {
           "type": "string",
-          "description": "Valid variants are: `\"AmazonLinux2\"` (default), `\"AmazonLinux2023\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"Ubuntu2004\"`, `\"Ubuntu1804\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`.",
-          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2&quot;</code> (default), <code>&quot;AmazonLinux2023&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Ubuntu1804&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>.",
+          "description": "Valid variants are: `\"AmazonLinux2\"` (default), `\"AmazonLinux2023\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"Ubuntu2004\"`, `\"Ubuntu1804\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`.",
+          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2&quot;</code> (default), <code>&quot;AmazonLinux2023&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Ubuntu1804&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>.",
           "default": "AmazonLinux2",
           "enum": [
             "AmazonLinux2",
             "AmazonLinux2023",
+            "UbuntuPro2404",
+            "Ubuntu2404",
             "UbuntuPro2204",
             "Ubuntu2204",
             "Ubuntu2004",
@@ -1688,12 +1696,14 @@
         },
         "amiFamily": {
           "type": "string",
-          "description": "Valid variants are: `\"AmazonLinux2\"` (default), `\"AmazonLinux2023\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"Ubuntu2004\"`, `\"Ubuntu1804\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`.",
-          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2&quot;</code> (default), <code>&quot;AmazonLinux2023&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Ubuntu1804&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>.",
+          "description": "Valid variants are: `\"AmazonLinux2\"` (default), `\"AmazonLinux2023\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"Ubuntu2004\"`, `\"Ubuntu1804\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`.",
+          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2&quot;</code> (default), <code>&quot;AmazonLinux2023&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Ubuntu1804&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>.",
           "default": "AmazonLinux2",
           "enum": [
             "AmazonLinux2",
             "AmazonLinux2023",
+            "UbuntuPro2404",
+            "Ubuntu2404",
             "UbuntuPro2204",
             "Ubuntu2204",
             "Ubuntu2004",

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -435,7 +435,7 @@ func (c *ClusterConfig) ValidateVPCConfig() error {
 		return fmt.Errorf("Ipv6Cidr and Ipv6CidrPool are only supported when IPFamily is set to IPv6")
 	}
 
-	if c.IPv6Enabled() {
+	if c.IPv6Enabled() && c.Status == nil {
 		if IsEnabled(c.VPC.AutoAllocateIPv6) {
 			return fmt.Errorf("auto allocate ipv6 is not supported with IPv6")
 		}
@@ -600,6 +600,10 @@ func (c *ClusterConfig) ValidatePrivateCluster() error {
 
 // validateKubernetesNetworkConfig validates the k8s network config
 func (c *ClusterConfig) validateKubernetesNetworkConfig() error {
+	// this check ensured the validation is only run on cluster creation
+	if c.Status != nil {
+		return nil
+	}
 	if c.KubernetesNetworkConfig == nil {
 		return nil
 	}


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

This PR addresses multiple E2E test failures at once, by making the following changes:

- regenerate JSON schema
- update test case to account for new default addon (`metrics-server`)
- ensure some IPv6 related validation are only run on cluster creation (and not on other commands e.g. deletion)
- ensure `custom_ami` test runs on at least EKS 1.31 as it's the minimum required for the recently added Ubuntu 24.04 support  

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

