### PR TITLE
Make metrics server create after node groups so it can get scheduled …

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/known_addons.go
+++ b/pkg/apis/eksctl.io/v1alpha5/known_addons.go
@@ -27,7 +27,7 @@ var KnownAddons = map[string]struct {
 	AWSEFSCSIDriverAddon: {},
 	MetricsServerAddon: {
 		IsDefault:             true,
-		CreateBeforeNodeGroup: true,
+		CreateBeforeNodeGroup: false, // Create after nodegroup so we get scheduled on Fargate profiles.
 		IsDefaultAutoMode:     true,
 		ExcludedRegions: []string{
 			RegionCNNorthwest1,


### PR DESCRIPTION
### Description

Make metrics-server get scheduled on Fargate by creating this after node groups (and fargate profiles).

One other aspect of this change is now we will wait for metrics-server to become healthy.

```
./eksctl create cluster --name nicktestfargate3 --version 1.32 --fargate --region eu-central-1      
2025-10-09 23:32:32 [ℹ]  eksctl version 0.216.0-dev+e774677fe.2025-10-09T23:31:28Z
2025-10-09 23:32:32 [ℹ]  using region eu-central-1
2025-10-09 23:32:32 [ℹ]  setting availability zones to [eu-central-1c eu-central-1a eu-central-1b]
2025-10-09 23:32:32 [ℹ]  subnets for eu-central-1c - public:192.168.0.0/19 private:192.168.96.0/19
2025-10-09 23:32:32 [ℹ]  subnets for eu-central-1a - public:192.168.32.0/19 private:192.168.128.0/19
2025-10-09 23:32:32 [ℹ]  subnets for eu-central-1b - public:192.168.64.0/19 private:192.168.160.0/19
2025-10-09 23:32:32 [!]  Auto Mode will be enabled by default in an upcoming release of eksctl. This means managed node groups and managed networking add-ons will no longer be created by default. To maintain current behavior, explicitly set 'autoModeConfig.enabled: false' in your cluster configuration. Learn more: https://eksctl.io/usage/auto-mode/
2025-10-09 23:32:32 [ℹ]  using Kubernetes version 1.32
2025-10-09 23:32:32 [ℹ]  creating EKS cluster "nicktestfargate3" in "eu-central-1" region with Fargate profile
2025-10-09 23:32:32 [ℹ]  if you encounter any issues, check CloudFormation console or try 'eksctl utils describe-stacks --region=eu-central-1 --cluster=nicktestfargate3'
2025-10-09 23:32:32 [ℹ]  Kubernetes API endpoint access will use default of {publicAccess=true, privateAccess=false} for cluster "nicktestfargate3" in "eu-central-1"
2025-10-09 23:32:32 [ℹ]  CloudWatch logging will not be enabled for cluster "nicktestfargate3" in "eu-central-1"
2025-10-09 23:32:32 [ℹ]  you can enable it with 'eksctl utils update-cluster-logging --enable-types={SPECIFY-YOUR-LOG-TYPES-HERE (e.g. all)} --region=eu-central-1 --cluster=nicktestfargate3'
2025-10-09 23:32:32 [ℹ]  default addons kube-proxy, coredns, metrics-server, vpc-cni were not specified, will install them as EKS addons
2025-10-09 23:32:32 [ℹ]  
2 sequential tasks: { create cluster control plane "nicktestfargate3", 
    3 sequential sub-tasks: { 
        1 task: { create addons },
        wait for control plane to become ready,
        create fargate profiles,
    } 
}
2025-10-09 23:32:32 [ℹ]  building cluster stack "eksctl-nicktestfargate3-cluster"
2025-10-09 23:32:33 [ℹ]  deploying stack "eksctl-nicktestfargate3-cluster"
2025-10-09 23:33:03 [ℹ]  waiting for CloudFormation stack "eksctl-nicktestfargate3-cluster"
2025-10-09 23:33:34 [ℹ]  waiting for CloudFormation stack "eksctl-nicktestfargate3-cluster"
2025-10-09 23:34:34 [ℹ]  waiting for CloudFormation stack "eksctl-nicktestfargate3-cluster"
2025-10-09 23:35:35 [ℹ]  waiting for CloudFormation stack "eksctl-nicktestfargate3-cluster"
2025-10-09 23:36:36 [ℹ]  waiting for CloudFormation stack "eksctl-nicktestfargate3-cluster"
2025-10-09 23:37:36 [ℹ]  waiting for CloudFormation stack "eksctl-nicktestfargate3-cluster"
2025-10-09 23:38:37 [ℹ]  waiting for CloudFormation stack "eksctl-nicktestfargate3-cluster"
2025-10-09 23:39:37 [ℹ]  waiting for CloudFormation stack "eksctl-nicktestfargate3-cluster"
2025-10-09 23:40:38 [ℹ]  waiting for CloudFormation stack "eksctl-nicktestfargate3-cluster"
2025-10-09 23:41:39 [ℹ]  waiting for CloudFormation stack "eksctl-nicktestfargate3-cluster"
2025-10-09 23:41:42 [ℹ]  creating addon: kube-proxy
2025-10-09 23:41:42 [ℹ]  successfully created addon: kube-proxy
2025-10-09 23:41:42 [ℹ]  creating addon: coredns
2025-10-09 23:41:43 [ℹ]  successfully created addon: coredns
2025-10-09 23:41:44 [!]  recommended policies were found for "vpc-cni" addon, but since OIDC is disabled on the cluster, eksctl cannot configure the requested permissions; the recommended way to provide IAM permissions for "vpc-cni" addon is via pod identity associations; after addon creation is completed, add all recommended policies to the config file, under `addon.PodIdentityAssociations`, and run `eksctl update addon`
2025-10-09 23:41:44 [ℹ]  creating addon: vpc-cni
2025-10-09 23:41:44 [ℹ]  successfully created addon: vpc-cni
2025-10-09 23:43:46 [ℹ]  creating Fargate profile "fp-default" on EKS cluster "nicktestfargate3"
2025-10-09 23:45:57 [ℹ]  created Fargate profile "fp-default" on EKS cluster "nicktestfargate3"
2025-10-09 23:46:28 [ℹ]  "coredns" is now schedulable onto Fargate
2025-10-09 23:47:33 [ℹ]  "coredns" is now scheduled onto Fargate
2025-10-09 23:47:33 [ℹ]  "coredns" pods are now scheduled onto Fargate
2025-10-09 23:47:33 [ℹ]  waiting for the control plane to become ready
2025-10-09 23:47:34 [✔]  saved kubeconfig as "/home/nblaskey/.kube/config"
2025-10-09 23:47:34 [ℹ]  no tasks
2025-10-09 23:47:34 [✔]  all EKS cluster resources for "nicktestfargate3" have been created
2025-10-09 23:47:34 [ℹ]  creating addon: metrics-server
2025-10-09 23:47:35 [ℹ]  successfully created addon: metrics-server
2025-10-09 23:47:36 [ℹ]  kubectl command should work with "/home/nblaskey/.kube/config", try 'kubectl get nodes'
2025-10-09 23:47:36 [✔]  EKS cluster "nicktestfargate3" in "eu-central-1" region is ready
```

Verify they are scheduled
```
kubectl get pods -A
NAMESPACE     NAME                              READY   STATUS    RESTARTS   AGE
kube-system   coredns-cdf79c5fd-k9bzv           1/1     Running   0          2m30s
kube-system   coredns-cdf79c5fd-qc6sx           1/1     Running   0          2m30s
kube-system   metrics-server-6fcc4968f9-rp8pk   1/1     Running   0          77s
kube-system   metrics-server-6fcc4968f9-vzbwv   1/1     Running   0          77s
```


### Checklist
- [x ] Added tests that cover your change (if possible)
- [x ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x ] Manually tested
- [x ] Made sure the title of the PR is a good description that can go into the release notes
- [x ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

