### PR TITLE
feat: add support for controlPlaneEgressMode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.25.8
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/aws/amazon-ec2-instance-selector/v3 v3.1.2
-	github.com/aws/aws-sdk-go-v2 v1.41.7
+	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.64.2
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.64.0
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.294.0
-	github.com/aws/aws-sdk-go-v2/service/eks v1.80.2
+	github.com/aws/aws-sdk-go-v2/service/eks v1.87.0
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.21
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.8
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.9
@@ -24,7 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/outposts v1.59.2
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.2
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.0
-	github.com/aws/smithy-go v1.25.1
+	github.com/aws/smithy-go v1.27.1
 	github.com/awslabs/amazon-eks-ami/nodeadm v0.0.0-20260213141146-147b13ea3f4a
 	github.com/benjamintf1/unmarshalledmatchers v1.0.0
 	github.com/blang/semver/v4 v4.0.0
@@ -136,8 +136,8 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.6 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aws/amazon-ec2-instance-selector/v3 v3.1.2 h1:F8GBspJo+RmR4rYyw75XywEEQHQxBbF7QYKaMMnYREc=
 github.com/aws/amazon-ec2-instance-selector/v3 v3.1.2/go.mod h1:wdlMRtz9G4IO6H1yZPsqfGBxR8E6B/bdxHlGkls4kGQ=
-github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
-github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
+github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
+github.com/aws/aws-sdk-go-v2 v1.42.0/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.6 h1:N4lRUXZpZ1KVEUn6hxtco/1d2lgYhNn1fHkkl8WhlyQ=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.6/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
 github.com/aws/aws-sdk-go-v2/config v1.32.16 h1:Q0iQ7quUgJP0F/SCRTieScnaMdXr9h/2+wze1u3cNeM=
@@ -118,10 +118,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.15 h1:fyvgWTszojq8hEnMi8PPBTvZdTt
 github.com/aws/aws-sdk-go-v2/credentials v1.19.15/go.mod h1:gJiYyMOjNg8OEdRWOf3CrFQxM2a98qmrtjx1zuiQfB8=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22 h1:IOGsJ1xVWhsi+ZO7/NW8OuZZBtMJLZbk4P5HDjJO0jQ=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22/go.mod h1:b+hYdbU+jGKfXE8kKM6g1+h+L/Go3vMvzlxBsiuGsxg=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 h1:f3vKqSo13fhTYb+JEcXwXefZQE26I1FB5eTSniU67ko=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29/go.mod h1:MzoLFUArKGpGD+ukmPiTPG1X5x4o6M2kq4v2dr1FiEc=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJagbOyotl/cxoLY4xviKuE7p2GY=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2EgswdZy9Mf9KNnzxZ3TiZlv4caKghPktDOkA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23 h1:FPXsW9+gMuIeKmz7j6ENWcWtBGTe1kH8r9thNt5Uxx4=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23/go.mod h1:7J8iGMdRKk6lw2C+cMIphgAnT8uTwBwNOsGkyOCm80U=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.64.2 h1:pzFtdV2DArJul6aM3+WiWjUQ63IzrSnSbvBr8FAokt4=
