### PR TITLE
Add AWS Global Accelerator support

### DIFF
--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -2434,6 +2434,9 @@
           "description": "enables IAM policy for cluster-autoscaler",
           "x-intellij-html-description": "enables IAM policy for cluster-autoscaler"
         },
+        "awsGlobalAccelerator": {
+          "type": "boolean"
+        },
         "awsLoadBalancerController": {
           "type": "boolean"
         },
@@ -2483,7 +2486,8 @@
         "awsLoadBalancerController",
         "albIngress",
         "xRay",
-        "cloudWatch"
+        "cloudWatch",
+        "awsGlobalAccelerator"
       ],
       "additionalProperties": false,
       "description": "holds all IAM addon policies",
@@ -3152,6 +3156,12 @@
           "x-intellij-html-description": "adds policies for cluster-autoscaler. See <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/cluster-autoscaler.html\">autoscaler AWS docs</a>.",
           "default": "false"
         },
+        "awsGlobalAccelerator": {
+          "type": "boolean",
+          "description": "adds policies for using the Amazon Global Accelerator. See [IAM Policy for AWS Global Accelerator Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/install/aga_controller_iam_policy/).",
+          "x-intellij-html-description": "adds policies for using the Amazon Global Accelerator. See <a href=\"https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/install/aga_controller_iam_policy/\">IAM Policy for AWS Global Accelerator Controller</a>.",
+          "default": "false"
+        },
         "awsLoadBalancerController": {
           "type": "boolean",
           "description": "adds policies for using the aws-load-balancer-controller. See [Load Balancer docs](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html).",
@@ -3196,7 +3206,8 @@
         "externalDNS",
         "certManager",
         "ebsCSIController",
-        "efsCSIController"
+        "efsCSIController",
+        "awsGlobalAccelerator"
       ],
       "additionalProperties": false,
       "description": "for attaching common IAM policies",

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -1290,6 +1290,7 @@ func NewNodeGroup() *NodeGroup {
 					DeprecatedALBIngress:      Disabled(),
 					XRay:                      Disabled(),
 					CloudWatch:                Disabled(),
+					AWSGlobalAccelerator:      Disabled(),
 				},
 			},
 			ScalingConfig: &ScalingConfig{},
@@ -1340,6 +1341,7 @@ func NewManagedNodeGroup() *ManagedNodeGroup {
 					DeprecatedALBIngress:      Disabled(),
 					XRay:                      Disabled(),
 					CloudWatch:                Disabled(),
+					AWSGlobalAccelerator:      Disabled(),
 				},
 			},
 			ScalingConfig:  &ScalingConfig{},
@@ -1565,6 +1567,8 @@ type (
 		XRay *bool `json:"xRay"`
 		// +optional
 		CloudWatch *bool `json:"cloudWatch"`
+		// +optional
+		AWSGlobalAccelerator *bool `json:"awsGlobalAccelerator"`
 	}
 
 	// NodeGroupSSH holds all the ssh access configuration to a NodeGroup

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -1215,6 +1215,9 @@ func validateNodeGroupIAMWithAddonPolicies(
 	if IsEnabled(policies.CloudWatch) {
 		return fmtFieldConflictErr(prefix + "cloudWatch")
 	}
+	if IsEnabled(policies.AWSGlobalAccelerator) {
+		return fmtFieldConflictErr(prefix + "awsGlobalAccelerator")
+	}
 	return nil
 }
 

