### PR TITLE
Fix integration test by waiting 2 minutes for ebs update

### DIFF
--- a/integration/tests/addons/addons_test.go
+++ b/integration/tests/addons/addons_test.go
@@ -809,7 +809,9 @@ var _ = Describe("(Integration) [EKS Addons test]", func() {
 			By("removing all pod identity associations owned by the addon")
 			clusterConfig.Addons[1].PodIdentityAssociations = &[]api.PodIdentityAssociation{}
 			// Don't wait for aws-ebs-csi-driver add-on because it won't become healthy without iam perms now.
-			Expect(makeUpdateAddonCMD("--timeout", "0")).To(RunSuccessfully())
+			// Update add-on has a bug where we wait even if we don't pass in --wait.
+			// We should fix that bug eventually then we can remove this timeout and fail condition.
+			Expect(makeUpdateAddonCMD("--timeout", "2m")).NotTo(RunSuccessfully())
 			assertAddonHasPodIDs(api.AWSEBSCSIDriverAddon, 0)
 
 			By("migrating an addon to pod identity using the utils command")


### PR DESCRIPTION
### Description

Previous attempt failed with can't use 0 timeout for cfn stacks.

Set timeout to 2 minutes so we delete the cfn stack and update the pod identity assocation but time out waiting for it to update.
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

