### PR TITLE
Remove deprecated "$COMPLETE" variable from version template for release drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -23,7 +23,6 @@ categories:
       - 'kind/docs'
 change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&#@`' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-template: '$COMPLETE'
 template: |
   # Release v$NEXT_MINOR_VERSION
 


### PR DESCRIPTION
### Description

Fix: Remove the version-template override. The release-drafter v7 default is $MAJOR.$MINOR.$PATCH$PRERELEASE, which matches the old v6 $COMPLETE behavior for stable releases and also keeps any future prerelease (-rc.N) rendering correct. An equivalent valid override version-template: '$MAJOR.$MINOR.$PATCH' would also work, but dropping the override is cleaner.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