--- a/pkg/apis/eksctl.io/v1alpha5/well_known_iam_policy.go
+++ b/pkg/apis/eksctl.io/v1alpha5/well_known_iam_policy.go
@@ -32,10 +32,14 @@ type WellKnownPolicies struct {
 	// efs-csi-controller. See [aws-efs-csi-driver
 	// docs](https://aws.amazon.com/blogs/containers/introducing-efs-csi-dynamic-provisioning).
 	EFSCSIController bool `json:"efsCSIController,inline"`
+	// AWSGlobalAccelerator adds policies for using the
+	// Amazon Global Accelerator. See [IAM Policy for
+	// AWS Global Accelerator Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/install/aga_controller_iam_policy/).
+	AWSGlobalAccelerator bool `json:"awsGlobalAccelerator,inline"`
 }
 
 func (p *WellKnownPolicies) HasPolicy() bool {
-	return p.ImageBuilder || p.AutoScaler || p.AWSLoadBalancerController || p.ExternalDNS || p.CertManager || p.EBSCSIController || p.EFSCSIController
+	return p.ImageBuilder || p.AutoScaler || p.AWSLoadBalancerController || p.ExternalDNS || p.CertManager || p.EBSCSIController || p.EFSCSIController || p.AWSGlobalAccelerator
 }
 
 func (p *WellKnownPolicies) String() string { return "" }

--- a/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/eksctl.io/v1alpha5/zz_generated.deepcopy.go
@@ -2072,6 +2072,11 @@ func (in *NodeGroupIAMAddonPolicies) DeepCopyInto(out *NodeGroupIAMAddonPolicies
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AWSGlobalAccelerator != nil {
+		in, out := &in.AWSGlobalAccelerator, &out.AWSGlobalAccelerator
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/awsapi/autoscaling.go
+++ b/pkg/awsapi/autoscaling.go
@@ -926,4 +926,3 @@ type ASG interface {
 	// [PutScalingPolicy]: https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_PutScalingPolicy.html
 	UpdateAutoScalingGroup(ctx context.Context, params *autoscaling.UpdateAutoScalingGroupInput, optFns ...func(*Options)) (*autoscaling.UpdateAutoScalingGroupOutput, error)
 }
-

--- a/pkg/awsapi/cloudwatchlogs.go
+++ b/pkg/awsapi/cloudwatchlogs.go
@@ -1888,4 +1888,3 @@ type CloudWatchLogs interface {
 	// destinations.
 	UpdateScheduledQuery(ctx context.Context, params *cloudwatchlogs.UpdateScheduledQueryInput, optFns ...func(*Options)) (*cloudwatchlogs.UpdateScheduledQueryOutput, error)
 }
-

--- a/pkg/awsapi/ec2.go
+++ b/pkg/awsapi/ec2.go
@@ -6458,4 +6458,3 @@ type EC2 interface {
 	// routing to Amazon Web Services because of BGP propagation delays.
 	WithdrawByoipCidr(ctx context.Context, params *ec2.WithdrawByoipCidrInput, optFns ...func(*Options)) (*ec2.WithdrawByoipCidrOutput, error)
 }
-

--- a/pkg/awsapi/eks.go
+++ b/pkg/awsapi/eks.go
@@ -573,4 +573,3 @@ type EKS interface {
 	// Amazon Web Services account.
 	UpdatePodIdentityAssociation(ctx context.Context, params *eks.UpdatePodIdentityAssociationInput, optFns ...func(*Options)) (*eks.UpdatePodIdentityAssociationOutput, error)
 }
-

--- a/pkg/cfn/builder/iam_helper.go
+++ b/pkg/cfn/builder/iam_helper.go
@@ -74,6 +74,11 @@ func createWellKnownPolicies(wellKnownPolicies api.WellKnownPolicies) ([]managed
 			customPolicyForRole{Name: "PolicyEFSCSIController", Statements: efsCSIControllerStatements()},
 		)
 	}
+	if wellKnownPolicies.AWSGlobalAccelerator {
+		customPolicies = append(customPolicies,
+			customPolicyForRole{Name: "PolicyAWSGlobalAccelerator", Statements: globalAcceleratorStatements()},
+		)
+	}
 	return managedPolicies, customPolicies
 }
 
