### PR TITLE
feat(ubuntu): add support for resolute

### DIFF
--- a/pkg/ami/auto_resolver.go
+++ b/pkg/ami/auto_resolver.go
@@ -35,6 +35,10 @@ func MakeImageSearchPatterns(version string) map[string]map[int]string {
 			ImageClassNeuron:  fmt.Sprintf("amazon-eks-gpu-node-%s-*", version),
 			ImageClassARM:     fmt.Sprintf("amazon-eks-arm64-node-%s-*", version),
 		},
+		api.NodeImageFamilyUbuntuPro2604: {
+			ImageClassGeneral: fmt.Sprintf("ubuntu-eks-pro/k8s_%s/images/*26.04-amd64*", version),
+			ImageClassARM:     fmt.Sprintf("ubuntu-eks-pro/k8s_%s/images/*26.04-arm64*", version),
+		},
 		api.NodeImageFamilyUbuntuPro2404: {
 			ImageClassGeneral: fmt.Sprintf("ubuntu-eks-pro/k8s_%s/images/*24.04-amd64*", version),
 			ImageClassARM:     fmt.Sprintf("ubuntu-eks-pro/k8s_%s/images/*24.04-arm64*", version),
@@ -46,6 +50,10 @@ func MakeImageSearchPatterns(version string) map[string]map[int]string {
 		api.NodeImageFamilyUbuntuPro2004: {
 			ImageClassGeneral: fmt.Sprintf("ubuntu-eks-pro/k8s_%s/images/*20.04-amd64*", version),
 			ImageClassARM:     fmt.Sprintf("ubuntu-eks-pro/k8s_%s/images/*20.04-arm64*", version),
+		},
+		api.NodeImageFamilyUbuntu2604: {
+			ImageClassGeneral: fmt.Sprintf("ubuntu-eks/k8s_%s/images/*26.04-amd64*", version),
+			ImageClassARM:     fmt.Sprintf("ubuntu-eks/k8s_%s/images/*26.04-arm64*", version),
 		},
 		api.NodeImageFamilyUbuntu2404: {
 			ImageClassGeneral: fmt.Sprintf("ubuntu-eks/k8s_%s/images/*24.04-amd64*", version),
@@ -83,7 +91,7 @@ func MakeImageSearchPatterns(version string) map[string]map[int]string {
 // OwnerAccountID returns the AWS account ID that owns worker AMI.
 func OwnerAccountID(imageFamily, region string) (string, error) {
 	switch imageFamily {
-	case api.NodeImageFamilyUbuntuPro2404, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntuPro2004, api.NodeImageFamilyUbuntu2004:
+	case api.NodeImageFamilyUbuntuPro2604, api.NodeImageFamilyUbuntu2604, api.NodeImageFamilyUbuntuPro2404, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntuPro2004, api.NodeImageFamilyUbuntu2004:
 		return ownerIDUbuntuFamily, nil
 	case api.NodeImageFamilyAmazonLinux2023, api.NodeImageFamilyAmazonLinux2:
 		return api.EKSResourceAccountID(region), nil

--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -1651,12 +1651,14 @@
         },
         "amiFamily": {
           "type": "string",
-          "description": "Valid variants are: `\"AmazonLinux2023\"` (default), `\"AmazonLinux2\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"UbuntuPro2004\"`, `\"Ubuntu2004\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`, `\"WindowsServer2025CoreContainer\"`, `\"WindowsServer2025FullContainer\"`.",
-          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2023&quot;</code> (default), <code>&quot;AmazonLinux2&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;UbuntuPro2004&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>, <code>&quot;WindowsServer2025CoreContainer&quot;</code>, <code>&quot;WindowsServer2025FullContainer&quot;</code>.",
+          "description": "Valid variants are: `\"AmazonLinux2023\"` (default), `\"AmazonLinux2\"`, `\"UbuntuPro2604\"`, `\"Ubuntu2604\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"UbuntuPro2004\"`, `\"Ubuntu2004\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`, `\"WindowsServer2025CoreContainer\"`, `\"WindowsServer2025FullContainer\"`.",
+          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2023&quot;</code> (default), <code>&quot;AmazonLinux2&quot;</code>, <code>&quot;UbuntuPro2604&quot;</code>, <code>&quot;Ubuntu2604&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;UbuntuPro2004&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>, <code>&quot;WindowsServer2025CoreContainer&quot;</code>, <code>&quot;WindowsServer2025FullContainer&quot;</code>.",
           "default": "AmazonLinux2023",
           "enum": [
             "AmazonLinux2023",
             "AmazonLinux2",
+            "UbuntuPro2604",
+            "Ubuntu2604",
             "UbuntuPro2404",
             "Ubuntu2404",
             "UbuntuPro2204",
@@ -2003,12 +2005,14 @@
         },
         "amiFamily": {
           "type": "string",
-          "description": "Valid variants are: `\"AmazonLinux2023\"` (default), `\"AmazonLinux2\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"UbuntuPro2004\"`, `\"Ubuntu2004\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`, `\"WindowsServer2025CoreContainer\"`, `\"WindowsServer2025FullContainer\"`.",
-          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2023&quot;</code> (default), <code>&quot;AmazonLinux2&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;UbuntuPro2004&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>, <code>&quot;WindowsServer2025CoreContainer&quot;</code>, <code>&quot;WindowsServer2025FullContainer&quot;</code>.",
+          "description": "Valid variants are: `\"AmazonLinux2023\"` (default), `\"AmazonLinux2\"`, `\"UbuntuPro2604\"`, `\"Ubuntu2604\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"UbuntuPro2004\"`, `\"Ubuntu2004\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`, `\"WindowsServer2025CoreContainer\"`, `\"WindowsServer2025FullContainer\"`.",
+          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2023&quot;</code> (default), <code>&quot;AmazonLinux2&quot;</code>, <code>&quot;UbuntuPro2604&quot;</code>, <code>&quot;Ubuntu2604&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;UbuntuPro2004&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>, <code>&quot;WindowsServer2025CoreContainer&quot;</code>, <code>&quot;WindowsServer2025FullContainer&quot;</code>.",
           "default": "AmazonLinux2023",
           "enum": [
             "AmazonLinux2023",
             "AmazonLinux2",
+            "UbuntuPro2604",
+            "Ubuntu2604",
             "UbuntuPro2404",
             "Ubuntu2404",
             "UbuntuPro2204",

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -212,6 +212,8 @@ const (
 	DefaultNodeImageFamily         = NodeImageFamilyAmazonLinux2023
 	NodeImageFamilyAmazonLinux2023 = "AmazonLinux2023"
 	NodeImageFamilyAmazonLinux2    = "AmazonLinux2"
+	NodeImageFamilyUbuntuPro2604   = "UbuntuPro2604"
+	NodeImageFamilyUbuntu2604      = "Ubuntu2604"
 	NodeImageFamilyUbuntuPro2404   = "UbuntuPro2404"
 	NodeImageFamilyUbuntu2404      = "Ubuntu2404"
 	NodeImageFamilyUbuntuPro2204   = "UbuntuPro2204"
@@ -598,6 +600,8 @@ func SupportedAMIFamilies() []string {
 	return []string{
 		NodeImageFamilyAmazonLinux2023,
 		NodeImageFamilyAmazonLinux2,
+		NodeImageFamilyUbuntuPro2604,
+		NodeImageFamilyUbuntu2604,
 		NodeImageFamilyUbuntuPro2404,
 		NodeImageFamilyUbuntu2404,
 		NodeImageFamilyUbuntuPro2204,

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -1655,7 +1655,9 @@ func IsBottlerocketImage(imageFamily string) bool {
 
 func IsUbuntuImage(imageFamily string) bool {
 	switch imageFamily {
-	case NodeImageFamilyUbuntuPro2404,
+	case NodeImageFamilyUbuntuPro2604,
+		NodeImageFamilyUbuntu2604,
+		NodeImageFamilyUbuntuPro2404,
 		NodeImageFamilyUbuntu2404,
 		NodeImageFamilyUbuntuPro2204,
 		NodeImageFamilyUbuntu2204,

--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -46,7 +46,7 @@ func NewBootstrapper(clusterConfig *api.ClusterConfig, ng *api.NodeGroup) (Boots
 		return NewWindowsBootstrapper(clusterConfig, ng, clusterDNS), nil
 	}
 	switch ng.AMIFamily {
-	case api.NodeImageFamilyUbuntuPro2404, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntuPro2004, api.NodeImageFamilyUbuntu2004:
+	case api.NodeImageFamilyUbuntuPro2604, api.NodeImageFamilyUbuntu2604, api.NodeImageFamilyUbuntuPro2404, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntuPro2004, api.NodeImageFamilyUbuntu2004:
 		return NewUbuntuBootstrapper(clusterConfig, ng, clusterDNS), nil
 	case api.NodeImageFamilyBottlerocket:
 		return NewBottlerocketBootstrapper(clusterConfig, ng), nil
@@ -78,7 +78,7 @@ func NewManagedBootstrapper(clusterConfig *api.ClusterConfig, ng *api.ManagedNod
 		return NewManagedAL2Bootstrapper(ng), nil
 	case api.NodeImageFamilyBottlerocket:
 		return NewManagedBottlerocketBootstrapper(clusterConfig, ng), nil
-	case api.NodeImageFamilyUbuntu2004, api.NodeImageFamilyUbuntuPro2004, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2404:
+	case api.NodeImageFamilyUbuntu2004, api.NodeImageFamilyUbuntuPro2004, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2404, api.NodeImageFamilyUbuntu2604, api.NodeImageFamilyUbuntuPro2604:
 		return NewUbuntuBootstrapper(clusterConfig, ng, clusterDNS), nil
 	}
 	return nil, nil


### PR DESCRIPTION
### Description

this change prepares for resolute support in EKS. note that we are a bit early and this is intended to support early internal development with the target being a simultaneous launch of EKS 1.35 on resolute alongside the release of 26.04. canonical will use the family directly to ensure k8s min version is satisfied

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [/] Manually tested (most features can't be directly tested, but impl follows previous patterns)
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

