### PR TITLE
fix: use latest managed addon version for kube-proxy image name

### DIFF
--- a/pkg/addons/default/kube_proxy.go
+++ b/pkg/addons/default/kube_proxy.go
@@ -115,39 +115,13 @@ func addArm64NodeSelector(daemonSet *v1.DaemonSet) error {
 }
 
 func getLatestKubeProxyImage(ctx context.Context, input AddonInput) (string, error) {
-	defaultClusterVersion := generateImageVersionFromClusterVersion(input.ControlPlaneVersion)
+	// Always use the latest version from managed addon versions
 	latestEKSReportedVersion, err := getLatestImageVersionFromEKS(ctx, input.AddonVersionDescriber, input.ControlPlaneVersion)
 	if err != nil {
 		return "", err
 	}
 
-	// Sometimes the EKS API is ahead, sometimes behind. Pick whichever is latest
-	eksVersionIsGreaterThanDefaultVersion, err := versionGreaterThan(latestEKSReportedVersion, defaultClusterVersion)
-	if err != nil {
-		return "", err
-	}
-
-	if eksVersionIsGreaterThanDefaultVersion {
-		return latestEKSReportedVersion, nil
-	}
-
-	return defaultClusterVersion, nil
-}
-
-func versionGreaterThan(v1, v2 string) (bool, error) {
-	v1Version, err := parseVersion(v1)
-	if err != nil {
-		return false, err
-	}
-	v2Version, err := parseVersion(v2)
-	if err != nil {
-		return false, err
-	}
-	return v1Version.GreaterThan(v2Version), nil
-}
-
-func generateImageVersionFromClusterVersion(controlPlaneVersion string) string {
-	return fmt.Sprintf("v%s-eksbuild.1", controlPlaneVersion)
+	return latestEKSReportedVersion, nil
 }
 
 func getLatestImageVersionFromEKS(ctx context.Context, addonDescriber AddonVersionDescriber, controlPlaneVersion string) (string, error) {

--- a/pkg/addons/default/kube_proxy_test.go
+++ b/pkg/addons/default/kube_proxy_test.go
@@ -151,7 +151,7 @@ var _ = Describe("KubeProxy", func() {
 				expectedImageTag: "1.23.1-minimal-eksbuild.2",
 			}),
 
-			Entry("version that is behind the default cluster version should not be used", versionUpdateEntry{
+			Entry("always uses the latest version from managed addon versions", versionUpdateEntry{
 				addonOutput: ekstypes.AddonInfo{
 					AddonName: aws.String("kube-proxy"),
 					AddonVersions: []ekstypes.AddonVersionInfo{
@@ -159,8 +159,8 @@ var _ = Describe("KubeProxy", func() {
 							AddonVersion: aws.String("v1.17.0-eksbuild.1"),
 						},
 						{
-							// Latest, unordered list to ensure we sort correctly
-							// behind the default-cluster version 1.18.1-eksbuild.1.
+							// Latest version from managed addon versions should always be used
+							// regardless of cluster version
 							AddonVersion: aws.String("v1.18.0-eksbuild.2"),
 						},
 						{
@@ -169,7 +169,24 @@ var _ = Describe("KubeProxy", func() {
 					},
 				},
 
-				expectedImageTag: "v1.23.1-eksbuild.1",
+				expectedImageTag: "v1.18.0-minimal-eksbuild.2",
+			}),
+
+			Entry("uses latest managed addon version when cluster version has no corresponding image (k8s v1.32.8 scenario)", versionUpdateEntry{
+				addonOutput: ekstypes.AddonInfo{
+					AddonName: aws.String("kube-proxy"),
+					AddonVersions: []ekstypes.AddonVersionInfo{
+						{
+							AddonVersion: aws.String("v1.32.6-eksbuild.1"),
+						},
+						{
+							// Latest available image is v1.32.7-eksbuild.1, even though cluster is v1.32.8
+							AddonVersion: aws.String("v1.32.7-eksbuild.1"),
+						},
+					},
+				},
+
+				expectedImageTag: "v1.32.7-minimal-eksbuild.1",
 			}),
 		)
 


### PR DESCRIPTION
Issue: https://github.com/eksctl-io/eksctl/issues/8504

When eksctl updates a self-managed kube-proxy addon, it previously used the larger version between describe-addon-versions API response and the k8s cluster version. This assumption is incorrect for cases like k8s v1.32.8 where the latest available image is v1.32.7-eksbuild.1.

Changes:
- Always use the latest version from managed addon versions API
- Remove version comparison logic and unused helper functions
- Update unit tests to reflect the new behavior
- Add test case for k8s v1.32.8 scenario

This ensures kube-proxy always uses the most recent available image version from AWS EKS managed addon API, which is more reliable than assuming cluster version has a corresponding image.

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

