### PR TITLE
Fix upgrade vpc-cni test relying on assumptions about vpc versions

### DIFF
--- a/integration/tests/update/update_cluster_test.go
+++ b/integration/tests/update/update_cluster_test.go
@@ -250,16 +250,6 @@ var _ = Describe("(Integration) Upgrading cluster", func() {
 		})
 
 		It("should upgrade aws-node", func() {
-			rawClient := getRawClient(context.Background(), clusterProvider)
-			getAWSNodeVersion := func() string {
-				awsNode, err := rawClient.ClientSet().AppsV1().DaemonSets(metav1.NamespaceSystem).Get(context.TODO(), "aws-node", metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				imageTag, err := addons.ImageTag(awsNode.Spec.Template.Spec.Containers[0].Image)
-				Expect(err).NotTo(HaveOccurred())
-				return imageTag
-			}
-			preUpdateAWSNodeVersion := getAWSNodeVersion()
-
 			cmd := params.EksctlUpdateCmd.
 				WithArgs(
 					"addon",
@@ -270,7 +260,6 @@ var _ = Describe("(Integration) Upgrading cluster", func() {
 					"--verbose", "4",
 				)
 			Expect(cmd).To(RunSuccessfully())
-			Eventually(getAWSNodeVersion, addonUpdatePollTimeout, k8sUpdatePollInterval).ShouldNot(Equal(preUpdateAWSNodeVersion))
 		})
 
 		It("should upgrade coredns", func() {


### PR DESCRIPTION
### Description

Fix bug in vpc-cni test where the latest version is the default version
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

