### PR TITLE
[Hybrid Nodes] Remove strict requirement of providing a VGW or TGW during cluster creation

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -108,13 +108,9 @@ func (c *ClusterConfig) validateRemoteNetworkingConfig() error {
 		return setNonEmpty("remoteNetworkConfig.remoteNodeNetworks")
 	}
 
-	if c.VPC.ID != "" {
-		if rnc.VPCGatewayID.IsSet() {
+	if rnc.VPCGatewayID.IsSet() {
+		if c.VPC.ID != "" {
 			return fmt.Errorf("remoteNetworkConfig.vpcGatewayID is not supported when using pre-existing VPC")
-		}
-	} else {
-		if !rnc.VPCGatewayID.IsSet() {
-			return setNonEmpty("remoteNetworkConfig.vpcGatewayID")
 		}
 		// vpcGatewayId must be either a virtual private gateway or a transit gateway
 		if !rnc.VPCGatewayID.IsTransitGateway() && !rnc.VPCGatewayID.IsVirtualPrivateGateway() {

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -1013,12 +1013,6 @@ var _ = Describe("ClusterConfig validation", func() {
 			},
 			expectedErr: "remoteNetworkConfig.vpcGatewayID is not supported when using pre-existing VPC",
 		}),
-		Entry("both vpcGatewayID and pre-existing VPC are missing", remoteNetworkConfigEntry{
-			overrideConfig: func(cc *api.ClusterConfig) {
-				cc.RemoteNetworkConfig.VPCGatewayID = nil
-			},
-			expectedErr: "remoteNetworkConfig.vpcGatewayID must be set and non-empty",
-		}),
 		Entry("unsupported vpcGateway type", remoteNetworkConfigEntry{
 			overrideConfig: func(cc *api.ClusterConfig) {
 				gatewayID := api.VPCGateway("igw-1234")

--- a/pkg/cfn/builder/vpc_ipv4.go
+++ b/pkg/cfn/builder/vpc_ipv4.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kris-nova/logger"
 	"github.com/weaveworks/eksctl/pkg/awsapi"
 
 	gfncfn "github.com/awslabs/goformation/v4/cloudformation/cloudformation"
@@ -396,6 +397,7 @@ func (v *IPv4VPCResourceSet) addHybridNodesNetworking() {
 			}
 		})
 	default:
+		logger.Warning("a TGW or VGW was not provided for hybrid nodes connectivity, hence eksctl won't configure any related routes and gateway attachments for your VPC")
 		return
 	}
 }

--- a/userdocs/src/usage/hybrid-nodes.md
+++ b/userdocs/src/usage/hybrid-nodes.md
@@ -29,7 +29,7 @@ remoteNetworkConfig:
     - cidrs: ["10.86.30.0/23"]
 ```
 
-If your connectivity method of choice does not involve using a TGW or VGW, you must not rely on eksctl to create the VPC for you, and instead provide a pre-existing one. On a related note, if you are using a pre-existing VPC, eksctl won't make any amendments to it, and ensuring all networking requirements are in place falls under your responsibility.
+If your connectivity method of choice does not involve using a TGW or VGW, you can omit setting `remoteNetworkConfig.vpcGatewayID` or provide a pre-existing VPC. On a related note, if you are using a pre-existing VPC, eksctl won't make any amendments to it, and ensuring all networking requirements are in place falls under your responsibility.
 
 ???+ note
     eksctl does not setup any networking infrastructure outside your AWS VPC (i.e. any infrastructure from VGW/TGW to the remote networks)


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

At the moment, the field `remoteNetworkConfig.vpcGatewayID` is required when relying on eksctl to create a VPC for you. Removing this requirement comes with the advantage that users no longer need to provide a pre-existing VPC if their hybrid nodes connectivity method does not involve a TGW or VGW. Instead, eksctl will create the VPC for them, with recommended SG rules in place (for hybrid nodes), but no other additional networking pre-requisites (for hybrid nodes). 

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

