### PR TITLE
For dns test, use an ECR busybox image

### DIFF
--- a/integration/data/test-dns.yaml
+++ b/integration/data/test-dns.yaml
@@ -13,7 +13,7 @@ spec:
       nodeSelector:
         used-for: test-pods
       containers:
-      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+      - image: public.ecr.aws/docker/library/busybox:1.36.1
         name: dns-test-cluster
         stdin: true
         tty: true
@@ -26,7 +26,7 @@ spec:
             command:
             - nslookup
             - kubernetes.default.svc.cluster.local.
-      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+      - image: public.ecr.aws/docker/library/busybox:1.36.1
         name: dns-test-eksctl
         stdin: true
         tty: true
@@ -39,7 +39,7 @@ spec:
             command:
             - nslookup
             - eksctl.io
-      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+      - image: public.ecr.aws/docker/library/busybox:1.36.1
         name: dns-test-k8s
         stdin: true
         tty: true
@@ -52,7 +52,7 @@ spec:
             command:
             - nslookup
             - k8s.io
-      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+      - image: public.ecr.aws/docker/library/busybox:1.36.1
         name: dns-test-kubernetes
         stdin: true
         tty: true
@@ -65,7 +65,7 @@ spec:
             command:
             - nslookup
             - kubernetes.io
-      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+      - image: public.ecr.aws/docker/library/busybox:1.36.1
         name: dns-test-eks-us
         stdin: true
         tty: true
@@ -78,7 +78,7 @@ spec:
             command:
             - nslookup
             - EKS.us-east-1.amazonaws.com
-      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+      - image: public.ecr.aws/docker/library/busybox:1.36.1
         name: dns-test-eks-eu
         stdin: true
         tty: true
@@ -91,7 +91,7 @@ spec:
             command:
             - nslookup
             - EKS.eu-west-1.amazonaws.com
-      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+      - image: public.ecr.aws/docker/library/busybox:1.36.1
         name: dns-test-ec2-us
         stdin: true
         tty: true
@@ -104,7 +104,7 @@ spec:
             command:
             - nslookup
             - ec2.us-east-2.amazonaws.com
-      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+      - image: public.ecr.aws/docker/library/busybox:1.36.1
         name: dns-test-ec2-eu
         stdin: true
         tty: true
@@ -117,7 +117,7 @@ spec:
             command:
             - nslookup
             - ec2.eu-west-2.amazonaws.com
-      - image: tutum/dnsutils@sha256:d2244ad47219529f1003bd1513f5c99e71655353a3a63624ea9cb19f8393d5fe
+      - image: public.ecr.aws/docker/library/busybox:1.36.1
         name: dns-test-ifconfig
         stdin: true
         tty: true


### PR DESCRIPTION
### Description

Getting image pulled failed on the previous image

Not sure if its due to dockerhub throttling but try using a more up to date ECR image

```
[0]   NAME             READY   STATUS
[0]   test-dns-6q2fj   0/1     ImagePullBackOff
[0]   test-dns-dp86h   0/1     ImagePullBackOff
[0]   test-dns-ncdrg   0/1     ImagePullBackOff
[0]   test-dns-pglnq   0/1     ImagePullBackOff
[0]   test-dns-st4kz   0/1     ImagePullBackOff
```
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

