### PR TITLE
Adding support for upgrading eks hybrid nodes on EKS clusters

### DIFF
--- a/pkg/actions/cluster/export_test.go
+++ b/pkg/actions/cluster/export_test.go
@@ -9,6 +9,8 @@ var (
 	DrainAllNodeGroups = drainAllNodeGroups
 )
 
+var UpdateRemoteNetworkConfig = (*OwnedCluster).updateRemoteNetworkConfig
+
 func (c *UnownedCluster) SetNewClientSet(newClientSet func() (kubernetes.Interface, error)) {
 	c.newClientSet = newClientSet
 }

--- a/pkg/actions/cluster/owned.go
+++ b/pkg/actions/cluster/owned.go
@@ -3,8 +3,12 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/kris-nova/logger"
 
 	"github.com/weaveworks/eksctl/pkg/actions/addon"
@@ -63,6 +67,11 @@ func (c *OwnedCluster) Upgrade(ctx context.Context, dryRun bool) error {
 		return err
 	}
 
+	remoteNetworkUpdateRequired, err := c.updateRemoteNetworkConfig(ctx, dryRun)
+	if err != nil {
+		return err
+	}
+
 	stackUpdateRequired, err := c.stackManager.AppendNewClusterStackResource(ctx, false, dryRun)
 	if err != nil {
 		return err
@@ -72,8 +81,45 @@ func (c *OwnedCluster) Upgrade(ctx context.Context, dryRun bool) error {
 		logger.Critical("failed checking nodegroups", err.Error())
 	}
 
-	cmdutils.LogPlanModeWarning(dryRun && (stackUpdateRequired || versionUpdateRequired))
+	cmdutils.LogPlanModeWarning(dryRun && (stackUpdateRequired || versionUpdateRequired || remoteNetworkUpdateRequired))
 	return nil
+}
+
+func (c *OwnedCluster) updateRemoteNetworkConfig(ctx context.Context, dryRun bool) (bool, error) {
+	if c.cfg.RemoteNetworkConfig == nil {
+		return false, nil
+	}
+
+	rnc := c.cfg.RemoteNetworkConfig
+	req := &ekstypes.RemoteNetworkConfigRequest{}
+	if rnc.RemoteNodeNetworks != nil {
+		req.RemoteNodeNetworks = make([]ekstypes.RemoteNodeNetwork, len(rnc.RemoteNodeNetworks))
+		for i, rn := range rnc.RemoteNodeNetworks {
+			req.RemoteNodeNetworks[i] = ekstypes.RemoteNodeNetwork{Cidrs: rn.CIDRs}
+		}
+	}
+	if rnc.RemotePodNetworks != nil {
+		req.RemotePodNetworks = make([]ekstypes.RemotePodNetwork, len(rnc.RemotePodNetworks))
+		for i, rp := range rnc.RemotePodNetworks {
+			req.RemotePodNetworks[i] = ekstypes.RemotePodNetwork{Cidrs: rp.CIDRs}
+		}
+	}
+
+	cmdutils.LogIntendedAction(dryRun, "update remote network config for cluster %q", c.cfg.Metadata.Name)
+	if !dryRun {
+		if err := c.ctl.UpdateClusterConfig(ctx, &awseks.UpdateClusterConfigInput{
+			Name:                aws.String(c.cfg.Metadata.Name),
+			RemoteNetworkConfig: req,
+		}); err != nil {
+			if strings.Contains(err.Error(), "No changes detected") {
+				logger.Info("remote network config is already up-to-date on cluster %q", c.cfg.Metadata.Name)
+				return false, nil
+			}
+			return false, fmt.Errorf("updating remote network config: %w", err)
+		}
+		logger.Success("remote network config updated successfully for cluster %q", c.cfg.Metadata.Name)
+	}
+	return true, nil
 }
 
 func (c *OwnedCluster) Delete(ctx context.Context, _, podEvictionWaitPeriod time.Duration, wait, force, disableNodegroupEviction bool, parallel int) error {

--- a/pkg/actions/cluster/remote_network_config_test.go
+++ b/pkg/actions/cluster/remote_network_config_test.go
@@ -1,0 +1,194 @@
+package cluster_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/weaveworks/eksctl/pkg/actions/cluster"
+	"github.com/weaveworks/eksctl/pkg/actions/cluster/mocks"
+	api "github.com/weaveworks/eksctl/pkg/apis/eksctl.io/v1alpha5"
+	"github.com/weaveworks/eksctl/pkg/cfn/manager/fakes"
+	"github.com/weaveworks/eksctl/pkg/eks"
+	"github.com/weaveworks/eksctl/pkg/testutils"
+	"github.com/weaveworks/eksctl/pkg/testutils/mockprovider"
+)
+
+var _ = Describe("UpdateRemoteNetworkConfig", func() {
+	var (
+		clusterName      string
+		p                *mockprovider.MockProvider
+		cfg              *api.ClusterConfig
+		fakeStackManager *fakes.FakeStackManager
+		ctl              *eks.ClusterProvider
+		ownedCluster     *cluster.OwnedCluster
+	)
+
+	BeforeEach(func() {
+		clusterName = "test-cluster"
+		p = mockprovider.NewMockProvider()
+		cfg = api.NewClusterConfig()
+		cfg.Metadata.Name = clusterName
+		fakeStackManager = new(fakes.FakeStackManager)
+		ctl = &eks.ClusterProvider{AWSProvider: p, Status: &eks.ProviderStatus{
+			ClusterInfo: &eks.ClusterInfo{
+				Cluster: testutils.NewFakeCluster(clusterName, ekstypes.ClusterStatusActive),
+			},
+		}}
+		ownedCluster = cluster.NewOwnedCluster(cfg, ctl, nil, fakeStackManager, &mocks.AutoModeDeleter{})
+	})
+
+	mockSuccessfulUpdate := func() {
+		p.MockEKS().On("UpdateClusterConfig", mock.Anything, mock.Anything).
+			Return(&awseks.UpdateClusterConfigOutput{
+				Update: &ekstypes.Update{
+					Id:     aws.String("update-123"),
+					Status: ekstypes.UpdateStatusSuccessful,
+				},
+			}, nil)
+		p.MockEKS().On("DescribeUpdate", mock.Anything, mock.Anything, mock.Anything).
+			Return(&awseks.DescribeUpdateOutput{
+				Update: &ekstypes.Update{
+					Id:     aws.String("update-123"),
+					Status: ekstypes.UpdateStatusSuccessful,
+				},
+			}, nil)
+	}
+
+	It("skips when remoteNetworkConfig is nil", func() {
+		cfg.RemoteNetworkConfig = nil
+		updated, err := cluster.UpdateRemoteNetworkConfig(ownedCluster, context.Background(), false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(BeFalse())
+		p.MockEKS().AssertNotCalled(GinkgoT(), "UpdateClusterConfig", mock.Anything, mock.Anything)
+	})
+
+	It("calls UpdateClusterConfig with correct input for node and pod networks", func() {
+		cfg.RemoteNetworkConfig = &api.RemoteNetworkConfig{
+			RemoteNodeNetworks: []*api.RemoteNetwork{
+				{CIDRs: []string{"10.80.0.0/16", "10.81.0.0/16"}},
+			},
+			RemotePodNetworks: []*api.RemoteNetwork{
+				{CIDRs: []string{"10.90.0.0/16"}},
+			},
+		}
+		mockSuccessfulUpdate()
+
+		updated, err := cluster.UpdateRemoteNetworkConfig(ownedCluster, context.Background(), false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(BeTrue())
+
+		calls := p.MockEKS().Calls
+		var updateCall mock.Call
+		for _, call := range calls {
+			if call.Method == "UpdateClusterConfig" {
+				updateCall = call
+				break
+			}
+		}
+		input := updateCall.Arguments[1].(*awseks.UpdateClusterConfigInput)
+		Expect(*input.Name).To(Equal(clusterName))
+		Expect(input.RemoteNetworkConfig.RemoteNodeNetworks).To(HaveLen(1))
+		Expect(input.RemoteNetworkConfig.RemoteNodeNetworks[0].Cidrs).To(Equal([]string{"10.80.0.0/16", "10.81.0.0/16"}))
+		Expect(input.RemoteNetworkConfig.RemotePodNetworks).To(HaveLen(1))
+		Expect(input.RemoteNetworkConfig.RemotePodNetworks[0].Cidrs).To(Equal([]string{"10.90.0.0/16"}))
+	})
+
+	It("passes nil for omitted networks (no defaulting)", func() {
+		cfg.RemoteNetworkConfig = &api.RemoteNetworkConfig{
+			RemoteNodeNetworks: []*api.RemoteNetwork{
+				{CIDRs: []string{"10.80.0.0/16"}},
+			},
+		}
+		mockSuccessfulUpdate()
+
+		updated, err := cluster.UpdateRemoteNetworkConfig(ownedCluster, context.Background(), false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(BeTrue())
+
+		calls := p.MockEKS().Calls
+		var updateCall mock.Call
+		for _, call := range calls {
+			if call.Method == "UpdateClusterConfig" {
+				updateCall = call
+				break
+			}
+		}
+		input := updateCall.Arguments[1].(*awseks.UpdateClusterConfigInput)
+		Expect(input.RemoteNetworkConfig.RemoteNodeNetworks).To(HaveLen(1))
+		Expect(input.RemoteNetworkConfig.RemotePodNetworks).To(BeNil())
+	})
+
+	It("sends empty lists for remove-all case", func() {
+		cfg.RemoteNetworkConfig = &api.RemoteNetworkConfig{
+			RemoteNodeNetworks: []*api.RemoteNetwork{},
+			RemotePodNetworks:  []*api.RemoteNetwork{},
+		}
+		mockSuccessfulUpdate()
+
+		updated, err := cluster.UpdateRemoteNetworkConfig(ownedCluster, context.Background(), false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(BeTrue())
+
+		calls := p.MockEKS().Calls
+		var updateCall mock.Call
+		for _, call := range calls {
+			if call.Method == "UpdateClusterConfig" {
+				updateCall = call
+				break
+			}
+		}
+		input := updateCall.Arguments[1].(*awseks.UpdateClusterConfigInput)
+		Expect(input.RemoteNetworkConfig.RemoteNodeNetworks).To(BeEmpty())
+		Expect(input.RemoteNetworkConfig.RemoteNodeNetworks).NotTo(BeNil())
+		Expect(input.RemoteNetworkConfig.RemotePodNetworks).To(BeEmpty())
+		Expect(input.RemoteNetworkConfig.RemotePodNetworks).NotTo(BeNil())
+	})
+
+	It("treats 'No changes detected' as success", func() {
+		cfg.RemoteNetworkConfig = &api.RemoteNetworkConfig{
+			RemoteNodeNetworks: []*api.RemoteNetwork{
+				{CIDRs: []string{"10.80.0.0/16"}},
+			},
+		}
+		p.MockEKS().On("UpdateClusterConfig", mock.Anything, mock.Anything).
+			Return(nil, fmt.Errorf("operation error EKS: UpdateClusterConfig, https response error StatusCode: 400, InvalidParameterException: No changes detected for remoteNetworkConfig"))
+
+		updated, err := cluster.UpdateRemoteNetworkConfig(ownedCluster, context.Background(), false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(BeFalse())
+	})
+
+	It("propagates other API errors", func() {
+		cfg.RemoteNetworkConfig = &api.RemoteNetworkConfig{
+			RemoteNodeNetworks: []*api.RemoteNetwork{
+				{CIDRs: []string{"10.80.0.0/16"}},
+			},
+		}
+		p.MockEKS().On("UpdateClusterConfig", mock.Anything, mock.Anything).
+			Return(nil, fmt.Errorf("operation error EKS: UpdateClusterConfig, https response error StatusCode: 400, InvalidParameterException: Only one remoteNodeNetwork is allowed"))
+
+		_, err := cluster.UpdateRemoteNetworkConfig(ownedCluster, context.Background(), false)
+		Expect(err).To(MatchError(ContainSubstring("Only one remoteNodeNetwork is allowed")))
+	})
+
+	It("does not call API in dry-run mode", func() {
+		cfg.RemoteNetworkConfig = &api.RemoteNetworkConfig{
+			RemoteNodeNetworks: []*api.RemoteNetwork{
+				{CIDRs: []string{"10.80.0.0/16"}},
+			},
+		}
+
+		updated, err := cluster.UpdateRemoteNetworkConfig(ownedCluster, context.Background(), true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(BeTrue())
+		p.MockEKS().AssertNotCalled(GinkgoT(), "UpdateClusterConfig", mock.Anything, mock.Anything)
+	})
+})

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -105,6 +105,10 @@ func (c *ClusterConfig) validateRemoteNetworkingConfig() error {
 	}
 
 	if len(rnc.RemoteNodeNetworks) == 0 {
+		// Both lists being explicitly empty is valid for updates (removes all remote networks).
+		if rnc.RemotePodNetworks != nil && len(rnc.RemotePodNetworks) == 0 {
+			return nil
+		}
 		return setNonEmpty("remoteNetworkConfig.remoteNodeNetworks")
 	}
 

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -105,8 +105,10 @@ func (c *ClusterConfig) validateRemoteNetworkingConfig() error {
 	}
 
 	if len(rnc.RemoteNodeNetworks) == 0 {
-		// Both lists being explicitly empty is valid for updates (removes all remote networks).
+		// Both lists being explicitly empty is valid for upgrades (removes all remote networks).
+		// For creates, this is a no-op since HasRemoteNetworkingConfigured() gates the CFN builder.
 		if rnc.RemotePodNetworks != nil && len(rnc.RemotePodNetworks) == 0 {
+			logger.Warning("remoteNetworkConfig has empty remoteNodeNetworks and remotePodNetworks; this will remove all remote networks on upgrade, or be ignored on create")
 			return nil
 		}
 		return setNonEmpty("remoteNetworkConfig.remoteNodeNetworks")

--- a/pkg/apis/eksctl.io/v1alpha5/validation_test.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation_test.go
@@ -1035,6 +1035,14 @@ var _ = Describe("ClusterConfig validation", func() {
 			},
 			expectedErr: "remoteNetworkConfig.remoteNodeNetworks must be set and non-empty",
 		}),
+		Entry("remoteNodeNetworks is empty with nil remotePodNetworks", remoteNetworkConfigEntry{
+			overrideConfig: func(cc *api.ClusterConfig) {
+				cc.RemoteNetworkConfig = &api.RemoteNetworkConfig{
+					RemoteNodeNetworks: []*api.RemoteNetwork{},
+				}
+			},
+			expectedErr: "remoteNetworkConfig.remoteNodeNetworks must be set and non-empty",
+		}),
 		Entry("both vpcGatewayID and pre-existing VPC are set", remoteNetworkConfigEntry{
 			overrideConfig: func(cc *api.ClusterConfig) {
 				cc.VPC.ID = "vpc-1234"
@@ -1065,6 +1073,18 @@ var _ = Describe("ClusterConfig validation", func() {
 			expectedErr: "remoteNetworkConfig.iam.caBundleCert is required when using IAMRolesAnywhere credentials provider",
 		}),
 	)
+
+	It("should allow both remoteNodeNetworks and remotePodNetworks to be empty for updates", func() {
+		cfg := api.NewClusterConfig()
+		api.SetClusterConfigDefaults(cfg)
+		api.SetClusterEndpointAccessDefaults(cfg.VPC)
+		cfg.RemoteNetworkConfig = &api.RemoteNetworkConfig{
+			RemoteNodeNetworks: []*api.RemoteNetwork{},
+			RemotePodNetworks:  []*api.RemoteNetwork{},
+		}
+		err := api.ValidateClusterConfig(cfg)
+		Expect(err).NotTo(HaveOccurred())
+	})
 
 	Describe("network config", func() {
 		var (

--- a/userdocs/src/usage/hybrid-nodes.md
+++ b/userdocs/src/usage/hybrid-nodes.md
@@ -4,7 +4,7 @@
 
 AWS EKS introduces Hybrid Nodes, a new feature that enables you to run on-premises and edge applications on customer-managed infrastructure with the same AWS EKS clusters, features, and tools you use in the AWS Cloud. AWS EKS Hybird Nodes brings an AWS-managed Kubernetes experience to on-premises environments for customers to simplify and standardize how you run applications across on-premises, edge and cloud environments. Read more at [EKS Hybrid Nodes][eks-hybrid-nodes].
 
-To facilitate support for this feature, eksctl introduces a new top-level field called `remoteNetworkConfig`. Any Hybrid Nodes related configuration shall be set up via this field, as part of the config file; there are no CLI flags counterparts. Additionally, at launch, any remote network config can only be set up during cluster creation and cannot be updated afterwards. This means, you won't be able to update existing clusters to use Hybrid Nodes. 
+To facilitate support for this feature, eksctl introduces a new top-level field called `remoteNetworkConfig`. Any Hybrid Nodes related configuration shall be set up via this field, as part of the config file; there are no CLI flags counterparts. You can enable or update Hybrid Nodes on existing clusters by adding `remoteNetworkConfig` to your config file and running `eksctl upgrade cluster`.
 
 The `remoteNetworkConfig` section of the config file allows you to setup the two core areas when it comes to joining remote nodes to you EKS clusters: **networking** and **credentials**.  
 


### PR DESCRIPTION
## Description

Adds support for updating `remoteNetworkConfig` on existing EKS clusters through `eksctl upgrade cluster`. Previously, remote network config could only be set during cluster creation — this change allows users to enable hybrid nodes, update CIDRs, or remove remote networks on existing clusters.

**What this does:**

- Adds `updateRemoteNetworkConfig` to the `Upgrade` flow in `owned.go`, called between version upgrade and CFN stack update
- Maps the config file's `remoteNetworkConfig` directly to the EKS `UpdateClusterConfig` API.
- Nil fields are omitted by the SDK (no-op), empty `[]` sends an empty array (removes)
- Catches the API's "No changes detected" 400 response and treats it as success
- Updates the validation to allow both `remoteNodeNetworks: []` and `remotePodNetworks: []` simultaneously (the "remove all" case), matching the EKS API's `validateRemoteNetworkConfigUpdateRequest` behavior

**Usage:**

```yaml
# Enable / update hybrid nodes
remoteNetworkConfig:
  remoteNodeNetworks:
    - cidrs: ["10.80.146.0/24"]
  remotePodNetworks:
    - cidrs: ["10.90.0.0/16"]

# Remove all remote networks (disable hybrid)
remoteNetworkConfig:
  remoteNodeNetworks: []
  remotePodNetworks: []

eksctl upgrade cluster -f cluster-config.yaml --approve
```

### Design decisions:

• Lives in upgrade cluster (not a utils command) because enabling hybrid nodes also requires CFN resources (VPC routes, IAM roles) which AppendNewClusterStackResource handles
• No client-side re-implementation of API validations — bad input gets clear API errors
• No defaulting — omitting remotePodNetworks sends nil (no change), setting it to [] sends empty (remove)

### Testing
```
ramaliar@7cf34dd2c821 eksctl % ./eksctl upgrade cluster -f ./cluster-config.yaml --approve
2026-04-27 17:00:38 [!]  remoteNetworkConfig.iam.roleARN is set; eksctl will add a corresponding entry in aws-auth configmap; but won't setup an additional SSM or IAMRolesAnywhere required config
2026-04-27 17:00:38 [!]  NOTE: cluster VPC (subnets, routing & NAT Gateway) configuration changes are not yet implemented
2026-04-27 17:00:39 [ℹ]  no cluster version update required
2026-04-27 17:00:39 [ℹ]  will update remote network config for cluster "test-eksctl"
2026-04-27 17:07:28 [✔]  remote network config updated successfully for cluster "test-eksctl"
2026-04-27 17:07:28 [ℹ]  re-building cluster stack "eksctl-test-eksctl-cluster"
2026-04-27 17:07:28 [!]  a TGW or VGW was not provided for hybrid nodes connectivity, hence eksctl won't configure any related routes and gateway attachments for your VPC
2026-04-27 17:07:28 [ℹ]  updating stack to add new resources [IngressControlPlaneRemoteNetworks2] and outputs []
2026-04-27 17:07:29 [ℹ]  waiting for CloudFormation changeset "eksctl-update-cluster-1777334848" for stack "eksctl-test-eksctl-cluster"
2026-04-27 17:07:59 [ℹ]  waiting for CloudFormation changeset "eksctl-update-cluster-1777334848" for stack "eksctl-test-eksctl-cluster"
2026-04-27 17:08:00 [ℹ]  waiting for CloudFormation stack "eksctl-test-eksctl-cluster"
2026-04-27 17:08:30 [ℹ]  waiting for CloudFormation stack "eksctl-test-eksctl-cluster"
2026-04-27 17:09:22 [ℹ]  waiting for CloudFormation stack "eksctl-test-eksctl-cluster"
2026-04-27 17:11:02 [ℹ]  waiting for CloudFormation stack "eksctl-test-eksctl-cluster"
2026-04-27 17:11:48 [ℹ]  waiting for CloudFormation stack "eksctl-test-eksctl-cluster"
2026-04-27 17:12:19 [ℹ]  waiting for CloudFormation stack "eksctl-test-eksctl-cluster"
2026-04-27 17:13:13 [ℹ]  waiting for CloudFormation stack "eksctl-test-eksctl-cluster"
2026-04-27 17:15:08 [ℹ]  waiting for CloudFormation stack "eksctl-test-eksctl-cluster"
2026-04-27 17:15:50 [ℹ]  waiting for CloudFormation stack "eksctl-test-eksctl-cluster"
2026-04-27 17:15:50 [ℹ]  checking security group configuration for all nodegroups
2026-04-27 17:15:50 [ℹ]  all nodegroups have up-to-date cloudformation templates
```


### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

