### PR TITLE
change ubuntu ami family to 2404

### DIFF
--- a/integration/tests/managed/managed_nodegroup_test.go
+++ b/integration/tests/managed/managed_nodegroup_test.go
@@ -364,7 +364,7 @@ var _ = Describe("(Integration) Create Managed Nodegroups", func() {
 					NodeGroupBase: &api.NodeGroupBase{
 						Name:         ubuntuNodegroup,
 						VolumeSize:   aws.Int(25),
-						AMIFamily:    "Ubuntu2204",
+						AMIFamily:    "Ubuntu2404",
 						InstanceType: "t3a.xlarge",
 					},
 				},


### PR DESCRIPTION
### Description

change ubuntu ami family to 2404

This is made as for default eks version 1.34, ubuntu2204 is not available

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

