### PR TITLE
only create iam role stack for capability if the roleArn is not provided

### DIFF
--- a/pkg/actions/capability/creator.go
+++ b/pkg/actions/capability/creator.go
@@ -70,8 +70,11 @@ func (c *Creator) CreateTasks(ctx context.Context, capabilities []api.Capability
 				if err := c.ensureClusterReady(ctx); err != nil {
 					return fmt.Errorf("cluster not ready for capability creation: %w", err)
 				}
-				if err := c.createIAMRoleStack(ctx, &cap); err != nil {
-					return err
+				// Only create IAM role stack if RoleARN is not provided
+				if cap.RoleARN == "" {
+					if err := c.createIAMRoleStack(ctx, &cap); err != nil {
+						return err
+					}
 				}
 
 				return c.createCapability(ctx, &cap)


### PR DESCRIPTION
### Description

Issue [#8654](https://github.com/eksctl-io/eksctl/issues/8654)

Create iam role stack for capability to create the role only if the role is not provided through the flag `--role-arn`

### Tests

Manually tested by providing the and without providing the role in the configuration and as flag `--role-arn`. The iam role-arn stack is only created and set if the flag is not provided. If the role-arn is provided by the customer wither through configuration or through flag, this is not created and customer provided role is used

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

