### PR TITLE
Add support for BottlerocketFips AMI family in managed nodegroups

### DIFF
--- a/pkg/ami/api.go
+++ b/pkg/ami/api.go
@@ -53,7 +53,7 @@ func Use(ctx context.Context, ec2API awsapi.EC2, ng *api.NodeGroupBase) error {
 		return fmt.Errorf("%q is an instance-store AMI and EBS block device mappings are not supported for instance-store AMIs", ng.AMI)
 
 	case ec2types.DeviceTypeEbs:
-		if ng.AMIFamily != api.NodeImageFamilyBottlerocket && !api.IsSetAndNonEmptyString(ng.VolumeName) {
+		if !api.IsBottlerocketImage(ng.AMIFamily) && !api.IsSetAndNonEmptyString(ng.VolumeName) {
 			// Volume name is preset for Bottlerocket.
 			ng.VolumeName = image.RootDeviceName
 		}

--- a/pkg/ami/ssm_resolver.go
+++ b/pkg/ami/ssm_resolver.go
@@ -84,6 +84,8 @@ func MakeSSMParameterName(version, instanceType, imageFamily string) (string, er
 		return fmt.Sprintf("/aws/service/ami-windows-latest/Windows_Server-2025-English-%s-EKS_Optimized-%s/%s", windowsAmiType(imageFamily), version, fieldName), nil
 	case api.NodeImageFamilyBottlerocket:
 		return fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/%s/latest/%s", imageType(imageFamily, instanceType, version), instanceEC2ArchName(instanceType), fieldName), nil
+	case api.NodeImageFamilyBottlerocketFips:
+		return fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-fips/%s/latest/%s", imageType(api.NodeImageFamilyBottlerocket, instanceType, version), instanceEC2ArchName(instanceType), fieldName), nil
 	case api.NodeImageFamilyUbuntu2004,
 		api.NodeImageFamilyUbuntuPro2004,
 		api.NodeImageFamilyUbuntu2204,
@@ -148,6 +150,10 @@ func MakeManagedSSMParameterName(version string, amiType ekstypes.AMITypes) stri
 		return fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/arm64/latest/image_version", version)
 	case ekstypes.AMITypesBottlerocketX8664, ekstypes.AMITypesBottlerocketX8664Nvidia:
 		return fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/latest/image_version", version)
+	case ekstypes.AMITypesBottlerocketArm64Fips, ekstypes.AMITypesBottlerocketArm64NvidiaFips:
+		return fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-fips/arm64/latest/image_version", version)
+	case ekstypes.AMITypesBottlerocketX8664Fips, ekstypes.AMITypesBottlerocketX8664NvidiaFips:
+		return fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-fips/x86_64/latest/image_version", version)
 	default:
 		return ""
 	}

--- a/pkg/ami/ssm_resolver_test.go
+++ b/pkg/ami/ssm_resolver_test.go
@@ -814,11 +814,7 @@ var _ = Describe("AMI Auto Resolution", func() {
 		It("should support SSM parameter generation for all AMI types but Windows", func() {
 			var eksAMIType ekstypes.AMITypes
 			for _, amiType := range eksAMIType.Values() {
-				if amiType == ekstypes.AMITypesCustom || strings.HasPrefix(string(amiType), "WINDOWS_") ||
-					// TODO: remove this condition after support for Bottlerocket FIPS AMI types.
-					amiType == ekstypes.AMITypesBottlerocketArm64Fips || amiType == ekstypes.AMITypesBottlerocketX8664Fips ||
-					// TODO: remove this condition after support for Bottlerocket Nvidia FIPS AMI types.
-					amiType == ekstypes.AMITypesBottlerocketArm64NvidiaFips || amiType == ekstypes.AMITypesBottlerocketX8664NvidiaFips {
+				if amiType == ekstypes.AMITypesCustom || strings.HasPrefix(string(amiType), "WINDOWS_") {
 					continue
 				}
 				ssmParameterName := MakeManagedSSMParameterName(api.Version1_31, amiType)

--- a/pkg/apis/eksctl.io/v1alpha5/amitype.go
+++ b/pkg/apis/eksctl.io/v1alpha5/amitype.go
@@ -40,6 +40,14 @@ func GetAMIType(amiFamily, instanceType string, strict bool) ekstypes.AMITypes {
 			ARM64Nvidia: ekstypes.AMITypesBottlerocketArm64Nvidia,
 			ARM64Neuron: ekstypes.AMITypesBottlerocketArm64,
 		},
+		NodeImageFamilyBottlerocketFips: {
+			X86x64:      ekstypes.AMITypesBottlerocketX8664Fips,
+			X86Nvidia:   ekstypes.AMITypesBottlerocketX8664NvidiaFips,
+			X86Neuron:   ekstypes.AMITypesBottlerocketX8664Fips,
+			ARM:         ekstypes.AMITypesBottlerocketArm64Fips,
+			ARM64Nvidia: ekstypes.AMITypesBottlerocketArm64NvidiaFips,
+			ARM64Neuron: ekstypes.AMITypesBottlerocketArm64Fips,
+		},
 		NodeImageFamilyWindowsServer2019FullContainer: {
 			X86x64:    ekstypes.AMITypesWindowsFull2019X8664,
 			X86Nvidia: ekstypes.AMITypesWindowsFull2019X8664,

--- a/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
+++ b/pkg/apis/eksctl.io/v1alpha5/assets/schema.json
@@ -1657,8 +1657,8 @@
         },
         "amiFamily": {
           "type": "string",
-          "description": "Valid variants are: `\"AmazonLinux2023\"` (default), `\"AmazonLinux2\"`, `\"UbuntuPro2604\"`, `\"Ubuntu2604\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"UbuntuPro2004\"`, `\"Ubuntu2004\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`, `\"WindowsServer2025CoreContainer\"`, `\"WindowsServer2025FullContainer\"`.",
-          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2023&quot;</code> (default), <code>&quot;AmazonLinux2&quot;</code>, <code>&quot;UbuntuPro2604&quot;</code>, <code>&quot;Ubuntu2604&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;UbuntuPro2004&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>, <code>&quot;WindowsServer2025CoreContainer&quot;</code>, <code>&quot;WindowsServer2025FullContainer&quot;</code>.",
+          "description": "Valid variants are: `\"AmazonLinux2023\"` (default), `\"AmazonLinux2\"`, `\"UbuntuPro2604\"`, `\"Ubuntu2604\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"UbuntuPro2004\"`, `\"Ubuntu2004\"`, `\"Bottlerocket\"`, `\"BottlerocketFips\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`, `\"WindowsServer2025CoreContainer\"`, `\"WindowsServer2025FullContainer\"`.",
+          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2023&quot;</code> (default), <code>&quot;AmazonLinux2&quot;</code>, <code>&quot;UbuntuPro2604&quot;</code>, <code>&quot;Ubuntu2604&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;UbuntuPro2004&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;BottlerocketFips&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>, <code>&quot;WindowsServer2025CoreContainer&quot;</code>, <code>&quot;WindowsServer2025FullContainer&quot;</code>.",
           "default": "AmazonLinux2023",
           "enum": [
             "AmazonLinux2023",
@@ -1672,6 +1672,7 @@
             "UbuntuPro2004",
             "Ubuntu2004",
             "Bottlerocket",
+            "BottlerocketFips",
             "WindowsServer2019CoreContainer",
             "WindowsServer2019FullContainer",
             "WindowsServer2022CoreContainer",
@@ -2011,8 +2012,8 @@
         },
         "amiFamily": {
           "type": "string",
-          "description": "Valid variants are: `\"AmazonLinux2023\"` (default), `\"AmazonLinux2\"`, `\"UbuntuPro2604\"`, `\"Ubuntu2604\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"UbuntuPro2004\"`, `\"Ubuntu2004\"`, `\"Bottlerocket\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`, `\"WindowsServer2025CoreContainer\"`, `\"WindowsServer2025FullContainer\"`.",
-          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2023&quot;</code> (default), <code>&quot;AmazonLinux2&quot;</code>, <code>&quot;UbuntuPro2604&quot;</code>, <code>&quot;Ubuntu2604&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;UbuntuPro2004&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>, <code>&quot;WindowsServer2025CoreContainer&quot;</code>, <code>&quot;WindowsServer2025FullContainer&quot;</code>.",
+          "description": "Valid variants are: `\"AmazonLinux2023\"` (default), `\"AmazonLinux2\"`, `\"UbuntuPro2604\"`, `\"Ubuntu2604\"`, `\"UbuntuPro2404\"`, `\"Ubuntu2404\"`, `\"UbuntuPro2204\"`, `\"Ubuntu2204\"`, `\"UbuntuPro2004\"`, `\"Ubuntu2004\"`, `\"Bottlerocket\"`, `\"BottlerocketFips\"`, `\"WindowsServer2019CoreContainer\"`, `\"WindowsServer2019FullContainer\"`, `\"WindowsServer2022CoreContainer\"`, `\"WindowsServer2022FullContainer\"`, `\"WindowsServer2025CoreContainer\"`, `\"WindowsServer2025FullContainer\"`.",
+          "x-intellij-html-description": "Valid variants are: <code>&quot;AmazonLinux2023&quot;</code> (default), <code>&quot;AmazonLinux2&quot;</code>, <code>&quot;UbuntuPro2604&quot;</code>, <code>&quot;Ubuntu2604&quot;</code>, <code>&quot;UbuntuPro2404&quot;</code>, <code>&quot;Ubuntu2404&quot;</code>, <code>&quot;UbuntuPro2204&quot;</code>, <code>&quot;Ubuntu2204&quot;</code>, <code>&quot;UbuntuPro2004&quot;</code>, <code>&quot;Ubuntu2004&quot;</code>, <code>&quot;Bottlerocket&quot;</code>, <code>&quot;BottlerocketFips&quot;</code>, <code>&quot;WindowsServer2019CoreContainer&quot;</code>, <code>&quot;WindowsServer2019FullContainer&quot;</code>, <code>&quot;WindowsServer2022CoreContainer&quot;</code>, <code>&quot;WindowsServer2022FullContainer&quot;</code>, <code>&quot;WindowsServer2025CoreContainer&quot;</code>, <code>&quot;WindowsServer2025FullContainer&quot;</code>.",
           "default": "AmazonLinux2023",
           "enum": [
             "AmazonLinux2023",
@@ -2026,6 +2027,7 @@
             "UbuntuPro2004",
             "Ubuntu2004",
             "Bottlerocket",
+            "BottlerocketFips",
             "WindowsServer2019CoreContainer",
             "WindowsServer2019FullContainer",
             "WindowsServer2022CoreContainer",

--- a/pkg/apis/eksctl.io/v1alpha5/defaults.go
+++ b/pkg/apis/eksctl.io/v1alpha5/defaults.go
@@ -220,7 +220,7 @@ func setNodeGroupBaseDefaults(ng *NodeGroupBase, meta *ClusterMeta) {
 		ng.InstanceSelector = &InstanceSelector{}
 	}
 	normalizeAMIFamily(ng)
-	if ng.AMIFamily == NodeImageFamilyBottlerocket {
+	if IsBottlerocketImage(ng.AMIFamily) {
 		setBottlerocketNodeGroupDefaults(ng)
 	}
 }
@@ -251,7 +251,7 @@ func setVolumeDefaults(ng *NodeGroupBase, controlPlaneOnOutposts bool, template 
 		}
 	}
 
-	if ng.AMIFamily == NodeImageFamilyBottlerocket && !IsSetAndNonEmptyString(ng.VolumeName) {
+	if IsBottlerocketImage(ng.AMIFamily) && !IsSetAndNonEmptyString(ng.VolumeName) {
 		ng.AdditionalEncryptedVolume = bottlerocketOSDisk
 		ng.VolumeName = aws.String(bottlerocketDataDisk)
 	}

--- a/pkg/apis/eksctl.io/v1alpha5/types.go
+++ b/pkg/apis/eksctl.io/v1alpha5/types.go
@@ -209,18 +209,19 @@ const (
 // All valid values of supported families should go in this block
 const (
 	// DefaultNodeImageFamily (default)
-	DefaultNodeImageFamily         = NodeImageFamilyAmazonLinux2023
-	NodeImageFamilyAmazonLinux2023 = "AmazonLinux2023"
-	NodeImageFamilyAmazonLinux2    = "AmazonLinux2"
-	NodeImageFamilyUbuntuPro2604   = "UbuntuPro2604"
-	NodeImageFamilyUbuntu2604      = "Ubuntu2604"
-	NodeImageFamilyUbuntuPro2404   = "UbuntuPro2404"
-	NodeImageFamilyUbuntu2404      = "Ubuntu2404"
-	NodeImageFamilyUbuntuPro2204   = "UbuntuPro2204"
-	NodeImageFamilyUbuntu2204      = "Ubuntu2204"
-	NodeImageFamilyUbuntuPro2004   = "UbuntuPro2004"
-	NodeImageFamilyUbuntu2004      = "Ubuntu2004"
-	NodeImageFamilyBottlerocket    = "Bottlerocket"
+	DefaultNodeImageFamily          = NodeImageFamilyAmazonLinux2023
+	NodeImageFamilyAmazonLinux2023  = "AmazonLinux2023"
+	NodeImageFamilyAmazonLinux2     = "AmazonLinux2"
+	NodeImageFamilyUbuntuPro2604    = "UbuntuPro2604"
+	NodeImageFamilyUbuntu2604       = "Ubuntu2604"
+	NodeImageFamilyUbuntuPro2404    = "UbuntuPro2404"
+	NodeImageFamilyUbuntu2404       = "Ubuntu2404"
+	NodeImageFamilyUbuntuPro2204    = "UbuntuPro2204"
+	NodeImageFamilyUbuntu2204       = "Ubuntu2204"
+	NodeImageFamilyUbuntuPro2004    = "UbuntuPro2004"
+	NodeImageFamilyUbuntu2004       = "Ubuntu2004"
+	NodeImageFamilyBottlerocket     = "Bottlerocket"
+	NodeImageFamilyBottlerocketFips = "BottlerocketFips"
 
 	NodeImageFamilyWindowsServer2019CoreContainer = "WindowsServer2019CoreContainer"
 	NodeImageFamilyWindowsServer2019FullContainer = "WindowsServer2019FullContainer"
@@ -609,6 +610,7 @@ func SupportedAMIFamilies() []string {
 		NodeImageFamilyUbuntuPro2004,
 		NodeImageFamilyUbuntu2004,
 		NodeImageFamilyBottlerocket,
+		NodeImageFamilyBottlerocketFips,
 		NodeImageFamilyWindowsServer2019CoreContainer,
 		NodeImageFamilyWindowsServer2019FullContainer,
 		NodeImageFamilyWindowsServer2022CoreContainer,

--- a/pkg/apis/eksctl.io/v1alpha5/validation.go
+++ b/pkg/apis/eksctl.io/v1alpha5/validation.go
@@ -814,7 +814,7 @@ func validateNodeGroupBase(np NodePool, path string, controlPlaneOnOutposts bool
 
 	if ng.AMIFamily != NodeImageFamilyAmazonLinux2023 &&
 		ng.AMIFamily != NodeImageFamilyAmazonLinux2 &&
-		ng.AMIFamily != NodeImageFamilyBottlerocket &&
+		!IsBottlerocketImage(ng.AMIFamily) &&
 		ng.AMIFamily != "" {
 		if instanceutils.IsNvidiaInstanceType(instanceType) {
 			logger.Warning(GPUDriversWarning(ng.AMIFamily))
@@ -831,7 +831,7 @@ func validateNodeGroupBase(np NodePool, path string, controlPlaneOnOutposts bool
 
 	if ng.AMIFamily != NodeImageFamilyAmazonLinux2 &&
 		ng.AMIFamily != NodeImageFamilyAmazonLinux2023 &&
-		ng.AMIFamily != NodeImageFamilyBottlerocket &&
+		!IsBottlerocketImage(ng.AMIFamily) &&
 		ng.AMIFamily != "" {
 		// Only AL2, AL2023 and Bottlerocket support Inferentia hosts.
 		if instanceutils.IsInferentiaInstanceType(instanceType) {
@@ -1007,14 +1007,14 @@ func ValidateNodeGroup(i int, ng *NodeGroup, cfg *ClusterConfig) error {
 		return errors.New("when using a custom AMI, amiFamily needs to be explicitly set via config file or via --node-ami-family flag")
 	}
 
-	if ng.Bottlerocket != nil && ng.AMIFamily != NodeImageFamilyBottlerocket {
-		return fmt.Errorf(`bottlerocket config can only be used with amiFamily "Bottlerocket" but found "%s" (path=%s.bottlerocket)`,
+	if ng.Bottlerocket != nil && !IsBottlerocketImage(ng.AMIFamily) {
+		return fmt.Errorf(`bottlerocket config can only be used with amiFamily "Bottlerocket" or "BottlerocketFips" but found "%s" (path=%s.bottlerocket)`,
 			ng.AMIFamily, path)
 	}
 
 	if ng.AMI != "" && ng.OverrideBootstrapCommand == nil &&
 		ng.AMIFamily != NodeImageFamilyAmazonLinux2023 &&
-		ng.AMIFamily != NodeImageFamilyBottlerocket &&
+		!IsBottlerocketImage(ng.AMIFamily) &&
 		!IsWindowsImage(ng.AMIFamily) {
 		return fmt.Errorf("%[1]s.overrideBootstrapCommand is required when using a custom AMI based on %s (%[1]s.ami)", path, ng.AMIFamily)
 	}
@@ -1045,7 +1045,7 @@ func ValidateNodeGroup(i int, ng *NodeGroup, cfg *ClusterConfig) error {
 		if ng.KubeletExtraConfig != nil {
 			return fieldNotSupported("kubeletExtraConfig")
 		}
-	} else if ng.AMIFamily == NodeImageFamilyBottlerocket {
+	} else if IsBottlerocketImage(ng.AMIFamily) {
 		if ng.KubeletExtraConfig != nil {
 			return fieldNotSupported("kubeletExtraConfig")
 		}
@@ -1380,7 +1380,7 @@ func ValidateManagedNodeGroup(index int, ng *ManagedNodeGroup) error {
 		}
 	}
 
-	if ng.AMIFamily == NodeImageFamilyBottlerocket {
+	if IsBottlerocketImage(ng.AMIFamily) {
 		fieldNotSupported := func(field string) error {
 			return &unsupportedFieldError{
 				ng:    ng.NodeGroupBase,
@@ -1459,7 +1459,7 @@ func ValidateManagedNodeGroup(index int, ng *ManagedNodeGroup) error {
 			return fmt.Errorf("cannot set amiFamily to %s when using a custom AMI for managed nodes, only %s are supported", ng.AMIFamily,
 				strings.Join(slices.Concat(SupportedAmazonLinuxImages, SupportedBottlerocketImages, SupportedUbuntuImages), ", "))
 		}
-		if ng.OverrideBootstrapCommand == nil && ng.AMIFamily != NodeImageFamilyAmazonLinux2023 && ng.AMIFamily != NodeImageFamilyBottlerocket {
+		if ng.OverrideBootstrapCommand == nil && ng.AMIFamily != NodeImageFamilyAmazonLinux2023 && !IsBottlerocketImage(ng.AMIFamily) {
 			return fmt.Errorf("%[1]s.overrideBootstrapCommand is required when using a custom AMI based on %s (%[1]s.ami)", path, ng.AMIFamily)
 		}
 		notSupportedWithCustomAMIErr := func(field string) error {
@@ -1684,7 +1684,7 @@ func IsAmazonLinuxImage(imageFamily string) bool {
 
 func IsBottlerocketImage(imageFamily string) bool {
 	switch imageFamily {
-	case NodeImageFamilyBottlerocket:
+	case NodeImageFamilyBottlerocket, NodeImageFamilyBottlerocketFips:
 		return true
 
 	default:

--- a/pkg/eks/nodegroup_service.go
+++ b/pkg/eks/nodegroup_service.go
@@ -65,7 +65,7 @@ func (n *NodeGroupService) Normalize(ctx context.Context, nodePools []api.NodePo
 			hasNativeAMIFamilySupport :=
 				ng.AMIFamily == api.NodeImageFamilyAmazonLinux2023 ||
 					ng.AMIFamily == api.NodeImageFamilyAmazonLinux2 ||
-					ng.AMIFamily == api.NodeImageFamilyBottlerocket ||
+					api.IsBottlerocketImage(ng.AMIFamily) ||
 					api.IsWindowsImage(ng.AMIFamily)
 
 			if !hasNativeAMIFamilySupport && !api.IsAMI(ng.AMI) {

--- a/pkg/nodebootstrap/userdata.go
+++ b/pkg/nodebootstrap/userdata.go
@@ -48,7 +48,7 @@ func NewBootstrapper(clusterConfig *api.ClusterConfig, ng *api.NodeGroup) (Boots
 	switch ng.AMIFamily {
 	case api.NodeImageFamilyUbuntuPro2604, api.NodeImageFamilyUbuntu2604, api.NodeImageFamilyUbuntuPro2404, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntuPro2004, api.NodeImageFamilyUbuntu2004:
 		return NewUbuntuBootstrapper(clusterConfig, ng, clusterDNS), nil
-	case api.NodeImageFamilyBottlerocket:
+	case api.NodeImageFamilyBottlerocket, api.NodeImageFamilyBottlerocketFips:
 		return NewBottlerocketBootstrapper(clusterConfig, ng), nil
 	case api.NodeImageFamilyAmazonLinux2023:
 		return NewAL2023Bootstrapper(clusterConfig, ng, clusterDNS), nil
@@ -76,7 +76,7 @@ func NewManagedBootstrapper(clusterConfig *api.ClusterConfig, ng *api.ManagedNod
 		return NewManagedAL2023Bootstrapper(clusterConfig, ng, clusterDNS), nil
 	case api.NodeImageFamilyAmazonLinux2:
 		return NewManagedAL2Bootstrapper(ng), nil
-	case api.NodeImageFamilyBottlerocket:
+	case api.NodeImageFamilyBottlerocket, api.NodeImageFamilyBottlerocketFips:
 		return NewManagedBottlerocketBootstrapper(clusterConfig, ng), nil
 	case api.NodeImageFamilyUbuntu2004, api.NodeImageFamilyUbuntuPro2004, api.NodeImageFamilyUbuntu2204, api.NodeImageFamilyUbuntuPro2204, api.NodeImageFamilyUbuntu2404, api.NodeImageFamilyUbuntuPro2404, api.NodeImageFamilyUbuntu2604, api.NodeImageFamilyUbuntuPro2604:
 		return NewUbuntuBootstrapper(clusterConfig, ng, clusterDNS), nil


### PR DESCRIPTION
### Description

Adds support for the BottlerocketFips AMI family, enabling users to create
managed and self-managed nodegroups with FIPS-enabled Bottlerocket AMIs
(BOTTLEROCKET_x86_64_FIPS, BOTTLEROCKET_ARM_64_FIPS, and their Nvidia
variants).

Changes:

- Added NodeImageFamilyBottlerocketFips constant and registered it in
SupportedAMIFamilies()
- Added AMI type mappings for all FIPS Bottlerocket variants (x86, ARM,
Nvidia)
- Added SSM parameter resolution using the aws-k8s-<version>-fips path
pattern for both self-managed and managed nodegroups
- Updated IsBottlerocketImage() to include the new family
- Replaced all hardcoded == NodeImageFamilyBottlerocket checks with
IsBottlerocketImage() so that validation, defaulting, GPU support, volume
naming, and bootstrapper selection all apply to the FIPS variant
- Removed the TODO exclusions in ssm_resolver_test.go that were tracking this
gap

Usage:

managedNodeGroups:
  - name: fips-ng
    amiFamily: BottlerocketFips
    instanceType: m5.xlarge
    desiredCapacity: 1

### Checklist
- [X] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `userdocs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes
- [x] (Core team) Added labels for change area (e.g. `area/nodegroup`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

