### PR TITLE
Add support for EKS Windows Server 2025 in eksctl

### DIFF
--- a/pkg/ami/auto_resolver.go
+++ b/pkg/ami/auto_resolver.go
@@ -71,6 +71,12 @@ func MakeImageSearchPatterns(version string) map[string]map[int]string {
 		api.NodeImageFamilyWindowsServer2022FullContainer: {
 			ImageClassGeneral: fmt.Sprintf("Windows_Server-2022-English-Full-EKS_Optimized-%v-*", version),
 		},
+		api.NodeImageFamilyWindowsServer2025CoreContainer: {
+			ImageClassGeneral: fmt.Sprintf("Windows_Server-2025-English-Core-EKS_Optimized-%v-*", version),
+		},
+		api.NodeImageFamilyWindowsServer2025FullContainer: {
+			ImageClassGeneral: fmt.Sprintf("Windows_Server-2025-English-Full-EKS_Optimized-%v-*", version),
+		},
 	}
 }
 

--- a/pkg/ami/ssm_resolver.go
+++ b/pkg/ami/ssm_resolver.go
@@ -71,6 +71,17 @@ func MakeSSMParameterName(version, instanceType, imageFamily string) (string, er
 			return "", fmt.Errorf("Windows Server 2022 %s requires EKS version %s and above", windowsAmiType(imageFamily), minVersion)
 		}
 		return fmt.Sprintf("/aws/service/ami-windows-latest/Windows_Server-2022-English-%s-EKS_Optimized-%s/%s", windowsAmiType(imageFamily), version, fieldName), nil
+	case api.NodeImageFamilyWindowsServer2025CoreContainer,
+		api.NodeImageFamilyWindowsServer2025FullContainer:
+		const minVersion = api.Version1_35
+		supportsWindows2025, err := utils.IsMinVersion(minVersion, version)
+		if err != nil {
+			return "", err
+		}
+		if !supportsWindows2025 {
+			return "", fmt.Errorf("Windows Server 2025 %s requires EKS version %s and above", windowsAmiType(imageFamily), minVersion)
+		}
+		return fmt.Sprintf("/aws/service/ami-windows-latest/Windows_Server-2025-English-%s-EKS_Optimized-%s/%s", windowsAmiType(imageFamily), version, fieldName), nil
 	case api.NodeImageFamilyBottlerocket:
 		return fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/%s/latest/%s", imageType(imageFamily, instanceType, version), instanceEC2ArchName(instanceType), fieldName), nil
 	case api.NodeImageFamilyUbuntu2004,

--- a/pkg/ami/ssm_resolver_test.go
+++ b/pkg/ami/ssm_resolver_test.go
@@ -175,6 +175,35 @@ var _ = Describe("AMI Auto Resolution", func() {
 					})
 				})
 
+				Context("Windows Server 2025 Core", func() {
+					BeforeEach(func() {
+						version = "1.35"
+						p = mockprovider.NewMockProvider()
+					})
+
+					It("should return a valid AMI", func() {
+						imageFamily = "WindowsServer2025CoreContainer"
+						addMockGetParameter(p, "/aws/service/ami-windows-latest/Windows_Server-2025-English-Core-EKS_Optimized-1.35/image_id", expectedAmi)
+
+						resolver := NewSSMResolver(p.MockSSM())
+						resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+						Expect(err).NotTo(HaveOccurred())
+						Expect(resolvedAmi).To(BeEquivalentTo(expectedAmi))
+						Expect(p.MockSSM().AssertNumberOfCalls(GinkgoT(), "GetParameter", 1)).To(BeTrue())
+					})
+
+					It("should return an error for EKS versions below 1.35", func() {
+						imageFamily = "WindowsServer2025CoreContainer"
+
+						resolver := NewSSMResolver(p.MockSSM())
+						resolvedAmi, err = resolver.Resolve(context.Background(), region, "1.34", instanceType, imageFamily)
+
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(MatchError(ContainSubstring("Windows Server 2025 Core requires EKS version 1.35 and above")))
+					})
+				})
+
 			})
 
 			Context("and Windows Full family", func() {
@@ -229,6 +258,35 @@ var _ = Describe("AMI Auto Resolution", func() {
 
 						Expect(err).To(HaveOccurred())
 						Expect(err).To(MatchError(ContainSubstring("Windows Server 2022 Full requires EKS version 1.23 and above")))
+					})
+				})
+
+				Context("Windows Server 2025 Full", func() {
+					BeforeEach(func() {
+						version = "1.35"
+						p = mockprovider.NewMockProvider()
+					})
+
+					It("should return a valid AMI", func() {
+						imageFamily = "WindowsServer2025FullContainer"
+						addMockGetParameter(p, "/aws/service/ami-windows-latest/Windows_Server-2025-English-Full-EKS_Optimized-1.35/image_id", expectedAmi)
+
+						resolver := NewSSMResolver(p.MockSSM())
+						resolvedAmi, err = resolver.Resolve(context.Background(), region, version, instanceType, imageFamily)
+
+						Expect(err).NotTo(HaveOccurred())
+						Expect(resolvedAmi).To(BeEquivalentTo(expectedAmi))
+						Expect(p.MockSSM().AssertNumberOfCalls(GinkgoT(), "GetParameter", 1)).To(BeTrue())
+					})
+
+					It("should return an error for EKS versions below 1.34", func() {
+						imageFamily = "WindowsServer2025FullContainer"
+
+						resolver := NewSSMResolver(p.MockSSM())
+						resolvedAmi, err = resolver.Resolve(context.Background(), region, "1.34", instanceType, imageFamily)
+
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(MatchError(ContainSubstring("Windows Server 2025 Full requires EKS version 1.35 and above")))
 					})
 				})
 

