### PR TITLE
Fix test failure for add-on waiting for ebs csi driver

### DIFF
--- a/integration/tests/addons/addons_test.go
+++ b/integration/tests/addons/addons_test.go
@@ -808,7 +808,7 @@ var _ = Describe("(Integration) [EKS Addons test]", func() {
 
 			By("removing all pod identity associations owned by the addon")
 			clusterConfig.Addons[1].PodIdentityAssociations = &[]api.PodIdentityAssociation{}
-			// Don't wait for aws-ebs-csi-driver add-on becuase it won't become healthy without iam perms now.
+			// Don't wait for aws-ebs-csi-driver add-on because it won't become healthy without iam perms now.
 			Expect(makeUpdateAddonCMD("--timeout", "0")).To(RunSuccessfully())
 			assertAddonHasPodIDs(api.AWSEBSCSIDriverAddon, 0)
 


### PR DESCRIPTION
### Description

aws-ebs-csi-driver now requires pod identity permissions to become healthy. Don't wait for this anymore. 
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

