### PR TITLE
replace AmazonLinux2 amis with AmazonLinux2023 | remove override-bootstrap test in custom_ami tests

### DIFF
--- a/integration/tests/custom_ami/custom_ami_test.go
+++ b/integration/tests/custom_ami/custom_ami_test.go
@@ -130,28 +130,6 @@ var _ = Describe("(Integration) [Test Custom AMI]", func() {
 		})
 	})
 
-	Context("override bootstrap command for managed and un-managed nodegroups", func() {
-
-		It("can create a working nodegroup which can join the cluster", func() {
-			By(fmt.Sprintf("using the following EKS optimised AMI: %s", customAMIAL2))
-			content, err := os.ReadFile(filepath.Join("testdata/override-bootstrap.yaml"))
-			Expect(err).NotTo(HaveOccurred())
-			content = bytes.ReplaceAll(content, []byte("<generated>"), []byte(params.ClusterName))
-			content = bytes.ReplaceAll(content, []byte("<generated-region>"), []byte(params.Region))
-			content = bytes.ReplaceAll(content, []byte("<generated-ami>"), []byte(customAMIAL2))
-			cmd := params.EksctlCreateCmd.
-				WithArgs(
-					"nodegroup",
-					"--config-file", "-",
-					"--verbose", "4",
-				).
-				WithoutArg("--region", params.Region).
-				WithStdin(bytes.NewReader(content))
-			Expect(cmd).To(RunSuccessfully())
-		})
-
-	})
-
 	Context("bottlerocket un-managed nodegroups", func() {
 
 		It("can create a working nodegroup which can join the cluster", func() {

--- a/integration/tests/dry_run/dry_run_test.go
+++ b/integration/tests/dry_run/dry_run_test.go
@@ -287,7 +287,7 @@ var _ = Describe("(Integration) [Dry-Run test]", func() {
 			Memory: "4",
 		}
 
-	}, "--managed=false", "--instance-selector-vcpus=2", "--instance-selector-memory=4", "--node-ami-family=AmazonLinux2"),
+	}, "--managed=false", "--instance-selector-vcpus=2", "--instance-selector-memory=4", "--node-ami-family=AmazonLinux2023"),
 
 		Entry("instance selector options with managed nodegroup", func(actual, expected *api.ClusterConfig) {
 			Expect(actual.ManagedNodeGroups[0].InstanceTypes).NotTo(BeEmpty())


### PR DESCRIPTION
### Description

replace AmazonLinux2 amis with AmazonLinux2023 | remove override-bootstrap test in custom_ami tests

Starting 1.32 version AL2 amis are not supported for nodes creation and the tests are failing. We are replacing the AL2 amis with AL2023 to fix the integration tests

Will create an issue to re-add the override-bootstrap test with AL2023 amis. This needs changes in the bootstrap scripts

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