--- a/pkg/apis/eksctl.io/v1alpha5/amitype.go
+++ b/pkg/apis/eksctl.io/v1alpha5/amitype.go
@@ -56,6 +56,14 @@ func GetAMIType(amiFamily, instanceType string, strict bool) ekstypes.AMITypes {
 			X86x64:    ekstypes.AMITypesWindowsCore2022X8664,
 			X86Nvidia: ekstypes.AMITypesWindowsCore2022X8664,
 		},
+		NodeImageFamilyWindowsServer2025FullContainer: {
+			X86x64:    ekstypes.AMITypes("WINDOWS_FULL_2025_x86_64"),
+			X86Nvidia: ekstypes.AMITypes("WINDOWS_FULL_2025_x86_64"),
+		},
+		NodeImageFamilyWindowsServer2025CoreContainer: {
+			X86x64:    ekstypes.AMITypes("WINDOWS_CORE_2025_x86_64"),
+			X86Nvidia: ekstypes.AMITypes("WINDOWS_CORE_2025_x86_64"),
+		},
 	}
 
 	amiType, ok := amiTypeMapping[amiFamily]

--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -1651,8 +1651,8 @@
         },
         "amiFamily": {
           "type": "string",
-          "description": "Valid variants are: `\"AmazonLinux2023\"` (default), `\"AmazonLinux2\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"UbuntuPro2004\"`, `\"Ubuntu2004\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`.",
-          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2023&quot;</code> (default), <code>&quot;AmazonLinux2&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;UbuntuPro2004&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>.",
+          "description": "Valid variants are: `\"AmazonLinux2023\"` (default), `\"AmazonLinux2\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"UbuntuPro2004\"`, `\"Ubuntu2004\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`, `\"WindowsServer2025CoreContainer\"`, `\"WindowsServer2025FullContainer\"`.",
+          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2023&quot;</code> (default), <code>&quot;AmazonLinux2&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;UbuntuPro2004&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>, <code>&quot;WindowsServer2025CoreContainer&quot;</code>, <code>&quot;WindowsServer2025FullContainer&quot;</code>.",
           "default": "AmazonLinux2023",
           "enum": [
             "AmazonLinux2023",
@@ -1667,7 +1667,9 @@
             "WindowsServer2019CoreContainer",
             "WindowsServer2019FullContainer",
             "WindowsServer2022CoreContainer",
-            "WindowsServer2022FullContainer"
+            "WindowsServer2022FullContainer",
+            "WindowsServer2025CoreContainer",
+            "WindowsServer2025FullContainer"
           ]
         },
         "asgSuspendProcesses": {
@@ -2001,8 +2003,8 @@
         },
         "amiFamily": {
           "type": "string",
-          "description": "Valid variants are: `\"AmazonLinux2023\"` (default), `\"AmazonLinux2\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"UbuntuPro2004\"`, `\"Ubuntu2004\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`.",
-          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2023&quot;</code> (default), <code>&quot;AmazonLinux2&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;UbuntuPro2004&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>.",
+          "description": "Valid variants are: `\"AmazonLinux2023\"` (default), `\"AmazonLinux2\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"UbuntuPro2004\"`, `\"Ubuntu2004\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`, `\"WindowsServer2025CoreContainer\"`, `\"WindowsServer2025FullContainer\"`.",
+          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2023&quot;</code> (default), <code>&quot;AmazonLinux2&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;UbuntuPro2004&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>, <code>&quot;WindowsServer2025CoreContainer&quot;</code>, <code>&quot;WindowsServer2025FullContainer&quot;</code>.",
           "default": "AmazonLinux2023",
           "enum": [
             "AmazonLinux2023",
@@ -2017,7 +2019,9 @@
             "WindowsServer2019CoreContainer",
             "WindowsServer2019FullContainer",
             "WindowsServer2022CoreContainer",
-            "WindowsServer2022FullContainer"
+            "WindowsServer2022FullContainer",
+            "WindowsServer2025CoreContainer",
+            "WindowsServer2025FullContainer"
           ]
         },
         "asgMetricsCollection": {

--- a/pkg/apis/eksctl.io/v1alpha5/outposts_validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/outposts_validation_test.go
@@ -217,6 +217,8 @@ var _ = Describe("Outposts validation", func() {
 		Entry("Windows2019Full", api.NodeImageFamilyWindowsServer2019FullContainer, true),
 		Entry("Windows2022Core", api.NodeImageFamilyWindowsServer2022CoreContainer, true),
 		Entry("Windows2022Full", api.NodeImageFamilyWindowsServer2022FullContainer, true),
+		Entry("Windows2025Core", api.NodeImageFamilyWindowsServer2025CoreContainer, true),
+		Entry("Windows2025Full", api.NodeImageFamilyWindowsServer2025FullContainer, true),
 	)
 
 	type nodeGroupEntry struct {

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -49,6 +49,7 @@ const (
 	Version1_32                  = "1.32"
 	Version1_33                  = "1.33"
 	Version1_34                  = "1.34"
+	Version1_35                  = "1.35"
 	DockershimDeprecationVersion = Version1_24
 	AmazonLinux2EOLVersion       = Version1_33
 	// EFABuiltInSupportVersion defines the minimum Kubernetes version that supports built-in EFA
@@ -224,6 +225,9 @@ const (
 
 	NodeImageFamilyWindowsServer2022CoreContainer = "WindowsServer2022CoreContainer"
 	NodeImageFamilyWindowsServer2022FullContainer = "WindowsServer2022FullContainer"
+
+	NodeImageFamilyWindowsServer2025CoreContainer = "WindowsServer2025CoreContainer"
+	NodeImageFamilyWindowsServer2025FullContainer = "WindowsServer2025FullContainer"
 )
 
 // Deprecated `NodeAMIFamily`
@@ -605,6 +609,8 @@ func SupportedAMIFamilies() []string {
 		NodeImageFamilyWindowsServer2019FullContainer,
 		NodeImageFamilyWindowsServer2022CoreContainer,
 		NodeImageFamilyWindowsServer2022FullContainer,
+		NodeImageFamilyWindowsServer2025CoreContainer,
+		NodeImageFamilyWindowsServer2025FullContainer,
 	}
 }
 

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -1674,7 +1674,9 @@ func IsWindowsImage(imageFamily string) bool {
 	case NodeImageFamilyWindowsServer2019CoreContainer,
 		NodeImageFamilyWindowsServer2019FullContainer,
 		NodeImageFamilyWindowsServer2022CoreContainer,
-		NodeImageFamilyWindowsServer2022FullContainer:
+		NodeImageFamilyWindowsServer2022FullContainer,
+		NodeImageFamilyWindowsServer2025CoreContainer,
+		NodeImageFamilyWindowsServer2025FullContainer:
 		return true
 
 	default:

--- a/userdocs/src/usage/custom-ami-support.md
+++ b/userdocs/src/usage/custom-ami-support.md
@@ -68,6 +68,8 @@ The `--node-ami-family` can take following keywords:
 | WindowsServer2019CoreContainer | Indicates that the EKS AMI image based on Windows Server 2019 Core Container should be used.                                |
 | WindowsServer2022FullContainer | Indicates that the EKS AMI image based on Windows Server 2022 Full Container should be used.                                |
 | WindowsServer2022CoreContainer | Indicates that the EKS AMI image based on Windows Server 2022 Core Container should be used.                                |
+| WindowsServer2025FullContainer | Indicates that the EKS AMI image based on Windows Server 2025 Full Container should be used.                                |
+| WindowsServer2025CoreContainer | Indicates that the EKS AMI image based on Windows Server 2025 Core Container should be used.                                |
 
 CLI flag example:
 ```sh


### PR DESCRIPTION
### Description

Added new AMI type for eksctl to recognize and handle. With EKS 1.35, Windows is releasing support for Windows Server 2025. This PR include the changes in eksctl to launch Windows Server 2025 node groups.

eksctl will handle the Windows Server 2025 same as Windows 2022. There is no special handling required in eksctl to support WS2025.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

