### PR TITLE
Populate role ARN from stack outputs on NoChangeError in pod identity update

### DIFF
--- a/pkg/actions/podidentityassociation/iam_role_updater.go
+++ b/pkg/actions/podidentityassociation/iam_role_updater.go
@@ -52,6 +52,9 @@ func (u *IAMRoleUpdater) Update(ctx context.Context, podIdentityAssociation api.
 		var noChangeErr *manager.NoChangeError
 		if errors.As(err, &noChangeErr) {
 			logger.Info("IAM resources for %s (pod identity association ID: %s) are already up-to-date", podIdentityAssociation.NameString(), podIdentityAssociationID)
+			if err := populateRoleARN(rs, stack); err != nil {
+				return "", false, err
+			}
 			return podIdentityAssociation.RoleARN, false, nil
 		}
 		return "", false, fmt.Errorf("updating IAM resources for pod identity association: %w", err)

--- a/pkg/actions/podidentityassociation/updater_test.go
+++ b/pkg/actions/podidentityassociation/updater_test.go
@@ -433,13 +433,21 @@ var _ = Describe("Pod Identity Update", func() {
 						ServiceAccountName: "aws-node",
 					},
 				}
+				describeStackOutputs := []cfntypes.Output{
+					{
+						OutputKey:   aws.String(outputs.IAMServiceAccountRoleName),
+						OutputValue: aws.String("arn:aws:iam::1234567:role/Role"),
+					},
+				}
 				mockListStackNames(stackManager, podIdentifiers)
 				for _, options := range []mockOptions{
 					{
-						podIdentifier: podIdentifiers[0],
+						podIdentifier:        podIdentifiers[0],
+						describeStackOutputs: describeStackOutputs,
 					},
 					{
-						podIdentifier: podIdentifiers[1],
+						podIdentifier:        podIdentifiers[1],
+						describeStackOutputs: describeStackOutputs,
 					},
 				} {
 					mockCalls(stackManager, eksAPI, options)
@@ -454,6 +462,72 @@ var _ = Describe("Pod Identity Update", func() {
 				Expect(stackManager.ListPodIdentityStackNamesCallCount()).To(Equal(1))
 				Expect(stackManager.DescribeStackCallCount()).To(Equal(2))
 				Expect(stackManager.MustUpdateStackCallCount()).To(Equal(2))
+				eksAPI.AssertExpectations(GinkgoT())
+			},
+		}),
+
+		Entry("IAM no changes but disableSessionTags triggers EKS update with roleName resolving ARN from stack", updateEntry{
+			podIdentityAssociations: []api.PodIdentityAssociation{
+				{
+					Namespace:          "default",
+					ServiceAccountName: "default",
+					RoleName:           "my-custom-role",
+					DisableSessionTags: aws.Bool(true),
+				},
+			},
+			mockCalls: func(stackManager *managerfakes.FakeStackManager, eksAPI *mocksv2.EKS) {
+				podIdentifier := podidentityassociation.Identifier{
+					Namespace:          "default",
+					ServiceAccountName: "default",
+				}
+				mockListStackNames(stackManager, []podidentityassociation.Identifier{podIdentifier})
+
+				stackName := makeIRSAv2StackName(podIdentifier)
+				associationID := fmt.Sprintf("%x", sha1.Sum([]byte(stackName)))
+				resolvedRoleARN := "arn:aws:iam::1234567:role/my-custom-role"
+
+				mockListPodIdentityAssociations(eksAPI, podIdentifier, []ekstypes.PodIdentityAssociationSummary{
+					{
+						AssociationId: aws.String(associationID),
+					},
+				}, nil)
+				eksAPI.On("DescribePodIdentityAssociation", mock.Anything, &eks.DescribePodIdentityAssociationInput{
+					AssociationId: aws.String(associationID),
+					ClusterName:   aws.String(clusterName),
+				}).Return(&eks.DescribePodIdentityAssociationOutput{
+					Association: &ekstypes.PodIdentityAssociation{
+						AssociationId: aws.String(associationID),
+						RoleArn:       aws.String(resolvedRoleARN),
+					},
+				}, nil)
+
+				stackManager.DescribeStackReturns(&cfntypes.Stack{
+					StackName: aws.String(stackName),
+					Outputs: []cfntypes.Output{
+						{
+							OutputKey:   aws.String(outputs.IAMServiceAccountRoleName),
+							OutputValue: aws.String(resolvedRoleARN),
+						},
+					},
+					Capabilities: []cfntypes.Capability{cfntypes.CapabilityCapabilityIam, cfntypes.CapabilityCapabilityNamedIam},
+				}, nil)
+
+				stackManager.MustUpdateStackReturns(&manager.NoChangeError{
+					Msg: "no changes found",
+				})
+
+				eksAPI.On("UpdatePodIdentityAssociation", mock.Anything, &eks.UpdatePodIdentityAssociationInput{
+					AssociationId:      aws.String(associationID),
+					ClusterName:        aws.String(clusterName),
+					RoleArn:            aws.String(resolvedRoleARN),
+					DisableSessionTags: aws.Bool(true),
+				}).Return(&eks.UpdatePodIdentityAssociationOutput{}, nil)
+			},
+
+			expectedCalls: func(stackManager *managerfakes.FakeStackManager, eksAPI *mocksv2.EKS) {
+				Expect(stackManager.ListPodIdentityStackNamesCallCount()).To(Equal(1))
+				Expect(stackManager.DescribeStackCallCount()).To(Equal(1))
+				Expect(stackManager.MustUpdateStackCallCount()).To(Equal(1))
 				eksAPI.AssertExpectations(GinkgoT())
 			},
 		}),


### PR DESCRIPTION
### Description

Fixes #8718.

When `eksctl update podidentityassociation` is run with a config that uses `roleName` (no explicit `roleARN`), and CloudFormation reports "nothing to update", the `IAMRoleUpdater.Update` method returns an empty string as the role ARN. If something else still needs updating on the EKS side (e.g. `disableSessionTags`), this empty ARN gets sent to `UpdatePodIdentityAssociation`, which fails with a misleading "Cross-account pass role is not allowed" error.

The problem is in the `NoChangeError` handler in `iam_role_updater.go`:

```go
if errors.As(err, &noChangeErr) {
    return podIdentityAssociation.RoleARN, false, nil  // empty when using roleName
}
```

The success path correctly resolves the ARN from CFN stack outputs via `populateRoleARN(rs, stack)`, but the no-change path skipped that. The `stack` from the earlier `DescribeStack` call is already in scope, so this fix just adds the same `populateRoleARN` call.

Trigger conditions (all four required):

1. Pod identity association exists with an eksctl-owned IAM stack
2. Config uses `roleName` + `permissionPolicyARNs` (no `roleARN`)
3. CFN returns `NoChangeError`
4. An EKS-side field still needs updating (e.g. `disableSessionTags`)

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)