### PR TITLE
[Hybrid Nodes] Make `remoteNetworkConfig.IAM.Provider` field case insensitive

### DIFF
--- a/examples/43-hybrid-nodes.yaml
+++ b/examples/43-hybrid-nodes.yaml
@@ -1,23 +1,15 @@
-# An example of cluster config with remote networking configured.
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 
 metadata:
-  name: hybrid-nodes
+  name: hybrid-2
   region: us-west-2
-
-accessConfig:
-  authenticationMode: API_AND_CONFIG_MAP
-
-vpc:
-  cidr: 10.226.98.0/23
+  version: "1.31"
 
 remoteNetworkConfig:
-  vpcGatewayID: tgw-028fbe2348e6eed74
   iam:
-    provider: IRA # default is ssm
-    caBundleCert: xxxx
+    provider: SSM
+    # caBundleCert: ceva
+  # vpcGatewayID: tgw-028fbe2348e6eed74
   remoteNodeNetworks:
-    # eksctl will create, behind the scenes, SG rules, routes, and a VPC gateway attachment,
-    # to facilitate communication between remote network(s) and EKS control plane, via the attached gateway
     - cidrs: ["10.80.146.0/24"]

--- a/pkg/cfn/builder/cluster.go
+++ b/pkg/cfn/builder/cluster.go
@@ -445,7 +445,7 @@ func (c *ClusterResourceSet) addResourcesForControlPlane(subnetDetails *SubnetDe
 
 func (c *ClusterResourceSet) addAccessEntryForRemoteNodes() {
 	getRemoteNodesRoleName := func() string {
-		switch *c.spec.RemoteNetworkConfig.IAM.Provider {
+		switch strings.ToLower(*c.spec.RemoteNetworkConfig.IAM.Provider) {
 		case api.SSMProvider:
 			return SSMRole
 		case api.IRAProvider:

--- a/pkg/cfn/builder/iam.go
+++ b/pkg/cfn/builder/iam.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
@@ -221,7 +222,7 @@ func (c *ClusterResourceSet) addSSM() {
 
 func (c *ClusterResourceSet) addResourcesForRemoteNodesRole() {
 	c.rs.withIAM = true
-	switch *c.spec.RemoteNetworkConfig.IAM.Provider {
+	switch strings.ToLower(*c.spec.RemoteNetworkConfig.IAM.Provider) {
 	case api.SSMProvider:
 		c.addSSM()
 	case api.IRAProvider:


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Fixes https://github.com/eksctl-io/eksctl/issues/8167

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