@@ -136,8 +136,8 @@ github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2 h1:pZxE29WA
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2/go.mod h1:nbe4Nf/HOY+e54Dl+yjv04scYTGTC+4ZthbfOuPTXQs=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.294.0 h1:776KnBqePBBR6zEDi0bUIHXzUBOISa2WgAKEgckUF8M=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.294.0/go.mod h1:rB577GvkmJADVOFGY8/j9sPv/ewcsEtQNsd9Lrn7Zx0=
-github.com/aws/aws-sdk-go-v2/service/eks v1.80.2 h1:+FLU7+D9AW9ZMQIg4YjIN/nTJV0A2TIB2f+ovZXqAdU=
-github.com/aws/aws-sdk-go-v2/service/eks v1.80.2/go.mod h1:nx52u/3RVDWkOcrAchYgt7CXkrd03A6Gvzi0trtMFjQ=
+github.com/aws/aws-sdk-go-v2/service/eks v1.87.0 h1:bftLltXNWmNr9ed3CaQnVlzNPTNTFdHguNhIsZF6DxM=
+github.com/aws/aws-sdk-go-v2/service/eks v1.87.0/go.mod h1:rbIASs+SfCDUXx2EdfMkNpDGptlW8hvMZ9AawRiUBqE=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.21 h1:VriOdPKF8YrkMpnT76ZwA2LXk5aBInOfuzN14QGTOJc=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.21/go.mod h1:sp4Mz5YUnYCvIkGNEcdEPp+DuHqquEZYXyIuKXuHzig=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.8 h1:xUwbqWhKASQsigeQfeBjhbm6dAP1EeTulHnNSYv5Xfc=
@@ -176,8 +176,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.20 h1:oK/njaL8GtyEihkWMD4k3Vg
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.20/go.mod h1:JHs8/y1f3zY7U5WcuzoJ/yAYGYtNIVPKLIbp61euvmg=
 github.com/aws/aws-sdk-go-v2/service/sts v1.42.0 h1:ks8KBcZPh3PYISr5dAiXCM5/Thcuxk8l+PG4+A0exds=
 github.com/aws/aws-sdk-go-v2/service/sts v1.42.0/go.mod h1:pFw33T0WLvXU3rw1WBkpMlkgIn54eCB5FYLhjDc9Foo=
-github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
-github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
+github.com/aws/smithy-go v1.27.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/awslabs/amazon-eks-ami/nodeadm v0.0.0-20260213141146-147b13ea3f4a h1:xGY9gNZ4pGlqZti3DlsR8WiHz9sjjfaofG0KH0UgAhg=
 github.com/awslabs/amazon-eks-ami/nodeadm v0.0.0-20260213141146-147b13ea3f4a/go.mod h1:JndTvVCUQsR9TiNZ6g9J5V2LGQkuhhgUGuxzWhNZLA0=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -1152,6 +1152,11 @@
           "description": "See [managing access to API](/usage/vpc-networking/#managing-access-to-the-kubernetes-api-server-endpoints)",
           "x-intellij-html-description": "See <a href=\"/usage/vpc-networking/#managing-access-to-the-kubernetes-api-server-endpoints\">managing access to API</a>"
         },
