### PR TITLE
added support us-isob-west-1 region

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/partitions.go
+++ b/pkg/apis/eksctl.io/v1alpha5/partitions.go
@@ -121,7 +121,7 @@ var Partitions = partitions{
 			"EKS":            "eks.amazonaws.com",
 			"EKSFargatePods": "eks-fargate-pods.amazonaws.com",
 		},
-		regions:                     []string{RegionUSISOBEast1},
+		regions:                     []string{RegionUSISOBEast1, RegionUSISOBWest1},
 		endpointServiceDomainPrefix: "gov.sgov.sc2s",
 		v1SDKDNSPrefix:              "sc2s.sgov.gov",
 	},

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -181,6 +181,9 @@ const (
 	// RegionUSISOBEast1 represents the region US ISOB East (Ohio).
 	RegionUSISOBEast1 = "us-isob-east-1"
 
+	// RegionUSISOBWest1 represents the region US ISOB West.
+	RegionUSISOBWest1 = "us-isob-west-1"
+
 	// RegionUSISOWest1 represents the region US ISO West.
 	RegionUSISOWest1 = "us-iso-west-1"
 
@@ -383,6 +386,9 @@ const (
 	// eksResourceAccountUSISOBEast1 defines the AWS EKS account ID that provides node resources in us-isob-east-1
 	eksResourceAccountUSISOBEast1 = "187977181151"
 
+	// eksResourceAccountUSISOBWest1 defines the AWS EKS account ID that provides node resources in us-isob-west-1
+	eksResourceAccountUSISOBWest1 = "321162350305"
+
 	// eksResourceAccountUSISOWest1 defines the AWS EKS account ID that provides node resources in us-iso-west-1
 	eksResourceAccountUSISOWest1 = "608367168043"
 
@@ -554,6 +560,7 @@ func SupportedRegions() []string {
 		RegionUSGovEast1,
 		RegionUSISOEast1,
 		RegionUSISOBEast1,
+		RegionUSISOBWest1,
 		RegionUSISOWest1,
 		RegionMXCentral1,
 		RegionAPSoutheast6,
@@ -651,6 +658,8 @@ func EKSResourceAccountID(region string) string {
 		return eksResourceAccountUSISOEast1
 	case RegionUSISOBEast1:
 		return eksResourceAccountUSISOBEast1
+	case RegionUSISOBWest1:
+		return eksResourceAccountUSISOBWest1
 	case RegionUSISOWest1:
 		return eksResourceAccountUSISOWest1
 	case RegionMXCentral1:

--- a/userdocs/theme/home.html
+++ b/userdocs/theme/home.html
@@ -541,7 +541,7 @@
                             <p>Creating fully private clusters on <a href="/usage/outposts">AWS Outposts</a>.</p>
                             <p>Supported Regions -
                                 Calgary - (<code>ca-west-1</code>),
-                                US ISO, ISOB and ISOF - (<code>us-iso-east-1</code>, <code>us-iso-west-1</code>, <code>us-isob-east-1</code>, <code>us-isof-south-1</code>, <code>us-isof-east-1</code>),
+                                US ISO, ISOB and ISOF - (<code>us-iso-east-1</code>, <code>us-iso-west-1</code>, <code>us-isob-east-1</code>, <code>us-isob-west-1</code>, <code>us-isof-south-1</code>, <code>us-isof-east-1</code>),
                                 EU ISOE - (<code>eu-isoe-west-1</code>),
                                 Tel Aviv (<code>il-central-1</code>),
                                 Melbourne (<code>ap-southeast-4</code>),


### PR DESCRIPTION
### Description

I added the necessary bits to enable eksctl to work on clusters in the us-isob-west-1 region.

### Checklist
- [N/A] Added tests that cover your change (if possible) - testing for isolated regions is by partition and existing testing for us-isob-east-1 region covers this
- [X] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

