### PR TITLE
Do not install metrics-server addon automatically.

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/known_addons.go
+++ b/pkg/apis/eksctl.io/v1alpha5/known_addons.go
@@ -27,7 +27,6 @@ var KnownAddons = map[string]struct {
 	AWSEBSCSIDriverAddon: {},
 	AWSEFSCSIDriverAddon: {},
 	MetricsServerAddon: {
-		IsDefault:             true,
 		CreateBeforeNodeGroup: false, // Create after nodegroup so we get scheduled on Fargate profiles.
 		IsDefaultAutoMode:     true,
 		ExcludedRegions: []string{


### PR DESCRIPTION
### Description

With this patch, the _metrics-server_ addon no longer gets installed as a core addon. This was not documented, and conflicts with users managing their own installation of metric-server.

This should not affect existing clusters, and brings creation of new clusters in line with the documentation and established behavior.

fixes: https://github.com/eksctl-io/eksctl/issues/8652

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

