### PR TITLE
fix integration test with eks default version change

### DIFF
--- a/integration/tests/custom_ami/custom_ami_test.go
+++ b/integration/tests/custom_ami/custom_ami_test.go
@@ -58,7 +58,7 @@ var _ = BeforeSuite(func() {
 
 	// retrieve AL2 AMI
 	input := &awsssm.GetParameterInput{
-		Name: aws.String(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", params.Version)),
+		Name: aws.String(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", api.Version1_32)),
 	}
 	output, err := ssm.GetParameter(context.Background(), input)
 	Expect(err).NotTo(HaveOccurred())

--- a/integration/tests/dry_run/dry_run_test.go
+++ b/integration/tests/dry_run/dry_run_test.go
@@ -68,7 +68,7 @@ accessConfig:
   authenticationMode: API_AND_CONFIG_MAP
 addonsConfig: {}
 nodeGroups:
-- amiFamily: AmazonLinux2
+- amiFamily: AmazonLinux2023
   containerRuntime: containerd
   disableIMDSv1: true
   disablePodIMDS: false


### PR DESCRIPTION
### Description

fix integration test with eks default version change

We recently changed the default version for eks to 1.34 for eksctl with https://github.com/eksctl-io/eksctl/commit/ace3ad17eeb7f23c9070827b6b625d8fa945d3ca. Although AL2 amis are not supported from 1.33 eks version so integration tests are failing
- https://github.com/eksctl-io/eksctl-ci/actions/runs/2159181234a7/job/62214916706
- https://github.com/eksctl-io/eksctl-ci/actions/runs/21591812347/job/62214917574

Fixing integration test to use 1.32 version for AL2 amis and other self ngs

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

