### PR TITLE
fix: Regionalize all container images in UseRegionalImage() 

### DIFF
--- a/pkg/addons/default/aws_node.go
+++ b/pkg/addons/default/aws_node.go
@@ -22,8 +22,9 @@ const (
 	// AWSNode is the name of the aws-node addon
 	AWSNode = "aws-node"
 
-	awsNodeImageFormatPrefix     = "%s.dkr.ecr.%s.%s/amazon-k8s-cni"
-	awsNodeInitImageFormatPrefix = "%s.dkr.ecr.%s.%s/amazon-k8s-cni-init"
+	awsNodeImageFormatPrefix      = "%s.dkr.ecr.%s.%s/amazon-k8s-cni"
+	awsNodeInitImageFormatPrefix  = "%s.dkr.ecr.%s.%s/amazon-k8s-cni-init"
+	awsNodeAgentImageFormatPrefix = "%s.dkr.ecr.%s.%s/amazon/aws-network-policy-agent"
 )
 
 //go:embed assets/aws-node.yaml
@@ -97,14 +98,37 @@ func UpdateAWSNode(ctx context.Context, input AddonInput, plan bool) (bool, erro
 				return false, fmt.Errorf("expected type %T; got %T", &appsv1.Deployment{}, resource.Info.Object)
 			}
 			container := &daemonSet.Spec.Template.Spec.Containers[0]
-			initContainer := &daemonSet.Spec.Template.Spec.InitContainers[0]
 			imageParts := strings.Split(container.Image, ":")
 			if len(imageParts) != 2 {
 				return false, fmt.Errorf("invalid container image: %s", container.Image)
 			}
 
 			container.Image = awsNodeImageFormatPrefix + ":" + imageParts[1]
-			initContainer.Image = awsNodeInitImageFormatPrefix + ":" + imageParts[1]
+
+			// Set image format prefix for the nodeagent container if present
+			for i := range daemonSet.Spec.Template.Spec.Containers {
+				c := &daemonSet.Spec.Template.Spec.Containers[i]
+				if c.Name == "aws-eks-nodeagent" {
+					agentImageParts := strings.Split(c.Image, ":")
+					if len(agentImageParts) != 2 {
+						return false, fmt.Errorf("invalid container image: %s", c.Image)
+					}
+					c.Image = awsNodeAgentImageFormatPrefix + ":" + agentImageParts[1]
+					break
+				}
+			}
+
+			// Set image format prefix for init containers
+			if len(daemonSet.Spec.Template.Spec.InitContainers) > 0 {
+				initContainer := &daemonSet.Spec.Template.Spec.InitContainers[0]
+				initImageParts := strings.Split(initContainer.Image, ":")
+				if len(initImageParts) != 2 {
+					return false, fmt.Errorf("invalid init container image: %s", initContainer.Image)
+				}
+				initContainer.Image = awsNodeInitImageFormatPrefix + ":" + initImageParts[1]
+			}
+
+			// Regionalize all containers and init containers
 			if err := addons.UseRegionalImage(&daemonSet.Spec.Template, input.Region); err != nil {
 				return false, err
 			}
@@ -118,9 +142,9 @@ func UpdateAWSNode(ctx context.Context, input AddonInput, plan bool) (bool, erro
 			}
 
 			initContainerTagMismatch := true // Will be true by default if the init containers don't exist