+        "controlPlaneEgressMode": {
+          "type": "string",
+          "description": "controls how the control plane routes egress traffic. Valid values: \"AWS_MANAGED\" (default), \"CUSTOMER_ROUTED\"",
+          "x-intellij-html-description": "controls how the control plane routes egress traffic. Valid values: &quot;AWS<em>MANAGED&quot; (default), &quot;CUSTOMER</em>ROUTED&quot;"
+        },
         "controlPlaneSecurityGroupIDs": {
           "items": {
             "type": "string"
@@ -1248,7 +1253,8 @@
         "clusterEndpoints",
         "publicAccessCIDRs",
         "controlPlaneSubnetIDs",
-        "controlPlaneSecurityGroupIDs"
+        "controlPlaneSecurityGroupIDs",
+        "controlPlaneEgressMode"
       ],
       "additionalProperties": false,
       "description": "holds global subnet and all child subnets",

--- a/pkg/apis/eksctl.io/v1alpha5/vpc.go
+++ b/pkg/apis/eksctl.io/v1alpha5/vpc.go
@@ -181,6 +181,10 @@ type (
 		// ControlPlaneSecurityGroupIDs configures the security groups for the control plane.
 		// +optional
 		ControlPlaneSecurityGroupIDs []string `json:"controlPlaneSecurityGroupIDs,omitempty"`
+		// ControlPlaneEgressMode controls how the control plane routes egress traffic.
+		// Valid values: "AWS_MANAGED" (default), "CUSTOMER_ROUTED"
+		// +optional
+		ControlPlaneEgressMode string `json:"controlPlaneEgressMode,omitempty"`
 	}
 	// ClusterSubnets holds private and public subnets
 	ClusterSubnets struct {

--- a/pkg/cfn/builder/cluster.go
+++ b/pkg/cfn/builder/cluster.go
@@ -332,6 +332,9 @@ func (c *ClusterResourceSet) addResourcesForControlPlane(subnetDetails *SubnetDe
 		SecurityGroupIds:      c.securityGroups,
 		PublicAccessCidrs:     gfnt.NewStringSlice(c.spec.VPC.PublicAccessCIDRs...),
 	}
+	if c.spec.VPC.ControlPlaneEgressMode != "" {
+		clusterVPC.ControlPlaneEgressMode = gfnt.NewString(c.spec.VPC.ControlPlaneEgressMode)
+	}
 	if subnetIDs := c.spec.VPC.ControlPlaneSubnetIDs; len(subnetIDs) > 0 {
 		clusterVPC.SubnetIds = gfnt.NewStringSlice(subnetIDs...)
 	} else {

--- a/pkg/ctl/cmdutils/update_cluster_vpc.go
+++ b/pkg/ctl/cmdutils/update_cluster_vpc.go
@@ -21,6 +21,8 @@ type UpdateClusterVPCOptions struct {
 	ControlPlaneSubnetIDs []string
 	// ControlPlaneSecurityGroupIDs configures the security group IDs for the control plane.
 	ControlPlaneSecurityGroupIDs []string
+	// ControlPlaneEgressMode configures how the control plane routes egress traffic.
+	ControlPlaneEgressMode string
 }
 
 // NewUpdateClusterVPCLoader will load config or use flags for 'eksctl utils update-cluster-vpc-config'.
@@ -33,6 +35,7 @@ func NewUpdateClusterVPCLoader(cmd *Cmd, options UpdateClusterVPCOptions) Cluste
 		"public-access-cidrs",
 		"control-plane-subnet-ids",
 		"control-plane-security-group-ids",
+		"control-plane-egress-mode",
 	}
 
 	l.flagsIncompatibleWithConfigFile.Insert(supportedOptions...)
@@ -73,11 +76,12 @@ func NewUpdateClusterVPCLoader(cmd *Cmd, options UpdateClusterVPCOptions) Cluste
 		clusterConfig.VPC.PublicAccessCIDRs = options.PublicAccessCIDRs
 		clusterConfig.VPC.ControlPlaneSubnetIDs = options.ControlPlaneSubnetIDs
 		clusterConfig.VPC.ControlPlaneSecurityGroupIDs = options.ControlPlaneSecurityGroupIDs
+		clusterConfig.VPC.ControlPlaneEgressMode = options.ControlPlaneEgressMode
 		return nil
 	}
 
 	l.validateWithConfigFile = func() error {
-		logger.Info("only changes to vpc.clusterEndpoints, vpc.publicAccessCIDRs, vpc.controlPlaneSubnetIDs and vpc.controlPlaneSecurityGroupIDs are updated in the EKS API, changes to any other fields will be ignored")
+		logger.Info("only changes to vpc.clusterEndpoints, vpc.publicAccessCIDRs, vpc.controlPlaneSubnetIDs, vpc.controlPlaneSecurityGroupIDs and vpc.controlPlaneEgressMode are updated in the EKS API, changes to any other fields will be ignored")
 		if l.ClusterConfig.VPC == nil {
 			l.ClusterConfig.VPC = api.NewClusterVPC(false)
 		}

--- a/pkg/ctl/utils/update_cluster_vpc_config.go
+++ b/pkg/ctl/utils/update_cluster_vpc_config.go
@@ -50,6 +50,9 @@ func updateClusterVPCConfigWithHandler(cmd *cmdutils.Cmd, handler func(cmd *cmdu
 		fs.StringSliceVar(&options.ControlPlaneSubnetIDs, "control-plane-subnet-ids", nil, "Subnet IDs for the control plane")
 		fs.StringSliceVar(&options.ControlPlaneSecurityGroupIDs, "control-plane-security-group-ids", nil, "Security group IDs for the control plane")
 	})
+	cmd.FlagSetGroup.InFlagSet("Control plane egress", func(fs *pflag.FlagSet) {
+		fs.StringVar(&options.ControlPlaneEgressMode, "control-plane-egress-mode", "", "control plane egress mode: AWS_MANAGED or CUSTOMER_ROUTED")
+	})
 
 	cmdutils.AddCommonFlagsForAWS(cmd, &cmd.ProviderConfig, false)
 }

--- a/pkg/ctl/utils/vpc_helper.go
+++ b/pkg/ctl/utils/vpc_helper.go
@@ -53,6 +53,11 @@ func (v *VPCHelper) UpdateClusterVPCConfig(ctx context.Context, vpc *api.Cluster
 			return err
 		}
 	}
