### PR TITLE
Remove kubernetes.io/cluster/<clusterName> tag from EFA security group

### DIFF
--- a/pkg/cfn/builder/nodegroup_test.go
+++ b/pkg/cfn/builder/nodegroup_test.go
@@ -644,8 +644,6 @@ var _ = Describe("Unmanaged NodeGroup Template Builder", func() {
 					properties := ngTemplate.Resources["EFASG"].Properties
 					Expect(properties.VpcID).To(ContainElement(vpcID))
 					Expect(properties.GroupDescription).To(Equal("EFA-enabled security group"))
-					Expect(properties.Tags[0].Key).To(Equal("eksctl/cluster/bonsai"))
-					Expect(properties.Tags[0].Value).To(Equal("owned"))
 
 					Expect(ngTemplate.Resources).To(HaveKey("EFAEgressSelf"))
 					properties = ngTemplate.Resources["EFAEgressSelf"].Properties

--- a/pkg/cfn/builder/vpc.go
+++ b/pkg/cfn/builder/vpc.go
@@ -103,14 +103,12 @@ func (rs *resourceSet) addEFASecurityGroup(vpcID *gfnt.Value, clusterName, desc 
 	efaSG := rs.newResource("EFASG", &gfnec2.SecurityGroup{
 		VpcId:            vpcID,
 		GroupDescription: gfnt.NewString("EFA-enabled security group"),
-		Tags: []gfncfn.Tag{{
-			// Use a different tag than kubernetes.io to avoid conflicting with
-			// aws load balancer controller which expects exactly one security group
-			// tagged with kubernetes.io.
-			// https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/pkg/networking/networking_manager.go#L558
-			Key:   gfnt.NewString("eksctl/cluster/" + clusterName),
-			Value: gfnt.NewString("owned"),
-		}},
+		// Don't add a kubernetes.io/cluster tag to avoid conflicting with
+		// aws load balancer controller which expects exactly one security group
+		// tagged with kubernetes.io. Resource will already be tagged with
+		// alpha.eksctl.io/cluster-name elsewhere.
+		// https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/pkg/networking/networking_manager.go#L558
+		Tags: []gfncfn.Tag{},
 	})
 
 	// Create ingress rule for EFA self-communication


### PR DESCRIPTION
### Description

Avoid conflict with aws load balancer controller by not adding the tag to EFA security group.
https://github.com/eksctl-io/eksctl/issues/8475
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Tested by creating cluster and verifying EFA had no kubernetes.io tag and had this tag ```alpha.eksctl.io/cluster-name```
```
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  version: "1.34"
  name: test-cluster35
  region: ap-south-1
#  region: us-west-1

nodeGroups:
  - name: efa-workers
    instanceType: c5n.18xlarge
    minSize: 1
    maxSize: 3
    availabilityZones: ["ap-south-1a"]
    efaEnabled: true


```

### Checklist
- [X] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [X] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