@@ -141,6 +146,10 @@ func createRole(cfnTemplate cfnTemplate, clusterIAMConfig *api.ClusterIAM, iamCo
 
 	if api.IsEnabled(iamConfig.WithAddonPolicies.XRay) {
 		cfnTemplate.attachAllowPolicy("PolicyXRay", refIR, xRayStatements())
+	}
+
+	if api.IsEnabled(iamConfig.WithAddonPolicies.AWSGlobalAccelerator) {
+		cfnTemplate.attachAllowPolicy("PolicyAWSGlobalAccelerator", refIR, globalAcceleratorStatements())
 	}
 
 	return nil

--- a/pkg/cfn/builder/iam_test.go
+++ b/pkg/cfn/builder/iam_test.go
@@ -336,7 +336,7 @@ var _ = Describe("template builder for IAM", func() {
             ]`))
 			Expect(t).To(HaveOutputWithValue(outputs.IAMServiceAccountRoleName, `{ "Fn::GetAtt": "Role1.Arn" }`))
 			Expect(t).To(HaveResourceWithPropertyValue("PolicyAWSLoadBalancerController", "PolicyDocument", expectedAWSLoadBalancerControllerPolicyDocument))
-			Expect(t).To(HaveResourceWithPropertyValue("PolicyAWSGlobalAccelerator", "PolicyDocument", expectedAWSAWSGlobalAcceleratorPolicyDocument))
+			Expect(t).To(HaveResourceWithPropertyValue("PolicyAWSGlobalAccelerator", "PolicyDocument", expectedAWSGlobalAcceleratorPolicyDocument))
 		})
 
 		It("can parse an iamserviceaccount addon template", func() {
@@ -809,7 +809,7 @@ const expectedAWSLoadBalancerControllerPolicyDocument = `{
   "Version": "2012-10-17"
 }`
 
-const expectedAWSAWSGlobalAcceleratorPolicyDocument = `{
+const expectedAWSGlobalAcceleratorPolicyDocument = `{
   "Statement": [
     {
       "Effect": "Allow",

--- a/pkg/cfn/builder/managed_nodegroup_test.go
+++ b/pkg/cfn/builder/managed_nodegroup_test.go
@@ -60,6 +60,14 @@ func TestManagedPolicyResources(t *testing.T) {
 			description:             "AutoScaler enabled",
 		},
 		{
+			addons: api.NodeGroupIAMAddonPolicies{
+				AWSGlobalAccelerator: api.Enabled(),
+			},
+			expectedNewPolicies:     []string{"PolicyAWSGlobalAccelerator"},
+			expectedManagedPolicies: makePartitionedPolicies("AmazonEKSWorkerNodePolicy", "AmazonEKS_CNI_Policy", "AmazonEC2ContainerRegistryPullOnly", "AmazonSSMManagedInstanceCore"),
+			description:             "AWSGlobalAccelerator enabled",
+		},
+		{
 			attachPolicy: cft.MakePolicyDocument(cft.MapOfInterfaces{
 				"Effect": "Allow",
 				"Action": []string{

--- a/pkg/cfn/builder/statement.go
+++ b/pkg/cfn/builder/statement.go
@@ -482,3 +482,128 @@ func efsCSIControllerStatements() []cft.MapOfInterfaces {
 		},
 	}
 }
+
+func globalAcceleratorStatements() []cft.MapOfInterfaces {
+	return []cft.MapOfInterfaces{
+		{
+			"Effect":   effectAllow,
+			"Action":   []string{"iam:CreateServiceLinkedRole"},
+			"Resource": resourceAll,
+			"Condition": map[string]interface{}{
+				"StringEquals": map[string][]string{
+					"iam:AWSServiceName": {
+						"globalaccelerator.amazonaws.com",
+					},
+				},
+			},
+		},
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"globalaccelerator:ListAccelerators",
+				"globalaccelerator:ListEndpointGroups",
+				"globalaccelerator:ListListeners",
+				"globalaccelerator:ListTagsForResource",
+				"ec2:DescribeRegions",
+				"tag:GetResources",
+			},
+		},
+		{
+			"Effect": effectAllow,
+			"Resource": []*gfnt.Value{
+				addARNPartitionPrefix("globalaccelerator::*:accelerator/*"),
+				addARNPartitionPrefix("globalaccelerator::*:accelerator/*/listener/*"),
+				addARNPartitionPrefix("globalaccelerator::*:accelerator/*/listener/*/endpoint-group/*"),
+			},
+			"Action": []string{
+				"globalaccelerator:DescribeAccelerator",
+				"globalaccelerator:DescribeEndpointGroup",
+				"globalaccelerator:DescribeListener",
+			},
+			"Condition": map[string]interface{}{
+				"Null": map[string]string{
+					"aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
+				},
+				"StringEquals": map[string]string{
+					"aws:ResourceTag/aga.k8s.aws/resource": "GlobalAccelerator",
+				},
+			},
+		},
+		{
+			"Effect":   effectAllow,
+			"Resource": resourceAll,
+			"Action": []string{
+				"globalaccelerator:CreateAccelerator",
+			},
+			"Condition": map[string]interface{}{
+				"Null": map[string]string{
+					"aws:RequestTag/elbv2.k8s.aws/cluster": "false",
+				},
+				"StringEquals": map[string]string{
+					"aws:RequestTag/aga.k8s.aws/resource": "GlobalAccelerator",
+				},
+			},
+		},
+		{
+			"Effect": effectAllow,
+			"Resource": []*gfnt.Value{
+				addARNPartitionPrefix("globalaccelerator::*:accelerator/*"),
+				addARNPartitionPrefix("globalaccelerator::*:accelerator/*/listener/*"),
+				addARNPartitionPrefix("globalaccelerator::*:accelerator/*/listener/*/endpoint-group/*"),
+			},
+			"Action": []string{
+				"globalaccelerator:UpdateAccelerator",
+				"globalaccelerator:DeleteAccelerator",
+				"globalaccelerator:CreateListener",
+				"globalaccelerator:UpdateListener",
+				"globalaccelerator:DeleteListener",
+				"globalaccelerator:CreateEndpointGroup",
+				"globalaccelerator:UpdateEndpointGroup",
+				"globalaccelerator:DeleteEndpointGroup",
+				"globalaccelerator:AddEndpoints",
+				"globalaccelerator:RemoveEndpoints",
+			},
+			"Condition": map[string]interface{}{
+				"Null": map[string]string{
+					"aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
+				},
+				"StringEquals": map[string]string{
+					"aws:ResourceTag/aga.k8s.aws/resource": "GlobalAccelerator",
+				},
+			},
+		},
+		{
+			"Effect":   effectAllow,
+			"Resource": addARNPartitionPrefix("globalaccelerator::*:accelerator/*"),
+			"Action": []string{
+				"globalaccelerator:TagResource",
+				"globalaccelerator:UntagResource",
+			},
+			"Condition": map[string]interface{}{
+				"Null": map[string]string{
+					"aws:RequestTag/elbv2.k8s.aws/cluster":  "true",
+					"aws:ResourceTag/elbv2.k8s.aws/cluster": "false",
+				},
+				"StringEquals": map[string]string{
+					"aws:ResourceTag/aga.k8s.aws/resource": "GlobalAccelerator",
+				},
+			},
+		},
+		{
+			"Effect":   effectAllow,
+			"Resource": addARNPartitionPrefix("globalaccelerator::*:accelerator/*"),
+			"Action": []string{
+				"globalaccelerator:TagResource",
+			},
+			"Condition": map[string]interface{}{
+				"Null": map[string]string{
+					"aws:RequestTag/elbv2.k8s.aws/cluster": "false",
+				},
+				"StringEquals": map[string]string{
+					"aws:RequestTag/aga.k8s.aws/resource": "GlobalAccelerator",
+				},
+			},
+		},
+	}
+}

--- a/pkg/ctl/cmdutils/filter/nodegroup_filter_test.go
+++ b/pkg/ctl/cmdutils/filter/nodegroup_filter_test.go
@@ -414,7 +414,8 @@ var expected = fmt.Sprintf(`
 				  "efs": false,
 				  "albIngress": false,
 				  "xRay": false,
-				  "cloudWatch": false
+				  "cloudWatch": false,
+                  "awsGlobalAccelerator": false
 			    }
 			  },
 			  "disableIMDSv1": true,
@@ -459,7 +460,8 @@ var expected = fmt.Sprintf(`
 				  "efs": false,
 				  "albIngress": false,
 				  "xRay": false,
-				  "cloudWatch": false
+				  "cloudWatch": false,
+                  "awsGlobalAccelerator": false
 			    }
 			  },
 			  "disableIMDSv1": true,
@@ -504,7 +506,8 @@ var expected = fmt.Sprintf(`
 				  "efs": false,
 				  "albIngress": false,
 				  "xRay": false,
-				  "cloudWatch": false
+				  "cloudWatch": false,
+                  "awsGlobalAccelerator": false
 			    }
 			  },
 			  "clusterDNS": "1.2.3.4",