-			if len(clusterDaemonSet.Spec.Template.Spec.InitContainers) > 0 {
+			if len(clusterDaemonSet.Spec.Template.Spec.InitContainers) > 0 && len(daemonSet.Spec.Template.Spec.InitContainers) > 0 {
 				initContainerTagMismatch, err = addons.ImageTagsDiffer(
-					initContainer.Image,
+					daemonSet.Spec.Template.Spec.InitContainers[0].Image,
 					clusterDaemonSet.Spec.Template.Spec.InitContainers[0].Image,
 				)
 				if err != nil {

--- a/pkg/addons/default/aws_node_test.go
+++ b/pkg/addons/default/aws_node_test.go
@@ -62,6 +62,7 @@ var _ = Describe("AWS Node", func() {
 	Describe("UpdateAWSNode", func() {
 		var preUpdateAwsNode *v1.DaemonSet
 		const expectedVersion = "v1.21.1"
+		const expectedNodeAgentVersion = "v1.3.1"
 		BeforeEach(func() {
 			loadSamples(rawClient, "testdata/sample-1.15.json")
 
@@ -83,6 +84,9 @@ var _ = Describe("AWS Node", func() {
 				Expect(awsNode.Spec.Template.Spec.Containers[0].Image).To(
 					Equal(fmt.Sprintf("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:%s", expectedVersion)),
 				)
+				Expect(awsNode.Spec.Template.Spec.Containers[1].Image).To(
+					Equal(fmt.Sprintf("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon/aws-network-policy-agent:%s", expectedNodeAgentVersion)),
+				)
 				Expect(awsNode.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 				Expect(awsNode.Spec.Template.Spec.InitContainers[0].Image).To(
 					Equal(fmt.Sprintf("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni-init:%s", expectedVersion)),
@@ -102,6 +106,9 @@ var _ = Describe("AWS Node", func() {
 				Expect(awsNode.Spec.Template.Spec.Containers).To(HaveLen(2))
 				Expect(awsNode.Spec.Template.Spec.Containers[0].Image).To(
 					Equal(fmt.Sprintf("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:%s", expectedVersion)),
+				)
+				Expect(awsNode.Spec.Template.Spec.Containers[1].Image).To(
+					Equal(fmt.Sprintf("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon/aws-network-policy-agent:%s", expectedNodeAgentVersion)),
 				)
 				Expect(awsNode.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 				Expect(awsNode.Spec.Template.Spec.InitContainers[0].Image).To(

--- a/pkg/addons/image.go
+++ b/pkg/addons/image.go
@@ -13,23 +13,38 @@ func awsDNSSuffixForRegion(region string) (string, error) {
 	return api.Partitions.V1SDKDNSPrefixForRegion(region)
 }
 
-// UseRegionalImage sets the region and AWS DNS suffix for a container image
+// UseRegionalImage sets the region and AWS DNS suffix for all container images
 // in format '%s.dkr.ecr.%s.%s/image:tag'
 func UseRegionalImage(spec *corev1.PodTemplateSpec, region string) error {
-	imageFormat := spec.Spec.Containers[0].Image
 	dnsSuffix, err := awsDNSSuffixForRegion(region)
 	if err != nil {
 		return err
 	}
-	regionalImage := fmt.Sprintf(imageFormat, api.EKSResourceAccountID(region), region, dnsSuffix)
-	spec.Spec.Containers[0].Image = regionalImage
 
-	if len(spec.Spec.InitContainers) > 0 {
-		imageFormat = spec.Spec.InitContainers[0].Image
-		regionalImage = fmt.Sprintf(imageFormat, api.EKSResourceAccountID(region), region, dnsSuffix)
-		spec.Spec.InitContainers[0].Image = regionalImage
+	for i := range spec.Spec.Containers {
+		imageFormat := spec.Spec.Containers[i].Image
+		if isRegionalImageFormat(imageFormat) {
+			regionalImage := fmt.Sprintf(imageFormat, api.EKSResourceAccountID(region), region, dnsSuffix)
+			spec.Spec.Containers[i].Image = regionalImage
+		}
 	}
+
+	for i := range spec.Spec.InitContainers {
+		imageFormat := spec.Spec.InitContainers[i].Image
+		if isRegionalImageFormat(imageFormat) {
+			regionalImage := fmt.Sprintf(imageFormat, api.EKSResourceAccountID(region), region, dnsSuffix)
+			spec.Spec.InitContainers[i].Image = regionalImage
+		}
+	}
+
 	return nil
+}
+
+// isRegionalImageFormat checks whether an image string contains format verbs
+// (i.e., it's a template like "%s.dkr.ecr.%s.%s/image:tag" rather than a
+// fully-resolved image URI).
+func isRegionalImageFormat(image string) bool {
+	return strings.Contains(image, "%s")
 }
 
 // ImageTag extracts the container image's tag.

--- a/pkg/addons/image_test.go
+++ b/pkg/addons/image_test.go
@@ -1,0 +1,132 @@
+package addons_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/weaveworks/eksctl/pkg/addons"
+)
+
+var _ = Describe("UseRegionalImage", func() {
+	var spec *corev1.PodTemplateSpec
+
+	Context("with a single container and single init container", func() {
+		BeforeEach(func() {
+			spec = &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "main",
+							Image: "%s.dkr.ecr.%s.%s/amazon-k8s-cni:v1.21.1",
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:  "init",
+							Image: "%s.dkr.ecr.%s.%s/amazon-k8s-cni-init:v1.21.1",
+						},
+					},
+				},
+			}
+		})
+
+		It("regionalizes both containers to the specified region", func() {
+			err := addons.UseRegionalImage(spec, "eu-west-1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec.Spec.Containers[0].Image).To(Equal("602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon-k8s-cni:v1.21.1"))
+			Expect(spec.Spec.InitContainers[0].Image).To(Equal("602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon-k8s-cni-init:v1.21.1"))
+		})
+	})
+
+	Context("with multiple containers including aws-eks-nodeagent", func() {
+		BeforeEach(func() {
+			spec = &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "aws-node",
+							Image: "%s.dkr.ecr.%s.%s/amazon-k8s-cni:v1.21.1",
+						},
+						{
+							Name:  "aws-eks-nodeagent",
+							Image: "%s.dkr.ecr.%s.%s/amazon/aws-network-policy-agent:v1.3.1",
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:  "aws-vpc-cni-init",
+							Image: "%s.dkr.ecr.%s.%s/amazon-k8s-cni-init:v1.21.1",
+						},
+					},
+				},
+			}
+		})
+
+		It("regionalizes all containers to the specified region", func() {
+			err := addons.UseRegionalImage(spec, "eu-central-1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec.Spec.Containers[0].Image).To(Equal("602401143452.dkr.ecr.eu-central-1.amazonaws.com/amazon-k8s-cni:v1.21.1"))
+			Expect(spec.Spec.Containers[1].Image).To(Equal("602401143452.dkr.ecr.eu-central-1.amazonaws.com/amazon/aws-network-policy-agent:v1.3.1"))
+			Expect(spec.Spec.InitContainers[0].Image).To(Equal("602401143452.dkr.ecr.eu-central-1.amazonaws.com/amazon-k8s-cni-init:v1.21.1"))
+		})
+
+		It("regionalizes to a Chinese region with correct DNS suffix", func() {
+			err := addons.UseRegionalImage(spec, "cn-northwest-1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec.Spec.Containers[0].Image).To(Equal("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni:v1.21.1"))
+			Expect(spec.Spec.Containers[1].Image).To(Equal("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon/aws-network-policy-agent:v1.3.1"))
+			Expect(spec.Spec.InitContainers[0].Image).To(Equal("961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-k8s-cni-init:v1.21.1"))
+		})
+	})
+
+	Context("with a mix of format-string and already-resolved images", func() {
+		BeforeEach(func() {
+			spec = &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "aws-node",
+							Image: "%s.dkr.ecr.%s.%s/amazon-k8s-cni:v1.21.1",
+						},
+						{
+							Name:  "sidecar",
+							Image: "public.ecr.aws/some-sidecar:latest",
+						},
+					},
+				},
+			}
+		})
+
+		It("only regionalizes images that are in format-string format", func() {
+			err := addons.UseRegionalImage(spec, "ap-southeast-1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec.Spec.Containers[0].Image).To(Equal("602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/amazon-k8s-cni:v1.21.1"))
+			Expect(spec.Spec.Containers[1].Image).To(Equal("public.ecr.aws/some-sidecar:latest"))
+		})
+	})
+
+	Context("with no init containers", func() {
+		BeforeEach(func() {
+			spec = &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "aws-node",
+							Image: "%s.dkr.ecr.%s.%s/amazon-k8s-cni:v1.21.1",
+						},
+					},
+				},
+			}
+		})
+
+		It("does not error when there are no init containers", func() {
+			err := addons.UseRegionalImage(spec, "us-east-1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec.Spec.Containers[0].Image).To(
+				Equal("602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:v1.21.1"),
+			)
+		})
+	})
+})


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

UseRegionalImage() only processed Containers[0] and InitContainers[0], missing the aws-eks-nodeagent container introduced in VPC CNI v1.14.0. This caused the nodeagent image to retain the default us-west-2 ECR URI on clusters in other regions when using `eksctl utils update-aws-node`.

Changes:
- UseRegionalImage() now iterates over all containers and init containers
- Added isRegionalImageFormat() guard to skip already-resolved URIs
- UpdateAWSNode() sets the image format prefix for aws-eks-nodeagent by name before calling UseRegionalImage()
- Added awsNodeAgentImageFormatPrefix constant
### Testing

#### Unit tests

- Added `pkg/addons/image_test.go` covering `UseRegionalImage()` with multiple containers, mixed format-string/resolved images, Chinese regions (`.amazonaws.com.cn` suffix), and empty init container slices.
- Updated `pkg/addons/default/aws_node_test.go` to assert `Containers[1]` (aws-eks-nodeagent) is regionalized in both standard (`us-east-1`) and Chinese (`cn-northwest-1`) region test cases.

#### Live cluster verification (eu-west-1)

1. Created a new EKS cluster (`regionalize-test`) in `eu-west-1` with one self-managed node.
2. Deleted the managed `vpc-cni` addon with `--preserve` to convert to self-managed VPC CNI.
3. Simulated the bug by manually setting the nodeagent image to `us-west-2`:
   ```
   aws-node:          602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon-k8s-cni:v1.20.5-eksbuild.1
   aws-eks-nodeagent: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-network-policy-agent:v1.2.7-eksbuild.2  ← wrong region
   ```
4. Ran `eksctl utils update-aws-node --cluster regionalize-test --region eu-west-1 --approve` with the patched binary.
5. Verified all images were correctly regionalized to `eu-west-1`:
   ```
   aws-node:          602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon-k8s-cni:v1.21.1
   aws-eks-nodeagent: 602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon/aws-network-policy-agent:v1.3.1  ← fixed
   aws-vpc-cni-init:  602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon-k8s-cni-init:v1.21.1
   ```
6. Confirmed pod was `2/2 Running` — both containers pulling successfully from the correct regional ECR.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