+	if vpc.ControlPlaneEgressMode != "" {
+		if err := v.updateControlPlaneEgressMode(ctx, vpc); err != nil {
+			return err
+		}
+	}
 	cmdutils.LogPlanModeWarning(v.PlanMode)
 	return nil
 }
@@ -96,6 +101,28 @@ func (v *VPCHelper) updateSubnetsSecurityGroups(ctx context.Context, vpc *api.Cl
 	cmdutils.LogCompletedAction(false, "control plane subnets and security groups for cluster %q in %q have been updated to: "+
 		"controlPlaneSubnetIDs=%v, controlPlaneSecurityGroupIDs=%v", v.ClusterMeta.Name, v.ClusterMeta.Region, vpcUpdate.SubnetIds, vpcUpdate.SecurityGroupIds)
 
+	return nil
+}
+
+func (v *VPCHelper) updateControlPlaneEgressMode(ctx context.Context, vpc *api.ClusterVPC) error {
+	current := string(v.Cluster.ResourcesVpcConfig.ControlPlaneEgressMode)
+	if current == vpc.ControlPlaneEgressMode {
+		logger.Success("control plane egress mode for cluster %q in %q is already %s",
+			v.ClusterMeta.Name, v.ClusterMeta.Region, current)
+		return nil
+	}
+	cmdutils.LogIntendedAction(v.PlanMode, "update control plane egress mode for cluster %q in %q to: %s",
+		v.ClusterMeta.Name, v.ClusterMeta.Region, vpc.ControlPlaneEgressMode)
+	if v.PlanMode {
+		return nil
+	}
+	if err := v.updateVPCConfig(ctx, &ekstypes.VpcConfigRequest{
+		ControlPlaneEgressMode: ekstypes.ControlPlaneEgressModeType(vpc.ControlPlaneEgressMode),
+	}); err != nil {
+		return err
+	}
+	cmdutils.LogCompletedAction(false, "control plane egress mode for cluster %q in %q has been updated to: %s",
+		v.ClusterMeta.Name, v.ClusterMeta.Region, vpc.ControlPlaneEgressMode)
 	return nil
 }
 

--- a/pkg/ctl/utils/vpc_helper_test.go
+++ b/pkg/ctl/utils/vpc_helper_test.go
@@ -315,6 +315,39 @@ var _ = DescribeTable("VPCHelper", func(e vpcHelperEntry) {
 		},
 	}),
 