@@ -540,7 +543,7 @@ var expected = fmt.Sprintf(`
 			    "withAddonPolicies": {
 			  	  "imageBuilder": false,
 			  	  "autoScaler": false,
-				    "awsLoadBalancerController": false,
+                  "awsLoadBalancerController": false,
 			  	  "externalDNS": false,
 			  	  "certManager": false,
 			  	  "appMesh": false,
@@ -550,7 +553,8 @@ var expected = fmt.Sprintf(`
 			  	  "efs": false,
 				  "albIngress": false,
 				  "xRay": false,
-				  "cloudWatch": false
+				  "cloudWatch": false,
+                  "awsGlobalAccelerator": false
 			    }
 			  },
 			  "disableIMDSv1": true,
@@ -588,7 +592,7 @@ var expected = fmt.Sprintf(`
 			    "withAddonPolicies": {
 			  	  "imageBuilder": false,
 			  	  "autoScaler": false,
-				    "awsLoadBalancerController": false,
+                  "awsLoadBalancerController": false,
 			  	  "externalDNS": false,
 			  	  "certManager": false,
 			  	  "appMesh": false,
@@ -598,7 +602,8 @@ var expected = fmt.Sprintf(`
 			  	  "efs": false,
 				  "albIngress": false,
 				  "xRay": false,
-				  "cloudWatch": false
+				  "cloudWatch": false,
+                  "awsGlobalAccelerator": false
 			    }
 			  },
 			  "clusterDNS": "4.2.8.14",
