### PR TITLE
karpenter: clarify createServiceAccount semantics in docs, schema, and runtime log

### DIFF
--- a/pkg/actions/karpenter/create.go
+++ b/pkg/actions/karpenter/create.go
@@ -60,7 +60,13 @@ func (i *Installer) Create(ctx context.Context) error {
 	}
 	if api.IsEnabled(i.Config.Karpenter.CreateServiceAccount) {
 		// Create the service account role only.
+		// The Karpenter Helm chart will create the Kubernetes service
+		// account (serviceAccount.create=true is passed to the chart in
+		// pkg/karpenter/karpenter.go).
 		iamServiceAccount.RoleOnly = api.Enabled()
+		logger.Info("karpenter.createServiceAccount=true: eksctl will create only the IAM role; the Karpenter Helm chart will create the %q service account in namespace %q", karpenter.DefaultServiceAccountName, karpenter.DefaultNamespace)
+	} else {
+		logger.Info("karpenter.createServiceAccount=false: eksctl will create both the IAM role and the %q service account in namespace %q", karpenter.DefaultServiceAccountName, karpenter.DefaultNamespace)
 	}
 	karpenterServiceAccountTaskTree := i.StackManager.NewTasksToCreateIAMServiceAccounts([]*api.ClusterIAMServiceAccount{iamServiceAccount}, i.OIDC, clientSetGetter)
 	logger.Info(karpenterServiceAccountTaskTree.Describe())

--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -1549,8 +1549,8 @@
       "properties": {
         "createServiceAccount": {
           "type": "boolean",
-          "description": "create a service account or not.",
-          "x-intellij-html-description": "create a service account or not."
+          "description": "controls which component creates the \"karpenter\" service account in the \"karpenter\" namespace. When true, eksctl creates only the IAM role via an iamserviceaccount CloudFormation stack and delegates service account creation to the Karpenter Helm chart (which is installed with serviceAccount.create=true). When false (the default), eksctl creates both the IAM role and the Kubernetes service account, and the Helm chart is installed with serviceAccount.create=false. Either way a \"karpenter\" service account exists on the cluster after installation; this flag does not prevent the service account from being created.",
+          "x-intellij-html-description": "controls which component creates the &quot;karpenter&quot; service account in the &quot;karpenter&quot; namespace. When true, eksctl creates only the IAM role via an iamserviceaccount CloudFormation stack and delegates service account creation to the Karpenter Helm chart (which is installed with serviceAccount.create=true). When false (the default), eksctl creates both the IAM role and the Kubernetes service account, and the Helm chart is installed with serviceAccount.create=false. Either way a &quot;karpenter&quot; service account exists on the cluster after installation; this flag does not prevent the service account from being created."
         },
         "defaultInstanceProfile": {
           "type": "string",

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -1136,7 +1136,16 @@ type Karpenter struct {
 	// Version defines the Karpenter version to install
 	// +required
 	Version string `json:"version"`
-	// CreateServiceAccount create a service account or not.
+	// CreateServiceAccount controls which component creates the "karpenter"
+	// service account in the "karpenter" namespace. When true, eksctl creates
+	// only the IAM role via an iamserviceaccount CloudFormation stack and
+	// delegates service account creation to the Karpenter Helm chart (which
+	// is installed with serviceAccount.create=true). When false (the default),
+	// eksctl creates both the IAM role and the Kubernetes service account,
+	// and the Helm chart is installed with serviceAccount.create=false.
+	// Either way a "karpenter" service account exists on the cluster after
+	// installation; this flag does not prevent the service account from being
+	// created.
 	// +optional
 	CreateServiceAccount *bool `json:"createServiceAccount,omitempty"`
 	// DefaultInstanceProfile override the default IAM instance profile

--- a/userdocs/src/usage/eksctl-karpenter.md
+++ b/userdocs/src/usage/eksctl-karpenter.md
@@ -35,10 +35,29 @@ to be set:
 ```yaml
 karpenter:
   version: '1.2.1'
-  createServiceAccount: true # default is false
+  createServiceAccount: true # default is false; see note below on its meaning
   defaultInstanceProfile: 'KarpenterNodeInstanceProfile' # default is to use the IAM instance profile created by eksctl
   withSpotInterruptionQueue: true # adds all required policies and rules for supporting Spot Interruption Queue, default is false
 ```
+
+### `createServiceAccount`
+
+This flag controls *which component* creates the `karpenter` service account in
+the `karpenter` namespace. It does **not** prevent the service account from
+being created — a `karpenter` service account will always exist on the cluster
+after installation.
+
+* `createServiceAccount: false` (default) — eksctl creates both the IAM role
+  (via an `iamserviceaccount` CloudFormation stack) and the Kubernetes service
+  account, and installs the Karpenter Helm chart with
+  `serviceAccount.create=false` so the chart reuses the existing service
+  account.
+* `createServiceAccount: true` — eksctl creates only the IAM role and installs
+  the Helm chart with `serviceAccount.create=true`, letting the chart create
+  the service account (annotated with the IAM role ARN for IRSA).
+
+Either mode results in a working `karpenter` service account; the choice
+affects only which tool owns the Kubernetes object.
 
 OIDC must be defined in order to install Karpenter.
 


### PR DESCRIPTION
### Description

The karpenter.createServiceAccount flag controls which component creates the 'karpenter' service account (eksctl vs the Karpenter Helm chart), not whether a service account is created. A SA always ends up on the cluster either way. The previous docs ("create a service account or not") and silent log output for the true case made this confusing

This change:
- Rewrites the CreateServiceAccount struct-field comment in pkg/apis/eksctl.io/v1alpha5/types.go to describe the actual behavior, and regenerates schema.json.
- Adds a dedicated 'createServiceAccount' subsection to userdocs/src/usage/eksctl-karpenter.md explaining both modes.
- Adds Info-level log output at runtime so eksctl reports which component will create the SA.

No behavior changes.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