+	Entry("control plane egress mode does not match desired config", vpcHelperEntry{
+		clusterVPC: &ekstypes.VpcConfigResponse{
+			EndpointPublicAccess:   true,
+			EndpointPrivateAccess:  false,
+			PublicAccessCidrs:      []string{"0.0.0.0/0"},
+			ControlPlaneEgressMode: ekstypes.ControlPlaneEgressModeTypeAwsManaged,
+		},
+		vpc: &api.ClusterVPC{
+			ControlPlaneEgressMode: "CUSTOMER_ROUTED",
+		},
+
+		expectedUpdates: []*eks.UpdateClusterConfigInput{
+			{
+				Name: aws.String("test"),
+				ResourcesVpcConfig: &ekstypes.VpcConfigRequest{
+					ControlPlaneEgressMode: ekstypes.ControlPlaneEgressModeType("CUSTOMER_ROUTED"),
+				},
+			},
+		},
+	}),
+
+	Entry("control plane egress mode already matches desired config", vpcHelperEntry{
+		clusterVPC: &ekstypes.VpcConfigResponse{
+			EndpointPublicAccess:   true,
+			EndpointPrivateAccess:  false,
+			PublicAccessCidrs:      []string{"0.0.0.0/0"},
+			ControlPlaneEgressMode: ekstypes.ControlPlaneEgressModeTypeCustomerRouted,
+		},
+		vpc: &api.ClusterVPC{
+			ControlPlaneEgressMode: "CUSTOMER_ROUTED",
+		},
+	}),
+
 	Entry("no fields match desired config", vpcHelperEntry{
 		clusterVPC: &ekstypes.VpcConfigResponse{
 			EndpointPublicAccess:  false,

--- a/pkg/goformation/cloudformation/eks/aws-eks-cluster_resourcesvpcconfig.go
+++ b/pkg/goformation/cloudformation/eks/aws-eks-cluster_resourcesvpcconfig.go
@@ -35,6 +35,11 @@ type Cluster_ResourcesVpcConfig struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html#cfn-eks-cluster-resourcesvpcconfig-subnetids
 	SubnetIds *types.Value `json:"SubnetIds,omitempty"`
 
+	// ControlPlaneEgressMode AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html#cfn-eks-cluster-resourcesvpcconfig-controlplaneegressmode
+	ControlPlaneEgressMode *types.Value `json:"ControlPlaneEgressMode,omitempty"`
+
 	// AWSCloudFormationDeletionPolicy represents a CloudFormation DeletionPolicy
 	AWSCloudFormationDeletionPolicy policies.DeletionPolicy `json:"-"`
 

--- a/pkg/printers/testdata/jsontest_2clusters.golden
+++ b/pkg/printers/testdata/jsontest_2clusters.golden
@@ -1,90 +1,92 @@
 [
-  {
-    "AccessConfig": {
-      "AuthenticationMode": "API_AND_CONFIG_MAP",
-      "BootstrapClusterCreatorAdminPermissions": true
+    {
+        "AccessConfig": {
+            "AuthenticationMode": "API_AND_CONFIG_MAP",
+            "BootstrapClusterCreatorAdminPermissions": true
+        },
+        "Arn": "arn-12345678",
+        "CertificateAuthority": null,
+        "ClientRequestToken": null,
+        "ComputeConfig": null,
+        "ConnectorConfig": null,
+        "ControlPlaneScalingConfig": null,
+        "CreatedAt": "0001-01-01T00:00:00Z",
+        "DeletionProtection": null,
+        "EncryptionConfig": null,
+        "Endpoint": null,
+        "Health": null,
+        "Id": null,
+        "Identity": null,
+        "KubernetesNetworkConfig": null,
+        "Logging": null,
+        "Name": "test-cluster-1",
+        "OutpostConfig": null,
+        "PlatformVersion": null,
+        "RemoteNetworkConfig": null,
+        "ResourcesVpcConfig": {
+            "ClusterSecurityGroupId": null,
+            "EndpointPrivateAccess": false,
+            "EndpointPublicAccess": false,
+            "PublicAccessCidrs": null,
+            "SecurityGroupIds": null,
+            "SubnetIds": [
+                "sub1",
+                "sub2"
+            ],
+            "VpcId": "vpc-1234",
+            "ControlPlaneEgressMode": ""
+        },
+        "RoleArn": null,
+        "Status": "ACTIVE",
+        "StorageConfig": null,
+        "Tags": null,
+        "Version": null,
+        "UpgradePolicy": null,
+        "ZonalShiftConfig": null
     },
-    "Arn": "arn-12345678",
-    "CertificateAuthority": null,
-    "ClientRequestToken": null,
-    "ComputeConfig": null,
-    "ConnectorConfig": null,
-    "ControlPlaneScalingConfig": null,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "DeletionProtection": null,
-    "EncryptionConfig": null,
-    "Endpoint": null,
-    "Health": null,
-    "Id": null,
-    "Identity": null,
-	"KubernetesNetworkConfig": null,
-    "Logging": null,
-    "Name": "test-cluster-1",
-    "OutpostConfig": null,
-    "PlatformVersion": null,
-    "RemoteNetworkConfig": null,
-    "ResourcesVpcConfig": {
-      "ClusterSecurityGroupId": null,
-      "EndpointPrivateAccess": false,
-      "EndpointPublicAccess": false,
-      "PublicAccessCidrs": null,
-      "SecurityGroupIds": null,
-      "SubnetIds": [
-        "sub1",
-        "sub2"
-      ],
-      "VpcId": "vpc-1234"
-    },
-    "RoleArn": null,
-    "Status": "ACTIVE",
-    "StorageConfig": null,
-    "Tags": null,
-    "Version": null,
-    "UpgradePolicy": null,
-    "ZonalShiftConfig": null
-  },
-  {
-    "AccessConfig": {
-      "AuthenticationMode": "API_AND_CONFIG_MAP",
-      "BootstrapClusterCreatorAdminPermissions": true
-    },
-    "Arn": "arn-87654321",
-    "CertificateAuthority": null,
-    "ClientRequestToken": null,
-    "ComputeConfig": null,
-    "ConnectorConfig": null,
-    "ControlPlaneScalingConfig": null,
-    "CreatedAt": "0001-01-01T00:00:00Z",
-    "DeletionProtection": null,
-    "EncryptionConfig": null,
-    "Endpoint": null,
-    "Health": null,
-    "Id": null,
-    "Identity": null,
-	"KubernetesNetworkConfig": null,
-    "Logging": null,
-    "Name": "test-cluster-2",
-    "OutpostConfig": null,
-    "PlatformVersion": null,
-    "RemoteNetworkConfig": null,
-    "ResourcesVpcConfig": {
-      "ClusterSecurityGroupId": null,
-      "EndpointPrivateAccess": false,
-      "EndpointPublicAccess": false,
-      "PublicAccessCidrs": null,
-      "SecurityGroupIds": null,
-      "SubnetIds": [
-        "sub1",
-        "sub2"
-      ],
-      "VpcId": "vpc-1234"
-    },
-    "RoleArn": null,
-    "Status": "ACTIVE",
-    "StorageConfig": null,
-    "Tags": null,
-    "Version": null,
-    "UpgradePolicy": null,
-    "ZonalShiftConfig": null
-  }
+    {
+        "AccessConfig": {
+            "AuthenticationMode": "API_AND_CONFIG_MAP",
+            "BootstrapClusterCreatorAdminPermissions": true
+        },
+        "Arn": "arn-87654321",
+        "CertificateAuthority": null,
+        "ClientRequestToken": null,
+        "ComputeConfig": null,
+        "ConnectorConfig": null,
+        "ControlPlaneScalingConfig": null,
+        "CreatedAt": "0001-01-01T00:00:00Z",
+        "DeletionProtection": null,
+        "EncryptionConfig": null,
+        "Endpoint": null,
+        "Health": null,
+        "Id": null,
+        "Identity": null,
+        "KubernetesNetworkConfig": null,
+        "Logging": null,
+        "Name": "test-cluster-2",
+        "OutpostConfig": null,
+        "PlatformVersion": null,
+        "RemoteNetworkConfig": null,
+        "ResourcesVpcConfig": {
+            "ClusterSecurityGroupId": null,
+            "EndpointPrivateAccess": false,
+            "EndpointPublicAccess": false,
+            "PublicAccessCidrs": null,
+            "SecurityGroupIds": null,
+            "SubnetIds": [
+                "sub1",
+                "sub2"
+            ],
+            "VpcId": "vpc-1234",
+            "ControlPlaneEgressMode": ""
+        },
+        "RoleArn": null,
+        "Status": "ACTIVE",
+        "StorageConfig": null,
+        "Tags": null,
+        "Version": null,
+        "UpgradePolicy": null,
+        "ZonalShiftConfig": null
+    }
 ]

--- a/pkg/printers/testdata/jsontest_single.golden
+++ b/pkg/printers/testdata/jsontest_single.golden
@@ -1,46 +1,47 @@
 [
-        {
-          "AccessConfig": {
+    {
+        "AccessConfig": {
             "AuthenticationMode": "API_AND_CONFIG_MAP",
             "BootstrapClusterCreatorAdminPermissions": true
-          },
-          "Arn": "arn-12345678",
-          "CertificateAuthority": null,
-          "ClientRequestToken": null,
-          "ComputeConfig": null,
-          "ConnectorConfig": null,
-          "ControlPlaneScalingConfig": null,
-          "CreatedAt": "0001-01-01T00:00:00Z",
-          "DeletionProtection": null,
-          "EncryptionConfig": null,
-          "Endpoint": null,
-          "Health": null,
-          "Id": null,
-          "Identity": null,
-          "KubernetesNetworkConfig": null,
-          "Logging": null,
-          "Name": "test-cluster",
-          "OutpostConfig": null,
-          "PlatformVersion": null,
-          "RemoteNetworkConfig": null,
-          "ResourcesVpcConfig": {
+        },
+        "Arn": "arn-12345678",
+        "CertificateAuthority": null,
+        "ClientRequestToken": null,
+        "ComputeConfig": null,
+        "ConnectorConfig": null,
+        "ControlPlaneScalingConfig": null,
+        "CreatedAt": "0001-01-01T00:00:00Z",
+        "DeletionProtection": null,
+        "EncryptionConfig": null,
+        "Endpoint": null,
+        "Health": null,
+        "Id": null,
+        "Identity": null,
+        "KubernetesNetworkConfig": null,
+        "Logging": null,
+        "Name": "test-cluster",
+        "OutpostConfig": null,
+        "PlatformVersion": null,
+        "RemoteNetworkConfig": null,
+        "ResourcesVpcConfig": {
             "ClusterSecurityGroupId": null,
             "EndpointPrivateAccess": false,
             "EndpointPublicAccess": false,
             "PublicAccessCidrs": null,
             "SecurityGroupIds": null,
             "SubnetIds": [
-              "sub1",
-              "sub2"
+                "sub1",
+                "sub2"
             ],
-            "VpcId": "vpc-1234"
-          },
-          "RoleArn": null,
-          "Status": "ACTIVE",
-          "StorageConfig": null,
-          "Tags": null,
-          "Version": null,
-          "UpgradePolicy": null,
-          "ZonalShiftConfig": null
-        }
-      ]
+            "VpcId": "vpc-1234",
+            "ControlPlaneEgressMode": ""
+        },
+        "RoleArn": null,
+        "Status": "ACTIVE",
+        "StorageConfig": null,
+        "Tags": null,
+        "Version": null,
+        "UpgradePolicy": null,
+        "ZonalShiftConfig": null
+    }
+]

--- a/pkg/printers/testdata/yamltest_2clusters.golden
+++ b/pkg/printers/testdata/yamltest_2clusters.golden
@@ -21,6 +21,7 @@
   PlatformVersion: null
   RemoteNetworkConfig: null
   ResourcesVpcConfig:
+    ControlPlaneEgressMode: ""
     ClusterSecurityGroupId: null
     EndpointPrivateAccess: false
     EndpointPublicAccess: false
@@ -60,6 +61,7 @@
   PlatformVersion: null
   RemoteNetworkConfig: null
   ResourcesVpcConfig:
+    ControlPlaneEgressMode: ""
     ClusterSecurityGroupId: null
     EndpointPrivateAccess: false
     EndpointPublicAccess: false

--- a/pkg/printers/testdata/yamltest_single.golden
+++ b/pkg/printers/testdata/yamltest_single.golden
@@ -21,6 +21,7 @@
   PlatformVersion: null
   RemoteNetworkConfig: null
   ResourcesVpcConfig:
+    ControlPlaneEgressMode: ""
     ClusterSecurityGroupId: null
     EndpointPrivateAccess: false
     EndpointPublicAccess: false

--- a/pkg/vpc/vpc.go
+++ b/pkg/vpc/vpc.go
@@ -695,6 +695,7 @@ func UseEndpointAccessFromCluster(ctx context.Context, provider api.ClusterProvi
 	}
 	spec.VPC.ClusterEndpoints.PublicAccess = &output.Cluster.ResourcesVpcConfig.EndpointPublicAccess
 	spec.VPC.ClusterEndpoints.PrivateAccess = &output.Cluster.ResourcesVpcConfig.EndpointPrivateAccess
+	spec.VPC.ControlPlaneEgressMode = string(output.Cluster.ResourcesVpcConfig.ControlPlaneEgressMode)
 	return nil
 }
 

--- a/userdocs/src/usage/vpc-cluster-access.md
+++ b/userdocs/src/usage/vpc-cluster-access.md
@@ -110,3 +110,39 @@ vpc:
 ```console
 eksctl utils update-cluster-vpc-config --cluster=<cluster> -f config.yaml
 ```
+
+## Control Plane Egress Mode
+
+You can configure how the EKS control plane routes egress traffic using `controlPlaneEgressMode`. When set to
+`CUSTOMER_ROUTED`, the control plane routes customer-controllable traffic (such as admission webhooks) through
+your VPC instead of AWS managed networking.
+
+To create a cluster with control plane egress mode configured:
+
+```yaml
+vpc:
+  controlPlaneEgressMode: CUSTOMER_ROUTED
+```
+
+```console
+eksctl create cluster -f config.yaml
+```
+
+To update an existing cluster's control plane egress mode:
+
+```console
+eksctl utils update-cluster-vpc-config --cluster=<cluster> --control-plane-egress-mode=CUSTOMER_ROUTED --approve
+```
+
+Or using a config file:
+
+```yaml
+vpc:
+  controlPlaneEgressMode: CUSTOMER_ROUTED
+```
+
+```console
+eksctl utils update-cluster-vpc-config -f config.yaml --approve
+```
+
+Valid values: `AWS_MANAGED` (default), `CUSTOMER_ROUTED`


### PR DESCRIPTION
[### Description

Add the ability to configure and update the control plane egress mode
for EKS clusters. This allows customers to route control plane egress
traffic through their VPC (CUSTOMER_ROUTED) instead of AWS managed
networking (AWS_MANAGED).

Config file usage (create):

```yaml
vpc:
  controlPlaneEgressMode: CUSTOMER_ROUTED
```

CLI usage (update):

```
eksctl utils update-cluster-vpc-config --cluster my-cluster \
  --control-plane-egress-mode CUSTOMER_ROUTED --approve
```

Valid values: `AWS_MANAGED` (default), `CUSTOMER_ROUTED`

### Testing

- Unit tests added for `UpdateControlPlaneEgressMode` (2 test cases)
- Functional validation against real EKS clusters:
  - Create cluster with CUSTOMER_ROUTED — verified ACTIVE with correct mode
  - Create cluster with AWS_MANAGED — verified ACTIVE with correct mode
  - Describe cluster shows field correctly via `eksctl get cluster -o yaml`
  - Update AWS_MANAGED to CUSTOMER_ROUTED — completed successfully (~7 min)
- `go vet`, `gofmt` clean
- All existing tests pass (108 in pkg/eks/)

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist
- [x] Ran `make check-all-generated-files-up-to-date` and committed the changes
- [x] Ran `go vet` and `gofmt`
- [x] Functionally tested end-to-end (create, describe, update)
](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateClusterConfig.html)