@@ -647,7 +652,8 @@ var expected = fmt.Sprintf(`
 			  	  "efs": false,
 				  "albIngress": false,
 				  "xRay": false,
-				  "cloudWatch": false
+				  "cloudWatch": false,
+                  "awsGlobalAccelerator": false
 			    }
 			  },
 			  "disableIMDSv1": true,

--- a/pkg/ctl/cmdutils/nodegroup_flags.go
+++ b/pkg/ctl/cmdutils/nodegroup_flags.go
@@ -96,12 +96,14 @@ func addCommonCreateNodeGroupIAMAddonsFlags(fs *pflag.FlagSet, ng *api.NodeGroup
 	ng.IAM.WithAddonPolicies.AWSLoadBalancerController = new(bool)
 	ng.IAM.WithAddonPolicies.XRay = new(bool)
 	ng.IAM.WithAddonPolicies.CloudWatch = new(bool)
+	ng.IAM.WithAddonPolicies.AWSGlobalAccelerator = new(bool)
 	fs.BoolVar(ng.IAM.WithAddonPolicies.AutoScaler, "asg-access", false, "enable IAM policy for cluster-autoscaler")
 	fs.BoolVar(ng.IAM.WithAddonPolicies.ExternalDNS, "external-dns-access", false, "enable IAM policy for external-dns")
 	fs.BoolVar(ng.IAM.WithAddonPolicies.ImageBuilder, "full-ecr-access", false, "enable full access to ECR")
 	fs.BoolVar(ng.IAM.WithAddonPolicies.AppMesh, "appmesh-access", false, "enable full access to AppMesh")
 	fs.BoolVar(ng.IAM.WithAddonPolicies.AppMeshPreview, "appmesh-preview-access", false, "enable full access to AppMesh Preview")
 	fs.BoolVar(ng.IAM.WithAddonPolicies.AWSLoadBalancerController, "alb-ingress-access", false, "enable full access for alb-ingress-controller")
+	fs.BoolVar(ng.IAM.WithAddonPolicies.AWSGlobalAccelerator, "global-accelerator-access", false, "enable IAM policy for Global Accelerator")
 }
 
 // AddNodeGroupFilterFlags add common `--include` and `--exclude` flags for filtering nodegroups


### PR DESCRIPTION
### Description

This PR adds IAM addon policy support for Global Accelerator. It wires the policy statements into the CFN builder, exposes configuration/flags, updates generated artefacts, and adds test coverage to ensure the policy is attached as expected for nodegroups and IRSA.

#### Key changes
Add Global Accelerator IAM policy statements and attach them in CFN.
Expose globalAccelerator in API defaults/validation and CLI flags.
Update the schema and deepcopy the generated files to include the new field.
Add unit tests for nodegroup and IAM policy attachment.

#### Impact
Nodegroup addon policy
IAM service account (well-known policies)
Schema/generated artefacts
Unit tests

#### Manual testing snippet
```
[n] ~/D/G/eksctl ☭ awsGlobalAccelerator ● (^._.^)ﾉ彡ミ
⫸  cat eks-sa.yaml 
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig
metadata:
  name: dev
  region: ap-east-1
  version: "1.34"

iam:
  withOIDC: true
  serviceAccounts:
    - metadata:
        name: test-eksctl
        namespace: kube-system
      wellKnownPolicies:
        awsLoadBalancerController: true
        awsGlobalAccelerator: true
[n] ~/D/G/eksctl ☭ awsGlobalAccelerator ● (^._.^)ﾉ彡ミ
⫸  ./eksctl create iamserviceaccount -f=/Users/shirinmi/Developer/GitHub/eksctl/eks-sa.yaml --approve
2026-02-09 23:07:07 [ℹ]  3 existing iamserviceaccount(s) (kube-system/aws-load-balancer-controller,kube-system/ebs-csi-controller-sa,kube-system/external-dns) will be excluded
2026-02-09 23:07:07 [ℹ]  1 iamserviceaccount (kube-system/test-eksctl) was included (based on the include/exclude rules)
2026-02-09 23:07:07 [!]  serviceaccounts that exist in Kubernetes will be excluded, use --override-existing-serviceaccounts to override
2026-02-09 23:07:07 [ℹ]  1 task: { 
    2 sequential sub-tasks: { 
        create IAM role for serviceaccount "kube-system/test-eksctl",
        create serviceaccount "kube-system/test-eksctl",
    } }2026-02-09 23:07:07 [ℹ]  building iamserviceaccount stack "eksctl-dev-addon-iamserviceaccount-kube-system-test-eksctl"
2026-02-09 23:07:07 [ℹ]  deploying stack "eksctl-dev-addon-iamserviceaccount-kube-system-test-eksctl"
2026-02-09 23:07:07 [ℹ]  waiting for CloudFormation stack "eksctl-dev-addon-iamserviceaccount-kube-system-test-eksctl"
2026-02-09 23:07:37 [ℹ]  waiting for CloudFormation stack "eksctl-dev-addon-iamserviceaccount-kube-system-test-eksctl"
2026-02-09 23:08:17 [ℹ]  waiting for CloudFormation stack "eksctl-dev-addon-iamserviceaccount-kube-system-test-eksctl"
2026-02-09 23:08:17 [ℹ]  created serviceaccount "kube-system/test-eksctl"
```

#### Manual testing screenshot
<img width="1081" height="561" alt="image" src="https://github.com/user-attachments/assets/50892a3c-911c-4a08-9e07-8bd9bec9ce02" />
<img width="1220" height="621" alt="image" src="https://github.com/user-attachments/assets/01c452b8-9459-4129-bd98-f8ae1076003e" />

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the README.md or the userdocs directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. area/nodegroup) and kind (e.g. kind/improvement)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in the same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
