### PR TITLE
Remove unnecessary type cast

### DIFF
--- a/pkg/cfn/builder/capability.go
+++ b/pkg/cfn/builder/capability.go
@@ -28,12 +28,12 @@ func (c *CapabilityResourceSet) AddAllResources() error {
 
 	var deletePropagationPolicy *gfnt.Value
 	if c.capability.DeletePropagationPolicy != "" {
-		deletePropagationPolicy = gfnt.NewString(string(c.capability.DeletePropagationPolicy))
+		deletePropagationPolicy = gfnt.NewString(c.capability.DeletePropagationPolicy)
 	}
 
 	capability := &gfneks.Capability{
 		CapabilityName:          gfnt.NewString(c.capability.Name),
-		Type:                    gfnt.NewString(string(c.capability.Type)),
+		Type:                    gfnt.NewString(c.capability.Type),
 		ClusterName:             gfnt.NewString(c.clusterName),
 		RoleArn:                 gfnt.NewString(c.capability.RoleARN),
 		DeletePropagationPolicy: deletePropagationPolicy,


### PR DESCRIPTION
Trivial as is.

BTW, I touch this file because I'm understanding:

```go
RoleArn:                 gfnt.NewString(c.capability.RoleARN),
```

and https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-eks-capability.html#cfn-eks-capability-rolearn

I still don't know whether this `RoleArn` is our chosen name for the to-be-created ArgoCD role, or something we're referring to use and that should be exist beforehand (and then, what do we use it for).